### PR TITLE
fix(e2e_appium): detect edited-message indicator, un-xfail test_edit

### DIFF
--- a/test/e2e_appium/locators/messaging/chat_locators.py
+++ b/test/e2e_appium/locators/messaging/chat_locators.py
@@ -167,7 +167,8 @@ class ChatLocators(BaseLocators):
         """Locator for a message that contains both the content and '(edited)' indicator."""
         escaped = content.replace('"', '\\"')
         return BaseLocators.xpath(
-            f"//android.widget.EditText[contains(@content-desc,'{escaped}') "
+            f"//*[contains(@resource-id,'chatMessageViewDelegate')]"
+            f"//*[contains(@content-desc,'{escaped}') "
             f"and contains(@content-desc,'(edited)')]"
         )
 

--- a/test/e2e_appium/tests/messaging/test_message_context_menu.py
+++ b/test/e2e_appium/tests/messaging/test_message_context_menu.py
@@ -462,12 +462,6 @@ class TestMessageContextMenuCrossDevice(_MessageContextMenuBase):
 
     @pytest.mark.gate
     @pytest.mark.smoke
-    @pytest.mark.xfail(
-        reason="edited indicator is not exposed to accessibility: StatusTextMessage.qml "
-        "sets Accessible.name from the raw message text, not the rendered '(edited)' "
-        "text, so message_is_edited cannot detect it. Needs a QML a11y fix.",
-        strict=False,
-    )
     @pytest.mark.spec("SC-MACT-02")
     async def test_edit_message_and_verify_on_both_devices(self) -> None:
         """Verify editing a sent message updates text and shows edit indicator on both devices.
@@ -479,7 +473,7 @@ class TestMessageContextMenuCrossDevice(_MessageContextMenuBase):
         and secondary.
         """
         original_text = _unique_message("edit_orig")
-        additional_text = " edited"
+        additional_text = " v2"
         edited_text = original_text + additional_text
         context_menu = MessageContextMenuPage(self.driver)
 


### PR DESCRIPTION
### What does the PR do
Un-xfail `test_edit_message_and_verify_on_both_devices` now that #21368 exposes the
"(edited)" indicator to accessibility, and match it with a locator scoped to the
message bubble (a TextView, not an EditText).

### Affected areas
e2e_appium — messaging edited-message detection.

### How to test
The Android e2e gate runs `test_edit_message_and_verify_on_both_devices` (previously
xfail'd). Verified on a 2-device Pi run (Samsung A36 + Moto G55).

### Risk
Test-only, no product code. Relies on #21368 (merged) for the accessibility indicator.
