### PR TITLE
fix: chat view channels are too thin

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -151,6 +151,7 @@ Item {
                 id: scroll
 
                 clip: false
+                padding: 0
                 anchors.fill: parent
                 anchors.bottomMargin: Style.current.padding
 


### PR DESCRIPTION
Closes #7682

### What does the PR do

Adjusts padding of the chat list column

### Affected areas

ContactsColumnView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-10-10 14-58-07](https://user-images.githubusercontent.com/5377645/194872858-481e5169-21e7-47bc-b201-5e71fbb2d7d6.png)

