### PR TITLE
Revert "fix(ChatMessageView): delayed binding for proper msg height calculation"

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -251,11 +251,6 @@ Item {
 
             width: ListView.view.width
 
-            Binding on height {
-                delayed: true
-                value: msgDelegate.implicitHeight
-            }
-
             objectName: "chatMessageViewDelegate"
             rootStore: root.rootStore
             messageStore: root.messageStore


### PR DESCRIPTION
Reverts status-im/status-desktop#7721

It turned out that it doesn't work as expected - causes scrolling slow in both 5.14.2 and 5.15.