### PR TITLE
feat(Wallet): sync saved addresses 7229

### DIFF
--- a/app/qml/Status/Application/MainView/MainView.qml
+++ b/app/qml/Status/Application/MainView/MainView.qml
@@ -34,6 +34,7 @@ Item {
             Layout.fillHeight: true
 
             sections: appSections.sections
+            currentIndex: 1
         }
 
         ColumnLayout {
@@ -59,6 +60,7 @@ Item {
                     delegate: Loader {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
+                        active: navBar.currentIndex === index
 
                         sourceComponent: modelData.content
                     }

--- a/libs/ApplicationCore/src/ApplicationCore/UserConfiguration.cpp
+++ b/libs/ApplicationCore/src/ApplicationCore/UserConfiguration.cpp
@@ -2,6 +2,8 @@
 
 #include "Helpers/conversions.h"
 
+#include <QCommandLineParser>
+
 #include <filesystem>
 
 namespace fs = std::filesystem;
@@ -40,8 +42,25 @@ void UserConfiguration::setUserDataFolder(const QString &newUserDataFolder)
 
 void UserConfiguration::generateReleaseConfiguration()
 {
-    m_userDataFolder = toPath(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation))/statusFolder/dataSubfolder;
+    if(!parseFromCommandLineAndReturnTrueIfSet())
+        m_userDataFolder = toPath(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation))/statusFolder/dataSubfolder;
     emit userDataFolderChanged();
+}
+
+bool UserConfiguration::parseFromCommandLineAndReturnTrueIfSet()
+{
+    QCommandLineParser parser;
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addPositionalArgument("dataDir", "Data folder");
+    parser.process(*QCoreApplication::instance());
+    auto args = parser.positionalArguments();
+    if (args.size() > 0) {
+        m_userDataFolder = toPath(args[0]);
+        emit userDataFolderChanged();
+        return true;
+    }
+    return false;
 }
 
 }

--- a/libs/ApplicationCore/src/ApplicationCore/UserConfiguration.h
+++ b/libs/ApplicationCore/src/ApplicationCore/UserConfiguration.h
@@ -9,14 +9,13 @@ namespace Status::ApplicationCore {
 
 namespace fs = std::filesystem;
 
+/// Contains necessary data for each created account hence this will be the same path for all accounts
 class UserConfiguration: public QObject
 {
     Q_OBJECT
     QML_ELEMENT
 
-    // Not sure why `qmlUserDataFolder` is writable??? We should not change it from the qml side.
-    // Even from the backend side this will be set only on the app start, and it will contain
-    // necessary data for each created account, so even we're switching accounts, this will be the same path.
+    /// @note userFolder is writable in order to allow changing it in tests until a proper abstraction is in place
     Q_PROPERTY(QString userDataFolder READ qmlUserDataFolder WRITE setUserDataFolder NOTIFY userDataFolderChanged)
 
 public:
@@ -31,6 +30,7 @@ signals:
 
 private:
     void generateReleaseConfiguration();
+    bool parseFromCommandLineAndReturnTrueIfSet();
 
     fs::path m_userDataFolder;
 };

--- a/libs/StatusGoQt/src/StatusGo/Wallet/SavedAddress.h
+++ b/libs/StatusGoQt/src/StatusGo/Wallet/SavedAddress.h
@@ -20,10 +20,12 @@ struct SavedAddress
 {
     Accounts::EOAddress address;
     QString name;
+    bool favourite;
+    ChainID chainId;
 };
 
 using SavedAddresses = std::vector<SavedAddress>;
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SavedAddress, address, name);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SavedAddress, address, name, favourite, chainId);
 
 }

--- a/libs/StatusGoQt/src/StatusGo/Wallet/WalletApi.cpp
+++ b/libs/StatusGoQt/src/StatusGo/Wallet/WalletApi.cpp
@@ -46,7 +46,7 @@ SavedAddresses getSavedAddresses()
     checkPrivateRpcCallResultAndReportError(resultJson);
 
     const auto &data = resultJson.get<CallPrivateRpcResponse>().result;
-    return data.is_null() ? nlohmann::json() : data;
+    return data.is_null() ? json::array() : data;
 }
 
 void saveAddress(const SavedAddress &address)
@@ -77,7 +77,7 @@ NetworkConfigurations getEthereumChains(bool onlyEnabled)
     checkPrivateRpcCallResultAndReportError(resultJson);
 
     const auto &data = resultJson.get<CallPrivateRpcResponse>().result;
-    return data.is_null() ? nlohmann::json() : data;
+    return data.is_null() ? json::array() : data;
 }
 
 Tokens getTokens(const ChainID &chainId)
@@ -94,7 +94,7 @@ Tokens getTokens(const ChainID &chainId)
     checkPrivateRpcCallResultAndReportError(resultJson);
 
     const auto &data = resultJson.get<CallPrivateRpcResponse>().result;
-    return data.is_null() ? nlohmann::json() : data;
+    return data.is_null() ? json::array() : data;
 }
 
 TokenBalances getTokensBalancesForChainIDs(const std::vector<ChainID> &chainIds,

--- a/libs/StatusGoQt/src/StatusGo/Wallet/WalletApi.cpp
+++ b/libs/StatusGoQt/src/StatusGo/Wallet/WalletApi.cpp
@@ -54,7 +54,7 @@ void saveAddress(const SavedAddress &address)
     std::vector<json> params = { address };
     json inputJson = {
         {"jsonrpc", "2.0"},
-        {"method", "wallet_addSavedAddress"},
+        {"method", "wakuext_upsertSavedAddress"},
         {"params", params}
     };
 

--- a/libs/StatusGoQt/src/StatusGo/Wallet/WalletApi.h
+++ b/libs/StatusGoQt/src/StatusGo/Wallet/WalletApi.h
@@ -31,7 +31,7 @@ DerivedAddresses getDerivedAddressesForPath(const HashedPassword &password,
 SavedAddresses getSavedAddresses();
 
 /// \brief Add a new or update existing saved wallet address
-/// \see \c addSavedAddress
+/// \see wakuext_upsertSavedAddress RPC method
 /// \throws \c CallPrivateRpcError
 void saveAddress(const SavedAddress &address);
 

--- a/libs/Wallet/src/SavedAddressesController.cpp
+++ b/libs/Wallet/src/SavedAddressesController.cpp
@@ -18,12 +18,13 @@ QAbstractListModel *SavedAddressesController::savedAddresses() const
     return m_savedAddresses.get();
 }
 
+// TODO: extend with favourite and chain ID
 void SavedAddressesController::saveAddress(const QString &address, const QString &name)
 {
     try
     {
         StatusGo::Wallet::saveAddress(StatusGo::Wallet::SavedAddress(
-            { StatusGo::Accounts::EOAddress(address), name }));
+            { StatusGo::Accounts::EOAddress(address), name, false, StatusGo::Wallet::ChainID(0) }));
     }
     catch(const StatusGo::CallPrivateRpcError& rpcError)
     {

--- a/resources/default-networks.json
+++ b/resources/default-networks.json
@@ -27,7 +27,7 @@
     "nativeCurrencyDecimals": 18,
     "isTest": true,
     "layer": 1,
-    "enabled": true
+    "enabled": false
   },
   {
     "chainId": 4,
@@ -57,7 +57,7 @@
     "nativeCurrencyDecimals": 18,
     "isTest": true,
     "layer": 1,
-    "enabled": false
+    "enabled": true
   },
   {
     "chainId": 10,

--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -10,6 +10,7 @@ import ../../../../app_service/service/activity_center/dto/[notification]
 import ../../../../app_service/service/contacts/dto/[contacts, status_update]
 import ../../../../app_service/service/devices/dto/[device]
 import ../../../../app_service/service/settings/dto/[settings]
+import ../../../../app_service/service/saved_address/[dto]
 
 type MessageSignal* = ref object of Signal
   bookmarks*: seq[BookmarkDto]
@@ -29,6 +30,7 @@ type MessageSignal* = ref object of Signal
   settings*: seq[SettingsFieldDto]
   clearedHistories*: seq[ClearedHistoryDto]
   verificationRequests*: seq[VerificationRequest]
+  savedAddresses*: seq[SavedAddressDto]
 
 type MessageDeliveredSignal* = ref object of Signal
   chatId*: string
@@ -117,6 +119,10 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   if event["event"]{"verificationRequests"} != nil:
     for jsonVerificationRequest in event["event"]["verificationRequests"]:
       signal.verificationRequests.add(jsonVerificationRequest.toVerificationRequest())
+
+  if event["event"]{"savedAddresses"} != nil:
+    for jsonSavedAddress in event["event"]["savedAddresses"]:
+      signal.savedAddresses.add(jsonSavedAddress.toSavedAddressDto())
 
   result = signal
 

--- a/src/app/modules/main/wallet_section/saved_addresses/controller.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/controller.nim
@@ -2,7 +2,6 @@ import io_interface
 import ../../../../core/eventemitter
 import ../../../../../app_service/service/saved_address/service as saved_address_service
 
-
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -77,10 +77,11 @@ rpc(addEthereumChain, "wallet"):
 rpc(deleteEthereumChain, "wallet"):
   chainId: int
 
-rpc(addSavedAddress, "wallet"):
+rpc(upsertSavedAddress, "wakuext"):
   savedAddress: SavedAddress
 
-rpc(deleteSavedAddress, "wallet"):
+rpc(deleteSavedAddress, "wakuext"):
+  chainId: int
   address: string
 
 rpc(getSavedAddresses, "wallet"):


### PR DESCRIPTION
### Closes #7229

Requires status-go change: https://github.com/status-im/status-go/pull/2865

### Affected areas

Wallet - Saved Addresses
Device Sync

### Supported test cases

Existing saved address migration and full sync

- Existing paired devices that have different saved addresses should sync on a manual sync trigger

For paired devices

- any change on one side should be mirrored on the other when online
- doing conflicting changes on the same saved address (same address) are resolved by applying the whole state of the newest change
  - newest change is decided based on the global time of the system

### StatusQ checklist

- [x] ~~add documentation if necessary (new component, new feature)~~
- [x] ~~update sandbox app~~
- [x] ~~test changes in both light and dark theme?~~

### Demo

https://user-images.githubusercontent.com/47554641/193814010-56c9835a-4ab6-4643-bc94-753f9c6a4e3f.mov


