### PR TITLE
fix(mobile): un-hide WiFi-only message sync setting

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -75,7 +75,6 @@ SettingsContentBase {
 
         StatusListItem {
             id: allowSyncingOnMobileNetwork
-            visible: false
 
             Layout.fillWidth: true
             implicitHeight: 64


### PR DESCRIPTION
## Problem

The \"Message syncing\" setting in Profile > Messaging (allows users to restrict sync to Wi-Fi only) has been hidden behind `visible: false` since v2.38. The backend implementation (`getSyncingOnMobileNetwork`) is complete and works correctly.

Battery research (#21045) shows that on cellular (LTE), the Waku keepalive traffic makes Status the dominant battery consumer at **~144 mAh/hr** (~3.2%/hr on a 4500 mAh battery) for a typical loaded account. Users who enable Wi-Fi-only syncing avoid this entirely — dropping from ~144 mAh/hr to ~1.6 mAh/hr (59.7× reduction, measured T4 vs T3 soaks).

## Change

Remove `visible: false` from `allowSyncingOnMobileNetwork` in `MessagingView.qml`.

One line deletion. The setting, its toggle popup, and the backend save/load are all already implemented and tested.

## Test plan

- [ ] Open Profile > Messaging — \"Message syncing\" row is visible showing current state (\"Mobile data and Wi-Fi\" or \"Wi-Fi only\")
- [ ] Tap row — popup appears with both options
- [ ] Select \"Wi-Fi only\" — setting saves, row label updates
- [ ] Background app on cellular — confirm no mobile data used by Status (via Settings > Network)
- [ ] Select \"Mobile data and Wi-Fi\" — normal sync resumes

## Related

- Issue: #21045 (battery drain research — R3 of proposed fixes)
- Companion: status-im/status-go PR (R1: background Waku interval, R2: deferred mailserver sync) — in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)