### PR TITLE
test(e2e-mobile): add object names to popups for test ids

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
@@ -51,7 +51,7 @@ StatusListItem {
     implicitWidth: ListView.view ? ListView.view.width : 0
 
     title: name
-    objectName: name
+    objectName: "savedAddressView_Delegate_" + name
     subTitle: {
         if (ens.length > 0)
             return ens

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -16,6 +16,7 @@ import AppLayouts.Profile.helpers
 
 StatusDialog {
     id: root
+    objectName: "AddEditSavedAddressPopup"
 
     required property WalletStores.RootStore store
     required property SharedStores.RootStore sharedRootStore

--- a/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
@@ -17,6 +17,7 @@ import shared.controls
 
 StatusDialog {
     id: root
+    objectName: "RemoveSavedAddressPopup"
 
     property string name
     property string address

--- a/ui/app/AppLayouts/Wallet/popups/SavedAddressActivityPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SavedAddressActivityPopup.qml
@@ -19,6 +19,7 @@ import utils
 
 StatusDialog {
     id: root
+    objectName: "SavedAddressActivityPopup"
 
     property SharedStores.NetworkConnectionStore networkConnectionStore
     property ContactsStore contactsStore


### PR DESCRIPTION
## Summary
- Add `savedAddressView_Delegate_` prefix to SavedAddressesDelegate objectName for reliable element identification
- Add objectName to SavedAddressActivityPopup, RemoveSavedAddressPopup, and AddEditSavedAddressPopup

## Why
The delegate's objectName was previously just the raw `name` property, making it difficult to reliably identify in e2e tests (could match toast messages containing the same text). These changes align with the existing naming convention used by the menu button (`savedAddressView_Delegate_menuButton_` + name).

## Test plan
- [ ] Saved addresses list items have correct resource-id in Appium inspector
- [ ] Popup dialogs have correct resource-id when opened
- [ ] Test completes without error.