### PR TITLE
fix(StatusChatInput): Move formatting menu from scroll

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1012,6 +1012,60 @@ Rectangle {
             color: isEdit ? Theme.palette.statusChatInput.secondaryBackgroundColor : Style.current.inputBackground
             radius: 20
 
+            StatusTextFormatMenu {
+                id: textFormatMenu
+
+                StatusChatInputTextFormationAction {
+                    wrapper: "**"
+                    icon.name: "bold"
+                    text: qsTr("Bold")
+                    selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
+                    onActionTriggered: checked ?
+                                           unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
+                                           wrapSelection(wrapper)
+                }
+                StatusChatInputTextFormationAction {
+                    wrapper: "*"
+                    icon.name: "italic"
+                    text: qsTr("Italic")
+                    selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
+                    checked: (surroundedBy("*") && !surroundedBy("**")) || surroundedBy("***")
+                    onActionTriggered: checked ?
+                                           unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
+                                           wrapSelection(wrapper)
+                }
+                StatusChatInputTextFormationAction {
+                    wrapper: "~~"
+                    icon.name: "strikethrough"
+                    text: qsTr("Strikethrough")
+                    selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
+                    onActionTriggered: checked ?
+                                           unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
+                                           wrapSelection(wrapper)
+                }
+                StatusChatInputTextFormationAction {
+                    wrapper: "`"
+                    icon.name: "code"
+                    text: qsTr("Code")
+                    selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
+                    onActionTriggered: checked ?
+                                           unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
+                                           wrapSelection(wrapper)
+                }
+                StatusChatInputTextFormationAction {
+                    wrapper: "> "
+                    icon.name: "quote"
+                    text: qsTr("Quote")
+                    checked: messageInputField.selectedText && isSelectedLinePrefixedBy(messageInputField.selectionStart, wrapper)
+
+                    onActionTriggered: checked
+                                       ? unprefixSelectedLine(wrapper)
+                                       : prefixSelectedLine(wrapper)
+                }
+                onClosed: {
+                    messageInputField.deselect();
+                }
+            }
             ColumnLayout {
                 id: validators
                 anchors.bottom: control.imageErrorMessageLocation === StatusChatInput.ImageErrorMessageLocation.Top ? parent.top : undefined
@@ -1237,60 +1291,6 @@ Rectangle {
                                 acceptedButtons: Qt.NoButton
                                 enabled: parent.hoveredLink
                                 cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor
-                            }
-                            StatusTextFormatMenu {
-                                id: textFormatMenu
-
-                                StatusChatInputTextFormationAction {
-                                    wrapper: "**"
-                                    icon.name: "bold"
-                                    text: qsTr("Bold")
-                                    selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
-                                    onActionTriggered: checked ?
-                                                           unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
-                                                           wrapSelection(wrapper)
-                                }
-                                StatusChatInputTextFormationAction {
-                                    wrapper: "*"
-                                    icon.name: "italic"
-                                    text: qsTr("Italic")
-                                    selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
-                                    checked: (surroundedBy("*") && !surroundedBy("**")) || surroundedBy("***")
-                                    onActionTriggered: checked ?
-                                                           unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
-                                                           wrapSelection(wrapper)
-                                }
-                                StatusChatInputTextFormationAction {
-                                    wrapper: "~~"
-                                    icon.name: "strikethrough"
-                                    text: qsTr("Strikethrough")
-                                    selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
-                                    onActionTriggered: checked ?
-                                                           unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
-                                                           wrapSelection(wrapper)
-                                }
-                                StatusChatInputTextFormationAction {
-                                    wrapper: "`"
-                                    icon.name: "code"
-                                    text: qsTr("Code")
-                                    selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
-                                    onActionTriggered: checked ?
-                                                           unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
-                                                           wrapSelection(wrapper)
-                                }
-                                StatusChatInputTextFormationAction {
-                                    wrapper: "> "
-                                    icon.name: "quote"
-                                    text: qsTr("Quote")
-                                    checked: messageInputField.selectedText && isSelectedLinePrefixedBy(messageInputField.selectionStart, wrapper)
-
-                                    onActionTriggered: checked
-                                                       ? unprefixSelectedLine(wrapper)
-                                                       : prefixSelectedLine(wrapper)
-                                }
-                                onClosed: {
-                                    messageInputField.deselect();
-                                }
                             }
                         }
 


### PR DESCRIPTION
Closes: #7751

### What does the PR do

Menu was bind on current position in scroll view cos parent was `TextArea`. I move the menu above the scroll. 

### Affected areas

StatusChatInput

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<img width="933" alt="Снимок экрана 2022-10-05 в 14 03 07" src="https://user-images.githubusercontent.com/82511785/194046765-81b79c43-c9e6-44c3-9f80-dd5fd570826e.png">

