### PR TITLE
fix(Reply): Add check if responsed message was deleted and add `<deleted>` to reply message

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -263,6 +263,7 @@ Item {
             messageId: model.id
             communityId: model.communityId
             responseToMessageWithId: model.responseToMessageWithId
+            responseToExistingMessage: model.responseToExistingMessage
             senderId: model.senderId
             senderDisplayName: model.senderDisplayName
             senderOptionalName: model.senderOptionalName

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -37,6 +37,8 @@ Loader {
     property string messageId: ""
     property string communityId: ""
     property string responseToMessageWithId: ""
+    property bool responseToExistingMessage: false
+
     property string senderId: ""
     property string senderDisplayName: ""
     property string senderOptionalName: ""
@@ -394,7 +396,7 @@ Loader {
 
             readonly property int contentType: convertContentType(root.messageContentType)
             readonly property bool isReply: root.responseTo !== ""
-            readonly property var replyMessage: root.messageStore && isReply ? root.messageStore.getMessageByIdAsJson(root.responseTo) : null
+            readonly property var replyMessage: root.messageStore && isReply && root.responseToExistingMessage ? root.messageStore.getMessageByIdAsJson(root.responseTo) : null
             readonly property string replySenderId: replyMessage ? replyMessage.senderId : ""
 
             function editCompletedHandler(newMessageText) {
@@ -590,7 +592,9 @@ Loader {
             }
 
             replyDetails: StatusMessageDetails {
-                messageText:  delegate.replyMessage ? delegate.replyMessage.messageText : ""
+                messageText:  delegate.replyMessage ? delegate.replyMessage.messageText
+                                                      //: There is should be a message for reply which source message was deleted
+                                                    : qsTr("&lt;deleted&gt;")
                 contentType: delegate.replyMessage ? delegate.convertContentType(delegate.replyMessage.contentType) : 0
                 messageContent: {
                     if (!delegate.replyMessage)


### PR DESCRIPTION
Closes: #7372



### What does the PR do

Add methods to `message_model` to for update and find messages which contains reply with deleted messages.

### Affected areas

Messages

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<img width="310" alt="Снимок экрана 2022-10-06 в 16 51 51" src="https://user-images.githubusercontent.com/82511785/194330866-53f03a80-f885-4b6c-829d-52d15bc6752e.png">

