### PR TITLE
fix(Community/Settings): Community overview/settings layout broken

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -60,13 +60,14 @@ StatusSectionLayout {
         centerPanelContentLoader.item.children[d.currentIndex].updateState();
     }
 
-    leftPanel: ColumnLayout {
+    leftPanel: Item {
         anchors.fill: parent
 
         ColumnLayout {
             anchors {
                 top: parent.top
                 bottom: footer.top
+                topMargin: 16
                 bottomMargin: 16
                 horizontalCenter: parent.horizontalCenter
             }
@@ -145,7 +146,6 @@ StatusSectionLayout {
         //anchors.margins: 32
         anchors {
             leftMargin: 28
-            rightMargin: 16
             bottomMargin: 16
         }
         active: root.community


### PR DESCRIPTION
Fixed #7666

### What does the PR do

Fixed top margin and content type.

Removed right margin in central panel.

### Affected areas

Community settings layout

### Screenshot of functionality 

![Screenshot 2022-10-05 at 13 14 36](https://user-images.githubusercontent.com/97019400/194048576-62e02afa-9b13-420c-bdec-a5c25a0d8915.png)


