### PR TITLE
feat(Browser): implement address bar suggestions + popup

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -184,6 +184,7 @@ add_library(StatusQ ${LIB_TYPE}
         include/StatusQ/rxvalidator.h
         include/StatusQ/shareutils.h
         include/StatusQ/stablearraysorter.h
+        include/StatusQ/statusbrowserautocompletemodel.h
         include/StatusQ/statuscolors.h
         include/StatusQ/statusemojimodel.h
         include/StatusQ/statussyntaxhighlighter.h
@@ -222,6 +223,7 @@ add_library(StatusQ ${LIB_TYPE}
         src/permissionutilsinternal.cpp
         src/rxvalidator.cpp
         src/stablearraysorter.cpp
+        src/statusbrowserautocompletemodel.cpp
         src/statuscolors.cpp
         src/statusemojimodel.cpp
         src/statussyntaxhighlighter.cpp

--- a/ui/StatusQ/include/StatusQ/statusbrowserautocompletemodel.h
+++ b/ui/StatusQ/include/StatusQ/statusbrowserautocompletemodel.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QAbstractListModel>
+
+struct AutocompleteEntry {
+    QString url;
+    bool isSearch{false};
+    inline bool operator==(const QString& otherUrl) const {
+        return url.compare(otherUrl, Qt::CaseInsensitive) == 0;
+    }
+    qint64 timestamp{0};
+};
+
+class StatusBrowserAutocompleteModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString userUID READ userUID WRITE setUserUID NOTIFY userUIDChanged REQUIRED FINAL)
+
+public:
+    enum SBARoles {
+        UrlRole = Qt::UserRole + 1,
+        EscapedUrlRole,
+        IsSearch,
+        Timestamp,
+    };
+    Q_ENUM(SBARoles)
+
+    explicit StatusBrowserAutocompleteModel(QObject *parent = nullptr);
+    ~StatusBrowserAutocompleteModel() override;
+
+    Q_INVOKABLE void addEntry(const QString& url, bool isSearch = false);
+
+protected:
+    int rowCount(const QModelIndex &parent = {}) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+signals:
+    void userUIDChanged();
+
+private:
+    QString userUID() const;
+    void setUserUID(const QString &newUserUID);
+    QString m_userUID;
+
+    QString settingsGroup() const;
+    void save();
+    void load();
+
+    QList<AutocompleteEntry> m_entries;
+};

--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -75,8 +75,8 @@ QC.Popup {
     /*!
        \qmlproperty bool fillHeightOnBottomSheet
         This property decides the height of the dialog when `bottomSheet` is active:
-          * If active: it fills the 90% of the screen viewport.
-          * If not active: the height is the minimum value between the implicitHeight and the 90% of the screen viewport.
+          * If active: it fills the 85% of the screen viewport.
+          * If not active: the height is the minimum value between the implicitHeight and the 85% of the screen viewport.
     */
     property bool fillHeightOnBottomSheet: false
 
@@ -105,7 +105,6 @@ QC.Popup {
         root {
             parent: root.directParent
             modal: false
-            dim: false
             closePolicy: QC.Popup.CloseOnEscape | QC.Popup.CloseOnPressOutsideParent
 
             x: root.relativeX
@@ -121,7 +120,6 @@ QC.Popup {
         root {
             parent: root.QC.Overlay.overlay || parent
             modal: true
-            dim: true
             closePolicy: QC.Popup.CloseOnPressOutside
 
             x: 0

--- a/ui/StatusQ/src/statusbrowserautocompletemodel.cpp
+++ b/ui/StatusQ/src/statusbrowserautocompletemodel.cpp
@@ -1,0 +1,143 @@
+#include "StatusQ/statusbrowserautocompletemodel.h"
+
+#include <QDateTime>
+#include <QDebug>
+#include <QRegularExpression>
+#include <QSettings>
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace {
+constexpr auto kUrlRoleName = "url";
+constexpr auto kEscapedUrlRoleName = "escapedUrl";
+constexpr auto kIsSearchRoleName = "isSearch";
+constexpr auto kTimestampRoleName = "timestamp";
+
+constexpr auto kAutocompleteHistoryEntry = "autocompleteHistory"_L1;
+
+const QRegularExpression rxEscapeUrl(u"^[a-zA-Z0-9+.-]+:///*|/*$"_s);
+}
+
+StatusBrowserAutocompleteModel::StatusBrowserAutocompleteModel(QObject *parent)
+    : QAbstractListModel(parent)
+{}
+
+StatusBrowserAutocompleteModel::~StatusBrowserAutocompleteModel()
+{
+    save();
+}
+
+void StatusBrowserAutocompleteModel::addEntry(const QString &url, bool isSearch)
+{
+    if (url.isEmpty() || m_entries.contains(url))
+        return;
+    const auto at = m_entries.size();
+    beginInsertRows({}, at, at);
+    m_entries.append({url, isSearch, QDateTime::currentMSecsSinceEpoch()});
+    endInsertRows();
+}
+
+int StatusBrowserAutocompleteModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return m_entries.size();
+}
+
+QVariant StatusBrowserAutocompleteModel::data(const QModelIndex &index, int role) const
+{
+    const auto row = index.row();
+    if (row < 0 || row >= rowCount())
+        return {};
+
+    const auto entry = m_entries.at(row);
+
+    switch (static_cast<StatusBrowserAutocompleteModel::SBARoles>(role)) {
+    case StatusBrowserAutocompleteModel::UrlRole:
+        return entry.url;
+    case StatusBrowserAutocompleteModel::IsSearch:
+        return entry.isSearch;
+    case StatusBrowserAutocompleteModel::EscapedUrlRole: {
+        auto tmpUrl = entry.url;
+        // Removes protocol + leading slashes AND/OR trailing slashes; breaks down the url into parts
+        return tmpUrl.remove(rxEscapeUrl).replace('/'_L1, ' '_L1);
+    }
+    case StatusBrowserAutocompleteModel::Timestamp:
+        return entry.timestamp;
+    }
+
+    return {};
+}
+
+QHash<int, QByteArray> StatusBrowserAutocompleteModel::roleNames() const
+{
+    static const QHash<int, QByteArray> roles{
+        {UrlRole, kUrlRoleName},
+        {EscapedUrlRole, kEscapedUrlRoleName},
+        {IsSearch, kIsSearchRoleName},
+        {Timestamp, kTimestampRoleName},
+    };
+
+    return roles;
+}
+
+QString StatusBrowserAutocompleteModel::userUID() const
+{
+    return m_userUID;
+}
+
+void StatusBrowserAutocompleteModel::setUserUID(const QString &newUserUID)
+{
+    if (m_userUID == newUserUID)
+        return;
+    m_userUID = newUserUID;
+    emit userUIDChanged();
+
+    load();
+}
+
+QString StatusBrowserAutocompleteModel::settingsGroup() const
+{
+    return QStringLiteral("AppMainLocalSettings_%1").arg(m_userUID);
+}
+
+void StatusBrowserAutocompleteModel::save()
+{
+    QSettings settings;
+    settings.beginGroup(settingsGroup());
+
+    const auto size = m_entries.size();
+    settings.beginWriteArray(kAutocompleteHistoryEntry, size);
+    for (qsizetype i = 0; i < size; ++i) {
+        settings.setArrayIndex(i);
+        const auto& entry = m_entries.at(i);
+        settings.setValue(kUrlRoleName, entry.url);
+        settings.setValue(kIsSearchRoleName, entry.isSearch);
+        settings.setValue(kTimestampRoleName, entry.timestamp);
+    }
+    settings.endArray();
+
+    settings.endGroup();
+}
+
+void StatusBrowserAutocompleteModel::load()
+{
+    QSettings settings;
+    settings.beginGroup(settingsGroup());
+    beginResetModel();
+
+    m_entries.clear();
+    const auto size = settings.beginReadArray(kAutocompleteHistoryEntry);
+    m_entries.reserve(size);
+    for (int i = 0; i < size; ++i) {
+        settings.setArrayIndex(i);
+        m_entries.append({settings.value(kUrlRoleName).toString(),
+                          settings.value(kIsSearchRoleName).toBool(),
+                          settings.value(kTimestampRoleName).toLongLong(),
+                          });
+    }
+    settings.endArray();
+
+    endResetModel();
+    settings.endGroup();
+}

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -16,6 +16,7 @@
 #include "StatusQ/rxvalidator.h"
 #include "StatusQ/shareutils.h"
 #include "StatusQ/statuscolors.h"
+#include "StatusQ/statusbrowserautocompletemodel.h"
 #include "StatusQ/statusemojimodel.h"
 #include "StatusQ/chatinputhighlighter.h"
 #include "StatusQ/statussyntaxhighlighter.h"
@@ -91,6 +92,7 @@ void registerStatusQTypes() {
     qmlRegisterType<UndefinedFilter>("StatusQ", 0, 1, "UndefinedFilter");
     qmlRegisterType<ConstantRole>("StatusQ", 0, 1, "ConstantRole");
 
+    qmlRegisterType<StatusBrowserAutocompleteModel>("StatusQ.Models", 0, 1, "StatusBrowserAutocompleteModel");
     qmlRegisterType<StatusEmojiModel>("StatusQ", 0, 1, "StatusEmojiModel");
     qmlRegisterType<FormattedDoubleProperty>("StatusQ", 0, 1, "FormattedDoubleProperty");
 

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -12,6 +12,7 @@ import StatusQ.Controls
 import StatusQ.Layout
 import StatusQ.Popups
 import StatusQ.Popups.Dialog
+import StatusQ.Models
 
 import utils
 import shared.popups.send
@@ -223,17 +224,25 @@ StatusSectionLayout {
             addNewTab("", "", true)
         }
 
+        readonly property var autocompleteHistory: StatusBrowserAutocompleteModel {
+            userUID: root.userUID
+        }
+
         function onRequestLaunchInBrowser(url) {
             if (localAccountSensitiveSettings.useBrowserEthereumExplorer !== Constants.browserEthereumExplorerNone && url.startsWith("0x")) {
                 webViewContext.setCurrentWebUrl(root.browserRootStore.get0xFormedUrl(localAccountSensitiveSettings.useBrowserEthereumExplorer, url))
                 return
             }
             if (localAccountSensitiveSettings.selectedBrowserSearchEngineId !== SearchEnginesConfig.browserSearchEngineNone && !Utils.isURL(url) && !Utils.isURLWithOptionalProtocol(url)) {
+                if (!currentTabIncognito)
+                    autocompleteHistory.addEntry(url, true /*isSearch*/)
                 webViewContext.setCurrentWebUrl(root.browserRootStore.getFormedUrl(localAccountSensitiveSettings.selectedBrowserSearchEngineId, url))
                 return
             } else if (Utils.isURLWithOptionalProtocol(url)) {
                 url = "https://" + url
             }
+            if (!currentTabIncognito)
+                autocompleteHistory.addEntry(url)
             webViewContext.setCurrentWebUrl(url);
         }
 
@@ -478,6 +487,7 @@ StatusSectionLayout {
                 currentTabIsDownloads: _internal.currentTabIsDownloads
                 browserDappsModel: browserDappsProvider.model
                 historyModel: _internal.currentWebView?.history?.items ?? null
+                autocompleteHistory: _internal.autocompleteHistory
             }
         }
 
@@ -534,6 +544,7 @@ StatusSectionLayout {
             incognitoMode: _internal.currentTabIncognito
             browserDappsModel: browserDappsProvider.model
             faviconUrl: _internal.currentWebView?.icon ?? ""
+            autocompleteHistory: _internal.autocompleteHistory
 
             onRequestReloadPage: webViewContext.reloadCurrent()
             onRequestStopLoadingPage: webViewContext.stopCurrent()

--- a/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
+++ b/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
@@ -1,10 +1,16 @@
 import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 
+import StatusQ.Core
+import StatusQ.Core.Utils as SQUtils
 import StatusQ.Core.Theme
 import StatusQ.Controls
 import StatusQ.Components
 
 import utils
+
+import SortFilterProxyModel
 
 StatusTextField {
     id: root
@@ -17,7 +23,11 @@ StatusTextField {
     property bool showFavicon
     property bool loading
 
+    property var autocompleteHistory
+
     readonly property url searchEngineIcon: Assets.svg(SearchEnginesConfig.getEngineIcon(localAccountSensitiveSettings.selectedBrowserSearchEngineId))
+
+    signal navigationRequested(string url)
 
     implicitHeight: 40
 
@@ -36,13 +46,19 @@ StatusTextField {
     EnterKey.type: Qt.EnterKeyGo
 
     text: root.url
+
     onActiveFocusChanged: {
         if (activeFocus) {
             selectAll()
-        } else {
-            if (text === "") // restore the old URL
+        } else if (!dropdown.visible) {
+            if (text !== root.url.toString() && root.url.toString() !== "") // restore the old (non empty) URL
                 text = Qt.binding(() => root.url)
         }
+    }
+
+    onAccepted: {
+        dropdown.close()
+        navigationRequested(text)
     }
 
     StatusRoundedImage {
@@ -75,9 +91,107 @@ StatusTextField {
         anchors.verticalCenter: parent.verticalCenter
         visible: parent.cursorVisible && !!parent.text
         tooltip.orientation: StatusToolTip.Orientation.Bottom
-        onClicked: {
-            parent.forceActiveFocus()
-            parent.clear()
+        onClicked: parent.clear()
+    }
+
+    SortFilterProxyModel {
+        id: sfpm
+        sourceModel: root.autocompleteHistory
+        filters: [
+            SQUtils.SearchFilter {
+                roleName: "escapedUrl"
+                searchPhrase: root.text
+            }
+        ]
+        sorters: [
+            RoleSorter {
+                roleName: "timestamp"
+                sortOrder: Qt.DescendingOrder
+            },
+            StringSorter {
+                roleName: "url"
+                caseSensitivity: Qt.CaseInsensitive
+            }
+        ]
+    }
+
+    Keys.forwardTo: dropdown
+    Keys.onEscapePressed: {
+        dropdown.close()
+        root.focus = sfpm.count > 0
+    }
+    Keys.onDownPressed: {
+        if (dropdown.visible) {
+            selectorPanel.forceActiveFocus()
+            selectorPanel.currentIndex = 0
         }
+    }
+
+    StatusDropdown {
+        id: dropdown
+
+        directParent: root
+        relativeX: root.width - width
+        relativeY: root.height + 2
+        width: root.width
+        bottomSheetAllowed: false
+        padding: 0
+        focus: false
+        dim: false
+
+        visible: sfpm.count > 0 && root.text !== ""
+
+        contentItem: StatusListView {
+            id: selectorPanel
+            width: root.width
+            implicitHeight: contentHeight
+            model: sfpm
+            currentIndex: -1
+            highlightFollowsCurrentItem: true
+            highlight: Rectangle {
+                radius: Theme.radius
+                color: selectorPanel.activeFocus ? Theme.palette.primaryColor2 : StatusColors.transparent
+            }
+            Keys.onUpPressed: {
+                if (currentIndex === 0)
+                    root.forceActiveFocus()
+                else
+                    currentIndex--
+            }
+
+            delegate: ItemDelegate {
+                width: ListView.view.width - Theme.padding
+                background: Rectangle {
+                    radius: Theme.radius
+                    color: selectorPanel.activeFocus ? StatusColors.transparent
+                                                     : hovered ? Theme.palette.primaryColor2
+                                                               : StatusColors.transparent
+                }
+                contentItem: RowLayout {
+                    StatusIcon {
+                        Layout.preferredWidth: 20
+                        Layout.preferredHeight: 20
+                        icon: model.isSearch ? "search" : "globe"
+                        color: Theme.palette.primaryColor1
+                    }
+                    StatusBaseText {
+                        Layout.fillWidth: true
+                        elide: Text.ElideMiddle
+                        maximumLineCount: 1
+                        text: model.url
+                        font.pixelSize: Theme.fontSize(14)
+                    }
+                }
+                onClicked: {
+                    dropdown.close()
+                    root.navigationRequested(model.url)
+                }
+                HoverHandler {
+                    cursorShape: hovered ? Qt.PointingHandCursor : undefined
+                }
+            }
+        }
+
+        onClosed: selectorPanel.currentIndex = -1
     }
 }

--- a/ui/app/AppLayouts/Browser/panels/BrowserLandscapeToolbar.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserLandscapeToolbar.qml
@@ -17,6 +17,7 @@ BrowserToolbarBase {
     id: root
 
     required property url url
+    property var autocompleteHistory
 
     function activateAddressBar() {
         addressBar.forceActiveFocus()
@@ -81,7 +82,8 @@ BrowserToolbarBase {
                     return StatusColors.transparent
                 return incognitoMode ? Theme.palette.privacyColors.secondary : Theme.palette.baseColor2
             }
-            onAccepted: root.requestLaunchInBrowser(text)
+            autocompleteHistory: root.autocompleteHistory
+            onNavigationRequested: url => root.requestLaunchInBrowser(url)
         }
 
         LandscapeToolbarButton {

--- a/ui/app/AppLayouts/Browser/panels/MobileAddressBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/MobileAddressBar.qml
@@ -20,6 +20,7 @@ Control {
     required property var browserDappsModel
     required property url url
     property url faviconUrl
+    property var autocompleteHistory
 
     signal requestStopLoadingPage()
     signal requestReloadPage()
@@ -64,7 +65,8 @@ Control {
                     return addressBar.cursorVisible ? Theme.palette.privacyColors.primary : Theme.palette.privacyColors.secondary
                 return addressBar.cursorVisible ? Theme.palette.baseColor2 : Theme.palette.background
             }
-            onAccepted: root.requestLaunchInBrowser(text)
+            autocompleteHistory: root.autocompleteHistory
+            onNavigationRequested: url => root.requestLaunchInBrowser(url)
         }
 
         BrowserHeaderButton {


### PR DESCRIPTION
### What does the PR do

- dedicated StatusBrowserAutocompleteModel; saving/loading the entries using QSettings
- added a popup BrowserAddressField which displays the suggestions as-you-type in a StatusDropdown

Fixes #20677

### Affected areas

Browser

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="2944" height="1800" alt="image" src="https://github.com/user-attachments/assets/fc1c1283-f33c-4151-82f0-562409438311" />

### Impact on end user

Improved Browser UX when entering URL/search


### How to test

- visit some sites, make some searches
- open a new tab, observe the the address field popup containing the visited/searched entries

### Risk 

low
