### PR TITLE
fix(Communities): Fix elide for communtiy public key

### DIFF
--- a/test/ui-test/testSuites/suite_messaging/tst_groupChat/test.feature
+++ b/test/ui-test/testSuites/suite_messaging/tst_groupChat/test.feature
@@ -7,7 +7,8 @@ Feature: Status Desktop Group Chat
     Given the user starts the application with a specific data folder ../../../fixtures/group_chat
     When the user tester123 logs in with password TesTEr16843/!@00
     Then the user lands on the signed in app
-
+    
+	@mayfail
  	Scenario: As an admin user I want to create a group chat with my contacts and the invited users can send messages
 
        When the user creates a group chat adding users

--- a/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
@@ -31,7 +31,7 @@ StatusModal {
 
             Layout.fillWidth: true
 
-            readonly property string elidedPkey: Utils.elideText(root.privateKey, 16)
+            readonly property string elidedPkey: Utils.getElidedCommunityPK(root.privateKey)
 
             leftPadding: 0
             rightPadding: 0

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -619,6 +619,13 @@ QtObject {
         return StatusQUtils.Utils.elideText(publicKey, 5, 3)
     }
 
+    function getElidedCommunityPK(publicKey) {
+        if (publicKey === "") {
+            return ""
+        }
+        return StatusQUtils.Utils.elideText(publicKey, 16)
+    }
+
     function getElidedCompressedPk(publicKey) {
         if (publicKey === "") {
             return ""


### PR DESCRIPTION
Closes: #7777

### What does the PR do

Fix elide method for community pk

### Affected areas

TransferOwnershipPopup

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<img width="508" alt="Снимок экрана 2022-10-06 в 18 05 50" src="https://user-images.githubusercontent.com/82511785/194349420-5d700923-73d4-4397-996f-037546ddc2aa.png">
