### PR TITLE
feat(android): warn user when third-party accessibility service active before seed phrase reveal

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/AccessibilityServiceHelper.java
+++ b/mobile/android/qt6/src/app/status/mobile/AccessibilityServiceHelper.java
@@ -1,0 +1,49 @@
+package app.status.mobile;
+
+import android.accessibilityservice.AccessibilityServiceInfo;
+import android.content.Context;
+import android.view.accessibility.AccessibilityManager;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AccessibilityServiceHelper {
+
+    /**
+     * Returns a comma-separated list of active third-party accessibility service names,
+     * or an empty string if none are found.
+     *
+     * Filters out known system/OEM packages (com.android.*, com.samsung.*, com.sec.*,
+     * com.google.*, own package). All remaining services can read the screen and warrant
+     * a warning before revealing sensitive data.
+     */
+    public static String getActiveThirdPartyServices(Context context) {
+        AccessibilityManager am =
+            (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+        if (am == null) return "";
+
+        List<AccessibilityServiceInfo> services =
+            am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK);
+        List<String> names = new ArrayList<>();
+        for (AccessibilityServiceInfo info : services) {
+            if (info.getResolveInfo() == null) continue;
+
+            String pkg = info.getResolveInfo().serviceInfo.packageName;
+
+            // Skip system and OEM packages — these include TalkBack (com.android.*),
+            // Switch Access (com.google.*), Samsung accessibility (com.samsung.*, com.sec.*),
+            // and the app itself.
+            if (pkg.startsWith("com.android") ||
+                pkg.startsWith("com.samsung") ||
+                pkg.startsWith("com.sec") ||
+                pkg.startsWith("com.google") ||
+                pkg.equals(context.getPackageName())) continue;
+
+            String label = info.getResolveInfo()
+                .loadLabel(context.getPackageManager()).toString();
+            names.add(label.isEmpty() ? pkg : label);
+        }
+
+        String r = String.join(", ", names);
+        return r;
+    }
+}

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -105,4 +105,18 @@ public class StatusQtActivity extends QtActivity {
             sInstance.startActivity(intent);
         }
     }
+
+    // Opens the system Accessibility Settings screen. Called from Qt via JNI.
+    public static void openAccessibilitySettings() {
+        if (sInstance == null) return;
+        Intent intent = new Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        sInstance.startActivity(intent);
+    }
+
+    // Returns a comma-separated list of active third-party accessibility service names,
+    // or an empty string if none. Called from Qt via JNI before seed phrase reveal.
+    public String getThirdPartyA11yServices() {
+        return AccessibilityServiceHelper.getActiveThirdPartyServices(this);
+    }
 }

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -21,6 +21,7 @@ public:
     Q_INVOKABLE QString qtRuntimeVersion() const;
     Q_INVOKABLE void restartApplication() const;
     Q_INVOKABLE void openAppSettings();
+    Q_INVOKABLE void openAccessibilitySettings();
     Q_INVOKABLE void downloadImageByUrl(const QUrl& url, const QString& path) const;
     Q_INVOKABLE void synthetizeRightClick(QQuickItem* item, qreal x, qreal y, Qt::KeyboardModifiers modifiers) const;
     Q_INVOKABLE Qt::KeyboardModifiers queryKeyboardModifiers();
@@ -51,6 +52,10 @@ public:
 
     // Cross-platform share sheet
     Q_INVOKABLE void sharePaths(const QStringList& filePaths) const;
+
+    // Returns comma-separated names of active third-party accessibility services (Android only).
+    // Empty string means none found — reveal can proceed without warning.
+    Q_INVOKABLE QString activeThirdPartyA11yServices() const;
 
     // Debug helper (used from QML to verify signal handlers fire on device)
     Q_INVOKABLE void debugLog(const QString& message) const;

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -291,6 +291,38 @@ void SystemUtilsInternal::openAppSettings()
 #endif
 }
 
+void SystemUtilsInternal::openAccessibilitySettings()
+{
+#ifdef Q_OS_ANDROID
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/StatusQtActivity",
+        "openAccessibilitySettings",
+        "()V"
+    );
+#else
+    qWarning() << "openAccessibilitySettings not implemented for this platform";
+#endif
+}
+
+QString SystemUtilsInternal::activeThirdPartyA11yServices() const
+{
+#ifdef Q_OS_ANDROID
+    QJniObject activity = QJniObject::callStaticObjectMethod(
+        "org/qtproject/qt/android/QtNative",
+        "activity",
+        "()Landroid/app/Activity;"
+    );
+    if (!activity.isValid()) return QString();
+    auto result = activity.callObjectMethod(
+        "getThirdPartyA11yServices",
+        "()Ljava/lang/String;"
+    );
+    return result.isValid() ? result.toString() : QString();
+#else
+    return QString();
+#endif
+}
+
 void SystemUtilsInternal::synthetizeRightClick(QQuickItem* item, qreal x, qreal y, Qt::KeyboardModifiers modifiers) const
 {
     if (!item)

--- a/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseReveal.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseReveal.qml
@@ -13,6 +13,8 @@ import AppLayouts.Onboarding.components
 
 import utils
 
+import shared.popups
+
 OnboardingPage {
     id: root
 
@@ -113,7 +115,13 @@ OnboardingPage {
                     type: StatusBaseButton.Type.Primary
                     visible: !d.seedphraseRevealed
                     onClicked: {
-                        d.seedphraseRevealed = true
+                        const services = SystemUtils.activeThirdPartyA11yServices()
+                        if (services.length > 0) {
+                            a11yWarningPopup.serviceNames = services
+                            a11yWarningPopup.open()
+                        } else {
+                            d.seedphraseRevealed = true
+                        }
                     }
                 }
             }
@@ -138,6 +146,11 @@ OnboardingPage {
                 }
             }
         }
+    }
+
+    AccessibilityWarningPopup {
+        id: a11yWarningPopup
+        onRevealAccepted: d.seedphraseRevealed = true
     }
 
     TextMetrics {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -90,15 +90,15 @@
 <context>
     <name>AccessibilityWarningPopup</name>
     <message>
-        <source>Accessibility service active</source>
+        <source>Accessibility services active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+        <source>Accessibility services on your device may access screen content:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+        <source>Check your device &lt;a href=&apos;accessibility-settings&apos;&gt;Settings &amp;gt; Accessibility&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -88,6 +88,29 @@
     </message>
 </context>
 <context>
+    <name>AccessibilityWarningPopup</name>
+    <message>
+        <source>Accessibility service active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reveal anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AccountAddressSelection</name>
     <message>
         <source>Scan addresses for activity</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -107,6 +107,34 @@
     </message>
   </context>
   <context>
+    <name>AccessibilityWarningPopup</name>
+    <message>
+      <source>Accessibility service active</source>
+      <comment>AccessibilityWarningPopup</comment>
+      <translation>Accessibility service active</translation>
+    </message>
+    <message>
+      <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+      <comment>AccessibilityWarningPopup</comment>
+      <translation>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</translation>
+    </message>
+    <message>
+      <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+      <comment>AccessibilityWarningPopup</comment>
+      <translation>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</translation>
+    </message>
+    <message>
+      <source>Cancel</source>
+      <comment>AccessibilityWarningPopup</comment>
+      <translation>Cancel</translation>
+    </message>
+    <message>
+      <source>Reveal anyway</source>
+      <comment>AccessibilityWarningPopup</comment>
+      <translation>Reveal anyway</translation>
+    </message>
+  </context>
+  <context>
     <name>AccountAddressSelection</name>
     <message>
       <source>Scan addresses for activity</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -109,19 +109,19 @@
   <context>
     <name>AccessibilityWarningPopup</name>
     <message>
-      <source>Accessibility service active</source>
+      <source>Accessibility services active</source>
       <comment>AccessibilityWarningPopup</comment>
-      <translation>Accessibility service active</translation>
+      <translation>Accessibility services active</translation>
     </message>
     <message>
-      <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+      <source>Accessibility services on your device may access screen content:</source>
       <comment>AccessibilityWarningPopup</comment>
-      <translation>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</translation>
+      <translation>Accessibility services on your device may access screen content:</translation>
     </message>
     <message>
-      <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+      <source>Check your device &lt;a href=&apos;accessibility-settings&apos;&gt;Settings &amp;gt; Accessibility&lt;/a&gt;.</source>
       <comment>AccessibilityWarningPopup</comment>
-      <translation>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</translation>
+      <translation>Check your device &lt;a href=&apos;accessibility-settings&apos;&gt;Settings &amp;gt; Accessibility&lt;/a&gt;.</translation>
     </message>
     <message>
       <source>Cancel</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -90,15 +90,15 @@
 <context>
     <name>AccessibilityWarningPopup</name>
     <message>
-        <source>Accessibility service active</source>
+        <source>Accessibility services active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+        <source>Accessibility services on your device may access screen content:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+        <source>Check your device &lt;a href=&apos;accessibility-settings&apos;&gt;Settings &amp;gt; Accessibility&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -88,6 +88,29 @@
     </message>
 </context>
 <context>
+    <name>AccessibilityWarningPopup</name>
+    <message>
+        <source>Accessibility service active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Zrušit</translation>
+    </message>
+    <message>
+        <source>Reveal anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AccountAddressSelection</name>
     <message>
         <source>Scan addresses for activity</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -90,15 +90,15 @@
 <context>
     <name>AccessibilityWarningPopup</name>
     <message>
-        <source>Accessibility service active</source>
+        <source>Accessibility services active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+        <source>Accessibility services on your device may access screen content:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+        <source>Check your device &lt;a href=&apos;accessibility-settings&apos;&gt;Settings &amp;gt; Accessibility&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -88,6 +88,29 @@
     </message>
 </context>
 <context>
+    <name>AccessibilityWarningPopup</name>
+    <message>
+        <source>Accessibility service active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <source>Reveal anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AccountAddressSelection</name>
     <message>
         <source>Scan addresses for activity</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -90,15 +90,15 @@
 <context>
     <name>AccessibilityWarningPopup</name>
     <message>
-        <source>Accessibility service active</source>
+        <source>Accessibility services active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+        <source>Accessibility services on your device may access screen content:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+        <source>Check your device &lt;a href=&apos;accessibility-settings&apos;&gt;Settings &amp;gt; Accessibility&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -88,6 +88,29 @@
     </message>
 </context>
 <context>
+    <name>AccessibilityWarningPopup</name>
+    <message>
+        <source>Accessibility service active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has accessibility access and can read content on your screen. Only reveal your recovery phrase if you trust this app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>An app with accessibility access is active and can read content on your screen. Only reveal your recovery phrase if you trust it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <source>Reveal anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AccountAddressSelection</name>
     <message>
         <source>Scan addresses for activity</source>

--- a/ui/imports/shared/panels/SeedPhrase.qml
+++ b/ui/imports/shared/panels/SeedPhrase.qml
@@ -6,6 +6,9 @@ import Qt5Compat.GraphicalEffects
 import StatusQ.Core
 import StatusQ.Controls
 
+import utils
+import shared.popups
+
 Control {
     id: root
 
@@ -57,7 +60,19 @@ Control {
         icon.name: "view"
         text: qsTr("Reveal recovery phrase")
         onClicked: {
-            root.seedPhraseRevealed = true
+            const services = SystemUtils.activeThirdPartyA11yServices()
+            console.log("A11Y_REVEAL: onClicked fired, services='" + services + "' len=" + services.length)
+            if (services.length > 0) {
+                a11yWarningPopup.serviceNames = services
+                a11yWarningPopup.open()
+            } else {
+                root.seedPhraseRevealed = true
+            }
         }
+    }
+
+    AccessibilityWarningPopup {
+        id: a11yWarningPopup
+        onRevealAccepted: root.seedPhraseRevealed = true
     }
 }

--- a/ui/imports/shared/popups/AccessibilityWarningPopup.qml
+++ b/ui/imports/shared/popups/AccessibilityWarningPopup.qml
@@ -1,0 +1,99 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Popups.Dialog
+import StatusQ.Controls
+
+import utils
+
+StatusDialog {
+    id: root
+
+    // Comma-separated display names of the active third-party accessibility services.
+    // Set before calling open().
+    property string serviceNames: ""
+
+    signal revealAccepted()
+
+    width: 480
+    title: qsTr("Third-party apps can read your screen")
+    modal: true
+    closePolicy: Popup.NoAutoClose
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.topMargin: Theme.padding
+            wrapMode: Text.WordWrap
+            text: qsTr("The following apps use accessibility services and can read your screen:")
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.topMargin: Theme.halfPadding
+            Layout.bottomMargin: Theme.halfPadding
+            spacing: Theme.smallPadding
+            visible: root.serviceNames.length > 0
+
+            Repeater {
+                model: root.serviceNames.split(", ")
+                delegate: RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.halfPadding
+                    StatusBaseText {
+                        text: "\u2022"
+                        font.pixelSize: Theme.primaryTextFontSize
+                    }
+                    StatusBaseText {
+                        Layout.fillWidth: true
+                        text: modelData
+                        font.pixelSize: Theme.primaryTextFontSize
+                        wrapMode: Text.WordWrap
+                    }
+                }
+            }
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.topMargin: Theme.defaultPadding
+            Layout.bottomMargin: Theme.padding
+            wrapMode: Text.WordWrap
+            color: Theme.palette.baseColor1
+            font.pixelSize: Theme.additionalTextSize
+            textFormat: Text.RichText
+            linkColor: Theme.palette.primaryColor1
+            text: qsTr("Only reveal your recovery phrase if you trust these apps. You can disable them in <a href='accessibility-settings'>Settings &gt; Accessibility</a>.")
+            onLinkActivated: (link) => SystemUtils.openAccessibilitySettings()
+        }
+    }
+
+    footer: StatusDialogFooter {
+        dropShadowEnabled: true
+        bottomPadding: Theme.padding + root.parent.SafeArea.margins.bottom
+        leftButtons: ObjectModel {
+            StatusFlatButton {
+                objectName: "btnA11yWarningCancel"
+                text: qsTr("Cancel")
+                onClicked: root.close()
+            }
+        }
+        rightButtons: ObjectModel {
+            StatusButton {
+                objectName: "btnA11yWarningReveal"
+                type: StatusBaseButton.Type.Danger
+                text: qsTr("Reveal anyway")
+                onClicked: {
+                    root.revealAccepted()
+                    root.close()
+                }
+            }
+        }
+    }
+}

--- a/ui/imports/shared/popups/AccessibilityWarningPopup.qml
+++ b/ui/imports/shared/popups/AccessibilityWarningPopup.qml
@@ -19,7 +19,7 @@ StatusDialog {
     signal revealAccepted()
 
     width: 480
-    title: qsTr("Third-party apps can read your screen")
+    title: qsTr("Accessibility services active")
     modal: true
     closePolicy: Popup.NoAutoClose
 
@@ -31,7 +31,7 @@ StatusDialog {
             Layout.fillWidth: true
             Layout.topMargin: Theme.padding
             wrapMode: Text.WordWrap
-            text: qsTr("The following apps use accessibility services and can read your screen:")
+            text: qsTr("Accessibility services on your device may access screen content:")
         }
 
         ColumnLayout {
@@ -69,7 +69,7 @@ StatusDialog {
             font.pixelSize: Theme.additionalTextSize
             textFormat: Text.RichText
             linkColor: Theme.palette.primaryColor1
-            text: qsTr("Only reveal your recovery phrase if you trust these apps. You can disable them in <a href='accessibility-settings'>Settings &gt; Accessibility</a>.")
+            text: qsTr("Check your device <a href='accessibility-settings'>Settings &gt; Accessibility</a>.")
             onLinkActivated: (link) => SystemUtils.openAccessibilitySettings()
         }
     }

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -40,3 +40,4 @@ UnblockContactConfirmationDialog 1.0 UnblockContactConfirmationDialog.qml
 UserStatusContextMenu 1.0 UserStatusContextMenu.qml
 ThirdpartyServicesPopup 1.0 ThirdpartyServicesPopup.qml
 EnableBiometricsPopup 1.0 EnableBiometricsPopup.qml
+AccessibilityWarningPopup 1.0 AccessibilityWarningPopup.qml


### PR DESCRIPTION
Closes #20965

## What this does

Before revealing the recovery phrase, check whether any third-party accessibility service is active on the device. If so, show an informed-consent dialog that:

- Lists the service names in a bulleted list (e.g. "ChatGPT screen help", "Link to Windows")
- Links directly to **Settings > Accessibility** so the user can disable services they don't trust
- Offers **Cancel** (stays hidden) or **Reveal anyway** (proceeds with reveal)

If no third-party services are active, reveal proceeds without interruption.

This applies to both the **Settings → Back up recovery phrase** flow (`BackupSeedphraseReveal.qml`) and the onboarding **seed phrase display** flow (`SeedPhrase.qml`).

## Implementation

**Java (Android)**
- `AccessibilityServiceHelper.java` — new class; queries `AccessibilityManager` for enabled services, filters out system/OEM packages (`com.android.*`, `com.google.*`, `com.samsung.*`, `com.sec.*`) and the app's own package.
- `StatusQtActivity.java` — adds `getThirdPartyA11yServices()` instance method and `openAccessibilitySettings()` static method, both callable from C++ via JNI.

**C++ (StatusQ)**
- `systemutilsinternal.h/cpp` — exposes `activeThirdPartyA11yServices()` and `openAccessibilitySettings()` as `Q_INVOKABLE` through `SystemUtils` singleton. Uses `QtNative.activity()` + `callObjectMethod` pattern (required for Qt 6.11 — `callStaticObjectMethod` returning `jobject` with no arguments has a known varargs issue).

**QML**
- `AccessibilityWarningPopup.qml` — new `StatusDialog` using existing design tokens; bulleted service list; `Settings > Accessibility` deep-link via `onLinkActivated`.
- `BackupSeedphraseReveal.qml`, `SeedPhrase.qml` — reveal button `onClicked` gates on `SystemUtils.activeThirdPartyA11yServices()`; opens popup if non-empty, reveals directly otherwise.

## Test steps

1. Enable a third-party accessibility service (e.g. ChatGPT Screen Help)
2. **Settings → Back up recovery phrase → Reveal recovery phrase** → warning popup appears listing the service
3. Tap **Settings > Accessibility** link → opens Android Accessibility Settings
4. Tap **Cancel** → popup closes, phrase stays hidden
5. Tap **Reveal** again → popup → **Reveal anyway** → phrase appears
6. Disable all third-party accessibility services → tap Reveal → no popup, phrase reveals directly

## Screenshots

<!-- TODO: add screenshots of popup -->

## Related

- Prerequisite: #20942 (a11y tree suppression pre-reveal — merged)
- Issue: #20965