### PR TITLE
fix(InvitationBubbleView): Fixed layout and button radius

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -34,6 +34,8 @@ Button {
     property color disabledTextColor
     property color borderColor: "transparent"
 
+    property int radius: size === StatusBaseButton.Size.Tiny ? 6 : 8
+
     property int size: StatusBaseButton.Size.Large
     property int type: StatusBaseButton.Type.Normal
 
@@ -70,7 +72,7 @@ Button {
     icon.width: 24
 
     background: Rectangle {
-        radius: root.size === StatusBaseButton.Size.Tiny ? 6 : 8
+        radius: root.radius
         border.color: root.borderColor
         color: {
             if (root.enabled)

--- a/ui/imports/shared/views/chat/InvitationBubbleView.qml
+++ b/ui/imports/shared/views/chat/InvitationBubbleView.qml
@@ -27,6 +27,7 @@ Item {
         property var invitedCommunity
 
         readonly property int margin: 12
+        readonly property int radius: 16
 
         function getCommunity() {
             try {
@@ -81,16 +82,16 @@ Item {
             id: rectangleBubble
 
             width: 270
-            height: columnLayout.implicitHeight
-            radius: 16
+            height: columnLayout.implicitHeight + border.width * 2
+            radius: d.radius
             color: Style.current.background
             border.color: Style.current.border
             border.width: 1
 
             ColumnLayout {
                 id: columnLayout
-
-                width: parent.width
+                anchors.fill: parent
+                anchors.margins: 1
 
                 spacing: 0
 
@@ -217,6 +218,7 @@ Item {
                     Layout.preferredHeight: 44
 
                     text: qsTr("Go to Community")
+                    radius: d.radius - 1 // We do -1, otherwise there's a gap between border and button
 
                     onClicked: {
                         if (d.invitedCommunity.joined || d.invitedCommunity.spectated) {
@@ -224,11 +226,6 @@ Item {
                         } else {
                             root.store.spectateCommunity(communityId, userProfile.name)
                         }
-                    }
-
-                    Component.onCompleted: {
-                        // FIXME: extract StatusButtonBackground or expose radius property in StatusBaseButton
-                        background.radius = 16
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/7812

### What does the PR do

* Invitation bubble size fixed
* Invitation bubble button radius fixed
* Exposed background `radius` property from `StatusBaseButton`

### Affected areas

chat community invitation

### Screenshot of functionality (including design for comparison)

<img width="1164" alt="Снимок экрана 2022-10-07 в 15 12 04" src="https://user-images.githubusercontent.com/25482501/194551788-cc83c68d-6f75-46ff-afeb-25678c7ba5c6.png">