### PR TITLE
chore(StatusChatImageLoader): uses mipmap filtering for unfurled images

### DIFF
--- a/ui/imports/shared/status/StatusChatImageLoader.qml
+++ b/ui/imports/shared/status/StatusChatImageLoader.qml
@@ -28,6 +28,7 @@ Item {
         fillMode: Image.PreserveAspectFit
         source: imageContainer.source
         playing: imageContainer.isAnimated && imageContainer.playing
+        mipmap: true
 
         layer.enabled: true
         layer.effect: OpacityMask {


### PR DESCRIPTION
Closes: #7689

### What does the PR do

Improves quality of unfurled image preview

before:
![Kazam_screenshot_00003](https://user-images.githubusercontent.com/20650004/193240635-5f217f8e-054d-4553-95cf-cda1e34e1c32.png)

after:
![Kazam_screenshot_00002](https://user-images.githubusercontent.com/20650004/193240659-8769f690-6307-4226-b14e-6e714e8f663c.png)

### Affected areas

`StatusChatImageLoader`
