### PR TITLE
fix(@desktop/chat): Fix moving channels between categories

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -159,7 +159,7 @@ proc init*(self: Controller) =
     self.events.on(SIGNAL_COMMUNITY_CATEGORY_REORDERED) do(e:Args):
       let args = CommunityChatOrderArgs(e)
       if (args.communityId == self.sectionId):
-        self.delegate.onReorderChatOrCategory(args.categoryId, args.position)
+        self.delegate.onReorderChatOrCategory(args.categoryId, args.position, args.categoryId)
 
     self.events.on(SIGNAL_COMMUNITY_CATEGORY_NAME_EDITED) do(e:Args):
       let args = CommunityCategoryArgs(e)
@@ -169,7 +169,7 @@ proc init*(self: Controller) =
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_REORDERED) do(e:Args):
       let args = CommunityChatOrderArgs(e)
       if (args.communityId == self.sectionId):
-        self.delegate.onReorderChatOrCategory(args.chatId, args.position)
+        self.delegate.onReorderChatOrCategory(args.chatId, args.position, args.categoryId)
 
     self.events.on(SIGNAL_RELOAD_MESSAGES) do(e: Args):
       let args = ReloadMessagesArgs(e)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -121,7 +121,7 @@ method onGroupChatDetailsUpdated*(self: AccessInterface, chatId: string, newName
 method onCommunityChannelEdited*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onReorderChatOrCategory*(self: AccessInterface, chatOrCatId: string, position: int) {.base.} =
+method onReorderChatOrCategory*(self: AccessInterface, chatOrCatId: string, position: int, newCategoryIdForChat: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCategoryCreated*(self: AccessInterface, category: Category, chats: seq[ChatDto]) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -433,7 +433,7 @@ method addNewChat*(
   if chatDto.categoryId.len == 0:
     let item = initItem(chatDto.id, chatName, chatImage, chatDto.color, chatDto.emoji,
       chatDto.description, chatDto.chatType.int, amIChatAdmin, chatDto.timestamp.int, hasNotification, notificationsCount,
-      chatDto.muted, blocked=false, active=false, position = 0, chatDto.categoryId, colorId, colorHash, chatDto.highlight,
+      chatDto.muted, blocked=false, active=false, chatDto.position, chatDto.categoryId, colorId, colorHash, chatDto.highlight,
       onlineStatus = onlineStatus)
     self.addSubmodule(chatDto.id, belongsToCommunity, isUsersListAvailable, events, settingsService, contactService, chatService,
                       communityService, messageService, gifService, mailserversService)
@@ -480,7 +480,6 @@ method doesTopLevelChatExist*(self: Module, chatId: string): bool =
 method removeCommunityChat*(self: Module, chatId: string) =
   if(not self.chatContentModules.contains(chatId)):
     return
-
   self.controller.removeCommunityChat(chatId)
 
 method onCommunityCategoryCreated*(self: Module, cat: Category, chats: seq[ChatDto]) =
@@ -537,8 +536,8 @@ method setFirstChannelAsActive*(self: Module) =
     let subItem = item.subItems.getItemAtIndex(0)
     self.setActiveItemSubItem(item.id, subItem.id)
 
-method onReorderChatOrCategory*(self: Module, chatOrCatId: string, position: int) =
-  self.view.chatsModel().reorder(chatOrCatId, position)
+method onReorderChatOrCategory*(self: Module, chatOrCatId: string, position: int, newCategoryIdForChat: string) =
+  self.view.chatsModel().reorder(chatOrCatId, position, newCategoryIdForChat)
 
 method onCategoryNameChanged*(self: Module, category: Category) =
   self.view.chatsModel().renameItem(category.id, category.name)
@@ -572,7 +571,7 @@ method onCommunityCategoryEdited*(self: Module, cat: Category, chats: seq[ChatDt
 method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
   if(not self.chatContentModules.contains(chatId)):
     return
-  self.view.chatsModel().removeItemById(chatId)
+  self.view.chatsModel().removeItemOrSubitemById(chatId)
   self.removeSubmodule(chatId)
 
   self.setFirstChannelAsActive()

--- a/src/app/modules/main/chat_section/sub_item.nim
+++ b/src/app/modules/main/chat_section/sub_item.nim
@@ -57,5 +57,6 @@ proc toJsonNode*(self: SubItem): JsonNode =
     "muted": self.muted,
     "blocked": self.blocked,
     "active": self.active,
-    "position": self.position
+    "position": self.position,
+    "categoryId": ""
   }


### PR DESCRIPTION
Fix #7422

### What does the PR do

Fixes reordering channels for community members.

### Affected areas

Community, channels list, channel categories

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/61889657/193846742-79ff9774-250b-4fba-849d-4ee1919b8a66.mov


