### PR TITLE
fix(@desktop/chat): Fix channel link in chat

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -254,6 +254,9 @@ proc getCategories*(self: Controller, communityId: string): seq[Category] =
 proc getChats*(self: Controller, communityId: string, categoryId: string): seq[ChatDto] =
   return self.communityService.getChats(communityId, categoryId)
 
+proc getAllChats*(self: Controller, communityId: string): seq[ChatDto] =
+  return self.communityService.getAllChats(communityId)
+
 proc getChatDetails*(self: Controller, chatId: string): ChatDto =
   return self.chatService.getChatById(chatId)
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -316,3 +316,6 @@ method updateLastMessageTimestamp*(self: AccessInterface, chatId: string, lastMe
 
 method contactsStatusUpdated*(self: AccessInterface, statusUpdates: seq[StatusUpdateDto]) =
   raise newException(ValueError, "No implementation available")
+
+method switchToChannel*(self: AccessInterface, channelName: string) =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -458,6 +458,18 @@ method addNewChat*(
     if setChatAsActive:
       self.setActiveItemSubItem(categoryItem.id, channelItem.id)
 
+method switchToChannel*(self: Module, channelName: string) =
+  if(not self.controller.isCommunity()):
+    return
+  let chats = self.controller.getAllChats(self.controller.getMySectionId())
+  for c in chats:
+    if c.name == channelName:
+      if c.categoryId == "":
+        self.setActiveItemSubItem(c.id, "")
+      else:
+        self.setActiveItemSubItem(c.categoryId, c.id)
+      return
+
 method doesCatOrChatExist*(self: Module, id: string): bool =
   return self.view.chatsModel().isItemWithIdAdded(id) or
     not self.view.chatsModel().getSubItemById(id).isNil

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -120,6 +120,9 @@ QtObject:
   proc setActiveItem*(self: View, itemId: string, subItemId: string = "") {.slot.} =
     self.delegate.setActiveItemSubItem(itemId, subItemId)
 
+  proc switchToChannel*(self: View, channelName: string) {.slot.} =
+    self.delegate.switchToChannel(channelName)
+
   proc activeItem*(self: View): ActiveItem =
     result = self.activeItem
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -490,6 +490,9 @@ Loader {
                     const pubkey = link.replace("//", "");
                     Global.openProfilePopup(pubkey)
                     return;
+                } else if (link.startsWith('#')) {
+                    rootStore.chatCommunitySectionModule.switchToChannel(link.replace("#", ""))
+                    return;
                 }
 
                 Global.openLink(link)


### PR DESCRIPTION
Fix status-im/status-desktop#7636

### What does the PR do

Clicking on a #link will open channel in a community.
The feature works only in community channels.
The channel must exist. Otherwise, nothing happens.

### Affected areas

Chats/ communities

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/61889657/194504582-4bac14d5-3131-4b1f-bde1-897fd7bb39d9.mov

