### PR TITLE
fix(scripts): pin aqtinstall to fix Qt installation

### DIFF
--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -88,7 +88,8 @@ function Install-MSYS2-Packages {
 
 function Install-Qt-SDK {
     Write-Host "Installing Qt $QtVersion SDK..."
-    run pip install aqtinstall
+    # FIXME: Drop once the proper fix is in release newer than 3.3.0
+    run pip install --no-cache-dir "git+https://github.com/miurahr/aqtinstall.git@8c3695d"
     run aqt install-qt -O "C:\Qt" windows desktop $QtVersion win64_msvc2022_64 -m all
 }
 


### PR DESCRIPTION
Currently it fails with errors like this:
```
WARNING : Failed to download checksum for the file 'online/qtsdkrepository/windows_x86/desktop/qt6_6110/qt6_6110/Updates.xml'. This may happen on unofficial mirrors.
ERROR   : Failed to locate XML data for Qt version '6.11.0'.
```
This has been fixed but is not yet in a release:
- https://github.com/miurahr/aqtinstall/pull/1000