### PR TITLE
fix(Community): big space in invite friends popup

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
@@ -72,9 +72,12 @@ ColumnLayout {
             root.pubKeys = pubKeysCopy
         }
         Layout.fillWidth: true
-        Layout.fillHeight: true
         Layout.leftMargin: Style.current.halfPadding
         Layout.rightMargin: Style.current.halfPadding
+    }
+
+    Item {
+        Layout.fillHeight: true
     }
 
     StatusModalDivider {


### PR DESCRIPTION
Closes #7707

### What does the PR do
Fixes invite contacts modal contact list has huge empty space between each contact

### Affected areas
CommunityProfilePopupInviteFriendsPanel

### Screenshot of functionality (including design for comparison)
<img width="695" alt="pp" src="https://user-images.githubusercontent.com/31625338/193600887-f4032db3-3973-4591-80e3-d8c1ffaaba8f.png">
