### PR TITLE
fix(AppMain): only show banner when disconnected

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -602,7 +602,8 @@ Item {
                     id: connectedBannerComponent
 
                     ModuleWarning {
-                        readonly property bool isConnected: bannersLayout.isConnected
+                        id: connectedBanner
+                        property bool isConnected: true
 
                         objectName: "connectionInfoBanner"
                         Layout.fillWidth: true
@@ -617,7 +618,7 @@ Item {
                         }
 
                         Component.onCompleted: {
-                            updateState()
+                            connectedBanner.isConnected = Qt.binding(() => bannersLayout.isConnected);
                         }
                         onIsConnectedChanged: {
                             updateState();


### PR DESCRIPTION
Closes #7416

### What does the PR do
Banners: only show banner when disconnected

### Affected areas
Banners
