### PR TITLE
feat(android): share target — text, links and images into the share flow

### DIFF
--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -21,6 +21,7 @@ NIM_TESTS_LINK_STATUSQ := \
 	send_handler_lookup_bench \
 	send_modal_instantiation_bench \
 	services_pause_bridge_test \
+	share_intake_wake_test \
 	signal_handler_test \
 	swap_key_harvest_bench \
 	swap_modal_instantiation_bench \

--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -126,16 +126,24 @@
                 <data android:scheme="https" />
             </intent-filter>
             <!--
-              Share target: text and links shared from other apps (share sheet).
-              Only text/plain is declared - exactly what chat can send today;
-              image MIME types join in the image-share slice. Extraction is
-              decision-free (StatusQtActivity.handleShareIntake); the share flow
-              launches at the Nim external-intake seam.
+              Share target: text, links and images shared from other apps
+              (share sheet). Only text/plain and image/* are declared - exactly
+              what chat can send today; video/audio/arbitrary files are not.
+              Extraction is decision-free (StatusQtActivity.handleShareIntake):
+              image streams are copied to app-private cache at receipt (OS read
+              grants expire); the share flow launches at the Nim
+              external-intake seam.
             -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
             </intent-filter>
         </activity>
 

--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -46,10 +46,12 @@
         android:allowBackup="true"
         android:hasFragileUserData="true"
         android:fullBackupOnly="false">
+        <!-- singleTask: share/view intents land in the caller's task, where singleTop
+             would spawn a second activity Qt cannot re-init against (dead screen). -->
         <activity
             android:name="app.status.mobile.StatusQtActivity"
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:resizeableActivity="true"
             android:windowSoftInputMode="adjustNothing"
             android:exported="true">

--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -125,6 +125,18 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>
+            <!--
+              Share target: text and links shared from other apps (share sheet).
+              Only text/plain is declared - exactly what chat can send today;
+              image MIME types join in the image-share slice. Extraction is
+              decision-free (StatusQtActivity.handleShareIntake); the share flow
+              launches at the Nim external-intake seam.
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -6,8 +6,11 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
 import androidx.core.splashscreen.SplashScreen;
 import java.util.concurrent.atomic.AtomicBoolean;
+import android.content.ContentResolver;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.provider.Settings;
@@ -222,7 +225,7 @@ public class StatusQtActivity extends QtActivity {
 
         String[] imagePaths = isImageShare
                 ? copySharedImagesToCache(
-                        imagesOnly(extractStreamUris(intent, isSendMultiple), isWildcard))
+                        imagesOnly(extractStreamUris(this, intent, isSendMultiple), isWildcard))
                 : new String[0];
         if (text.isEmpty() && imagePaths.length == 0) {
             if (isImageShare) {
@@ -253,20 +256,52 @@ public class StatusQtActivity extends QtActivity {
         pendingIntakeShareText = null;
     }
 
-    private static List<Uri> extractStreamUris(Intent intent, boolean multiple) {
+    private static List<Uri> extractStreamUris(Context ctx, Intent intent, boolean multiple) {
         ArrayList<Uri> uris = new ArrayList<>();
         if (multiple) {
             ArrayList<Uri> streams = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
             if (streams != null) {
                 for (Uri stream : streams) {
-                    if (stream != null) uris.add(stream);
+                    if (isSharableStream(ctx, stream)) uris.add(stream);
                 }
             }
         } else {
             Uri stream = intent.getParcelableExtra(Intent.EXTRA_STREAM);
-            if (stream != null) uris.add(stream);
+            if (isSharableStream(ctx, stream)) uris.add(stream);
         }
         return uris;
+    }
+
+    // The sender chooses the URI but we do the opening, so an unvetted stream
+    // makes us a confused deputy: openInputStream() resolves file:// directly,
+    // and a content:// URI on one of our OWN providers is readable by us
+    // regardless of what the sender can reach. Either lets a zero-permission
+    // app name a path in our private storage and have us copy it out.
+    // Accept only content:// from somebody else.
+    private static boolean isSharableStream(Context ctx, Uri uri) {
+        if (uri == null) return false;
+        if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+            Log.w(TAG, "share intake: rejecting non-content stream: " + uri.getScheme());
+            return false;
+        }
+        if (belongsToUs(ctx, uri)) {
+            Log.w(TAG, "share intake: rejecting stream on our own provider: " + uri.getAuthority());
+            return false;
+        }
+        return true;
+    }
+
+    // Resolved through PackageManager rather than compared against a literal:
+    // the authority carries applicationIdSuffix (".debug"), and this also
+    // covers any provider we add later.
+    private static boolean belongsToUs(Context ctx, Uri uri) {
+        final String authority = uri.getAuthority();
+        if (authority == null) return true; // unresolvable: treat as untrusted
+        final ProviderInfo info =
+                ctx.getPackageManager().resolveContentProvider(authority, 0);
+        // Unknown authority: not ours, and openInputStream would fail anyway.
+        if (info == null) return false;
+        return ctx.getPackageName().equals(info.packageName);
     }
 
     // Resolved before copying: the copy loop runs on the UI thread, so a

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -88,8 +88,22 @@ public class StatusQtActivity extends QtActivity {
             sweepShareIntakeCache();
         }
 
-        handleUrlIntake(getIntent());
-        handleShareIntake(getIntent());
+        // Delivery dedup, not routing: getIntent() on an Activity recreation
+        // (unlock, config change, process-death restore) or a history/recents
+        // launch returns the task-root intent — possibly a days-old VIEW/SEND
+        // a previous instance already processed. Re-processing it clobbers a
+        // newer buffered share (URL buffering clears the pending share) or
+        // replays an old deep link. Only a truly fresh launch handles the
+        // creation intent; fresh warm deliveries arrive via onNewIntent.
+        if (savedInstanceState == null && !isHistoryLaunch(getIntent())) {
+            handleUrlIntake(getIntent());
+            handleShareIntake(getIntent());
+        }
+    }
+
+    private static boolean isHistoryLaunch(Intent intent) {
+        return intent != null
+                && (intent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0;
     }
 
     @Override

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -208,9 +208,10 @@ public class StatusQtActivity extends QtActivity {
         if (!isSend && !isSendMultiple) return;
         String type = intent.getType();
         if (type == null) return;
-        // Mirrors the manifest: image shares (single or multiple) and
-        // single text shares; anything else is dropped.
-        boolean isImageShare = type.startsWith("image/");
+        // Android matches "text/*" and "*/*" intents against our concrete
+        // text/plain and image/* filters, so the type can be a wildcard.
+        boolean isWildcard = "*/*".equals(type);
+        boolean isImageShare = type.startsWith("image/") || isWildcard;
         if (!isImageShare && !(isSend && type.startsWith("text/"))) return;
 
         String text = intent.getStringExtra(Intent.EXTRA_TEXT);
@@ -220,9 +221,16 @@ public class StatusQtActivity extends QtActivity {
         if (text == null) text = "";
 
         String[] imagePaths = isImageShare
-                ? copySharedImagesToCache(extractStreamUris(intent, isSendMultiple))
+                ? copySharedImagesToCache(
+                        imagesOnly(extractStreamUris(intent, isSendMultiple), isWildcard))
                 : new String[0];
-        if (text.isEmpty() && imagePaths.length == 0) return;
+        if (text.isEmpty() && imagePaths.length == 0) {
+            if (isImageShare) {
+                Toast.makeText(this, "Only images and text can be shared to Status",
+                        Toast.LENGTH_LONG).show();
+            }
+            return;
+        }
 
         if (!userLoggedIn.get()) {
             clearPendingShare();
@@ -259,6 +267,22 @@ public class StatusQtActivity extends QtActivity {
             if (stream != null) uris.add(stream);
         }
         return uris;
+    }
+
+    // Resolved before copying: the copy loop runs on the UI thread, so a
+    // wildcard share's video or archive would block it.
+    private List<Uri> imagesOnly(List<Uri> uris, boolean resolveTypes) {
+        if (!resolveTypes) return uris;
+        ArrayList<Uri> images = new ArrayList<>();
+        for (Uri uri : uris) {
+            String mime = getContentResolver().getType(uri);
+            if (mime != null && mime.startsWith("image/")) {
+                images.add(uri);
+            } else {
+                Log.w(TAG, "share intake: dropping non-image stream (" + mime + ")");
+            }
+        }
+        return images;
     }
 
     // Copies each shared stream into the share-intake cache dir and returns

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -28,15 +28,20 @@ public class StatusQtActivity extends QtActivity {
     private static StatusQtActivity sInstance = null;
 
     private static final AtomicBoolean userLoggedIn = new AtomicBoolean(false);
-    // Java mirror of the Nim pending intake slot (single, last-wins): holds the
-    // intake URL until mainWindowReady, since on a cold start the native side
-    // isn't up yet to receive it. No routing here — that lives at the Nim
-    // external-intake seam.
+    // Java mirror of the Nim pending intake slot (single, last-wins across
+    // kinds): holds the intake URL or shared text until mainWindowReady, since
+    // on a cold start the native side isn't up yet to receive it. Setting one
+    // clears the other. No routing here — that lives at the Nim external-intake
+    // seam.
     private static String pendingIntakeUrl = null;
+    private static String pendingIntakeShareText = null;
 
-    // JNI hook: implemented in native code to forward external intake URLs
-    // (deep links and arbitrary web links) to Qt
+    // JNI hooks: implemented in native code (StatusQ urlschemeevent.cpp) to
+    // forward external intake to Qt — URLs (deep links and arbitrary web
+    // links) and shared text (share target; a shared link arrives as text and
+    // must launch the share flow, not URL routing).
     private static native void passDeepLinkToQt(String deepLink);
+    private static native void passShareTextToQt(String text);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -61,6 +66,7 @@ public class StatusQtActivity extends QtActivity {
         DensityListener.start(this);
 
         handleUrlIntake(getIntent());
+        handleShareIntake(getIntent());
     }
 
     @Override
@@ -84,6 +90,7 @@ public class StatusQtActivity extends QtActivity {
         super.onNewIntent(intent);
         setIntent(intent);
         handleUrlIntake(intent);
+        handleShareIntake(intent);
     }
 
     @Override
@@ -128,6 +135,10 @@ public class StatusQtActivity extends QtActivity {
             passDeepLinkToQt(pendingIntakeUrl);
             pendingIntakeUrl = null;
         }
+        if (pendingIntakeShareText != null) {
+            passShareTextToQt(pendingIntakeShareText);
+            pendingIntakeShareText = null;
+        }
     }
 
     // Thin, decision-free platform layer: extract the URL payload from the
@@ -139,9 +150,40 @@ public class StatusQtActivity extends QtActivity {
         if (Intent.ACTION_VIEW.equals(action) && data != null) {
             if (!userLoggedIn.get()) {
                 pendingIntakeUrl = data.toString();
+                pendingIntakeShareText = null;
                 return;
             }
             passDeepLinkToQt(data.toString());
+        }
+    }
+
+    // Thin, decision-free platform layer: extract the shared text from the
+    // SEND intent and forward it to the external-intake seam.
+    private void handleShareIntake(Intent intent) {
+        if (intent == null) return;
+        if (!Intent.ACTION_SEND.equals(intent.getAction())) return;
+        String type = intent.getType();
+        if (type == null || !type.startsWith("text/")) return;
+        String text = intent.getStringExtra(Intent.EXTRA_TEXT);
+        if (text == null || text.isEmpty()) {
+            text = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+        }
+        if (text == null || text.isEmpty()) return;
+        if (!userLoggedIn.get()) {
+            pendingIntakeShareText = text;
+            pendingIntakeUrl = null;
+            return;
+        }
+        passShareTextToQt(text);
+    }
+
+    // Backgrounds the whole task, revealing the app the user came from — used
+    // when the share flow is cancelled ("cancel returns to the source app").
+    // Called from Qt via JNI.
+    public static void moveAppTaskToBack() {
+        final StatusQtActivity activity = sInstance;
+        if (activity != null) {
+            activity.runOnUiThread(() -> activity.moveTaskToBack(true));
         }
     }
 

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -15,6 +15,13 @@ import android.util.Log;
 import im.status.mobileui.PushNotificationHelper;
 import android.content.ActivityNotFoundException;
 import android.widget.Toast;
+import android.webkit.MimeTypeMap;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 public class StatusQtActivity extends QtActivity {
     private static final String TAG = "StatusQtActivity";
@@ -28,20 +35,29 @@ public class StatusQtActivity extends QtActivity {
     private static StatusQtActivity sInstance = null;
 
     private static final AtomicBoolean userLoggedIn = new AtomicBoolean(false);
+    // App-private cache subdirectory holding copies of shared image streams.
+    // Copies are made immediately at receipt (OS read grants on content URIs
+    // expire once the source activity result is consumed); the Nim side owns
+    // deletion after send/cancel and only ever deletes inside a directory of
+    // this name (share_intake_cache.nim keeps the same constant).
+    private static final String SHARE_INTAKE_CACHE_DIR = "share-intake";
+
     // Java mirror of the Nim pending intake slot (single, last-wins across
-    // kinds): holds the intake URL or shared text until mainWindowReady, since
-    // on a cold start the native side isn't up yet to receive it. Setting one
-    // clears the other. No routing here — that lives at the Nim external-intake
-    // seam.
+    // kinds): holds the intake URL or shared payload until mainWindowReady,
+    // since on a cold start the native side isn't up yet to receive it.
+    // Setting one clears the other; a replaced share's cached image copies are
+    // deleted. No routing here — that lives at the Nim external-intake seam.
     private static String pendingIntakeUrl = null;
     private static String pendingIntakeShareText = null;
+    private static String[] pendingIntakeShareImagePaths = null;
 
     // JNI hooks: implemented in native code (StatusQ urlschemeevent.cpp) to
     // forward external intake to Qt — URLs (deep links and arbitrary web
-    // links) and shared text (share target; a shared link arrives as text and
-    // must launch the share flow, not URL routing).
+    // links) and shared content (share target; a shared link arrives as text
+    // and must launch the share flow, not URL routing; imagePaths are the
+    // app-private cached copies, never OS-managed URIs).
     private static native void passDeepLinkToQt(String deepLink);
-    private static native void passShareTextToQt(String text);
+    private static native void passShareToQt(String text, String[] imagePaths);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -64,6 +80,13 @@ public class StatusQtActivity extends QtActivity {
         ShakeDetector.start(this);
         // Set up density change detection
         DensityListener.start(this);
+
+        // A fresh launch can't have an in-flight share flow: drop cached
+        // copies a previous run left behind (killed before send/cancel
+        // cleanup), before this launch's intent adds new ones.
+        if (savedInstanceState == null) {
+            sweepShareIntakeCache();
+        }
 
         handleUrlIntake(getIntent());
         handleShareIntake(getIntent());
@@ -135,9 +158,12 @@ public class StatusQtActivity extends QtActivity {
             passDeepLinkToQt(pendingIntakeUrl);
             pendingIntakeUrl = null;
         }
-        if (pendingIntakeShareText != null) {
-            passShareTextToQt(pendingIntakeShareText);
+        if (pendingIntakeShareText != null || pendingIntakeShareImagePaths != null) {
+            passShareToQt(pendingIntakeShareText != null ? pendingIntakeShareText : "",
+                          pendingIntakeShareImagePaths != null ? pendingIntakeShareImagePaths
+                                                               : new String[0]);
             pendingIntakeShareText = null;
+            pendingIntakeShareImagePaths = null;
         }
     }
 
@@ -150,31 +176,125 @@ public class StatusQtActivity extends QtActivity {
         if (Intent.ACTION_VIEW.equals(action) && data != null) {
             if (!userLoggedIn.get()) {
                 pendingIntakeUrl = data.toString();
-                pendingIntakeShareText = null;
+                clearPendingShare();
                 return;
             }
             passDeepLinkToQt(data.toString());
         }
     }
 
-    // Thin, decision-free platform layer: extract the shared text from the
-    // SEND intent and forward it to the external-intake seam.
+    // Thin, decision-free platform layer: extract the shared payload from the
+    // SEND/SEND_MULTIPLE intent — copying image streams to app-private cache
+    // immediately, before any read grant can expire — and forward it to the
+    // external-intake seam.
     private void handleShareIntake(Intent intent) {
         if (intent == null) return;
-        if (!Intent.ACTION_SEND.equals(intent.getAction())) return;
+        String action = intent.getAction();
+        boolean isSend = Intent.ACTION_SEND.equals(action);
+        boolean isSendMultiple = Intent.ACTION_SEND_MULTIPLE.equals(action);
+        if (!isSend && !isSendMultiple) return;
         String type = intent.getType();
-        if (type == null || !type.startsWith("text/")) return;
+        if (type == null) return;
+
         String text = intent.getStringExtra(Intent.EXTRA_TEXT);
         if (text == null || text.isEmpty()) {
             text = intent.getStringExtra(Intent.EXTRA_SUBJECT);
         }
-        if (text == null || text.isEmpty()) return;
+        if (text == null) text = "";
+
+        String[] imagePaths = new String[0];
+        if (type.startsWith("image/")) {
+            imagePaths = copySharedImagesToCache(extractStreamUris(intent, isSendMultiple));
+        } else if (!isSend || !type.startsWith("text/")) {
+            return;
+        }
+        if (text.isEmpty() && imagePaths.length == 0) return;
+
         if (!userLoggedIn.get()) {
+            clearPendingShare();
             pendingIntakeShareText = text;
+            pendingIntakeShareImagePaths = imagePaths;
             pendingIntakeUrl = null;
             return;
         }
-        passShareTextToQt(text);
+        passShareToQt(text, imagePaths);
+    }
+
+    // Last-wins: a replaced pending share must not leak its cached copies.
+    private static void clearPendingShare() {
+        if (pendingIntakeShareImagePaths != null) {
+            for (String path : pendingIntakeShareImagePaths) {
+                new File(path).delete();
+            }
+        }
+        pendingIntakeShareImagePaths = null;
+        pendingIntakeShareText = null;
+    }
+
+    private static List<Uri> extractStreamUris(Intent intent, boolean multiple) {
+        ArrayList<Uri> uris = new ArrayList<>();
+        if (multiple) {
+            ArrayList<Uri> streams = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+            if (streams != null) {
+                for (Uri stream : streams) {
+                    if (stream != null) uris.add(stream);
+                }
+            }
+        } else {
+            Uri stream = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+            if (stream != null) uris.add(stream);
+        }
+        return uris;
+    }
+
+    // Copies each shared stream into the share-intake cache dir and returns
+    // the copies' absolute paths. Streams that fail to copy are skipped (the
+    // rest of the share still goes through).
+    private String[] copySharedImagesToCache(List<Uri> uris) {
+        ArrayList<String> paths = new ArrayList<>();
+        File dir = new File(getCacheDir(), SHARE_INTAKE_CACHE_DIR);
+        if (!dir.exists() && !dir.mkdirs()) {
+            Log.w(TAG, "share intake: cannot create cache dir " + dir);
+            return new String[0];
+        }
+        int index = 0;
+        for (Uri uri : uris) {
+            File out = new File(dir,
+                    "share-" + System.currentTimeMillis() + "-" + (index++) + extensionForUri(uri));
+            try (InputStream in = getContentResolver().openInputStream(uri);
+                 OutputStream os = new FileOutputStream(out)) {
+                if (in == null) {
+                    out.delete();
+                    continue;
+                }
+                byte[] buffer = new byte[64 * 1024];
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    os.write(buffer, 0, read);
+                }
+                paths.add(out.getAbsolutePath());
+            } catch (Exception e) {
+                Log.w(TAG, "share intake: failed to copy shared image " + uri, e);
+                out.delete();
+            }
+        }
+        return paths.toArray(new String[0]);
+    }
+
+    private String extensionForUri(Uri uri) {
+        String mime = getContentResolver().getType(uri);
+        String ext = mime != null
+                ? MimeTypeMap.getSingleton().getExtensionFromMimeType(mime)
+                : null;
+        return ext != null ? "." + ext : "";
+    }
+
+    private void sweepShareIntakeCache() {
+        File[] files = new File(getCacheDir(), SHARE_INTAKE_CACHE_DIR).listFiles();
+        if (files == null) return;
+        for (File file : files) {
+            file.delete();
+        }
     }
 
     // Backgrounds the whole task, revealing the app the user came from — used

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -158,10 +158,9 @@ public class StatusQtActivity extends QtActivity {
             passDeepLinkToQt(pendingIntakeUrl);
             pendingIntakeUrl = null;
         }
-        if (pendingIntakeShareText != null || pendingIntakeShareImagePaths != null) {
-            passShareToQt(pendingIntakeShareText != null ? pendingIntakeShareText : "",
-                          pendingIntakeShareImagePaths != null ? pendingIntakeShareImagePaths
-                                                               : new String[0]);
+        // Text and image paths are always set (non-null) and cleared together.
+        if (pendingIntakeShareText != null) {
+            passShareToQt(pendingIntakeShareText, pendingIntakeShareImagePaths);
             pendingIntakeShareText = null;
             pendingIntakeShareImagePaths = null;
         }
@@ -195,6 +194,10 @@ public class StatusQtActivity extends QtActivity {
         if (!isSend && !isSendMultiple) return;
         String type = intent.getType();
         if (type == null) return;
+        // Mirrors the manifest: image shares (single or multiple) and
+        // single text shares; anything else is dropped.
+        boolean isImageShare = type.startsWith("image/");
+        if (!isImageShare && !(isSend && type.startsWith("text/"))) return;
 
         String text = intent.getStringExtra(Intent.EXTRA_TEXT);
         if (text == null || text.isEmpty()) {
@@ -202,12 +205,9 @@ public class StatusQtActivity extends QtActivity {
         }
         if (text == null) text = "";
 
-        String[] imagePaths = new String[0];
-        if (type.startsWith("image/")) {
-            imagePaths = copySharedImagesToCache(extractStreamUris(intent, isSendMultiple));
-        } else if (!isSend || !type.startsWith("text/")) {
-            return;
-        }
+        String[] imagePaths = isImageShare
+                ? copySharedImagesToCache(extractStreamUris(intent, isSendMultiple))
+                : new String[0];
         if (text.isEmpty() && imagePaths.length == 0) return;
 
         if (!userLoggedIn.get()) {

--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -16,18 +16,6 @@ logScope:
 const StatusInternalLink* = "status-app://"
 const StatusExternalLink* = "https://status.app/"
 
-proc parseImagePaths(imagePathsJson: string): seq[string] =
-  ## Tolerant decode of a JSON array of image paths; a malformed payload is
-  ## logged and treated as no images — it must never take the app down.
-  if imagePathsJson.len == 0:
-    return @[]
-  try:
-    for pathNode in parseJson(imagePathsJson).getElems():
-      result.add(pathNode.getStr())
-  except CatchableError:
-    warn "share intake image paths payload is not valid JSON", imagePathsJson
-    return @[]
-
 QtObject:
   type UrlsManager* = ref object of QObject
     events: EventEmitter
@@ -107,7 +95,7 @@ QtObject:
     ## paths are app-private cached copies made by the platform layer at
     ## receipt.
     self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeShare,
-      text: text, imagePaths: parseImagePaths(imagePathsJson)))
+      text: text, imagePaths: parseImagePathsJson(imagePathsJson)))
 
   proc newUrlsManager*(events: EventEmitter, urlSchemeEvent: UrlSchemeEvent,
       singleInstance: SingleInstance, protocolUriOnStart: string,

--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -4,6 +4,7 @@ import app/global/single_instance
 import ../eventemitter
 import ../intake/external_intake
 import ../intake/pending_intake_slot
+import ../intake/share_intake_cache
 
 import ../../global/app_signals
 
@@ -14,6 +15,18 @@ logScope:
 
 const StatusInternalLink* = "status-app://"
 const StatusExternalLink* = "https://status.app/"
+
+proc parseImagePaths(imagePathsJson: string): seq[string] =
+  ## Tolerant decode of a JSON array of image paths; a malformed payload is
+  ## logged and treated as no images — it must never take the app down.
+  if imagePathsJson.len == 0:
+    return @[]
+  try:
+    for pathNode in parseJson(imagePathsJson).getElems():
+      result.add(pathNode.getStr())
+  except CatchableError:
+    warn "share intake image paths payload is not valid JSON", imagePathsJson
+    return @[]
 
 QtObject:
   type UrlsManager* = ref object of QObject
@@ -28,8 +41,10 @@ QtObject:
       self, SLOT("onUrlActivated(QString)"), ConnectionType.QueuedConnection)
     discard QObject.connect(singleInstance, SIGNAL("eventReceived(QString)"),
       self, SLOT("onUrlActivated(QString)"), ConnectionType.QueuedConnection)
-    discard QObject.connect(urlSchemeEvent, SIGNAL("shareTextActivated(QString)"),
-      self, SLOT("onShareTextActivated(QString)"), ConnectionType.QueuedConnection)
+    discard QObject.connect(urlSchemeEvent, SIGNAL("shareActivated(QString,QString)"),
+      self, SLOT("onShareActivated(QString,QString)"), ConnectionType.QueuedConnection)
+    discard QObject.connect(urlSchemeEvent, SIGNAL("appForegrounded()"),
+      self, SLOT("onAppForegrounded()"), ConnectionType.QueuedConnection)
 
   proc delete*(self: UrlsManager) =
     self.QObject.delete
@@ -37,9 +52,10 @@ QtObject:
   proc consumePendingIntake(self: UrlsManager) =
     ## Delivers (reads + clears) the App Group pending intake slot written by
     ## the iOS share extension and feeds it into the external intake seam.
-    ## Payload contract (ShareViewController.m): {"type": "share", "text": ...}.
-    ## Malformed payloads are logged and dropped — a broken slot file must
-    ## never take the app down.
+    ## Payload contract (ShareViewController.m):
+    ## {"type": "share", "text": ..., "imagePaths": [...]} (imagePaths
+    ## optional). Malformed payloads are logged and dropped — a broken slot
+    ## file must never take the app down.
     if self.intakeSlot.isNil:
       return
     let payload = self.intakeSlot.take()
@@ -48,8 +64,11 @@ QtObject:
     try:
       let parsed = parseJson(payload)
       if parsed{"type"}.getStr() == "share":
+        var imagePaths: seq[string] = @[]
+        for pathNode in parsed{"imagePaths"}.getElems():
+          imagePaths.add(pathNode.getStr())
         self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeShare,
-          text: parsed{"text"}.getStr()))
+          text: parsed{"text"}.getStr(), imagePaths: imagePaths))
       else:
         warn "pending intake slot payload has an unknown type", payload
     except CatchableError:
@@ -74,11 +93,21 @@ QtObject:
       .multiReplace(("\n", ""))
     self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeUrl, url: url))
 
-  proc onShareTextActivated*(self: UrlsManager, text: string) {.slot.} =
-    ## Share-target hand-off (Android SEND intent): shared text/links launch
-    ## the share flow. The payload is kept verbatim — unlike URLs it may
-    ## legitimately contain whitespace and newlines.
-    self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeShare, text: text))
+  proc onAppForegrounded*(self: UrlsManager) {.slot.} =
+    ## Wake-less fallback (iOS): the app came to the foreground; if the share
+    ## extension left a payload in the slot because its unsupported openURL
+    ## wake failed or was dropped, deliver it now instead of waiting for the
+    ## next full app start. No-op when the slot is inactive or empty.
+    self.consumePendingIntake()
+
+  proc onShareActivated*(self: UrlsManager, text: string, imagePathsJson: string) {.slot.} =
+    ## Share-target hand-off (Android SEND/SEND_MULTIPLE intents): shared
+    ## text/links and images launch the share flow. The text is kept verbatim —
+    ## unlike URLs it may legitimately contain whitespace and newlines; image
+    ## paths are app-private cached copies made by the platform layer at
+    ## receipt.
+    self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeShare,
+      text: text, imagePaths: parseImagePaths(imagePathsJson)))
 
   proc newUrlsManager*(events: EventEmitter, urlSchemeEvent: UrlSchemeEvent,
       singleInstance: SingleInstance, protocolUriOnStart: string,
@@ -96,9 +125,13 @@ QtObject:
     result.intake.onBrowserTabUrl = proc(url: string) =
       self.events.emit(SIGNAL_EXTERNAL_URL_INTAKE_BROWSER_TAB,
         ExternalUrlIntakeArgs(url: url))
-    result.intake.onShareText = proc(text: string) =
+    result.intake.onShare = proc(text: string, imagePaths: seq[string]) =
       self.events.emit(SIGNAL_EXTERNAL_SHARE_INTAKE,
-        ExternalShareIntakeArgs(text: text))
+        ExternalShareIntakeArgs(text: text, imagePaths: imagePaths))
+    result.intake.onShareImagesDiscarded = proc(imagePaths: seq[string]) =
+      # A pending share was replaced last-wins before delivery: its cached
+      # image copies are unreferenced now and must not accumulate.
+      releaseCachedShareFiles(imagePaths)
 
     if protocolUriOnStart != "":
       # Launched via URL: park it in the pending intake slot until appReady.

--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -1,10 +1,13 @@
-import nimqml, strutils, chronicles
+import nimqml, strutils, json, chronicles
 import ./url_scheme_event
 import app/global/single_instance
 import ../eventemitter
 import ../intake/external_intake
+import ../intake/pending_intake_slot
 
 import ../../global/app_signals
+
+export ShareIntakeWakeUrl
 
 logScope:
   topics = "urls-manager"
@@ -16,6 +19,7 @@ QtObject:
   type UrlsManager* = ref object of QObject
     events: EventEmitter
     intake: ExternalIntake
+    intakeSlot: PendingIntakeSlot
 
   proc setup(self: UrlsManager, urlSchemeEvent: UrlSchemeEvent,
       singleInstance: SingleInstance) =
@@ -24,9 +28,32 @@ QtObject:
       self, SLOT("onUrlActivated(QString)"), ConnectionType.QueuedConnection)
     discard QObject.connect(singleInstance, SIGNAL("eventReceived(QString)"),
       self, SLOT("onUrlActivated(QString)"), ConnectionType.QueuedConnection)
+    discard QObject.connect(urlSchemeEvent, SIGNAL("shareTextActivated(QString)"),
+      self, SLOT("onShareTextActivated(QString)"), ConnectionType.QueuedConnection)
 
   proc delete*(self: UrlsManager) =
     self.QObject.delete
+
+  proc consumePendingIntake(self: UrlsManager) =
+    ## Delivers (reads + clears) the App Group pending intake slot written by
+    ## the iOS share extension and feeds it into the external intake seam.
+    ## Payload contract (ShareViewController.m): {"type": "share", "text": ...}.
+    ## Malformed payloads are logged and dropped — a broken slot file must
+    ## never take the app down.
+    if self.intakeSlot.isNil:
+      return
+    let payload = self.intakeSlot.take()
+    if payload.len == 0:
+      return
+    try:
+      let parsed = parseJson(payload)
+      if parsed{"type"}.getStr() == "share":
+        self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeShare,
+          text: parsed{"text"}.getStr()))
+      else:
+        warn "pending intake slot payload has an unknown type", payload
+    except CatchableError:
+      warn "pending intake slot payload is not valid JSON", payload
 
   proc convertInternalLinkToExternal*(self: UrlsManager, statusDeepLink: string): string =
     let idx = find(statusDeepLink, StatusInternalLink)
@@ -36,17 +63,31 @@ QtObject:
       result = StatusExternalLink & result
 
   proc onUrlActivated*(self: UrlsManager, urlRaw: string) {.slot.} =
+    if urlRaw.strip().startsWith(ShareIntakeWakeUrl):
+      # Wake ping from the share extension — not a routable deep link; the
+      # actual payload travels through the App Group pending intake slot.
+      self.consumePendingIntake()
+      return
+
     let url = urlRaw.multiReplace((" ", ""))
       .multiReplace(("\r\n", ""))
       .multiReplace(("\n", ""))
     self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeUrl, url: url))
 
+  proc onShareTextActivated*(self: UrlsManager, text: string) {.slot.} =
+    ## Share-target hand-off (Android SEND intent): shared text/links launch
+    ## the share flow. The payload is kept verbatim — unlike URLs it may
+    ## legitimately contain whitespace and newlines.
+    self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeShare, text: text))
+
   proc newUrlsManager*(events: EventEmitter, urlSchemeEvent: UrlSchemeEvent,
-      singleInstance: SingleInstance, protocolUriOnStart: string): UrlsManager =
+      singleInstance: SingleInstance, protocolUriOnStart: string,
+      intakeSlot: PendingIntakeSlot = nil): UrlsManager =
     new(result)
     result.setup(urlSchemeEvent, singleInstance)
     result.events = events
     result.intake = newExternalIntake()
+    result.intakeSlot = intakeSlot
 
     let self = result
     result.intake.onDeepLinkUrl = proc(url: string) =
@@ -55,6 +96,9 @@ QtObject:
     result.intake.onBrowserTabUrl = proc(url: string) =
       self.events.emit(SIGNAL_EXTERNAL_URL_INTAKE_BROWSER_TAB,
         ExternalUrlIntakeArgs(url: url))
+    result.intake.onShareText = proc(text: string) =
+      self.events.emit(SIGNAL_EXTERNAL_SHARE_INTAKE,
+        ExternalShareIntakeArgs(text: text))
 
     if protocolUriOnStart != "":
       # Launched via URL: park it in the pending intake slot until appReady.
@@ -62,3 +106,7 @@ QtObject:
 
   proc appReady*(self: UrlsManager) =
     self.intake.setReady()
+    # Degraded fallback: if the extension's unsupported openURL wake never
+    # arrived (killed, or the OS dropped it), the payload is still sitting in
+    # the slot — deliver it on this (manual) open. No-op when the slot is empty.
+    self.consumePendingIntake()

--- a/src/app/core/intake/external_intake.nim
+++ b/src/app/core/intake/external_intake.nim
@@ -2,8 +2,7 @@
 ## hand-off, macOS QFileOpenEvent, iOS QDesktopServices handler, desktop
 ## single-instance forwarding) hands the app an intake event. Covers the `url`
 ## kind (browser candidacy slice) and the `share` kind (share target slice:
-## text and links shared from another app launch the share flow); image share
-## payloads extend the `share` kind later.
+## text, links and images shared from another app launch the share flow).
 ##
 ## Routing lives at this seam, not in the platform layer:
 ## - `status-app:` links and `status.app` web links keep the existing
@@ -29,6 +28,8 @@ type
       url*: string
     of ExternalIntakeShare:
       text*: string ## shared plain text; shared links arrive as text too
+      imagePaths*: seq[string] ## app-private cached copies of shared images
+                               ## (copied at receipt; never OS-managed URIs)
 
   UrlIntakeRoute* = enum
     UrlIntakeDeepLink   ## existing Status deep-link routing
@@ -39,7 +40,11 @@ type
     pendingSlot: Option[ExternalIntakeEvent]
     onDeepLinkUrl*: proc(url: string)
     onBrowserTabUrl*: proc(url: string)
-    onShareText*: proc(text: string)
+    onShare*: proc(text: string, imagePaths: seq[string])
+    onShareImagesDiscarded*: proc(imagePaths: seq[string])
+      ## A buffered share carrying images was dropped without dispatch
+      ## (last-wins overwrite of the pending slot); the cached copies are now
+      ## unreferenced and must be released.
 
 const StatusExternalLinkHost = "status.app"
 
@@ -84,17 +89,30 @@ proc dispatch(self: ExternalIntake, event: ExternalIntakeEvent) =
       if not self.onBrowserTabUrl.isNil:
         self.onBrowserTabUrl(event.url)
   of ExternalIntakeShare:
-    if not self.onShareText.isNil:
-      self.onShareText(event.text)
+    if not self.onShare.isNil:
+      self.onShare(event.text, event.imagePaths)
+
+proc discardPendingShareImages(self: ExternalIntake) =
+  ## The pending slot is about to be overwritten (last-wins): if it holds a
+  ## share carrying images, report them as discarded so the cached copies can
+  ## be released.
+  if self.pendingSlot.isNone or self.onShareImagesDiscarded.isNil:
+    return
+  let pending = self.pendingSlot.get()
+  if pending.kind == ExternalIntakeShare and pending.imagePaths.len > 0:
+    self.onShareImagesDiscarded(pending.imagePaths)
 
 proc submit*(self: ExternalIntake, event: ExternalIntakeEvent) =
   ## Platform-layer entry point. Until ready, events land in the pending
-  ## intake slot — single, last-wins across kinds. Blank share payloads are
-  ## dropped here (the platform layer is decision-free), so they can neither
-  ## launch an empty share flow nor clobber a pending intake.
-  if event.kind == ExternalIntakeShare and event.text.isEmptyOrWhitespace:
+  ## intake slot — single, last-wins across kinds. Empty share payloads
+  ## (blank text and no images) are dropped here (the platform layer is
+  ## decision-free), so they can neither launch an empty share flow nor
+  ## clobber a pending intake.
+  if event.kind == ExternalIntakeShare and event.text.isEmptyOrWhitespace and
+      event.imagePaths.len == 0:
     return
   if not self.ready:
+    self.discardPendingShareImages()
     self.pendingSlot = some(event)
     return
   self.dispatch(event)

--- a/src/app/core/intake/external_intake.nim
+++ b/src/app/core/intake/external_intake.nim
@@ -92,7 +92,7 @@ proc submit*(self: ExternalIntake, event: ExternalIntakeEvent) =
   ## intake slot — single, last-wins across kinds. Blank share payloads are
   ## dropped here (the platform layer is decision-free), so they can neither
   ## launch an empty share flow nor clobber a pending intake.
-  if event.kind == ExternalIntakeShare and event.text.strip().len == 0:
+  if event.kind == ExternalIntakeShare and event.text.isEmptyOrWhitespace:
     return
   if not self.ready:
     self.pendingSlot = some(event)

--- a/src/app/core/intake/external_intake.nim
+++ b/src/app/core/intake/external_intake.nim
@@ -1,7 +1,9 @@
 ## The single typed entry point where the platform layer (Android JNI deep-link
 ## hand-off, macOS QFileOpenEvent, iOS QDesktopServices handler, desktop
-## single-instance forwarding) hands the app an intake event. This slice covers
-## the `url` kind; share payloads extend `ExternalIntakeKind` later.
+## single-instance forwarding) hands the app an intake event. Covers the `url`
+## kind (browser candidacy slice) and the `share` kind (share target slice:
+## text and links shared from another app launch the share flow); image share
+## payloads extend the `share` kind later.
 ##
 ## Routing lives at this seam, not in the platform layer:
 ## - `status-app:` links and `status.app` web links keep the existing
@@ -19,11 +21,14 @@ import std/[options, strutils, uri]
 type
   ExternalIntakeKind* = enum
     ExternalIntakeUrl
+    ExternalIntakeShare
 
   ExternalIntakeEvent* = object
     case kind*: ExternalIntakeKind
     of ExternalIntakeUrl:
       url*: string
+    of ExternalIntakeShare:
+      text*: string ## shared plain text; shared links arrive as text too
 
   UrlIntakeRoute* = enum
     UrlIntakeDeepLink   ## existing Status deep-link routing
@@ -34,6 +39,7 @@ type
     pendingSlot: Option[ExternalIntakeEvent]
     onDeepLinkUrl*: proc(url: string)
     onBrowserTabUrl*: proc(url: string)
+    onShareText*: proc(text: string)
 
 const StatusExternalLinkHost = "status.app"
 
@@ -77,10 +83,17 @@ proc dispatch(self: ExternalIntake, event: ExternalIntakeEvent) =
     of UrlIntakeBrowserTab:
       if not self.onBrowserTabUrl.isNil:
         self.onBrowserTabUrl(event.url)
+  of ExternalIntakeShare:
+    if not self.onShareText.isNil:
+      self.onShareText(event.text)
 
 proc submit*(self: ExternalIntake, event: ExternalIntakeEvent) =
   ## Platform-layer entry point. Until ready, events land in the pending
-  ## intake slot — single, last-wins.
+  ## intake slot — single, last-wins across kinds. Blank share payloads are
+  ## dropped here (the platform layer is decision-free), so they can neither
+  ## launch an empty share flow nor clobber a pending intake.
+  if event.kind == ExternalIntakeShare and event.text.strip().len == 0:
+    return
   if not self.ready:
     self.pendingSlot = some(event)
     return

--- a/src/app/core/intake/pending_intake_slot.nim
+++ b/src/app/core/intake/pending_intake_slot.nim
@@ -1,0 +1,63 @@
+## Pending intake slot — the App Group hand-off buffer between the iOS share
+## extension and the host app (see mobile/ios/shareExtension/).
+##
+## Single file, last-wins: the extension overwrites `share.json` in the slot
+## directory; the host app takes (reads + clears) it when it comes to the
+## foreground. The extension wakes the host via the unsupported responder-chain
+## openURL workaround (ShareIntakeWakeUrl); if that wake fails, the payload
+## simply stays in the file and is delivered on the next manual app open —
+## degraded UX, no data loss.
+##
+## Kept free of Qt/chronicles imports so the semantics are unit-testable on any
+## platform (test/nim/pending_intake_slot_test.nim). The iOS-only slot directory
+## comes from StatusQ (statusq_shareintake_pending_dir); on platforms without an
+## App Group container the dir is empty and the slot is inactive.
+
+import std/os
+
+const
+  PendingIntakeFileName* = "share.json"
+  ShareIntakeWakeUrl* = "status-app://share-intake"
+    ## Wake ping sent by the share extension via openURL. Carries no data — the
+    ## payload travels through the slot file. Must match kWakeUrl in
+    ## mobile/ios/shareExtension/ShareViewController.m.
+
+type PendingIntakeSlot* = ref object
+  slotDir: string
+
+proc newPendingIntakeSlot*(slotDir: string): PendingIntakeSlot =
+  ## An empty `slotDir` (no App Group container on this platform/build) yields
+  ## an inactive slot: writes are dropped, take() always returns "".
+  PendingIntakeSlot(slotDir: slotDir)
+
+proc isActive*(self: PendingIntakeSlot): bool =
+  self.slotDir.len > 0
+
+proc filePath*(self: PendingIntakeSlot): string =
+  if not self.isActive():
+    return ""
+  self.slotDir / PendingIntakeFileName
+
+proc write*(self: PendingIntakeSlot, payload: string) =
+  ## Overwrites any previous payload (last-wins). The iOS extension writes the
+  ## same file natively; this Nim writer exists for tests and future
+  ## non-extension intake producers. IO failures are swallowed — losing a slot
+  ## write must never take the app down.
+  if not self.isActive():
+    return
+  try:
+    createDir(self.slotDir)
+    writeFile(self.filePath(), payload)
+  except CatchableError:
+    discard
+
+proc take*(self: PendingIntakeSlot): string =
+  ## Reads and clears the pending payload; "" when there is none.
+  let path = self.filePath()
+  if not self.isActive() or not fileExists(path):
+    return ""
+  try:
+    result = readFile(path)
+    removeFile(path)
+  except CatchableError:
+    result = ""

--- a/src/app/core/intake/share_intake_cache.nim
+++ b/src/app/core/intake/share_intake_cache.nim
@@ -9,10 +9,27 @@
 ## Deletion is guarded to files inside a `share-intake` directory: the same
 ## image-send path also carries user-owned files (regular picker sends), which
 ## must never be touched.
+##
+## Also owns the wire format the paths travel in across the Qt signal/slot
+## boundary: a JSON array of absolute paths.
 
-import std/os
+import std/[json, os]
+import chronicles
 
 const ShareIntakeCacheDirName* = "share-intake"
+
+proc parseImagePathsJson*(imagePathsJson: string): seq[string] =
+  ## Tolerant decode of the image-paths wire format (a JSON array of absolute
+  ## paths); a malformed payload is logged and treated as no images — it must
+  ## never take the app down.
+  if imagePathsJson.len == 0:
+    return @[]
+  try:
+    for pathNode in parseJson(imagePathsJson).getElems():
+      result.add(pathNode.getStr())
+  except CatchableError:
+    warn "share intake image paths payload is not valid JSON", imagePathsJson
+    return @[]
 
 proc isShareIntakeCachedFile*(path: string): bool =
   ## True only for files directly inside a `share-intake` directory — the only

--- a/src/app/core/intake/share_intake_cache.nim
+++ b/src/app/core/intake/share_intake_cache.nim
@@ -1,0 +1,30 @@
+## Cache lifecycle for shared media (see CONTEXT.md -> "External intake").
+##
+## The platform layer copies shared image streams into an app-private cache
+## directory named `share-intake` immediately at receipt (OS read grants on
+## content URIs expire; the intake must hold copies, never OS-managed URIs).
+## Those copies are deleted after the share is sent or cancelled — and, for a
+## pending share replaced last-wins, when it is discarded.
+##
+## Deletion is guarded to files inside a `share-intake` directory: the same
+## image-send path also carries user-owned files (regular picker sends), which
+## must never be touched.
+
+import std/os
+
+const ShareIntakeCacheDirName* = "share-intake"
+
+proc isShareIntakeCachedFile*(path: string): bool =
+  ## True only for files directly inside a `share-intake` directory — the only
+  ## files the cache lifecycle owns.
+  extractFilename(parentDir(path)) == ShareIntakeCacheDirName
+
+proc releaseCachedShareFiles*(imagePaths: seq[string]) =
+  ## Best-effort deletion of share-intake cached copies; paths outside a
+  ## `share-intake` directory and already-missing files are ignored.
+  for path in imagePaths:
+    if isShareIntakeCachedFile(path):
+      try:
+        removeFile(path)
+      except CatchableError:
+        discard

--- a/src/app/core/main.nim
+++ b/src/app/core/main.nim
@@ -5,7 +5,8 @@ import
   eventemitter,
   ./tasks/threadpool,
   ./signals/signals_manager,
-  ./custom_urls/urls_manager
+  ./custom_urls/urls_manager,
+  ./intake/pending_intake_slot
 
 export eventemitter
 export threadpool, signals_manager
@@ -28,9 +29,10 @@ proc delete*(self: StatusFoundation) =
   self.threadpool.teardown()
 
 proc initUrlSchemeManager*(self: StatusFoundation, urlSchemeEvent: UrlSchemeEvent,
-    singleInstance: SingleInstance, protocolUriOnStart: string) =
+    singleInstance: SingleInstance, protocolUriOnStart: string,
+    intakeSlot: PendingIntakeSlot = nil) =
   self.urlsManager = newUrlsManager(self.events, urlSchemeEvent, singleInstance,
-    protocolUriOnStart)
+    protocolUriOnStart, intakeSlot)
 
 proc appReady*(self: StatusFoundation) =
   self.urlsManager.appReady()

--- a/src/app/global/app_signals.nim
+++ b/src/app/global/app_signals.nim
@@ -53,11 +53,13 @@ const SIGNAL_EXTERNAL_URL_INTAKE_BROWSER_TAB* = "externalUrlIntakeBrowserTab"
 type
   ExternalShareIntakeArgs* = ref object of Args
     text*: string
+    imagePaths*: seq[string]
 
 const SIGNAL_EXTERNAL_SHARE_INTAKE* = "externalShareIntake"
 ## Emitted for content shared to Status from another app (share target):
 ## it must launch the share flow (destination picker -> preview -> send).
-## Text and links both arrive as `text`.
+## Text and links both arrive as `text`; shared images arrive as `imagePaths`
+## (app-private cached copies made at receipt, never OS-managed URIs).
 
 const SIGNAL_MAIN_LOADED* = "signalMainLoaded"
 

--- a/src/app/global/app_signals.nim
+++ b/src/app/global/app_signals.nim
@@ -50,6 +50,15 @@ const SIGNAL_EXTERNAL_URL_INTAKE_BROWSER_TAB* = "externalUrlIntakeBrowserTab"
 ## (browser candidacy): it must open as a new tab in the in-app browser with
 ## the browser section foregrounded.
 
+type
+  ExternalShareIntakeArgs* = ref object of Args
+    text*: string
+
+const SIGNAL_EXTERNAL_SHARE_INTAKE* = "externalShareIntake"
+## Emitted for content shared to Status from another app (share target):
+## it must launch the share flow (destination picker -> preview -> send).
+## Text and links both arrive as `text`.
+
 const SIGNAL_MAIN_LOADED* = "signalMainLoaded"
 
 type

--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -95,13 +95,15 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):
     let args = MessageSendingSuccess(e)
-    self.delegate.updateLastMessage(args.chat.id, args.chat.communityId, args.chat.chatType, args.chat.lastMessage)
+    self.delegate.updateLastMessage(args.chat.id, args.chat.communityId, args.chat.chatType, args.chat.lastMessage,
+      args.chat.timestamp.int)
 
   self.events.on(SIGNAL_NEW_MESSAGE_RECEIVED) do(e: Args):
     let args = MessagesArgs(e)
     if args.messages.len == 0:
       return
-    self.delegate.updateLastMessage(args.chatId, args.sectionId, args.chatType, args.messages[0])
+    self.delegate.updateLastMessage(args.chatId, args.sectionId, args.chatType, args.messages[0],
+      args.lastMessageTimestamp)
 
 proc activeSectionId*(self: Controller): string =
   return self.activeSectionId

--- a/src/app/modules/main/app_search/io_interface.nim
+++ b/src/app/modules/main/app_search/io_interface.nim
@@ -64,5 +64,5 @@ method chatAdded*(self: AccessInterface, chat: ChatDto) {.base.} =
 method chatRemoved*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method updateLastMessage*(self: AccessInterface, chatId, communityId: string, chatType: ChatType, lastmessage: MessageDto) {.base.} =
+method updateLastMessage*(self: AccessInterface, chatId, communityId: string, chatType: ChatType, lastmessage: MessageDto, lastMessageTimestamp: int) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/app_search/models/chat_search_item.nim
+++ b/src/app/modules/main/app_search/models/chat_search_item.nim
@@ -10,8 +10,10 @@ type
     emoji: string
     chatType: int
     lastMessageText: string
+    lastMessageTimestamp: int
+    canPost: bool
 
-proc initItem*(chatId, name, color: string, colorId: int, icon, sectionId, sectionName, emoji: string, chatType: int, lastMessageText: string): ChatSearchItem =
+proc initItem*(chatId, name, color: string, colorId: int, icon, sectionId, sectionName, emoji: string, chatType: int, lastMessageText: string, lastMessageTimestamp: int, canPost: bool): ChatSearchItem =
   result = ChatSearchItem()
   result.chatId = chatId
   result.name = name
@@ -23,6 +25,8 @@ proc initItem*(chatId, name, color: string, colorId: int, icon, sectionId, secti
   result.emoji = emoji
   result.chatType = chatType
   result.lastMessageText = lastMessageText
+  result.lastMessageTimestamp = lastMessageTimestamp
+  result.canPost = canPost
 
 proc chatId*(self: ChatSearchItem): string =
   self.chatId
@@ -68,6 +72,18 @@ proc lastMessageText*(self: ChatSearchItem): string =
 
 proc `lastMessageText=`*(self: ChatSearchItem, value: string) =
   self.lastMessageText = value
+
+proc lastMessageTimestamp*(self: ChatSearchItem): int =
+  self.lastMessageTimestamp
+
+proc `lastMessageTimestamp=`*(self: ChatSearchItem, value: int) =
+  self.lastMessageTimestamp = value
+
+proc canPost*(self: ChatSearchItem): bool =
+  self.canPost
+
+proc `canPost=`*(self: ChatSearchItem, value: bool) =
+  self.canPost = value
 
 proc chatType*(self: ChatSearchItem): int =
   self.chatType

--- a/src/app/modules/main/app_search/models/chat_search_model.nim
+++ b/src/app/modules/main/app_search/models/chat_search_model.nim
@@ -15,6 +15,8 @@ type
     Emoji
     ChatType
     LastMessageText
+    LastMessageTimestamp
+    CanPost
 
 QtObject:
   type Model* = ref object of QAbstractListModel
@@ -83,6 +85,8 @@ QtObject:
       ModelRole.Emoji.int:"emoji",
       ModelRole.ChatType.int:"chatType",
       ModelRole.LastMessageText.int:"lastMessageText",
+      ModelRole.LastMessageTimestamp.int:"lastMessageTimestamp",
+      ModelRole.CanPost.int:"canPost",
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -113,6 +117,10 @@ QtObject:
         result = newQVariant(item.chatType)
       of ModelRole.LastMessageText:
         result = newQVariant(item.lastMessageText)
+      of ModelRole.LastMessageTimestamp:
+        result = newQVariant(item.lastMessageTimestamp)
+      of ModelRole.CanPost:
+        result = newQVariant(item.canPost)
 
   proc updateChatItem*(self:Model, chatId, name, color, icon, emoji: string) =
     updateItemRolesAndNotify self.getItemIndexById(chatId):
@@ -128,6 +136,14 @@ QtObject:
   proc updateLastMessageTextOnChatItem*(self:Model, chatId, lastMessageText: string) =
     updateItemRolesAndNotify self.getItemIndexById(chatId):
       updateRole(lastMessageText)
+
+  proc updateLastMessageTimestampOnChatItem*(self:Model, chatId: string, lastMessageTimestamp: int) =
+    updateItemRolesAndNotify self.getItemIndexById(chatId):
+      updateRole(lastMessageTimestamp)
+
+  proc updateCanPostOnChatItem*(self:Model, chatId: string, canPost: bool) =
+    updateItemRolesAndNotify self.getItemIndexById(chatId):
+      updateRole(canPost)
 
   proc updateSectionNameOnChats*(self:Model, sectionId, sectionName: string) =
     for item in self.items:

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -376,6 +376,8 @@ proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, pe
           self.controller.getCommunityById(chat.communityId).chats)
       else:
         self.controller.getMessagesParsedPlainText(chat.lastMessage, []),
+    lastMessageTimestamp = chat.timestamp.int,
+    canPost = chat.canPost,
   )
 
 method buildChatSearchModel*(self: Module) =
@@ -418,6 +420,7 @@ method updateChatItems*(self: Module, updatedChats: seq[ChatDto]) =
       # 1-1 chat properties are updated when a contact is updated, so we can skip it here
       continue
     self.view.chatSearchModel().updateChatItem(chat.id, chat.name, chat.color, chat.icon, chat.emoji)
+    self.view.chatSearchModel().updateCanPostOnChatItem(chat.id, chat.canPost)
 
 method contactUpdated*(self: Module, contactId: string) =
   let contactDetails = self.controller.getContactDetails(contactId)
@@ -439,7 +442,7 @@ method chatAdded*(self: Module, chat: ChatDto) =
 method chatRemoved*(self: Module, chatId: string) =
   self.view.chatSearchModel().removeItemById(chatId)
 
-method updateLastMessage*(self: Module, chatId, communityId: string, chatType: ChatType, lastMessage: MessageDto) =
+method updateLastMessage*(self: Module, chatId, communityId: string, chatType: ChatType, lastMessage: MessageDto, lastMessageTimestamp: int) =
   self.view.chatSearchModel().updateLastMessageTextOnChatItem(
     chatId,
     if chatType == ChatType.CommunityChat and communityId != "":
@@ -448,3 +451,5 @@ method updateLastMessage*(self: Module, chatId, communityId: string, chatType: C
     else:
       self.controller.getMessagesParsedPlainText(lastMessage, [])
   )
+  if lastMessageTimestamp > 0:
+    self.view.chatSearchModel().updateLastMessageTimestampOnChatItem(chatId, lastMessageTimestamp)

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -304,6 +304,10 @@ proc init*(self: Controller) =
     let args = ExternalUrlIntakeArgs(e)
     self.delegate.openUrlInNewBrowserTab(args.url)
 
+  self.events.on(SIGNAL_EXTERNAL_SHARE_INTAKE) do(e: Args):
+    let args = ExternalShareIntakeArgs(e)
+    self.delegate.launchShareFlow(args.text)
+
   self.events.on(SIGNAL_OS_NOTIFICATION_CLICKED) do(e: Args):
     var args = ClickedNotificationArgs(e)
     self.delegate.osNotificationClicked(args.details)

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -306,7 +306,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_EXTERNAL_SHARE_INTAKE) do(e: Args):
     let args = ExternalShareIntakeArgs(e)
-    self.delegate.launchShareFlow(args.text)
+    self.delegate.launchShareFlow(args.text, args.imagePaths)
 
   self.events.on(SIGNAL_OS_NOTIFICATION_CLICKED) do(e: Args):
     var args = ClickedNotificationArgs(e)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -354,6 +354,9 @@ method activateStatusDeepLink*(self: AccessInterface, statusDeepLink: string) {.
 method openUrlInNewBrowserTab*(self: AccessInterface, url: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method launchShareFlow*(self: AccessInterface, text: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method setCommunityIdToSpectate*(self: AccessInterface, commnityId: string, channelUuid: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -354,7 +354,10 @@ method activateStatusDeepLink*(self: AccessInterface, statusDeepLink: string) {.
 method openUrlInNewBrowserTab*(self: AccessInterface, url: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method launchShareFlow*(self: AccessInterface, text: string) {.base.} =
+method launchShareFlow*(self: AccessInterface, text: string, imagePaths: seq[string]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method releaseShareIntakeFiles*(self: AccessInterface, imagePathsJson: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setCommunityIdToSpectate*(self: AccessInterface, commnityId: string, channelUuid: string = "") {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2237,13 +2237,7 @@ method releaseShareIntakeFiles*[T](self: Module[T], imagePathsJson: string) =
   ## sending, so the cached copies of the shared images are released here.
   ## (The send path releases them in the image-send task, after the files
   ## have been consumed.)
-  try:
-    var imagePaths: seq[string] = @[]
-    for pathNode in parseJson(imagePathsJson).getElems():
-      imagePaths.add(pathNode.getStr())
-    releaseCachedShareFiles(imagePaths)
-  except CatchableError:
-    error "invalid share intake image paths payload", imagePathsJson
+  releaseCachedShareFiles(parseImagePathsJson(imagePathsJson))
 
 method onDeactivateChatLoader*[T](self: Module[T], sectionId: string, chatId: string) =
   if (sectionId.len > 0 and self.chatSectionModules.contains(sectionId)):

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -81,6 +81,7 @@ import app/core/notifications/details
 import app/core/eventemitter
 import app/core/custom_urls/urls_manager
 import app/core/intake/external_intake
+import app/core/intake/share_intake_cache
 
 export io_interface
 
@@ -151,6 +152,8 @@ type
     profileMigrationFlowInProgress: bool
     urlToOpenInNewBrowserTab: string
     shareTextToDeliver: string
+    shareImagePathsToDeliver: seq[string]
+    shareToDeliverPending: bool
 
 {.push warning[Deprecated]: off.}
 
@@ -158,7 +161,7 @@ type
 proc switchToContactOrDisplayUserProfile[T](self: Module[T], publicKey: string)
 method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string)
 method openUrlInNewBrowserTab*[T](self: Module[T], url: string)
-method launchShareFlow*[T](self: Module[T], text: string)
+method launchShareFlow*[T](self: Module[T], text: string, imagePaths: seq[string])
 proc checkIfWeHaveNotifications[T](self: Module[T])
 proc updateIconBadgeNumber[T](self: Module[T])
 proc createMemberItem[T](self: Module[T], memberId: string, requestId: string, state: MembershipRequestState, role: MemberRole, airdropAddress: string = ""): MemberItem
@@ -1053,10 +1056,13 @@ method onChatsLoaded*[T](
     self.urlToOpenInNewBrowserTab = ""
     self.openUrlInNewBrowserTab(url)
 
-  if self.shareTextToDeliver != "":
+  if self.shareToDeliverPending:
     let text = self.shareTextToDeliver
+    let imagePaths = self.shareImagePathsToDeliver
+    self.shareToDeliverPending = false
     self.shareTextToDeliver = ""
-    self.launchShareFlow(text)
+    self.shareImagePathsToDeliver = @[]
+    self.launchShareFlow(text, imagePaths)
 
 method onMediaServerStarted*[T](self: Module[T], port: int) =
   self.view.model().updateMediaServerPort(port)
@@ -2211,15 +2217,33 @@ method openUrlInNewBrowserTab*[T](self: Module[T], url: string) =
     return
   self.view.emitOpenUrlInNewBrowserTabSignal(url)
 
-method launchShareFlow*[T](self: Module[T], text: string) =
+method launchShareFlow*[T](self: Module[T], text: string, imagePaths: seq[string]) =
   ## Share route of the external intake seam: content shared to Status from
   ## another app launches the share flow (destination picker -> preview ->
   ## send). Buffered until the main view is loaded, mirroring the deep-link
-  ## and browser-tab routes above.
+  ## and browser-tab routes above; the buffer is last-wins, and a replaced
+  ## share's cached image copies are released so they don't accumulate.
   if not self.chatsLoaded:
+    if self.shareToDeliverPending:
+      releaseCachedShareFiles(self.shareImagePathsToDeliver)
+    self.shareToDeliverPending = true
     self.shareTextToDeliver = text
+    self.shareImagePathsToDeliver = imagePaths
     return
-  self.view.emitLaunchShareFlowSignal(text)
+  self.view.emitLaunchShareFlowSignal(text, $(%imagePaths))
+
+method releaseShareIntakeFiles*[T](self: Module[T], imagePathsJson: string) =
+  ## Cache lifecycle, cancel path: the share flow was dismissed without
+  ## sending, so the cached copies of the shared images are released here.
+  ## (The send path releases them in the image-send task, after the files
+  ## have been consumed.)
+  try:
+    var imagePaths: seq[string] = @[]
+    for pathNode in parseJson(imagePathsJson).getElems():
+      imagePaths.add(pathNode.getStr())
+    releaseCachedShareFiles(imagePaths)
+  except CatchableError:
+    error "invalid share intake image paths payload", imagePathsJson
 
 method onDeactivateChatLoader*[T](self: Module[T], sectionId: string, chatId: string) =
   if (sectionId.len > 0 and self.chatSectionModules.contains(sectionId)):

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -150,6 +150,7 @@ type
     pendingProfileMigrationCheck: bool
     profileMigrationFlowInProgress: bool
     urlToOpenInNewBrowserTab: string
+    shareTextToDeliver: string
 
 {.push warning[Deprecated]: off.}
 
@@ -157,6 +158,7 @@ type
 proc switchToContactOrDisplayUserProfile[T](self: Module[T], publicKey: string)
 method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string)
 method openUrlInNewBrowserTab*[T](self: Module[T], url: string)
+method launchShareFlow*[T](self: Module[T], text: string)
 proc checkIfWeHaveNotifications[T](self: Module[T])
 proc updateIconBadgeNumber[T](self: Module[T])
 proc createMemberItem[T](self: Module[T], memberId: string, requestId: string, state: MembershipRequestState, role: MemberRole, airdropAddress: string = ""): MemberItem
@@ -1050,6 +1052,11 @@ method onChatsLoaded*[T](
     let url = self.urlToOpenInNewBrowserTab
     self.urlToOpenInNewBrowserTab = ""
     self.openUrlInNewBrowserTab(url)
+
+  if self.shareTextToDeliver != "":
+    let text = self.shareTextToDeliver
+    self.shareTextToDeliver = ""
+    self.launchShareFlow(text)
 
 method onMediaServerStarted*[T](self: Module[T], port: int) =
   self.view.model().updateMediaServerPort(port)
@@ -2203,6 +2210,16 @@ method openUrlInNewBrowserTab*[T](self: Module[T], url: string) =
     self.urlToOpenInNewBrowserTab = url
     return
   self.view.emitOpenUrlInNewBrowserTabSignal(url)
+
+method launchShareFlow*[T](self: Module[T], text: string) =
+  ## Share route of the external intake seam: content shared to Status from
+  ## another app launches the share flow (destination picker -> preview ->
+  ## send). Buffered until the main view is loaded, mirroring the deep-link
+  ## and browser-tab routes above.
+  if not self.chatsLoaded:
+    self.shareTextToDeliver = text
+    return
+  self.view.emitLaunchShareFlowSignal(text)
 
 method onDeactivateChatLoader*[T](self: Module[T], sectionId: string, chatId: string) =
   if (sectionId.len > 0 and self.chatSectionModules.contains(sectionId)):

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -439,6 +439,10 @@ QtObject:
   proc emitOpenUrlInNewBrowserTabSignal*(self: View, url: string) =
     self.openUrlInNewBrowserTab(url)
 
+  proc launchShareFlow*(self: View, text: string) {.signal.}
+  proc emitLaunchShareFlowSignal*(self: View, text: string) =
+    self.launchShareFlow(text)
+
   proc navigateToMessageDetails*(self: View) {.signal.}
   proc emitNavigateToMessageDetailsSignal*(self: View) =
     self.navigateToMessageDetails()

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -439,9 +439,14 @@ QtObject:
   proc emitOpenUrlInNewBrowserTabSignal*(self: View, url: string) =
     self.openUrlInNewBrowserTab(url)
 
-  proc launchShareFlow*(self: View, text: string) {.signal.}
-  proc emitLaunchShareFlowSignal*(self: View, text: string) =
-    self.launchShareFlow(text)
+  proc launchShareFlow*(self: View, text: string, imagePathsJson: string) {.signal.}
+  proc emitLaunchShareFlowSignal*(self: View, text: string, imagePathsJson: string) =
+    self.launchShareFlow(text, imagePathsJson)
+
+  proc releaseShareIntakeFiles*(self: View, imagePathsJson: string) {.slot.} =
+    ## Share-flow cancel path: releases the cached copies of shared images
+    ## (JSON array of absolute paths, as delivered by launchShareFlow).
+    self.delegate.releaseShareIntakeFiles(imagePathsJson)
 
   proc navigateToMessageDetails*(self: View) {.signal.}
   proc emitNavigateToMessageDetailsSignal*(self: View) =

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -156,8 +156,10 @@ const asyncSendImagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
       "chatId": arg.chatId,
     })
   finally:
-    # Share-intake cache lifecycle, send path: the shared images have been
-    # consumed (or the send failed for good) — release the app-private cached
-    # copies. Guarded inside releaseCachedShareFiles to files in a
-    # `share-intake` directory, so regular picker sends are untouched.
-    releaseCachedShareFiles(imagePaths)
+    # Release the app-private cached copies now the shared images have been
+    # consumed (or the send failed for good). Mobile only: this list is
+    # whatever the user picked, and the guard inside only matches on the
+    # parent directory name — on desktop, where there is no share-intake
+    # cache at all, a match could only ever be a user-owned file.
+    when defined(android) or defined(ios):
+      releaseCachedShareFiles(imagePaths)

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -114,9 +114,11 @@ type
 
 const asyncSendImagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncSendImagesTaskArg](argEncoded)
+  var imagePaths: seq[string] = @[]
   try:
     var images = Json.decode(arg.imagePathsJson, seq[string])
-    var imagePaths: seq[string] = @[]
+    # imagePaths is declared above the try: the finally below releases the
+    # share-intake cached copies and needs it in scope.
     var temporaryImagePaths: seq[string] = @[]
     defer:
       for imagePath in temporaryImagePaths:
@@ -153,3 +155,9 @@ const asyncSendImagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
       "error": e.msg,
       "chatId": arg.chatId,
     })
+  finally:
+    # Share-intake cache lifecycle, send path: the shared images have been
+    # consumed (or the send failed for good) — release the app-private cached
+    # copies. Guarded inside releaseCachedShareFiles to files in a
+    # `share-intake` directory, so regular picker sends are untouched.
+    releaseCachedShareFiles(imagePaths)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -15,6 +15,7 @@ import backend/communities as status_communities
 import backend/group_chat as status_group_chat
 import app/global/[global_singleton, utils]
 import app/core/eventemitter
+import app/core/intake/share_intake_cache
 import app/core/signals/types
 
 import ../../common/message as message_common

--- a/src/statusq_bridge.nim
+++ b/src/statusq_bridge.nim
@@ -22,6 +22,7 @@ proc statusq_urlscheme_install_event_filter*(obj: pointer) {.cdecl, importc.}
 proc statusq_urlscheme_emit_deeplink*(obj: pointer, url: cstring) {.cdecl, importc.}
 proc statusq_urlscheme_emit_appforegrounded*(obj: pointer) {.cdecl, importc.}
 proc statusq_urlscheme_emit_appbackgrounded*(obj: pointer) {.cdecl, importc.}
+proc statusq_urlscheme_emit_sharetext*(obj: pointer, text: cstring) {.cdecl, importc.}
 proc statusq_urlscheme_delete*(obj: pointer) {.cdecl, importc.}
 
 when defined(monitoring):

--- a/src/statusq_bridge.nim
+++ b/src/statusq_bridge.nim
@@ -22,8 +22,12 @@ proc statusq_urlscheme_install_event_filter*(obj: pointer) {.cdecl, importc.}
 proc statusq_urlscheme_emit_deeplink*(obj: pointer, url: cstring) {.cdecl, importc.}
 proc statusq_urlscheme_emit_appforegrounded*(obj: pointer) {.cdecl, importc.}
 proc statusq_urlscheme_emit_appbackgrounded*(obj: pointer) {.cdecl, importc.}
-proc statusq_urlscheme_emit_sharetext*(obj: pointer, text: cstring) {.cdecl, importc.}
+proc statusq_urlscheme_emit_share*(obj: pointer, text: cstring, imagePathsJson: cstring) {.cdecl, importc.}
 proc statusq_urlscheme_delete*(obj: pointer) {.cdecl, importc.}
+
+# Pending intake slot dir (iOS share-extension App Group hand-off); "" on
+# platforms without an App Group container. Pointer valid for process lifetime.
+proc statusq_shareintake_pending_dir*(): cstring {.cdecl, importc.}
 
 when defined(monitoring):
   proc statusq_registerMonitoringType*() {.cdecl, importc.}

--- a/storybook/pages/RecentPostableDestinationsAdaptorPage.qml
+++ b/storybook/pages/RecentPostableDestinationsAdaptorPage.qml
@@ -1,0 +1,130 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core.Theme
+
+import mainui.adaptors
+
+SplitView {
+    id: root
+
+    ListModel {
+        id: destinationsModel
+
+        readonly property var data: [
+            {
+                chatId: "chat-alice",
+                name: "Alice",
+                color: "#ff7d46",
+                colorId: 1,
+                icon: "",
+                emoji: "",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 400,
+                canPost: true
+            },
+            {
+                chatId: "chat-design-group",
+                name: "Design crew",
+                color: "#7cda00",
+                colorId: 2,
+                icon: "",
+                emoji: "🎨",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 900,
+                canPost: true
+            },
+            {
+                chatId: "channel-announcements",
+                name: "announcements",
+                color: "#887af9",
+                colorId: 3,
+                icon: "",
+                emoji: "",
+                sectionId: "community-1",
+                sectionName: "CryptoKitties",
+                lastMessageTimestamp: 1000,
+                canPost: false
+            },
+            {
+                chatId: "channel-general",
+                name: "general",
+                color: "#887af9",
+                colorId: 4,
+                icon: "",
+                emoji: "",
+                sectionId: "community-1",
+                sectionName: "CryptoKitties",
+                lastMessageTimestamp: 700,
+                canPost: true
+            }
+        ]
+
+        Component.onCompleted: append(data)
+    }
+
+    RecentPostableDestinationsAdaptor {
+        id: adaptor
+        sourceModel: destinationsModel
+    }
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ListView {
+            anchors.fill: parent
+            model: adaptor.model
+            spacing: 4
+
+            delegate: Label {
+                text: "%1 (%2) — lastMessageTimestamp: %3".arg(model.name)
+                        .arg(model.sectionName).arg(model.lastMessageTimestamp)
+            }
+        }
+    }
+
+    Pane {
+        SplitView.fillHeight: true
+        SplitView.preferredWidth: 350
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                text: "Source rows (toggle post rights, bump recency); the left "
+                      + "pane shows the adaptor output: postable only, most "
+                      + "recent first."
+            }
+
+            Repeater {
+                model: destinationsModel
+
+                RowLayout {
+                    Layout.fillWidth: true
+
+                    CheckBox {
+                        text: "%1 canPost".arg(model.name)
+                        checked: model.canPost
+                        onToggled: destinationsModel.setProperty(index, "canPost", checked)
+                    }
+
+                    Button {
+                        text: "Bump"
+                        onClicked: destinationsModel.setProperty(index, "lastMessageTimestamp",
+                                                                 model.lastMessageTimestamp + 1000)
+                    }
+                }
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+        }
+    }
+}

--- a/storybook/pages/RecentPostableDestinationsAdaptorPage.qml
+++ b/storybook/pages/RecentPostableDestinationsAdaptorPage.qml
@@ -2,8 +2,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-import StatusQ.Core.Theme
-
 import mainui.adaptors
 
 SplitView {

--- a/storybook/pages/ShareDestinationPickerPanelPage.qml
+++ b/storybook/pages/ShareDestinationPickerPanelPage.qml
@@ -1,8 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Layouts
-
-import StatusQ.Core.Theme
 
 import Storybook
 

--- a/storybook/pages/ShareDestinationPickerPanelPage.qml
+++ b/storybook/pages/ShareDestinationPickerPanelPage.qml
@@ -1,0 +1,104 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core.Theme
+
+import Storybook
+
+import mainui
+import mainui.adaptors
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    ListModel {
+        id: destinationsModel
+
+        readonly property var data: [
+            {
+                chatId: "chat-alice",
+                name: "Alice",
+                color: "#ff7d46",
+                colorId: 1,
+                icon: "",
+                emoji: "",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 400,
+                canPost: true
+            },
+            {
+                chatId: "chat-design-group",
+                name: "Design crew",
+                color: "#7cda00",
+                colorId: 2,
+                icon: "",
+                emoji: "🎨",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 900,
+                canPost: true
+            },
+            {
+                chatId: "channel-announcements",
+                name: "announcements",
+                color: "#887af9",
+                colorId: 3,
+                icon: "",
+                emoji: "",
+                sectionId: "community-1",
+                sectionName: "CryptoKitties",
+                lastMessageTimestamp: 1000,
+                canPost: false
+            },
+            {
+                chatId: "channel-general",
+                name: "general",
+                color: "#887af9",
+                colorId: 4,
+                icon: "",
+                emoji: "",
+                sectionId: "community-1",
+                sectionName: "CryptoKitties",
+                lastMessageTimestamp: 700,
+                canPost: true
+            }
+        ]
+
+        Component.onCompleted: append(data)
+    }
+
+    RecentPostableDestinationsAdaptor {
+        id: adaptor
+        sourceModel: destinationsModel
+    }
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ShareDestinationPickerPanel {
+            anchors.centerIn: parent
+            width: 400
+            height: 500
+
+            model: adaptor.model
+
+            onDestinationPicked: (sectionId, chatId, name) => {
+                logs.logEvent("ShareDestinationPickerPanel::destinationPicked: "
+                              + sectionId + " / " + chatId + " / " + name)
+            }
+            onCancelRequested: logs.logEvent("ShareDestinationPickerPanel::cancelRequested")
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.fillHeight: true
+        SplitView.preferredWidth: 320
+
+        logsView.logText: logs.logText
+    }
+}

--- a/storybook/pages/SharePreviewPanelPage.qml
+++ b/storybook/pages/SharePreviewPanelPage.qml
@@ -2,8 +2,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-import StatusQ.Core.Theme
-
 import Storybook
 
 import mainui

--- a/storybook/pages/SharePreviewPanelPage.qml
+++ b/storybook/pages/SharePreviewPanelPage.qml
@@ -11,6 +11,11 @@ SplitView {
 
     Logs { id: logs }
 
+    // Self-contained 1x1 PNG so the page works in isolation, standing in for
+    // the cached file paths the share intake delivers.
+    readonly property string sampleImage:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+
     Pane {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
@@ -22,6 +27,12 @@ SplitView {
 
             destinationName: destinationNameField.text
             text: "Look at this https://example.com/article"
+            imagePaths: {
+                const paths = []
+                for (let i = 0; i < imageCountSpinBox.value; i++)
+                    paths.push(root.sampleImage)
+                return paths
+            }
 
             onSendRequested: (text) => logs.logEvent("SharePreviewPanel::sendRequested: " + text)
             onBackRequested: logs.logEvent("SharePreviewPanel::backRequested")
@@ -42,6 +53,15 @@ SplitView {
             TextField {
                 id: destinationNameField
                 text: "Design crew"
+            }
+            Label {
+                text: "Shared images"
+            }
+            SpinBox {
+                id: imageCountSpinBox
+                from: 0
+                to: 10
+                value: 2
             }
         }
     }

--- a/storybook/pages/SharePreviewPanelPage.qml
+++ b/storybook/pages/SharePreviewPanelPage.qml
@@ -1,0 +1,50 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core.Theme
+
+import Storybook
+
+import mainui
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        SharePreviewPanel {
+            anchors.centerIn: parent
+            width: 400
+            height: 500
+
+            destinationName: destinationNameField.text
+            text: "Look at this https://example.com/article"
+
+            onSendRequested: (text) => logs.logEvent("SharePreviewPanel::sendRequested: " + text)
+            onBackRequested: logs.logEvent("SharePreviewPanel::backRequested")
+            onCancelRequested: logs.logEvent("SharePreviewPanel::cancelRequested")
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.fillHeight: true
+        SplitView.preferredWidth: 320
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            Label {
+                text: "Destination name"
+            }
+            TextField {
+                id: destinationNameField
+                text: "Design crew"
+            }
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_RecentPostableDestinationsAdaptor.qml
+++ b/storybook/qmlTests/tests/tst_RecentPostableDestinationsAdaptor.qml
@@ -1,0 +1,111 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Core.Utils
+
+import mainui.adaptors
+
+Item {
+    id: root
+
+    Component {
+        id: testComponent
+
+        RecentPostableDestinationsAdaptor {}
+    }
+
+    Component {
+        id: destinationsModelComponent
+
+        ListModel {
+            readonly property var data: [
+                {
+                    chatId: "chat-alice",
+                    name: "Alice",
+                    sectionId: "personal-section",
+                    sectionName: "Chat",
+                    lastMessageTimestamp: 400,
+                    canPost: true
+                },
+                {
+                    chatId: "chat-design-group",
+                    name: "Design crew",
+                    sectionId: "personal-section",
+                    sectionName: "Chat",
+                    lastMessageTimestamp: 900,
+                    canPost: true
+                },
+                {
+                    chatId: "channel-announcements",
+                    name: "announcements",
+                    sectionId: "community-1",
+                    sectionName: "CryptoKitties",
+                    lastMessageTimestamp: 1000,
+                    canPost: false
+                },
+                {
+                    chatId: "channel-general",
+                    name: "general",
+                    sectionId: "community-1",
+                    sectionName: "CryptoKitties",
+                    lastMessageTimestamp: 700,
+                    canPost: true
+                }
+            ]
+
+            Component.onCompleted: append(data)
+        }
+    }
+
+    TestCase {
+        name: "RecentPostableDestinationsAdaptorTest"
+
+        function test_filtersOutNonPostableDestinations() {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const adaptor = createTemporaryObject(testComponent, root,
+                                                  { sourceModel: sourceModel })
+            const model = adaptor.model
+
+            compare(model.rowCount(), 3)
+            compare(ModelUtils.indexOf(model, "chatId", "channel-announcements"), -1)
+        }
+
+        function test_sortsByRecencyMostRecentFirst() {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const adaptor = createTemporaryObject(testComponent, root,
+                                                  { sourceModel: sourceModel })
+            const model = adaptor.model
+
+            compare(ModelUtils.get(model, 0).chatId, "chat-design-group")
+            compare(ModelUtils.get(model, 1).chatId, "channel-general")
+            compare(ModelUtils.get(model, 2).chatId, "chat-alice")
+        }
+
+        function test_reactsToPostRightsChanges() {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const adaptor = createTemporaryObject(testComponent, root,
+                                                  { sourceModel: sourceModel })
+            const model = adaptor.model
+
+            // gaining post rights adds the destination
+            sourceModel.setProperty(2, "canPost", true)
+            compare(model.rowCount(), 4)
+            compare(ModelUtils.get(model, 0).chatId, "channel-announcements")
+
+            // losing post rights removes it
+            sourceModel.setProperty(2, "canPost", false)
+            compare(model.rowCount(), 3)
+            compare(ModelUtils.indexOf(model, "chatId", "channel-announcements"), -1)
+        }
+
+        function test_reactsToRecencyChanges() {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const adaptor = createTemporaryObject(testComponent, root,
+                                                  { sourceModel: sourceModel })
+            const model = adaptor.model
+
+            sourceModel.setProperty(0, "lastMessageTimestamp", 2000)
+            compare(ModelUtils.get(model, 0).chatId, "chat-alice")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ShareDestinationPickerPanel.qml
+++ b/storybook/qmlTests/tests/tst_ShareDestinationPickerPanel.qml
@@ -1,0 +1,142 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Core.Utils
+
+import mainui
+
+Item {
+    id: root
+
+    width: 500
+    height: 600
+
+    Component {
+        id: testComponent
+
+        ShareDestinationPickerPanel {
+            anchors.fill: parent
+        }
+    }
+
+    Component {
+        id: destinationsModelComponent
+
+        ListModel {
+            readonly property var data: [
+                {
+                    chatId: "chat-design-group",
+                    name: "Design crew",
+                    color: "#7cda00",
+                    colorId: 2,
+                    icon: "",
+                    emoji: "🎨",
+                    sectionId: "personal-section",
+                    sectionName: "Chat"
+                },
+                {
+                    chatId: "channel-general",
+                    name: "general",
+                    color: "#887af9",
+                    colorId: 4,
+                    icon: "",
+                    emoji: "",
+                    sectionId: "community-1",
+                    sectionName: "CryptoKitties"
+                },
+                {
+                    chatId: "chat-alice",
+                    name: "Alice",
+                    color: "#ff7d46",
+                    colorId: 1,
+                    icon: "",
+                    emoji: "",
+                    sectionId: "personal-section",
+                    sectionName: "Chat"
+                }
+            ]
+
+            Component.onCompleted: append(data)
+        }
+    }
+
+    SignalSpy {
+        id: destinationPickedSpy
+        signalName: "destinationPicked"
+    }
+
+    SignalSpy {
+        id: cancelRequestedSpy
+        signalName: "cancelRequested"
+    }
+
+    TestCase {
+        name: "ShareDestinationPickerPanelTest"
+        when: windowShown
+
+        function init() {
+            destinationPickedSpy.clear()
+            cancelRequestedSpy.clear()
+        }
+
+        function createPicker() {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const picker = createTemporaryObject(testComponent, root,
+                                                 { model: sourceModel })
+            destinationPickedSpy.target = picker
+            cancelRequestedSpy.target = picker
+            waitForRendering(picker)
+            return picker
+        }
+
+        function test_listsAllDestinations() {
+            const picker = createPicker()
+            const listView = findChild(picker, "shareDestinationPickerListView")
+            verify(listView)
+            compare(listView.count, 3)
+        }
+
+        function test_searchFiltersAcrossDestinations() {
+            const picker = createPicker()
+            const listView = findChild(picker, "shareDestinationPickerListView")
+            const searchBox = findChild(picker, "shareDestinationPickerSearchBox")
+            verify(searchBox)
+
+            searchBox.text = "ali"
+            tryCompare(listView, "count", 1)
+            compare(ModelUtils.get(listView.model, 0).name, "Alice")
+
+            // also matches the community (section) name
+            searchBox.text = "CryptoKit"
+            tryCompare(listView, "count", 1)
+            compare(ModelUtils.get(listView.model, 0).name, "general")
+
+            searchBox.text = ""
+            tryCompare(listView, "count", 3)
+        }
+
+        function test_pickingDestinationEmitsIntent() {
+            const picker = createPicker()
+            const delegate = findChild(picker, "shareDestinationDelegate_general")
+            verify(delegate)
+
+            mouseClick(delegate)
+
+            compare(destinationPickedSpy.count, 1)
+            compare(destinationPickedSpy.signalArguments[0][0], "community-1")
+            compare(destinationPickedSpy.signalArguments[0][1], "channel-general")
+            compare(destinationPickedSpy.signalArguments[0][2], "general")
+        }
+
+        function test_cancelEmitsIntent() {
+            const picker = createPicker()
+            const cancelButton = findChild(picker, "shareDestinationPickerCancelButton")
+            verify(cancelButton)
+
+            mouseClick(cancelButton)
+
+            compare(cancelRequestedSpy.count, 1)
+            compare(destinationPickedSpy.count, 0)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ShareDestinationPickerPanel.qml
+++ b/storybook/qmlTests/tests/tst_ShareDestinationPickerPanel.qml
@@ -117,7 +117,7 @@ Item {
 
         function test_pickingDestinationEmitsIntent() {
             const picker = createPicker()
-            const delegate = findChild(picker, "shareDestinationDelegate_general")
+            const delegate = findChild(picker, "shareDestinationDelegate_general_channel-general")
             verify(delegate)
 
             mouseClick(delegate)

--- a/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
+++ b/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
@@ -1,0 +1,107 @@
+import QtQuick
+import QtTest
+
+import mainui
+
+Item {
+    id: root
+
+    width: 500
+    height: 600
+
+    Component {
+        id: testComponent
+
+        SharePreviewPanel {
+            anchors.fill: parent
+            destinationName: "Design crew"
+            text: "Look at this https://example.com/article"
+        }
+    }
+
+    SignalSpy {
+        id: sendRequestedSpy
+        signalName: "sendRequested"
+    }
+
+    SignalSpy {
+        id: backRequestedSpy
+        signalName: "backRequested"
+    }
+
+    SignalSpy {
+        id: cancelRequestedSpy
+        signalName: "cancelRequested"
+    }
+
+    TestCase {
+        name: "SharePreviewPanelTest"
+        when: windowShown
+
+        function init() {
+            sendRequestedSpy.clear()
+            backRequestedSpy.clear()
+            cancelRequestedSpy.clear()
+        }
+
+        function createPreview() {
+            const preview = createTemporaryObject(testComponent, root)
+            sendRequestedSpy.target = preview
+            backRequestedSpy.target = preview
+            cancelRequestedSpy.target = preview
+            waitForRendering(preview)
+            return preview
+        }
+
+        function test_sendEmitsEditedText() {
+            const preview = createPreview()
+            const textArea = findChild(preview, "sharePreviewTextArea")
+            const sendButton = findChild(preview, "sharePreviewSendButton")
+            verify(textArea)
+            verify(sendButton)
+
+            compare(textArea.text, "Look at this https://example.com/article")
+            verify(sendButton.enabled)
+
+            textArea.text = "Edited before sending"
+            mouseClick(sendButton)
+
+            compare(sendRequestedSpy.count, 1)
+            compare(sendRequestedSpy.signalArguments[0][0], "Edited before sending")
+        }
+
+        function test_sendDisabledOnBlankText() {
+            const preview = createPreview()
+            const textArea = findChild(preview, "sharePreviewTextArea")
+            const sendButton = findChild(preview, "sharePreviewSendButton")
+
+            textArea.text = "   "
+            verify(!sendButton.enabled)
+
+            mouseClick(sendButton)
+            compare(sendRequestedSpy.count, 0)
+        }
+
+        function test_backEmitsIntent() {
+            const preview = createPreview()
+            const backButton = findChild(preview, "sharePreviewBackButton")
+            verify(backButton)
+
+            mouseClick(backButton)
+
+            compare(backRequestedSpy.count, 1)
+            compare(sendRequestedSpy.count, 0)
+        }
+
+        function test_cancelEmitsIntent() {
+            const preview = createPreview()
+            const cancelButton = findChild(preview, "sharePreviewCancelButton")
+            verify(cancelButton)
+
+            mouseClick(cancelButton)
+
+            compare(cancelRequestedSpy.count, 1)
+            compare(sendRequestedSpy.count, 0)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
+++ b/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
@@ -74,6 +74,8 @@ Item {
             const preview = createPreview()
             const textArea = findChild(preview, "sharePreviewTextArea")
             const sendButton = findChild(preview, "sharePreviewSendButton")
+            verify(textArea)
+            verify(sendButton)
 
             textArea.text = "   "
             verify(!sendButton.enabled)

--- a/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
+++ b/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
@@ -9,6 +9,11 @@ Item {
     width: 500
     height: 600
 
+    // Self-contained 1x1 PNG standing in for the cached file paths the share
+    // intake delivers (no filesystem dependency, no Image load warnings).
+    readonly property string sampleImage:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+
     Component {
         id: testComponent
 
@@ -104,6 +109,62 @@ Item {
 
             compare(cancelRequestedSpy.count, 1)
             compare(sendRequestedSpy.count, 0)
+        }
+
+        function test_thumbnailsHiddenForTextShare() {
+            const preview = createPreview()
+            const thumbnails = findChild(preview, "sharePreviewThumbnailsList")
+            verify(thumbnails)
+
+            compare(thumbnails.count, 0)
+            verify(!thumbnails.visible)
+        }
+
+        function test_thumbnailShownPerSharedImage() {
+            const preview = createPreview()
+            const thumbnails = findChild(preview, "sharePreviewThumbnailsList")
+            verify(thumbnails)
+
+            preview.imagePaths = [root.sampleImage, root.sampleImage, root.sampleImage]
+            waitForRendering(preview)
+
+            compare(thumbnails.count, 3)
+            verify(thumbnails.visible)
+            const thumbnail = findChild(thumbnails, "sharePreviewThumbnail")
+            verify(thumbnail)
+            tryCompare(thumbnail, "status", Image.Ready)
+        }
+
+        function test_sendEnabledWithImagesAndBlankCaption() {
+            const preview = createPreview()
+            const textArea = findChild(preview, "sharePreviewTextArea")
+            const sendButton = findChild(preview, "sharePreviewSendButton")
+            verify(textArea)
+            verify(sendButton)
+
+            preview.imagePaths = [root.sampleImage]
+            textArea.text = ""
+            verify(sendButton.enabled)
+
+            mouseClick(sendButton)
+
+            compare(sendRequestedSpy.count, 1)
+            compare(sendRequestedSpy.signalArguments[0][0], "")
+        }
+
+        function test_sendWithImagesEmitsEditedCaption() {
+            const preview = createPreview()
+            const textArea = findChild(preview, "sharePreviewTextArea")
+            const sendButton = findChild(preview, "sharePreviewSendButton")
+            verify(textArea)
+            verify(sendButton)
+
+            preview.imagePaths = [root.sampleImage, root.sampleImage]
+            textArea.text = "Gallery caption"
+            mouseClick(sendButton)
+
+            compare(sendRequestedSpy.count, 1)
+            compare(sendRequestedSpy.signalArguments[0][0], "Gallery caption")
         }
     }
 }

--- a/test/nim/external_intake_test.nim
+++ b/test/nim/external_intake_test.nim
@@ -13,6 +13,8 @@ type Capture = ref object
   deepLinks: seq[string]
   browserTabs: seq[string]
   shares: seq[string]
+  shareImagePaths: seq[seq[string]]
+  discardedImagePaths: seq[seq[string]]
 
 proc newCapturingIntake(capture: Capture): ExternalIntake =
   result = newExternalIntake()
@@ -20,14 +22,17 @@ proc newCapturingIntake(capture: Capture): ExternalIntake =
     capture.deepLinks.add(url)
   result.onBrowserTabUrl = proc(url: string) =
     capture.browserTabs.add(url)
-  result.onShareText = proc(text: string) =
+  result.onShare = proc(text: string, imagePaths: seq[string]) =
     capture.shares.add(text)
+    capture.shareImagePaths.add(imagePaths)
+  result.onShareImagesDiscarded = proc(imagePaths: seq[string]) =
+    capture.discardedImagePaths.add(imagePaths)
 
 proc urlIntake(url: string): ExternalIntakeEvent =
   ExternalIntakeEvent(kind: ExternalIntakeUrl, url: url)
 
-proc shareIntake(text: string): ExternalIntakeEvent =
-  ExternalIntakeEvent(kind: ExternalIntakeShare, text: text)
+proc shareIntake(text: string, imagePaths: seq[string] = @[]): ExternalIntakeEvent =
+  ExternalIntakeEvent(kind: ExternalIntakeShare, text: text, imagePaths: imagePaths)
 
 suite "external_intake routing":
 
@@ -152,6 +157,76 @@ suite "external_intake share events":
     intake.submit(shareIntake("   \n  "))
 
     check capture.shares.len == 0
+
+  test "share image paths reach the share handler once ready":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(shareIntake("caption",
+      @["/cache/share-intake/a.png", "/cache/share-intake/b.jpg"]))
+
+    check capture.shares == @["caption"]
+    check capture.shareImagePaths ==
+      @[@["/cache/share-intake/a.png", "/cache/share-intake/b.jpg"]]
+
+  test "an image share with blank text dispatches with an empty caption":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(shareIntake("", @["/cache/share-intake/screenshot.png"]))
+
+    check capture.shares == @[""]
+    check capture.shareImagePaths == @[@["/cache/share-intake/screenshot.png"]]
+
+  test "an image share buffered before ready is delivered at ready":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(shareIntake("pre-login", @["/cache/share-intake/a.png"]))
+    check capture.shares.len == 0
+    check intake.hasPending()
+
+    intake.setReady()
+
+    check capture.shares == @["pre-login"]
+    check capture.shareImagePaths == @[@["/cache/share-intake/a.png"]]
+    check capture.discardedImagePaths.len == 0
+
+  test "a pending image share overwritten in the slot reports its images as discarded":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(shareIntake("first", @["/cache/share-intake/old.png"]))
+    intake.submit(shareIntake("second", @["/cache/share-intake/new.png"]))
+    intake.setReady()
+
+    check capture.discardedImagePaths == @[@["/cache/share-intake/old.png"]]
+    check capture.shares == @["second"]
+    check capture.shareImagePaths == @[@["/cache/share-intake/new.png"]]
+
+  test "a url overwriting a pending image share reports the images as discarded":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(shareIntake("share", @["/cache/share-intake/img.png"]))
+    intake.submit(urlIntake("https://status.app/c/community-id"))
+    intake.setReady()
+
+    check capture.discardedImagePaths == @[@["/cache/share-intake/img.png"]]
+    check capture.shares.len == 0
+    check capture.deepLinks == @["https://status.app/c/community-id"]
+
+  test "overwriting a pending text-only share reports no discarded images":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(shareIntake("text only"))
+    intake.submit(shareIntake("later", @["/cache/share-intake/a.png"]))
+    intake.setReady()
+
+    check capture.discardedImagePaths.len == 0
 
 suite "external_intake pending slot":
 

--- a/test/nim/external_intake_test.nim
+++ b/test/nim/external_intake_test.nim
@@ -1,9 +1,10 @@
 ## Unit tests for the external intake seam (app/core/intake/external_intake).
 ## Covers the routing decision (Status links keep deep-link behavior, any other
-## web URL becomes a browser-tab intake) and the pending intake slot semantics
-## (pre-ready buffering, single slot, last-wins, delivered once at ready).
-## Prior art: url_scheme_event_test.nim exercises the platform side of this
-## same boundary.
+## web URL becomes a browser-tab intake), the share-event route (share target:
+## shared text/links launch the share flow) and the pending intake slot
+## semantics (pre-ready buffering, single slot, last-wins across kinds,
+## delivered once at ready). Prior art: url_scheme_event_test.nim exercises the
+## platform side of this same boundary.
 
 import unittest
 import app/core/intake/external_intake
@@ -11,6 +12,7 @@ import app/core/intake/external_intake
 type Capture = ref object
   deepLinks: seq[string]
   browserTabs: seq[string]
+  shares: seq[string]
 
 proc newCapturingIntake(capture: Capture): ExternalIntake =
   result = newExternalIntake()
@@ -18,9 +20,14 @@ proc newCapturingIntake(capture: Capture): ExternalIntake =
     capture.deepLinks.add(url)
   result.onBrowserTabUrl = proc(url: string) =
     capture.browserTabs.add(url)
+  result.onShareText = proc(text: string) =
+    capture.shares.add(text)
 
 proc urlIntake(url: string): ExternalIntakeEvent =
   ExternalIntakeEvent(kind: ExternalIntakeUrl, url: url)
+
+proc shareIntake(text: string): ExternalIntakeEvent =
+  ExternalIntakeEvent(kind: ExternalIntakeShare, text: text)
 
 suite "external_intake routing":
 
@@ -87,6 +94,64 @@ suite "external_intake dispatch":
 
     check capture.browserTabs == @["https://example.com/article"]
     check capture.deepLinks.len == 0
+
+suite "external_intake share events":
+
+  test "share text reaches the share handler once ready":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(shareIntake("look at this https://example.com/article"))
+
+    check capture.shares == @["look at this https://example.com/article"]
+    check capture.deepLinks.len == 0
+    check capture.browserTabs.len == 0
+
+  test "share submitted before ready is buffered and delivered at ready":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(shareIntake("quote from another app"))
+    check capture.shares.len == 0
+    check intake.hasPending()
+
+    intake.setReady()
+
+    check capture.shares == @["quote from another app"]
+    check not intake.hasPending()
+
+  test "the pending slot is last-wins across intake kinds":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(urlIntake("https://example.com/article"))
+    intake.submit(shareIntake("second share wins"))
+    intake.setReady()
+
+    check capture.browserTabs.len == 0
+    check capture.shares == @["second share wins"]
+
+  test "a later url intake overwrites a pending share":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(shareIntake("first share"))
+    intake.submit(urlIntake("https://status.app/c/community-id"))
+    intake.setReady()
+
+    check capture.shares.len == 0
+    check capture.deepLinks == @["https://status.app/c/community-id"]
+
+  test "blank share text dispatches nothing":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(shareIntake(""))
+    intake.submit(shareIntake("   \n  "))
+
+    check capture.shares.len == 0
 
 suite "external_intake pending slot":
 

--- a/test/nim/pending_intake_slot_test.nim
+++ b/test/nim/pending_intake_slot_test.nim
@@ -1,0 +1,54 @@
+## Unit tests for the pending intake slot (app/core/intake/pending_intake_slot):
+## the last-wins, single-payload file buffer used for the iOS share-extension
+## App Group hand-off. The extension writes the same file natively
+## (mobile/ios/shareExtension/ShareViewController.m); these tests pin down the
+## host-side semantics: take() delivers exactly once, last write wins, and an
+## undelivered payload survives until the next take (degraded wake fallback).
+
+import unittest, os
+import app/core/intake/pending_intake_slot
+
+suite "pending_intake_slot":
+  setup:
+    let slotDir = getTempDir() / "pending_intake_slot_test"
+    removeDir(slotDir)
+
+  teardown:
+    removeDir(slotDir)
+
+  test "slot without a container dir is inactive and never delivers":
+    let slot = newPendingIntakeSlot("")
+    check not slot.isActive()
+    check slot.filePath() == ""
+    slot.write("ignored")
+    check slot.take() == ""
+
+  test "write then take delivers the payload":
+    let slot = newPendingIntakeSlot(slotDir)
+    check slot.isActive()
+    slot.write("""{"type":"share","text":"hello"}""")
+    check slot.take() == """{"type":"share","text":"hello"}"""
+
+  test "take clears the slot - payload is delivered exactly once":
+    let slot = newPendingIntakeSlot(slotDir)
+    slot.write("payload")
+    check slot.take() == "payload"
+    check slot.take() == ""
+    check not fileExists(slot.filePath())
+
+  test "second write overwrites the first (last-wins)":
+    let slot = newPendingIntakeSlot(slotDir)
+    slot.write("first")
+    slot.write("second")
+    check slot.take() == "second"
+    check slot.take() == ""
+
+  test "take on an empty slot returns empty string":
+    let slot = newPendingIntakeSlot(slotDir)
+    check slot.take() == ""
+
+  test "payload survives across slot instances (writer and reader are different processes)":
+    let writer = newPendingIntakeSlot(slotDir)
+    writer.write("from-extension")
+    let reader = newPendingIntakeSlot(slotDir)
+    check reader.take() == "from-extension"

--- a/test/nim/share_intake_cache_test.nim
+++ b/test/nim/share_intake_cache_test.nim
@@ -1,0 +1,43 @@
+## Unit tests for the share-intake cache lifecycle helper
+## (app/core/intake/share_intake_cache). The platform layer copies shared
+## media into an app-private `share-intake` cache directory at receipt;
+## releaseCachedShareFiles deletes those copies after send or cancel, and must
+## never touch files outside a `share-intake` directory (regular picker sends
+## pass user-owned paths through the same image-send task).
+
+import unittest, os
+import app/core/intake/share_intake_cache
+
+suite "share_intake_cache":
+  setup:
+    let baseDir = getTempDir() / "share_intake_cache_test"
+    removeDir(baseDir)
+    let cacheDir = baseDir / ShareIntakeCacheDirName
+    createDir(cacheDir)
+
+  teardown:
+    removeDir(baseDir)
+
+  test "releases cached copies inside a share-intake directory":
+    let first = cacheDir / "a.png"
+    let second = cacheDir / "b.jpg"
+    writeFile(first, "img")
+    writeFile(second, "img")
+
+    releaseCachedShareFiles(@[first, second])
+
+    check not fileExists(first)
+    check not fileExists(second)
+
+  test "files outside a share-intake directory are left alone":
+    let userFile = baseDir / "keep.png"
+    writeFile(userFile, "img")
+
+    releaseCachedShareFiles(@[userFile])
+
+    check fileExists(userFile)
+
+  test "missing files and empty input are ignored":
+    releaseCachedShareFiles(@[cacheDir / "already-gone.png"])
+    releaseCachedShareFiles(@[])
+    check true

--- a/test/nim/share_intake_cache_test.nim
+++ b/test/nim/share_intake_cache_test.nim
@@ -41,3 +41,12 @@ suite "share_intake_cache":
     releaseCachedShareFiles(@[cacheDir / "already-gone.png"])
     releaseCachedShareFiles(@[])
     check true
+
+  test "decodes the image-paths wire format":
+    check parseImagePathsJson("""["/cache/share-intake/a.png","/b.jpg"]""") ==
+      @["/cache/share-intake/a.png", "/b.jpg"]
+
+  test "empty and malformed image-paths payloads decode to no images":
+    check parseImagePathsJson("").len == 0
+    check parseImagePathsJson("[]").len == 0
+    check parseImagePathsJson("not json").len == 0

--- a/test/nim/share_intake_wake_test.nim
+++ b/test/nim/share_intake_wake_test.nim
@@ -4,11 +4,14 @@
 ##  - the iOS extension's wake URL (unsupported openURL trick) delivers and
 ##    clears the App Group pending intake slot without being routed as a deep
 ##    link, and a share payload in the slot reaches the external intake seam
-##    as SIGNAL_EXTERNAL_SHARE_INTAKE;
+##    as SIGNAL_EXTERNAL_SHARE_INTAKE — immediately when ready, buffered until
+##    appReady otherwise (login-first rule), last-wins across several shares;
+##    blank/unknown-type/malformed payloads are cleared and dispatch nothing;
 ##  - appReady delivers a payload left behind when the wake never arrived
 ##    (degraded fallback: next manual app open, no data loss);
-##  - the Android SEND hand-off (shareTextActivated signal) reaches
-##    SIGNAL_EXTERNAL_SHARE_INTAKE, with pre-ready buffering.
+##  - the Android SEND/SEND_MULTIPLE hand-off (shareActivated signal) reaches
+##    SIGNAL_EXTERNAL_SHARE_INTAKE — text-only and with cached image paths —
+##    with pre-ready buffering.
 
 import unittest, os
 import nimqml
@@ -49,8 +52,11 @@ suite "share_intake_wake":
     let slot = newPendingIntakeSlot(slotDir)
     let manager = newUrlsManager(events, urlSchemeEvent, singleInstance, "", slot)
     var sharedTexts: seq[string] = @[]
+    var sharedImagePaths: seq[seq[string]] = @[]
     events.on(SIGNAL_EXTERNAL_SHARE_INTAKE) do(e: Args):
-      sharedTexts.add(ExternalShareIntakeArgs(e).text)
+      let args = ExternalShareIntakeArgs(e)
+      sharedTexts.add(args.text)
+      sharedImagePaths.add(args.imagePaths)
 
   teardown:
     removeDir(slotDir)
@@ -67,6 +73,65 @@ suite "share_intake_wake":
     check slot.take() == ""
     check sharedTexts == @["shared from the extension"]
 
+  test "wake url before appReady buffers the slot share until appReady (login-first)":
+    # Logged-out share: the extension wakes the host, the host consumes the
+    # slot immediately (file cleared), but the seam holds the share until
+    # main-window-ready — login/onboarding first, share flow after.
+    slot.write("""{"type":"share","text":"shared while logged out"}""")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+
+    check not fileExists(slot.filePath())
+    check sharedTexts.len == 0
+
+    manager.appReady()
+
+    check sharedTexts == @["shared while logged out"]
+
+  test "later slot share wins when several arrive before delivery":
+    slot.write("""{"type":"share","text":"first share"}""")
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+
+    slot.write("""{"type":"share","text":"second share wins"}""")
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+
+    manager.appReady()
+
+    check sharedTexts == @["second share wins"]
+
+  test "blank slot share text is cleared and dispatches nothing":
+    manager.appReady()
+    slot.write("""{"type":"share","text":"   \n  "}""")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+
+    check not fileExists(slot.filePath())
+    check sharedTexts.len == 0
+
+  test "slot payload with an unknown type is cleared and dispatches nothing":
+    manager.appReady()
+    slot.write("""{"type":"image","path":"/somewhere.png"}""")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+
+    check not fileExists(slot.filePath())
+    check sharedTexts.len == 0
+
+  test "slot share payload with image paths reaches the intake seam":
+    manager.appReady()
+    slot.write("""{"type":"share","text":"pic","imagePaths":["/cache/share-intake/img.png"]}""")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+
+    check sharedTexts == @["pic"]
+    check sharedImagePaths == @[@["/cache/share-intake/img.png"]]
+
   test "malformed slot payload is cleared and dispatches nothing":
     manager.appReady()
     slot.write("not json at all")
@@ -80,14 +145,36 @@ suite "share_intake_wake":
   test "android share text reaches the intake seam once ready":
     manager.appReady()
 
-    statusq_urlscheme_emit_sharetext(urlSchemeEvent.vptr,
-      "look at this https://example.com/article")
+    statusq_urlscheme_emit_share(urlSchemeEvent.vptr,
+      "look at this https://example.com/article", "[]")
     processEventsUntil(proc(): bool = sharedTexts.len > 0)
 
     check sharedTexts == @["look at this https://example.com/article"]
+    check sharedImagePaths == @[newSeq[string]()]
+
+  test "android share with cached image paths reaches the intake seam":
+    manager.appReady()
+
+    statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "gallery caption",
+      """["/cache/share-intake/a.png","/cache/share-intake/b.jpg"]""")
+    processEventsUntil(proc(): bool = sharedTexts.len > 0)
+
+    check sharedTexts == @["gallery caption"]
+    check sharedImagePaths ==
+      @[@["/cache/share-intake/a.png", "/cache/share-intake/b.jpg"]]
+
+  test "android image share with no text reaches the intake seam":
+    manager.appReady()
+
+    statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "",
+      """["/cache/share-intake/screenshot.png"]""")
+    processEventsUntil(proc(): bool = sharedTexts.len > 0)
+
+    check sharedTexts == @[""]
+    check sharedImagePaths == @[@["/cache/share-intake/screenshot.png"]]
 
   test "share text before appReady is buffered and delivered at appReady":
-    statusq_urlscheme_emit_sharetext(urlSchemeEvent.vptr, "pre-login share")
+    statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "pre-login share", "[]")
     drainEvents() # let the queued slot run; the seam must buffer, not dispatch
     check sharedTexts.len == 0
 
@@ -95,13 +182,28 @@ suite "share_intake_wake":
 
     check sharedTexts == @["pre-login share"]
 
+  test "app foregrounding delivers a payload left behind when the wake never arrived":
+    # Wake-less fallback for an already-running app: the user backgrounds
+    # Status, shares (extension writes the slot, openURL wake fails/dropped),
+    # then manually returns to Status — the payload must not wait for a full
+    # app restart.
+    manager.appReady()
+    slot.write("""{"type":"share","text":"delivered on foreground"}""")
+
+    statusq_urlscheme_emit_appforegrounded(urlSchemeEvent.vptr)
+    processEventsUntil(proc(): bool = sharedTexts.len > 0)
+
+    check not fileExists(slot.filePath())
+    check sharedTexts == @["delivered on foreground"]
+
   test "appReady delivers a payload left behind when the wake never arrived":
-    slot.write("payload-from-killed-wake")
+    slot.write("""{"type":"share","text":"payload from a killed wake"}""")
 
     manager.appReady()
 
     check not fileExists(slot.filePath())
     check slot.take() == ""
+    check sharedTexts == @["payload from a killed wake"]
 
   test "appReady with an empty slot is a no-op":
     manager.appReady()

--- a/test/nim/share_intake_wake_test.nim
+++ b/test/nim/share_intake_wake_test.nim
@@ -1,0 +1,108 @@
+## Integration test for the Nim side of the share-target hand-off
+## (urls_manager + pending_intake_slot). Proves the delivery paths over the
+## real StatusQ signals:
+##  - the iOS extension's wake URL (unsupported openURL trick) delivers and
+##    clears the App Group pending intake slot without being routed as a deep
+##    link, and a share payload in the slot reaches the external intake seam
+##    as SIGNAL_EXTERNAL_SHARE_INTAKE;
+##  - appReady delivers a payload left behind when the wake never arrived
+##    (degraded fallback: next manual app open, no data loss);
+##  - the Android SEND hand-off (shareTextActivated signal) reaches
+##    SIGNAL_EXTERNAL_SHARE_INTAKE, with pre-ready buffering.
+
+import unittest, os
+import nimqml
+import app/core/eventemitter
+import app/core/custom_urls/url_scheme_event
+import app/core/custom_urls/urls_manager
+import app/core/intake/pending_intake_slot
+import app/global/app_signals
+import app/global/single_instance
+import statusq_bridge
+# Selective import: pulling all of gen_qcoreapplication would re-export the seaqt
+# gen_qobject_types.QObject and make nimqml's QObject ambiguous (see url_scheme_event_test).
+from seaqt/qcoreapplication import QCoreApplication, create, processEvents
+
+discard QCoreApplication.create()  # one app for the whole suite
+
+proc processEventsUntil(cond: proc(): bool) =
+  var spins = 0
+  while not cond() and spins < 100:
+    QCoreApplication.processEvents()
+    sleep(5)
+    inc spins
+
+proc drainEvents() =
+  for _ in 0 ..< 10:
+    QCoreApplication.processEvents()
+    sleep(5)
+
+suite "share_intake_wake":
+  setup:
+    # Not "share_intake_wake_test": newSingleInstance below creates its local
+    # socket under that name in the temp dir and removeDir would trip on it.
+    let slotDir = getTempDir() / "share_intake_wake_test_slot"
+    removeDir(slotDir)
+    let events = createEventEmitter()
+    let urlSchemeEvent = newUrlSchemeEvent()
+    let singleInstance = newSingleInstance("share_intake_wake_test", "")
+    let slot = newPendingIntakeSlot(slotDir)
+    let manager = newUrlsManager(events, urlSchemeEvent, singleInstance, "", slot)
+    var sharedTexts: seq[string] = @[]
+    events.on(SIGNAL_EXTERNAL_SHARE_INTAKE) do(e: Args):
+      sharedTexts.add(ExternalShareIntakeArgs(e).text)
+
+  teardown:
+    removeDir(slotDir)
+
+  test "wake url delivers the slot share payload to the intake seam":
+    manager.appReady()
+    slot.write("""{"type":"share","text":"shared from the extension"}""")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+
+    # consumed by the manager: cleared after read, nothing left to take
+    check not fileExists(slot.filePath())
+    check slot.take() == ""
+    check sharedTexts == @["shared from the extension"]
+
+  test "malformed slot payload is cleared and dispatches nothing":
+    manager.appReady()
+    slot.write("not json at all")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+
+    check not fileExists(slot.filePath())
+    check sharedTexts.len == 0
+
+  test "android share text reaches the intake seam once ready":
+    manager.appReady()
+
+    statusq_urlscheme_emit_sharetext(urlSchemeEvent.vptr,
+      "look at this https://example.com/article")
+    processEventsUntil(proc(): bool = sharedTexts.len > 0)
+
+    check sharedTexts == @["look at this https://example.com/article"]
+
+  test "share text before appReady is buffered and delivered at appReady":
+    statusq_urlscheme_emit_sharetext(urlSchemeEvent.vptr, "pre-login share")
+    drainEvents() # let the queued slot run; the seam must buffer, not dispatch
+    check sharedTexts.len == 0
+
+    manager.appReady()
+
+    check sharedTexts == @["pre-login share"]
+
+  test "appReady delivers a payload left behind when the wake never arrived":
+    slot.write("payload-from-killed-wake")
+
+    manager.appReady()
+
+    check not fileExists(slot.filePath())
+    check slot.take() == ""
+
+  test "appReady with an empty slot is a no-op":
+    manager.appReady()
+    check slot.take() == ""

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -258,6 +258,7 @@ add_library(StatusQ ${LIB_TYPE}
         src/urlutils.cpp
         src/statuslayoutstate.cpp
         src/ios_utils.h
+        include/StatusQ/shareintake.h
 
         src/StatusQ/Controls/NativeSwipeHandlerItem.cpp
         src/StatusQ/Controls/NativeIndicatorItem.cpp
@@ -297,6 +298,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     qt_import_plugins(${PROJECT_NAME} INCLUDE Qt6::QDarwinCameraPermissionPlugin)
     target_sources(StatusQ PRIVATE
         src/shareutils_other.cpp
+        src/shareintake_other.cpp
         src/keychain_apple.mm
         src/osnotification_apple.mm
         src/accessibility_crash_filter.mm
@@ -332,10 +334,12 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
         src/StatusQ/Controls/NativeSwipeHandlerItem_android.cpp
         src/StatusQ/Controls/NativeIndicatorItem_android.cpp
         src/shareutils_android.cpp
+        src/shareintake_other.cpp
     )
 else ()
     target_sources(StatusQ PRIVATE
         src/shareutils_other.cpp
+        src/shareintake_other.cpp
         src/keychain_other.cpp
     )
 endif ()

--- a/ui/StatusQ/include/StatusQ/shareintake.h
+++ b/ui/StatusQ/include/StatusQ/shareintake.h
@@ -1,0 +1,16 @@
+#ifndef STATUSQ_SHARE_INTAKE_H
+#define STATUSQ_SHARE_INTAKE_H
+
+#include <QString>
+
+namespace Status::ShareIntake
+{
+    // Directory of the pending intake slot shared with the iOS share extension
+    // (a subdirectory of the App Group container). Empty on platforms without
+    // an App Group container, or when the container cannot be resolved (e.g.
+    // the app-groups entitlement is missing) — an empty dir means the slot is
+    // inactive on the Nim side (src/app/core/intake/pending_intake_slot.nim).
+    QString pendingIntakeDir();
+}
+
+#endif // STATUSQ_SHARE_INTAKE_H

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -44,6 +44,9 @@ public:
     Q_INVOKABLE void setAndroidStatusBarIconColor(bool lightIcons);
     // Notify Android that main window is ready (for custom activity) (hides the splash screen)
     Q_INVOKABLE void setMainWindowReady();
+    // Background the whole Android task, revealing the app the user came from
+    // (share flow cancel: "return to the source app"); no-op elsewhere
+    Q_INVOKABLE void moveAppTaskToBack();
     
     // Get Android keyboard state (uses WindowInsets API, works Android 11-16+)
     Q_INVOKABLE int androidKeyboardHeight() const;

--- a/ui/StatusQ/include/StatusQ/urlschemeevent.h
+++ b/ui/StatusQ/include/StatusQ/urlschemeevent.h
@@ -15,6 +15,7 @@ namespace Status
             void emitAppForegroundedToQt();
             void emitAppBackgroundedToQt();
             void watchApplicationState();
+            void emitShareTextToQt(const QString& text);
             static void setInstance(UrlSchemeEvent* instance);
 
             void registerUrlHandler();
@@ -33,6 +34,7 @@ namespace Status
             // NOT backgrounded: share sheets and system alerts briefly
             // deactivate the app without suspending it.
             void appBackgrounded();
+            void shareTextActivated(const QString& text);
     };
 }
 

--- a/ui/StatusQ/include/StatusQ/urlschemeevent.h
+++ b/ui/StatusQ/include/StatusQ/urlschemeevent.h
@@ -15,7 +15,7 @@ namespace Status
             void emitAppForegroundedToQt();
             void emitAppBackgroundedToQt();
             void watchApplicationState();
-            void emitShareTextToQt(const QString& text);
+            void emitShareToQt(const QString& text, const QStringList& imagePaths);
             static void setInstance(UrlSchemeEvent* instance);
 
             void registerUrlHandler();
@@ -34,7 +34,10 @@ namespace Status
             // NOT backgrounded: share sheets and system alerts briefly
             // deactivate the app without suspending it.
             void appBackgrounded();
-            void shareTextActivated(const QString& text);
+            // Share-target hand-off: shared text/links plus app-private cached
+            // copies of shared images, as a JSON array of absolute paths (a
+            // JSON string keeps the Nim slot signature to plain QStrings).
+            void shareActivated(const QString& text, const QString& imagePathsJson);
     };
 }
 

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -4,6 +4,8 @@
 #include <QByteArray>
 #include <QBasicTimer>
 #include <QElapsedTimer>
+#include <QJsonArray>
+#include <QJsonDocument>
 #include <QGuiApplication>
 #include <QHash>
 #include <QPointer>
@@ -304,8 +306,17 @@ Q_DECL_EXPORT void statusq_urlscheme_emit_appbackgrounded(void* obj) {
     static_cast<Status::UrlSchemeEvent*>(obj)->emitAppBackgroundedToQt();
 }
 
-Q_DECL_EXPORT void statusq_urlscheme_emit_sharetext(void* obj, const char* text) {
-    static_cast<Status::UrlSchemeEvent*>(obj)->emitShareTextToQt(QString::fromUtf8(text));
+// imagePathsJson: JSON array of absolute paths of app-private cached copies
+// of the shared images (may be null or "[]" for text-only shares).
+Q_DECL_EXPORT void statusq_urlscheme_emit_share(void* obj, const char* text, const char* imagePathsJson) {
+    QStringList paths;
+    if (imagePathsJson) {
+        const auto doc = QJsonDocument::fromJson(QByteArray(imagePathsJson));
+        const auto array = doc.array();
+        for (const auto& value : array)
+            paths << value.toString();
+    }
+    static_cast<Status::UrlSchemeEvent*>(obj)->emitShareToQt(QString::fromUtf8(text), paths);
 }
 
 Q_DECL_EXPORT void statusq_urlscheme_delete(void* obj) {

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -17,6 +17,7 @@
 #include <StatusQ/networkaccessfactory.h>
 #include <StatusQ/typesregistration.h>
 #include <StatusQ/osnotification.h>
+#include <StatusQ/shareintake.h>
 #include <StatusQ/urlschemeevent.h>
 #ifdef MONITORING
 #include <QProcessEnvironment>
@@ -321,6 +322,14 @@ Q_DECL_EXPORT void statusq_urlscheme_emit_share(void* obj, const char* text, con
 
 Q_DECL_EXPORT void statusq_urlscheme_delete(void* obj) {
     static_cast<QObject*>(obj)->deleteLater();
+}
+
+// Pending intake slot directory (iOS share-extension App Group hand-off);
+// "" on platforms without an App Group container. The returned pointer stays
+// valid for the process lifetime.
+Q_DECL_EXPORT const char* statusq_shareintake_pending_dir() {
+    static const QByteArray dir = Status::ShareIntake::pendingIntakeDir().toUtf8();
+    return dir.constData();
 }
 
 #ifdef MONITORING

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -304,6 +304,10 @@ Q_DECL_EXPORT void statusq_urlscheme_emit_appbackgrounded(void* obj) {
     static_cast<Status::UrlSchemeEvent*>(obj)->emitAppBackgroundedToQt();
 }
 
+Q_DECL_EXPORT void statusq_urlscheme_emit_sharetext(void* obj, const char* text) {
+    static_cast<Status::UrlSchemeEvent*>(obj)->emitShareTextToQt(QString::fromUtf8(text));
+}
+
 Q_DECL_EXPORT void statusq_urlscheme_delete(void* obj) {
     static_cast<QObject*>(obj)->deleteLater();
 }

--- a/ui/StatusQ/src/shareintake_other.cpp
+++ b/ui/StatusQ/src/shareintake_other.cpp
@@ -1,0 +1,7 @@
+#include <StatusQ/shareintake.h>
+
+// No App Group container outside iOS: the pending intake slot is inactive.
+QString Status::ShareIntake::pendingIntakeDir()
+{
+    return {};
+}

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -550,6 +550,17 @@ void SystemUtilsInternal::setMainWindowReady()
 #endif
 }
 
+void SystemUtilsInternal::moveAppTaskToBack()
+{
+#ifdef Q_OS_ANDROID
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/StatusQtActivity",
+        "moveAppTaskToBack",
+        "()V"
+    );
+#endif
+}
+
 int SystemUtilsInternal::androidKeyboardHeight() const
 {
     return m_androidKeyboardHeight;

--- a/ui/StatusQ/src/urlschemeevent.cpp
+++ b/ui/StatusQ/src/urlschemeevent.cpp
@@ -12,6 +12,8 @@ using namespace Status;
 #include <QDebug>
 #include <QDesktopServices>
 #include <QGuiApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
 
 void UrlSchemeEvent::registerUrlHandler()
 {
@@ -50,6 +52,12 @@ void UrlSchemeEvent::watchApplicationState()
     // appBackgrounded/appForegrounded drive the iOS pausable-services
     // bridge (src/app/core/services_pause_bridge.nim): pause on suspension,
     // resume — and media-server rebind — on return to the foreground.
+    // appForegrounded also drives the pending intake slot contract
+    // (src/app/core/intake/pending_intake_slot.nim): the host takes the
+    // payload when it comes to the foreground. This covers the wake-less iOS
+    // fallback for an already-running app — the share extension wrote the
+    // slot but its unsupported openURL wake failed or was dropped. Harmless
+    // elsewhere: consuming an inactive/empty slot is a no-op.
     // Under QCoreApplication (unit tests) there is no application state; skip.
     if (auto* app = qobject_cast<QGuiApplication*>(QCoreApplication::instance())) {
         connect(app, &QGuiApplication::applicationStateChanged, this,
@@ -90,11 +98,15 @@ void UrlSchemeEvent::emitDeepLinkToQt(const QString& url)
     emit urlActivated(url);
 }
 
-void UrlSchemeEvent::emitShareTextToQt(const QString& text)
+void UrlSchemeEvent::emitShareToQt(const QString& text, const QStringList& imagePaths)
 {
-    if (text.isEmpty()) return;
+    if (text.isEmpty() && imagePaths.isEmpty()) return;
 
-    emit shareTextActivated(text);
+    QJsonArray paths;
+    for (const auto& path : imagePaths)
+        paths.append(path);
+
+    emit shareActivated(text, QString::fromUtf8(QJsonDocument(paths).toJson(QJsonDocument::Compact)));
 }
 
 static UrlSchemeEvent* g_urlSchemeEventInstance = nullptr;
@@ -116,17 +128,27 @@ Java_app_status_mobile_StatusQtActivity_passDeepLinkToQt(JNIEnv* /*env*/, jclass
     }
 }
 
-// Share-target hand-off: text/links shared from another app. Kept separate
-// from the URL channel — a shared link must launch the share flow, not URL
-// routing.
+// Share-target hand-off: text/links and images shared from another app. Kept
+// separate from the URL channel — a shared link must launch the share flow,
+// not URL routing. Image paths are app-private cached copies made by the Java
+// layer at receipt (OS read grants expire), never OS-managed content URIs.
 extern "C" JNIEXPORT void JNICALL
-Java_app_status_mobile_StatusQtActivity_passShareTextToQt(JNIEnv* /*env*/, jclass /*clazz*/, jstring text)
+Java_app_status_mobile_StatusQtActivity_passShareToQt(JNIEnv* env, jclass /*clazz*/, jstring text, jobjectArray imagePaths)
 {
     const QString shareText = QJniObject(text).toString();
-    if (shareText.isEmpty()) return;
+
+    QStringList paths;
+    if (imagePaths) {
+        const jsize count = env->GetArrayLength(imagePaths);
+        for (jsize i = 0; i < count; ++i) {
+            auto path = static_cast<jstring>(env->GetObjectArrayElement(imagePaths, i));
+            paths << QJniObject(path).toString();
+            env->DeleteLocalRef(path);
+        }
+    }
 
     if (g_urlSchemeEventInstance) {
-        g_urlSchemeEventInstance->emitShareTextToQt(shareText);
+        g_urlSchemeEventInstance->emitShareToQt(shareText, paths);
     }
 }
 #endif

--- a/ui/StatusQ/src/urlschemeevent.cpp
+++ b/ui/StatusQ/src/urlschemeevent.cpp
@@ -90,6 +90,13 @@ void UrlSchemeEvent::emitDeepLinkToQt(const QString& url)
     emit urlActivated(url);
 }
 
+void UrlSchemeEvent::emitShareTextToQt(const QString& text)
+{
+    if (text.isEmpty()) return;
+
+    emit shareTextActivated(text);
+}
+
 static UrlSchemeEvent* g_urlSchemeEventInstance = nullptr;
 
 void UrlSchemeEvent::setInstance(UrlSchemeEvent* instance)
@@ -106,6 +113,20 @@ Java_app_status_mobile_StatusQtActivity_passDeepLinkToQt(JNIEnv* /*env*/, jclass
 
     if (g_urlSchemeEventInstance) {
         g_urlSchemeEventInstance->emitDeepLinkToQt(deepLink);
+    }
+}
+
+// Share-target hand-off: text/links shared from another app. Kept separate
+// from the URL channel — a shared link must launch the share flow, not URL
+// routing.
+extern "C" JNIEXPORT void JNICALL
+Java_app_status_mobile_StatusQtActivity_passShareTextToQt(JNIEnv* /*env*/, jclass /*clazz*/, jstring text)
+{
+    const QString shareText = QJniObject(text).toString();
+    if (shareText.isEmpty()) return;
+
+    if (g_urlSchemeEventInstance) {
+        g_urlSchemeEventInstance->emitShareTextToQt(shareText);
     }
 }
 #endif

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -310,6 +310,31 @@ QtObject {
         return result
     }
 
+    function sendMessageToChat(sectionId, chatId, text) {
+        // Share-flow send: resolves the destination's own section module, so it
+        // works for any destination regardless of which section this store
+        // instance is bound to. The personal chat section hosts 1-1 and group
+        // chats; any other destination lives in a community section.
+        const isPersonalSectionChat =
+            StatusQUtils.ModelUtils.contains(root.mainModuleInst.getChatSectionModule().model,
+                                             "itemId", chatId)
+        const sectionModule = isPersonalSectionChat ? root.mainModuleInst.getChatSectionModule()
+                                                    : getCommunitySectionModule(sectionId)
+        sectionModule.prepareChatContentModuleForChatId(chatId)
+        const chatContentModule = sectionModule.getChatContentModule()
+
+        const textMsg = cleanMessageText(text)
+        if (textMsg.trim() === "")
+            return false
+
+        chatContentModule.inputAreaModule.sendMessage(
+                    textMsg,
+                    "",
+                    Utils.isOnlyEmoji(textMsg) ? Constants.messageContentType.emojiType
+                                               : Constants.messageContentType.messageType)
+        return true
+    }
+
     function openCloseCreateChatView() {
         if (root.openCreateChat) {
             Global.closeCreateChatView()

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -310,7 +310,7 @@ QtObject {
         return result
     }
 
-    function sendMessageToChat(sectionId, chatId, text) {
+    function sendMessageToChat(sectionId, chatId, text, imagePaths = []) {
         // Share-flow send: resolves the destination's own section module, so it
         // works for any destination regardless of which section this store
         // instance is bound to. The personal chat section hosts 1-1 and group
@@ -324,6 +324,16 @@ QtObject {
         const chatContentModule = sectionModule.getChatContentModule()
 
         const textMsg = cleanMessageText(text)
+
+        if (imagePaths.length > 0) {
+            // Shared images: one send for all of them, the text as the
+            // accompanying message. Paths are local absolute paths (cached
+            // copies), already in the form sendImages expects.
+            chatContentModule.inputAreaModule.sendImages(
+                        JSON.stringify(imagePaths), textMsg.trim(), "")
+            return true
+        }
+
         if (textMsg.trim() === "")
             return false
 

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -259,6 +259,10 @@ QtObject {
                 root.openUrlInNewBrowserTab(url)
             }
 
+            function onLaunchShareFlow(text) {
+                root.launchShareFlow(text)
+            }
+
             function onOpenActivityCenter(group) {
                 root.activityCenterStore.setActiveNotificationGroup(group)
                 root.openActivityCenter()
@@ -315,6 +319,7 @@ QtObject {
     signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
     signal openUrl(string link)
     signal openUrlInNewBrowserTab(string link)
+    signal launchShareFlow(string text)
     signal openActivityCenter()
     signal wcLinkActivated(string link)
     signal profileMigrationFlowRequested(bool migrateToKeycard)

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -259,8 +259,8 @@ QtObject {
                 root.openUrlInNewBrowserTab(url)
             }
 
-            function onLaunchShareFlow(text) {
-                root.launchShareFlow(text)
+            function onLaunchShareFlow(text, imagePathsJson) {
+                root.launchShareFlow(text, JSON.parse(imagePathsJson))
             }
 
             function onOpenActivityCenter(group) {
@@ -319,12 +319,18 @@ QtObject {
     signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
     signal openUrl(string link)
     signal openUrlInNewBrowserTab(string link)
-    signal launchShareFlow(string text)
+    signal launchShareFlow(string text, var imagePaths)
     signal openActivityCenter()
     signal wcLinkActivated(string link)
     signal profileMigrationFlowRequested(bool migrateToKeycard)
     signal displayUserProfile(string publicKey)
     signal showToastPairingFallbackCompleted()
+
+    // Share-flow cancel path: releases the app-private cached copies of the
+    // shared images (the send path releases them after the send consumed them).
+    function releaseShareIntakeFiles(imagePaths) {
+        internal.mainModuleInst.releaseShareIntakeFiles(JSON.stringify(imagePaths))
+    }
     // End of Settings related stuff
 
     // End of Onboarding related stuff

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -81,7 +81,7 @@ Item {
                                    appMain.privacyStore?.thirdpartyServicesEnabled ?? true : true
         onOpenUrl: (link) => Global.requestOpenLink(link)
         onOpenUrlInNewBrowserTab: (link) => d.openUrlInNewBrowserTab(link)
-        onLaunchShareFlow: (text) => d.launchShareFlow(text)
+        onLaunchShareFlow: (text, imagePaths) => d.launchShareFlow(text, imagePaths)
         onOpenActivityCenter: () => {
             d.closeActivityCenterOnNextBack = false
             mainLayoutItem.openACCenterPanel = true
@@ -1117,9 +1117,12 @@ Item {
         // External intake, share route: content shared to Status from another
         // app launches the share flow (destination picker -> preview -> send).
         // Last-wins: a share arriving while the flow is open restarts it with
-        // the new text.
-        function launchShareFlow(text: string) {
+        // the new payload; the replaced share's cached image copies are
+        // released so they don't accumulate.
+        function launchShareFlow(text: string, imagePaths) {
+            d.releaseShareFlowImages()
             shareFlowLoader.sharedText = text
+            shareFlowLoader.sharedImagePaths = imagePaths
             if (!shareFlowLoader.active)
                 shareFlowLoader.active = true
             else
@@ -1127,19 +1130,34 @@ Item {
             shareFlowLoader.item.open()
         }
 
-        // Cancel from picker or preview: nothing is sent; on Android the whole
-        // task is backgrounded so the user lands back in the source app.
+        // Cancel from picker or preview: nothing is sent, the cached copies of
+        // the shared images are released; on Android the whole task is
+        // backgrounded so the user lands back in the source app.
         function cancelShareFlow() {
+            d.releaseShareFlowImages()
             shareFlowLoader.item.close()
             if (SQUtils.Utils.isAndroid)
                 SystemUtils.moveAppTaskToBack()
         }
 
-        // Send the shared text to the picked destination and land in that chat.
+        // Send the shared content to the picked destination and land in that
+        // chat. The cached image copies are NOT released here — the image-send
+        // task consumes the files asynchronously and releases them once done.
         function completeShareFlow(sectionId: string, chatId: string, text: string) {
+            const imagePaths = shareFlowLoader.sharedImagePaths
+            shareFlowLoader.sharedImagePaths = []
             shareFlowLoader.item.close()
-            appMain.rootChatStore.sendMessageToChat(sectionId, chatId, text)
+            appMain.rootChatStore.sendMessageToChat(sectionId, chatId, text, imagePaths)
             rootStore.setActiveSectionChat(sectionId, chatId)
+        }
+
+        // Cache lifecycle: drop the flow's cached shared-image copies (cancel
+        // and last-wins-replacement paths).
+        function releaseShareFlowImages() {
+            if (shareFlowLoader.sharedImagePaths.length === 0)
+                return
+            rootStore.releaseShareIntakeFiles(shareFlowLoader.sharedImagePaths)
+            shareFlowLoader.sharedImagePaths = []
         }
 
         function tryOpenNavigationEducationPopup() {
@@ -2877,9 +2895,12 @@ Item {
         id: shareFlowLoader
         active: false
 
-        // The shared text (external intake, share route); editable in the
-        // preview step before sending.
+        // The shared payload (external intake, share route): text editable in
+        // the preview step; image paths are app-private cached copies whose
+        // lifecycle ends with the flow (released on cancel/replace, or by the
+        // image-send task after send).
         property string sharedText
+        property var sharedImagePaths: []
 
         sourceComponent: Popup {
             id: shareFlowPopup
@@ -2930,6 +2951,7 @@ Item {
                     property string destinationChatId
 
                     text: shareFlowLoader.sharedText
+                    imagePaths: shareFlowLoader.sharedImagePaths
 
                     onSendRequested: (text) => d.completeShareFlow(destinationSectionId,
                                                                    destinationChatId, text)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -81,6 +81,7 @@ Item {
                                    appMain.privacyStore?.thirdpartyServicesEnabled ?? true : true
         onOpenUrl: (link) => Global.requestOpenLink(link)
         onOpenUrlInNewBrowserTab: (link) => d.openUrlInNewBrowserTab(link)
+        onLaunchShareFlow: (text) => d.launchShareFlow(text)
         onOpenActivityCenter: () => {
             d.closeActivityCenterOnNextBack = false
             mainLayoutItem.openACCenterPanel = true
@@ -1111,6 +1112,34 @@ Item {
                 if (browser && browser.openUrlInNewTab)
                     browser.openUrlInNewTab(link)
             })
+        }
+
+        // External intake, share route: content shared to Status from another
+        // app launches the share flow (destination picker -> preview -> send).
+        // Last-wins: a share arriving while the flow is open restarts it with
+        // the new text.
+        function launchShareFlow(text: string) {
+            shareFlowLoader.sharedText = text
+            if (!shareFlowLoader.active)
+                shareFlowLoader.active = true
+            else
+                shareFlowLoader.item.restart()
+            shareFlowLoader.item.open()
+        }
+
+        // Cancel from picker or preview: nothing is sent; on Android the whole
+        // task is backgrounded so the user lands back in the source app.
+        function cancelShareFlow() {
+            shareFlowLoader.item.close()
+            if (SQUtils.Utils.isAndroid)
+                SystemUtils.moveAppTaskToBack()
+        }
+
+        // Send the shared text to the picked destination and land in that chat.
+        function completeShareFlow(sectionId: string, chatId: string, text: string) {
+            shareFlowLoader.item.close()
+            appMain.rootChatStore.sendMessageToChat(sectionId, chatId, text)
+            rootStore.setActiveSectionChat(sectionId, chatId)
         }
 
         function tryOpenNavigationEducationPopup() {
@@ -2842,6 +2871,73 @@ Item {
         sequences: ["Ctrl+,", StandardKey.Preferences]
         onActivated: globalConns.onAppSectionBySectionTypeChanged(Constants.appSection.profile,
                                                                   Utils.getSettingsSubsectionForSection(d.activeSectionType))
+    }
+
+    Loader {
+        id: shareFlowLoader
+        active: false
+
+        // The shared text (external intake, share route); editable in the
+        // preview step before sending.
+        property string sharedText
+
+        sourceComponent: Popup {
+            id: shareFlowPopup
+
+            parent: appMain
+            x: (appMain.width - width) / 2
+            y: (appMain.height - height) / 2
+            width: appMain.isPortraitMode ? appMain.width : 480
+            height: appMain.isPortraitMode ? appMain.height
+                                           : Math.min(640, appMain.height - 2 * Theme.bigPadding)
+            modal: true
+            closePolicy: Popup.NoAutoClose
+            padding: Theme.padding
+
+            onClosed: shareFlowLoader.active = false
+
+            function restart() {
+                shareFlowSteps.currentIndex = 0
+                sharePreviewPanel.text = shareFlowLoader.sharedText
+            }
+
+            RecentPostableDestinationsAdaptor {
+                id: shareDestinationsAdaptor
+                sourceModel: rootStore.chatSearchModel
+            }
+
+            StackLayout {
+                id: shareFlowSteps
+                anchors.fill: parent
+                currentIndex: 0
+
+                ShareDestinationPickerPanel {
+                    model: shareDestinationsAdaptor.model
+
+                    onDestinationPicked: (sectionId, chatId, name) => {
+                        sharePreviewPanel.destinationSectionId = sectionId
+                        sharePreviewPanel.destinationChatId = chatId
+                        sharePreviewPanel.destinationName = name
+                        shareFlowSteps.currentIndex = 1
+                    }
+                    onCancelRequested: d.cancelShareFlow()
+                }
+
+                SharePreviewPanel {
+                    id: sharePreviewPanel
+
+                    property string destinationSectionId
+                    property string destinationChatId
+
+                    text: shareFlowLoader.sharedText
+
+                    onSendRequested: (text) => d.completeShareFlow(destinationSectionId,
+                                                                   destinationChatId, text)
+                    onBackRequested: shareFlowSteps.currentIndex = 0
+                    onCancelRequested: d.cancelShareFlow()
+                }
+            }
+        }
     }
 
     Loader {

--- a/ui/app/mainui/adaptors/RecentPostableDestinationsAdaptor.qml
+++ b/ui/app/mainui/adaptors/RecentPostableDestinationsAdaptor.qml
@@ -1,0 +1,36 @@
+import QtQml
+
+import StatusQ.Core.Utils
+
+import SortFilterProxyModel
+
+/**
+  * Data-oriented adaptor producing the "recent postable destinations" model
+  * (see CONTEXT.md): from a plain model of chats/channels it keeps only the
+  * destinations the user can post to (1-1 chats, group chats, community
+  * channels with post rights) and orders them by recency of the last message.
+  *
+  * Expected source roles: canPost (bool), lastMessageTimestamp (int) plus
+  * whatever display roles the consumer needs — all source roles pass through.
+  * Consumed by the share-flow destination picker; the direct-share shortcut
+  * publisher slice reuses it later.
+  */
+QObject {
+    id: root
+
+    property alias sourceModel: proxyModel.sourceModel
+
+    readonly property SortFilterProxyModel model: SortFilterProxyModel {
+        id: proxyModel
+
+        filters: ValueFilter {
+            roleName: "canPost"
+            value: true
+        }
+
+        sorters: RoleSorter {
+            roleName: "lastMessageTimestamp"
+            sortOrder: Qt.DescendingOrder
+        }
+    }
+}

--- a/ui/app/mainui/adaptors/qmldir
+++ b/ui/app/mainui/adaptors/qmldir
@@ -1,3 +1,4 @@
 AllContactsAdaptor 1.0 AllContactsAdaptor.qml
 ContactsModelAdaptor 1.0 ContactsModelAdaptor.qml
 PrimaryNavSidebarAdaptor 1.0 PrimaryNavSidebarAdaptor.qml
+RecentPostableDestinationsAdaptor 1.0 RecentPostableDestinationsAdaptor.qml

--- a/ui/app/mainui/panels/ShareDestinationPickerPanel.qml
+++ b/ui/app/mainui/panels/ShareDestinationPickerPanel.qml
@@ -1,0 +1,120 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Components
+import StatusQ.Controls
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Core.Utils
+
+import SortFilterProxyModel
+
+import utils
+
+/**
+  * Destination picker step of the share flow: a searchable list of postable
+  * destinations, recents first. Takes the model in (recency-sorted postable
+  * destinations, see RecentPostableDestinationsAdaptor; roles: chatId, name,
+  * color, colorId, icon, emoji, sectionId, sectionName) and emits intent
+  * signals out — no store access.
+  */
+Control {
+    id: root
+
+    /* Recency-sorted model of postable destinations */
+    required property var model
+
+    signal destinationPicked(string sectionId, string chatId, string name)
+    signal cancelRequested()
+
+    QtObject {
+        id: d
+
+        readonly property string searchPhrase: searchBox.text
+    }
+
+    contentItem: ColumnLayout {
+        spacing: Theme.halfPadding
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                text: qsTr("Share to")
+                font.pixelSize: Theme.primaryTextFontSize
+                font.weight: Font.DemiBold
+                elide: Text.ElideRight
+            }
+
+            StatusFlatRoundButton {
+                objectName: "shareDestinationPickerCancelButton"
+                icon.name: "close"
+                type: StatusFlatRoundButton.Type.Tertiary
+                onClicked: root.cancelRequested()
+            }
+        }
+
+        StatusInput {
+            id: searchBox
+            objectName: "shareDestinationPickerSearchBox"
+
+            Layout.fillWidth: true
+            placeholderText: qsTr("Search chats and channels")
+            input.asset.name: "search"
+        }
+
+        StatusListView {
+            id: listView
+            objectName: "shareDestinationPickerListView"
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            model: SortFilterProxyModel {
+                sourceModel: root.model
+
+                filters: AnyOf {
+                    SearchFilter {
+                        roleName: "name"
+                        searchPhrase: d.searchPhrase
+                    }
+                    SearchFilter {
+                        roleName: "sectionName"
+                        searchPhrase: d.searchPhrase
+                    }
+                    enabled: !!d.searchPhrase
+                }
+            }
+
+            delegate: StatusListItem {
+                objectName: "shareDestinationDelegate_" + model.name
+                width: ListView.view.width
+                title: model.name
+                label: model.sectionName
+                statusListItemIcon {
+                    name: model.name
+                    active: true
+                }
+                asset.width: 30
+                asset.height: 30
+                asset.color: model.color ? model.color
+                                         : Utils.colorForColorId(Theme.palette, model.colorId)
+                asset.name: model.icon
+                asset.emoji: model.emoji
+                asset.charactersLen: 2
+                asset.letterSize: asset._twoLettersSize
+                onClicked: root.destinationPicked(model.sectionId, model.chatId, model.name)
+            }
+
+            StatusBaseText {
+                anchors.centerIn: parent
+                visible: listView.count === 0
+                text: qsTr("No destinations found")
+                color: Theme.palette.baseColor1
+            }
+        }
+    }
+}

--- a/ui/app/mainui/panels/ShareDestinationPickerPanel.qml
+++ b/ui/app/mainui/panels/ShareDestinationPickerPanel.qml
@@ -90,7 +90,8 @@ Control {
             }
 
             delegate: StatusListItem {
-                objectName: "shareDestinationDelegate_" + model.name
+                // name alone collides (two channels called "general") and is mutable
+                objectName: "shareDestinationDelegate_" + model.name + "_" + model.chatId
                 width: ListView.view.width
                 title: model.name
                 label: model.sectionName

--- a/ui/app/mainui/panels/SharePreviewPanel.qml
+++ b/ui/app/mainui/panels/SharePreviewPanel.qml
@@ -7,8 +7,9 @@ import StatusQ.Core
 import StatusQ.Core.Theme
 
 /**
-  * Preview step of the share flow: the shared text, editable before sending
-  * to the picked destination. Takes data in (destination name, initial text)
+  * Preview step of the share flow: the shared content — image thumbnails (if
+  * any) and the text/caption, editable before sending to the picked
+  * destination. Takes data in (destination name, initial text, image paths)
   * and emits intent signals out — no store access.
   */
 Control {
@@ -17,12 +18,28 @@ Control {
     /* Display name of the picked destination */
     property string destinationName
 
-    /* The shared text; editable by the user before sending */
+    /* The shared text (or image caption); editable by the user before sending */
     property alias text: previewTextArea.text
+
+    /* Local paths (or image URLs) of the shared images; empty for text shares */
+    property var imagePaths: []
 
     signal sendRequested(string text)
     signal backRequested()
     signal cancelRequested()
+
+    QtObject {
+        id: d
+
+        // Nim hands over plain absolute file paths; QML Image needs a URL.
+        // Already-formed URLs (file:, data:, qrc:, image:) pass through, which
+        // keeps the component previewable with self-contained test data.
+        function toImageSource(path) {
+            if (/^(file|data|qrc|image|https?):/.test(path))
+                return path
+            return "file://" + path
+        }
+    }
 
     contentItem: ColumnLayout {
         spacing: Theme.halfPadding
@@ -53,6 +70,35 @@ Control {
             }
         }
 
+        StatusListView {
+            id: thumbnailsList
+            objectName: "sharePreviewThumbnailsList"
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: 96
+            visible: count > 0
+
+            orientation: ListView.Horizontal
+            spacing: Theme.halfPadding
+            model: root.imagePaths
+
+            delegate: Rectangle {
+                width: 96
+                height: 96
+                radius: Theme.radius
+                color: Theme.palette.baseColor2
+                clip: true
+
+                Image {
+                    objectName: "sharePreviewThumbnail"
+                    anchors.fill: parent
+                    source: d.toImageSource(modelData)
+                    fillMode: Image.PreserveAspectCrop
+                    asynchronous: true
+                }
+            }
+        }
+
         StatusScrollView {
             Layout.fillWidth: true
             Layout.fillHeight: true
@@ -72,7 +118,8 @@ Control {
             objectName: "sharePreviewSendButton"
             Layout.alignment: Qt.AlignRight
             text: qsTr("Send")
-            enabled: previewTextArea.text.trim().length > 0
+            // Images alone are sendable (empty caption); text shares need text.
+            enabled: previewTextArea.text.trim().length > 0 || root.imagePaths.length > 0
             onClicked: root.sendRequested(previewTextArea.text)
         }
     }

--- a/ui/app/mainui/panels/SharePreviewPanel.qml
+++ b/ui/app/mainui/panels/SharePreviewPanel.qml
@@ -1,0 +1,79 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Controls
+import StatusQ.Core
+import StatusQ.Core.Theme
+
+/**
+  * Preview step of the share flow: the shared text, editable before sending
+  * to the picked destination. Takes data in (destination name, initial text)
+  * and emits intent signals out — no store access.
+  */
+Control {
+    id: root
+
+    /* Display name of the picked destination */
+    property string destinationName
+
+    /* The shared text; editable by the user before sending */
+    property alias text: previewTextArea.text
+
+    signal sendRequested(string text)
+    signal backRequested()
+    signal cancelRequested()
+
+    contentItem: ColumnLayout {
+        spacing: Theme.halfPadding
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            StatusFlatRoundButton {
+                objectName: "sharePreviewBackButton"
+                icon.name: "arrow-left"
+                type: StatusFlatRoundButton.Type.Tertiary
+                onClicked: root.backRequested()
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                text: qsTr("Share to %1").arg(root.destinationName)
+                font.pixelSize: Theme.primaryTextFontSize
+                font.weight: Font.DemiBold
+                elide: Text.ElideRight
+            }
+
+            StatusFlatRoundButton {
+                objectName: "sharePreviewCancelButton"
+                icon.name: "close"
+                type: StatusFlatRoundButton.Type.Tertiary
+                onClicked: root.cancelRequested()
+            }
+        }
+
+        StatusScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            padding: 0
+
+            StatusTextArea {
+                id: previewTextArea
+                objectName: "sharePreviewTextArea"
+
+                width: parent.width
+                placeholderText: qsTr("Message")
+                wrapMode: TextEdit.Wrap
+            }
+        }
+
+        StatusButton {
+            objectName: "sharePreviewSendButton"
+            Layout.alignment: Qt.AlignRight
+            text: qsTr("Send")
+            enabled: previewTextArea.text.trim().length > 0
+            onClicked: root.sendRequested(previewTextArea.text)
+        }
+    }
+}

--- a/ui/app/mainui/qmldir
+++ b/ui/app/mainui/qmldir
@@ -6,4 +6,6 @@ ToastsManager 1.0 ToastsManager.qml
 StatusTrayIcon 1.0 StatusTrayIcon.qml
 DropAreaPanel 1.0 panels/DropAreaPanel.qml
 PrimaryNavSidebar 1.0 panels/PrimaryNavSidebar.qml
+ShareDestinationPickerPanel 1.0 panels/ShareDestinationPickerPanel.qml
+SharePreviewPanel 1.0 panels/SharePreviewPanel.qml
 PrimaryNavSidebarButton 1.0 controls/PrimaryNavSidebarButton.qml

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -15551,6 +15551,36 @@ to load</source>
     </message>
 </context>
 <context>
+    <name>ShareDestinationPickerPanel</name>
+    <message>
+        <source>Share to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search chats and channels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No destinations found</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SharePreviewPanel</name>
+    <message>
+        <source>Share to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ShareProfileDialog</name>
     <message>
         <source>Profile link</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -15635,6 +15635,36 @@ selhalo</translation>
     </message>
 </context>
 <context>
+    <name>ShareDestinationPickerPanel</name>
+    <message>
+        <source>Share to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search chats and channels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No destinations found</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SharePreviewPanel</name>
+    <message>
+        <source>Share to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">Zpráva</translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">Odeslat</translation>
+    </message>
+</context>
+<context>
     <name>ShareProfileDialog</name>
     <message>
         <source>Profile link</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -15566,6 +15566,36 @@ al cargar</translation>
     </message>
 </context>
 <context>
+    <name>ShareDestinationPickerPanel</name>
+    <message>
+        <source>Share to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search chats and channels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No destinations found</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SharePreviewPanel</name>
+    <message>
+        <source>Share to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">Mensaje</translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">Enviar</translation>
+    </message>
+</context>
+<context>
     <name>ShareProfileDialog</name>
     <message>
         <source>Profile link</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -15498,6 +15498,36 @@ to load</source>
     </message>
 </context>
 <context>
+    <name>ShareDestinationPickerPanel</name>
+    <message>
+        <source>Share to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search chats and channels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No destinations found</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SharePreviewPanel</name>
+    <message>
+        <source>Share to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">메시지</translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">보내기</translation>
+    </message>
+</context>
+<context>
     <name>ShareProfileDialog</name>
     <message>
         <source>Profile link</source>


### PR DESCRIPTION
Part of #21684. Part of #20439. Slice of the share epic — targets `feat/share-integration`, not `master`.

Status becomes a share target on Android: sharing text, links or images from any app opens the Status share flow — pick a destination, preview, send.

- Manifest SEND / SEND_MULTIPLE intent filters (text, links, single & multiple images, image + caption) + `singleTask` launch mode so a share lands in the existing app instance instead of spawning a dead second instance inside the caller's task
- Activity-side intake: shared content is copied into an app-cache partition (lifecycle-cleaned) and handed to the intake seam — works cold-start and warm; stale task-root intents are not re-processed on Activity recreation
- First version of the in-app share flow: searchable destination picker (1-1s, groups, community channels), share preview, send path
- Platform-neutral pending-intake slot + wake handling shared with iOS (the iOS share-extension PR builds on it)
- Storybook pages, QML tests and Nim tests (`share_intake_wake_test`, `share_intake_cache_test`, `pending_intake_slot_test`)

**How tested:** Nim + QML unit tests; device-verified on a Galaxy S21 (Android 15): cold-start and warm shares, single/multiple images, caption, theme, no duplicate processing after recreation.

**Stacked chain:** #21768 (feature branch → `master`) ← #21686 (core, merged) ← #21769 (Android target) ← #21770 (direct share) ← #21771 (iOS extension) ← #21772 (donations) ← #21773 (flow polish). Each PR is based on its predecessor's branch, so the diff shows only this PR's own commits. When a predecessor merges, this PR is retargeted and rebased. #21687 (media lifecycle) is independent and targets `master` directly.

