### PR TITLE
fix(StatusSearchPopup): images in search results are broken

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -283,6 +283,8 @@ StatusModal {
                         asset.charactersLen: model.isUserIcon ? 2 : 1
                         titleAsideText: root.formatTimestampFn(model.time)
                         asset.name: model.image
+                        asset.width: 40
+                        asset.height: 40
                         asset.isImage: !!model.image
                         badge.primaryText: model.badgePrimaryText
                         badge.secondaryText: model.badgeSecondaryText


### PR DESCRIPTION
Closes: #7658

### What does the PR do

Fixes search results icons

### Affected areas

StatusSearchPopup

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-10-03 14-25-36](https://user-images.githubusercontent.com/5377645/193576875-2f2a62b6-889e-4f57-a5d6-a6fe54b17415.png)

