### PR TITLE
perf(chat): only perform verification requests on scroll if necessary

### DIFF
--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -183,7 +183,7 @@ method getCommunitySectionModule*(self: AccessInterface, communityId: string): Q
 method getAppSearchModule*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getContactDetailsAsJson*(self: AccessInterface, publicKey: string): string {.base.} =
+method getContactDetailsAsJson*(self: AccessInterface, publicKey: string, getVerificationRequest: bool): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method resolveENS*(self: AccessInterface, ensName: string, uuid: string, reason: string = "") {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -751,10 +751,12 @@ method communityEdited*[T](
 method getVerificationRequestFrom*[T](self: Module[T], publicKey: string): VerificationRequest =
   self.controller.getVerificationRequestFrom(publicKey)
 
-method getContactDetailsAsJson*[T](self: Module[T], publicKey: string): string =
+method getContactDetailsAsJson*[T](self: Module[T], publicKey: string, getVerificationRequest: bool): string =
   let contact = self.controller.getContact(publicKey)
   let (name, _, _) = self.controller.getContactNameAndImage(contact.id)
-  let request = self.getVerificationRequestFrom(publicKey)
+  var requestStatus = 0
+  if getVerificationRequest:
+    requestStatus = self.getVerificationRequestFrom(publicKey).status.int
   let jsonObj = %* {
     "displayName": name,
     "displayIcon": contact.image.thumbnail,
@@ -776,7 +778,7 @@ method getContactDetailsAsJson*[T](self: Module[T], publicKey: string): string =
     "trustStatus": contact.trustStatus.int,
     # TODO rename verificationStatus to outgoingVerificationStatus
     "verificationStatus": contact.verificationStatus.int,
-    "incomingVerificationStatus": request.status.int,
+    "incomingVerificationStatus": requestStatus,
     "hasAddedUs": contact.hasAddedUs,
     "socialLinks": $contact.socialLinks.toJsonNode(),
     "bio": contact.bio

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -189,8 +189,8 @@ QtObject:
   QtProperty[QVariant] appSearchModule:
     read = getAppSearchModule
 
-  proc getContactDetailsAsJson(self: View, publicKey: string): string {.slot.} =
-    return self.delegate.getContactDetailsAsJson(publicKey)
+  proc getContactDetailsAsJson(self: View, publicKey: string, getVerificationRequest: bool): string {.slot.} =
+    return self.delegate.getContactDetailsAsJson(publicKey, getVerificationRequest)
 
   proc resolveENS*(self: View, ensName: string, uuid: string) {.slot.} =
     self.delegate.resolveENS(ensName, uuid)

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -581,7 +581,7 @@ Loader {
                     assetSettings.isImage: root.isDiscordMessage
                     pubkey: root.senderId
                     colorId: Utils.colorIdForPubkey(root.senderId)
-                    colorHash: Utils.getColorHashAsJson(root.senderId)
+                    colorHash: Utils.getColorHashAsJson(root.senderId, false, !root.isDiscordMessage)
                     showRing: !root.isDiscordMessage
                 }
             }
@@ -615,7 +615,7 @@ Loader {
                     showRing: delegate.replyMessage && delegate.replyMessage.messageContentType != Constants.discordMessageType
                     pubkey: delegate.replySenderId
                     colorId: Utils.colorIdForPubkey(delegate.replySenderId)
-                    colorHash: Utils.getColorHashAsJson(delegate.replySenderId)
+                    colorHash: Utils.getColorHashAsJson(delegate.replySenderId, false, !root.isDiscordMessage)
                 }
             }
 

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -528,8 +528,8 @@ QtObject {
         return qsTr("> 5 mins")
     }
 
-    function getContactDetailsAsJson(publicKey) {
-        let jsonObj = mainModule.getContactDetailsAsJson(publicKey)
+    function getContactDetailsAsJson(publicKey, getVerificationRequest=true) {
+        let jsonObj = mainModule.getContactDetailsAsJson(publicKey, getVerificationRequest)
         try {
             let obj = JSON.parse(jsonObj)
             return obj
@@ -562,10 +562,10 @@ QtObject {
         }
     }
 
-    function isEnsVerified(publicKey) {
+    function isEnsVerified(publicKey, getVerificationRequest=true) {
         if (!publicKey)
-            return false
-        return getContactDetailsAsJson(publicKey).ensVerified
+          return false
+        return getContactDetailsAsJson(publicKey, getVerificationRequest).ensVerified
     }
 
     function getEmojiHashAsJson(publicKey) {
@@ -576,10 +576,10 @@ QtObject {
         return JSON.parse(jsonObj)
     }
 
-    function getColorHashAsJson(publicKey, force=false) {
+    function getColorHashAsJson(publicKey, force=false, getVerificationRequest=true) {
         if (publicKey === "")
             return
-        if (!force && isEnsVerified(publicKey))
+        if (!force && isEnsVerified(publicKey, getVerificationRequest))
             return
         let jsonObj = globalUtils.getColorHashAsJson(publicKey)
         return JSON.parse(jsonObj)


### PR DESCRIPTION
There was an issue where imported messages from third-party services would cause super laggy scroll behaviour in the chat view.

The reason for that is that on scroll, the app keeps calling `getVerificationRequestFrom()` on the chatkey of the community. Typically the results of these requests are cached so that it should perform the call only once, but because there's no actual verification request/contact for the community chat key (all third-party messages are signed by the community), the call keeps on happening over and over.

This commit adds a flag to `getContactDetailsAsJson` and `isEnsVerified` to control whether or not the call to `getVerificationRequestFrom` should in fact be made (which should not be the case for imported messages).

The result of this is a smoother scrolling experience.

Fixes #7767

