### PR TITLE
Fix/issue 7701 search list

### DIFF
--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -138,7 +138,8 @@ QtObject:
       # Handling community updates
       if (receivedData.communities.len > 0):
         for community in receivedData.communities:
-          self.updateOrAddChannelGroup(community.toChannelGroupDto())
+          if (community.joined):
+            self.updateOrAddChannelGroup(community.toChannelGroupDto())
   
   proc sortPersonnalChatAsFirst[T, D](x, y: (T, D)): int =
     if (x[1].channelGroupType == Personal): return -1


### PR DESCRIPTION
Closes: #7701 

It's hard to reproduce cos `Status` community shown after some time and it's only one place where it possible to be included in search list

### What does the PR do

This PR adds check to handling communities updates which excludes unjoined communities from updates

### Affected areas

AppSearch, Activity Center. 

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it
