### PR TITLE
fix(DragnDrop): re-enabled drag and drop

### DIFF
--- a/ui/app/mainui/panels/DropAreaPanel.qml
+++ b/ui/app/mainui/panels/DropAreaPanel.qml
@@ -1,0 +1,70 @@
+import QtQuick 2.14
+import utils 1.0
+
+DropArea {
+    id: root
+
+    property bool enabled: false
+    property alias droppedUrls: rptDraggedPreviews.model
+    property int activeChatType
+
+    signal droppedOnValidScreen(var drop)
+
+    function cleanup() {
+        rptDraggedPreviews.model = []
+    }
+
+    Component.onCompleted: {
+        Global.dragArea = this;
+    }
+
+    onDropped: (drop) => {
+                if (enabled) {
+                    droppedOnValidScreen(drop)
+                } else {
+                    drop.accepted = false
+                }
+                cleanup()
+            }
+    onEntered: {
+        if (!enabled || !!drag.source) {
+            drag.accepted = false
+            return
+        }
+
+        // needed because drag.urls is not a normal js array
+        rptDraggedPreviews.model = drag.urls.filter(img => Utils.hasDragNDropImageExtension(img))
+    }
+    onPositionChanged: {
+        rptDraggedPreviews.x = drag.x
+        rptDraggedPreviews.y = drag.y
+    }
+
+    onExited: cleanup()
+
+    Loader {
+        active: root.containsDrag
+        width: active ? parent.width : 0
+        height: active ? parent.height : 0
+        sourceComponent: Rectangle {
+            id: dropRectangle
+            color: Style.current.background
+            opacity: 0.8
+        }
+    }
+
+    Repeater {
+        id: rptDraggedPreviews
+        Image {
+            source: modelData
+            width: 80
+            height: 80
+            sourceSize.width: 160
+            sourceSize.height: 160
+            fillMode: Image.PreserveAspectFit
+            x: index * 10 + rptDraggedPreviews.x
+            y: index * 10 + rptDraggedPreviews.y
+            z: 1
+        }
+    }
+}

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -827,7 +827,7 @@ Rectangle {
 
     Connections {
         enabled: control.isActiveChannel
-        target: Global.appMain.dragAndDrop
+        target: Global.dragArea
         ignoreUnknownSignals: true
         onDroppedOnValidScreen: (drop) => {
                                     let validImages = validateImages(drop.urls)

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -10,6 +10,7 @@ Item {
 
     property var applicationWindow
     property var appMain
+    property var dragArea
     property bool popupOpened: false
     property int settingsSubsection: Constants.settingsSubsection.profile
 


### PR DESCRIPTION
Closes #7484

### What does the PR do
StatusChatInput re-enabled drag and drop images

### Affected areas
StatusChatInput

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/194359441-afd32d2b-d892-4dfb-a2d5-7152aa065b06.mov


