### PR TITLE
fix: Reply to sticker adds message advising user to upgrade

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -88,7 +88,7 @@ Item {
                 textField.color: Theme.palette.baseColor1
                 textField.height: 18
                 clip: true
-                visible: !!replyDetails.messageText
+                visible: !!replyDetails.messageText && replyDetails.contentType !== StatusMessage.ContentType.Sticker
                 allowShowMore: false
             }
             StatusImageMessage {
@@ -96,7 +96,7 @@ Item {
                 Layout.preferredHeight: imageAlias.paintedHeight
                 imageWidth: 56
                 source: replyDetails.contentType === StatusMessage.ContentType.Image ? replyDetails.messageContent : ""
-//                visible: replyDetails.contentType === StatusMessage.ContentType.Image
+                visible: source
                 shapeType: StatusImageMessage.ShapeType.ROUNDED
             }
             Item {


### PR DESCRIPTION
Closes #7724

### What does the PR do

Fixes erroneous message when replying to a sticker

### Affected areas

StatusMessageReply

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-10-03 19-40-00](https://user-images.githubusercontent.com/5377645/193643287-34b68aae-d8bb-43a5-b259-c17aa7f457fb.png)


