### PR TITLE
fix(e2e_appium): log xfail tests as XFAIL in console, not FAILED

### DIFF
--- a/test/e2e_appium/config/logging_config.py
+++ b/test/e2e_appium/config/logging_config.py
@@ -342,11 +342,14 @@ def log_test_start(test_name: str, **context):
     )
 
 
-def log_test_end(test_name: str, success: bool, duration_ms: int, **context):
+def log_test_end(test_name: str, success: bool, duration_ms: int, *, xfail: bool = False, **context):
     """Log test completion with results."""
     logger = get_logger("tests")
-    emoji = "✅" if success else "❌"
-    status = "PASSED" if success else "FAILED"
+    if xfail:
+        emoji, status = "⚠️", "XFAIL"
+    else:
+        emoji = "✅" if success else "❌"
+        status = "PASSED" if success else "FAILED"
 
     logger.info(
         f"{emoji} Test {status}: {test_name} ({duration_ms}ms)",

--- a/test/e2e_appium/conftest.py
+++ b/test/e2e_appium/conftest.py
@@ -309,16 +309,21 @@ def pytest_runtest_teardown(item, nextitem):
 
     # Determine test success from the test result
     success = True
+    is_xfail = False
     duration_ms = 0
 
     if hasattr(item, "rep_call"):
-        success = item.rep_call.passed
+        rep = item.rep_call
+        success = rep.passed
+        # An xfail reports as skipped-with-wasxfail (rep.passed is False), so
+        # log it as a distinct XFAIL outcome rather than FAILED.
+        is_xfail = getattr(rep, "wasxfail", None) is not None and rep.skipped
 
     if hasattr(item, "_test_start_time"):
         duration = datetime.now() - item._test_start_time
         duration_ms = int(duration.total_seconds() * 1000)
 
-    log_test_end(test_name, success, duration_ms)
+    log_test_end(test_name, success, duration_ms, xfail=is_xfail)
     _apply_test_cooldown(item)
 
 


### PR DESCRIPTION
pytest_runtest_teardown derived test success from rep_call.passed, which is False for an xfailed test (it reports as skipped-with-wasxfail). As a result every xfail was logged as "Test FAILED" in the run console log even though the run was green. This detects xfail and logs a distinct "XFAIL" line so logs don't mislabel expected failures.