### PR TITLE
fix(Wallet): allow to edit name and color for a new account without authentication

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -182,6 +182,6 @@ method authenticateUser*(self: Module) =
 
 method onUserAuthenticated*(self: Module, password: string) =
   if password.len > 0:
-    self.view.userAuthenticaionSuccess(password)
+    self.view.userAuthenticationSuccess(password)
   else:
     self.view.userAuthentiactionFail()

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -277,8 +277,8 @@ QtObject:
 
   proc validSeedPhrase*(self: View, value: string): bool {.slot.} =
     return self.delegate.validSeedPhrase(value)
-  
-  proc userAuthenticaionSuccess*(self: View, password: string) {.signal.}
+
+  proc userAuthenticationSuccess*(self: View, password: string) {.signal.}
   proc userAuthentiactionFail*(self: View) {.signal.}
 
   proc authenticateUser*(self: View) {.slot.} =

--- a/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
@@ -42,7 +42,7 @@ StatusModal {
 
     Connections {
         target: walletSectionAccounts
-        onUserAuthenticaionSuccess: {
+        onUserAuthenticationSuccess: {
             validationError.text = ""
             d.password = password
             d.getDerivedAddressList()
@@ -189,7 +189,6 @@ StatusModal {
                 input.isIconSelectable: true
                 input.asset.color: colorSelectionGrid.selectedColor ? colorSelectionGrid.selectedColor : Theme.palette.directColor1
                 input.leftPadding: Style.current.padding
-                enabled: !d.authenticationNeeded
                 onIconClicked: {
                     root.emojiPopup.open()
                     root.emojiPopup.emojiSize = StatusQUtils.Emoji.size.verySmall
@@ -215,7 +214,6 @@ StatusModal {
             StatusColorSelectorGrid {
                 id: colorSelectionGrid
                 anchors.horizontalCenter: parent.horizontalCenter
-                enabled: !d.authenticationNeeded
                 titleText: qsTr("color").toUpperCase()
             }
 


### PR DESCRIPTION
### Fixes: #7714

There is no good reason to keep users providing account information before authenticating

Note: the account creation still doesn't work; covered by https://github.com/status-im/status-desktop/issues/7715

### Affected areas

Wallet account creation

### Screenshot of functionality (including design for comparison)

- [x] Discussed and agreed with the design team in daily

![image](https://user-images.githubusercontent.com/47554641/194147101-54f660bd-6c77-4997-96c2-aedc49423c3a.png)

