### PR TITLE
fix(StatusMessageReply): Fixed text formatting in replied message

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -221,6 +221,9 @@ Rectangle {
                 profileClickable: root.profileClickable
                 onReplyProfileClicked: root.replyProfileClicked(sender, mouse)
                 audioMessageInfoText: root.audioMessageInfoText
+                onLinkActivated: {
+                    root.linkActivated(link);
+                }
             }
         }
 
@@ -286,25 +289,8 @@ Rectangle {
                     visible: active
                     sourceComponent: StatusTextMessage {
                         objectName: "StatusMessage_textMessage"
-                        textField.text: {
-                            if (root.messageDetails.contentType === StatusMessage.ContentType.Sticker)
-                                return "";
-
-                            const formattedMessage = Utils.linkifyAndXSS(root.messageDetails.messageText);
-
-                            if (root.messageDetails.contentType === StatusMessage.ContentType.Emoji)
-                                return Emoji.parse(formattedMessage, Emoji.size.middle, Emoji.format.png);
-
-                            if (root.isEdited) {
-                                const index = formattedMessage.endsWith("code>") ? formattedMessage.length : formattedMessage.length - 4;
-                                const editedMessage = formattedMessage.slice(0, index)
-                                                    + ` <span class="isEdited">` + qsTr("(edited)") + `</span>`
-                                                    + formattedMessage.slice(index);
-                                return Utils.getMessageWithStyle(Emoji.parse(editedMessage), textField.hoveredLink)
-                            }
-
-                            return Utils.getMessageWithStyle(Emoji.parse(formattedMessage), textField.hoveredLink)
-                        }
+                        messageDetails: root.messageDetails
+                        isEdited: root.isEdited
                         onLinkActivated: {
                             root.linkActivated(link);
                         }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -15,6 +15,7 @@ Item {
     property bool profileClickable: true
 
     signal replyProfileClicked(var sender, var mouse)
+    signal linkActivated(string link)
 
     implicitHeight: layout.implicitHeight
     implicitWidth: layout.implicitWidth
@@ -83,12 +84,16 @@ Item {
             }
             StatusTextMessage {
                 Layout.fillWidth: true
-                textField.text: replyDetails.messageText
                 textField.font.pixelSize: Theme.secondaryTextFontSize
                 textField.color: Theme.palette.baseColor1
+                convertToSingleLine: true
                 clip: true
                 visible: !!replyDetails.messageText && replyDetails.contentType !== StatusMessage.ContentType.Sticker
                 allowShowMore: false
+                messageDetails: root.replyDetails
+                onLinkActivated: {
+                    root.linkActivated(link);
+                }
             }
             StatusImageMessage {
                 Layout.fillWidth: true

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -4,9 +4,14 @@ import QtGraphicalEffects 1.0
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1
 
 Item {
     id: root
+
+    property StatusMessageDetails messageDetails: StatusMessageDetails {}
+    property bool isEdited: false
+    property bool convertToSingleLine: false
 
     property alias textField: chatText
     property bool allowShowMore: true
@@ -21,19 +26,46 @@ Item {
         property bool readMore: false
         readonly property bool veryLongChatText: chatText.length > 1000
         readonly property int showMoreHeight: showMoreLoader.visible ? showMoreLoader.height : 0
+
+        readonly property string text: {
+            if (root.messageDetails.contentType === StatusMessage.ContentType.Sticker)
+                return "";
+
+            const formattedMessage = Utils.linkifyAndXSS(root.messageDetails.messageText);
+
+            if (root.messageDetails.contentType === StatusMessage.ContentType.Emoji)
+                return Emoji.parse(formattedMessage, Emoji.size.middle, Emoji.format.png);
+
+            if (root.isEdited) {
+                const index = formattedMessage.endsWith("code>") ? formattedMessage.length : formattedMessage.length - 4;
+                const editedMessage = formattedMessage.slice(0, index)
+                                    + ` <span class="isEdited">` + qsTr("(edited)") + `</span>`
+                                    + formattedMessage.slice(index);
+                return Utils.getMessageWithStyle(Emoji.parse(editedMessage), chatText.hoveredLink)
+            }
+
+            if (root.convertToSingleLine) {
+                const singleLineMessage = Utils.convertToSingleLine(formattedMessage)
+                return Utils.getMessageWithStyle(Emoji.parse(singleLineMessage), chatText.hoveredLink)
+            }
+
+            return Utils.getMessageWithStyle(Emoji.parse(formattedMessage), chatText.hoveredLink)
+        }
     }
 
     TextEdit {
         id: chatText
         objectName: "StatusTextMessage_chatText"
 
-        readonly property int effectiveHeight: d.veryLongChatText && !d.readMore ? Math.min(chatText.implicitHeight, 200)
-                                                                                 : chatText.implicitHeight
+        readonly property int effectiveHeight: d.veryLongChatText && !d.readMore
+                                               ? Math.min(chatText.implicitHeight, 200)
+                                               : chatText.implicitHeight
 
         width: parent.width
         height: effectiveHeight + d.showMoreHeight / 2
         visible: !opMask.active
         clip: true
+        text: d.text
         selectedTextColor: Theme.palette.directColor1
         selectionColor: Theme.palette.primaryColor3
         color: Theme.palette.directColor1

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -218,6 +218,10 @@ QtObject {
                 `${msg}`
     }
 
+    function convertToSingleLine(text) {
+        return text.replace(/<br\s*\/>/gm, " ")
+    }
+
     function delegateModelSort(srcGroup, dstGroup, lessThan) {
         const insertPosition = (lessThan, item) => {
             let lower = 0


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/7696

# Draft PR

Waiting @John-44 approve on design question.
I propose an idea to convert multiline messages to single line, when they're displayed as replied message:

| Current | Proposal |
|---------|----------|
| <img width="506" alt="1" src="https://user-images.githubusercontent.com/25482501/194089279-66f30422-75ea-4e8e-941f-a4eda0c8b656.png">|<img width="506" alt="1" src="https://user-images.githubusercontent.com/25482501/194089338-dcc2fa12-ea7e-41a5-ac5d-2dd148c6520e.png">|

### What does the PR do

For replied messages:
* added correct styling
* fixed link clicks
* multiline messages are converted to single line 

### Affected areas

chat (message text content, mainly for replied messages)

### StatusQ checklist

- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/25482501/194088599-a692323a-36f1-4d65-b414-0afc337fba40.png">