### PR TITLE
fix(StatusChatListItem): fix online status badge hover color

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListItem.qml
@@ -94,8 +94,8 @@ Rectangle {
             badge {
                 visible: type === StatusChatListItem.Type.OneToOneChat
                 color: onlineStatus === StatusChatListItem.OnlineStatus.Online ? Theme.palette.successColor1 : Theme.palette.baseColor1
-                border.width: 1
-                border.color: root.color
+                border.width: 2
+                border.color: hoverHander.hovered ? Theme.palette.statusBadge.hoverBorderColor : root.color
                 implicitHeight: 9
                 implicitWidth: 9
             }


### PR DESCRIPTION
Fixes: #7755

### What does the PR do

Fixes wrong online badge hover color, esp. visible in dark mode

### Affected areas

StatusChatListItem

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Default, not hovered:
![Snímek obrazovky z 2022-10-05 15-32-13](https://user-images.githubusercontent.com/5377645/194073268-0174f0e3-07cb-4e0b-bf52-ed7461bfd814.png)

Online hovered:
![Snímek obrazovky z 2022-10-05 15-32-22](https://user-images.githubusercontent.com/5377645/194073338-04f35c0a-5ab4-4920-ad91-cec8133bf4f2.png)

Offline hovered:
![Snímek obrazovky z 2022-10-05 15-32-27](https://user-images.githubusercontent.com/5377645/194073375-18faae36-3fd0-481f-8cb7-d8a57f938512.png)

Light mode, for comparison:
![Snímek obrazovky z 2022-10-05 15-34-59](https://user-images.githubusercontent.com/5377645/194073704-b312dd94-7f81-40eb-9e9d-c19b927c0bd1.png)
