### PR TITLE
fix(Chat/CommunityColumn): Create new chat button looks inconsistent across views

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -74,9 +74,10 @@ Item {
         id: adHocChatButton
         icon.name: "edit"
         objectName: "startChatButton"
+        icon.color: Theme.palette.directColor1
         anchors.verticalCenter: communityHeader.verticalCenter
         anchors.right: parent.right
-        anchors.rightMargin: 14
+        anchors.rightMargin: Style.current.padding
         checked: root.store.openCreateChat
         highlighted: root.store.openCreateChat
         onClicked: {

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -44,6 +44,7 @@ Item {
         anchors {
             fill: parent
             margins: Style.current.padding
+            topMargin: Style.current.smallPadding
             bottomMargin: 0
         }
         spacing: Style.current.padding


### PR DESCRIPTION
Fixes #7648

### What does the PR do

Added consistency between chat / community views: Colour and button position modified to be the same.

### Affected areas

Community / Chat left column headers

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/194846815-61a7c7f2-f249-409c-8176-61c0fac2d675.mov