### PR TITLE
feat(Utils): Tracer can be used directly in layouts

### DIFF
--- a/ui/imports/utils/Tracer.qml
+++ b/ui/imports/utils/Tracer.qml
@@ -1,7 +1,59 @@
 import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
 
 Rectangle {
-    anchors.fill: parent
-    color: "transparent"
-    border.color: "red"
+    id: root
+
+    border.color: 'red'
+    color: 'transparent'
+
+    QtObject {
+        id: internal
+
+        property Item originalParent
+        property int counter: 0
+
+        PropertyAnimation on counter {
+            id: positionUpdater
+
+            running: false
+            from: 0
+            to: 1000
+            duration: 1000
+            loops: Animation.Infinite
+        }
+
+        onCounterChanged: {
+            const overlay = originalParent.Overlay.overlay
+
+            if (!overlay)
+                return
+
+            root.parent = overlay
+            root.visible = originalParent.visible
+            const rect = originalParent.mapToItem(
+                           overlay, 0, 0, originalParent.width, originalParent.height)
+            root.x = rect.x
+            root.y = rect.y
+            root.width = rect.width
+            root.height = rect.height
+        }
+    }
+
+    Component.onCompleted: {
+        if (parent instanceof ColumnLayout
+                || parent instanceof RowLayout
+                || parent instanceof GridLayout
+                || parent instanceof Column
+                || parent instanceof Row
+                || parent instanceof Grid
+                || parent instanceof Flow) {
+            internal.originalParent = parent
+            positionUpdater.running = true
+        } else {
+            if (!anchors.fill)
+                anchors.fill = parent
+        }
+    }
 }


### PR DESCRIPTION
### What does the PR do

So far `Tracer {}` component could be used to track boundaries of only non-layout components. Now it can be used directly in layouts as well, e.g.:
```
ColumnLayout {
   ...
   RowLayout {
      ...
      Tracer {}
   }
}
```
It's especially useful for nested layouts, when it's not possible to use `Tracer` via setting `anchors.fill: someId`.

### Affected areas
`Tracer`

### Screenshot of functionality (including design for comparison)
![Screenshot from 2022-10-06 13-59-51](https://user-images.githubusercontent.com/20650004/194312660-c2c2a50b-338b-450b-844f-a0b5ef3d82e1.png)
![Screenshot from 2022-10-06 13-59-32](https://user-images.githubusercontent.com/20650004/194312672-1b7ef1d6-14a6-4202-829f-64ba9af5127b.png)

