### PR TITLE
feat(share): chat-style preview, own-sends ranking, instant local echo

### DIFF
--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -15,6 +15,7 @@ NIM_BENCHES := $(addprefix nim-test-run/,$(NIM_BENCH_FILES))
 # need it built first.
 NIM_TESTS_LINK_STATUSQ := \
 	asset_proxy_chain_bench \
+	chat_search_model_test \
 	collectibles_selector_bench \
 	collectibles_selector_model_bench \
 	send_handler_adaptors_bench \

--- a/src/app/modules/main/app_search/models/chat_search_item.nim
+++ b/src/app/modules/main/app_search/models/chat_search_item.nim
@@ -11,9 +11,10 @@ type
     chatType: int
     lastMessageText: string
     lastMessageTimestamp: int
+    lastOwnMessageTimestamp: int
     canPost: bool
 
-proc initItem*(chatId, name, color: string, colorId: int, icon, sectionId, sectionName, emoji: string, chatType: int, lastMessageText: string, lastMessageTimestamp: int, canPost: bool): ChatSearchItem =
+proc initItem*(chatId, name, color: string, colorId: int, icon, sectionId, sectionName, emoji: string, chatType: int, lastMessageText: string, lastMessageTimestamp: int, canPost: bool, lastOwnMessageTimestamp: int = 0): ChatSearchItem =
   result = ChatSearchItem()
   result.chatId = chatId
   result.name = name
@@ -26,6 +27,7 @@ proc initItem*(chatId, name, color: string, colorId: int, icon, sectionId, secti
   result.chatType = chatType
   result.lastMessageText = lastMessageText
   result.lastMessageTimestamp = lastMessageTimestamp
+  result.lastOwnMessageTimestamp = lastOwnMessageTimestamp
   result.canPost = canPost
 
 proc chatId*(self: ChatSearchItem): string =
@@ -78,6 +80,12 @@ proc lastMessageTimestamp*(self: ChatSearchItem): int =
 
 proc `lastMessageTimestamp=`*(self: ChatSearchItem, value: int) =
   self.lastMessageTimestamp = value
+
+proc lastOwnMessageTimestamp*(self: ChatSearchItem): int =
+  self.lastOwnMessageTimestamp
+
+proc `lastOwnMessageTimestamp=`*(self: ChatSearchItem, value: int) =
+  self.lastOwnMessageTimestamp = value
 
 proc canPost*(self: ChatSearchItem): bool =
   self.canPost

--- a/src/app/modules/main/app_search/models/chat_search_item.nim
+++ b/src/app/modules/main/app_search/models/chat_search_item.nim
@@ -14,7 +14,7 @@ type
     lastOwnMessageTimestamp: int
     canPost: bool
 
-proc initItem*(chatId, name, color: string, colorId: int, icon, sectionId, sectionName, emoji: string, chatType: int, lastMessageText: string, lastMessageTimestamp: int, canPost: bool, lastOwnMessageTimestamp: int = 0): ChatSearchItem =
+proc initItem*(chatId, name, color: string, colorId: int, icon, sectionId, sectionName, emoji: string, chatType: int, lastMessageText: string, lastMessageTimestamp: int, lastOwnMessageTimestamp: int, canPost: bool): ChatSearchItem =
   result = ChatSearchItem()
   result.chatId = chatId
   result.name = name

--- a/src/app/modules/main/app_search/models/chat_search_model.nim
+++ b/src/app/modules/main/app_search/models/chat_search_model.nim
@@ -16,6 +16,7 @@ type
     ChatType
     LastMessageText
     LastMessageTimestamp
+    LastOwnMessageTimestamp
     CanPost
 
 QtObject:
@@ -67,13 +68,13 @@ QtObject:
       return
     self.removeItemByIndex(index)
 
-  method rowCount(self: Model, index: QModelIndex = nil): int =
+  method rowCount*(self: Model, index: QModelIndex = nil): int =
     if not self.built:
       self.delegate.buildChatSearchModel()
       self.built = true
     return self.items.len
 
-  method roleNames(self: Model): Table[int, string] =
+  method roleNames*(self: Model): Table[int, string] =
     {
       ModelRole.ChatId.int:"chatId",
       ModelRole.Name.int:"name",
@@ -86,10 +87,11 @@ QtObject:
       ModelRole.ChatType.int:"chatType",
       ModelRole.LastMessageText.int:"lastMessageText",
       ModelRole.LastMessageTimestamp.int:"lastMessageTimestamp",
+      ModelRole.LastOwnMessageTimestamp.int:"lastOwnMessageTimestamp",
       ModelRole.CanPost.int:"canPost",
     }.toTable
 
-  method data(self: Model, index: QModelIndex, role: int): QVariant =
+  method data*(self: Model, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.items.len, role, ModelRole)
 
     let item = self.items[index.row]
@@ -119,6 +121,8 @@ QtObject:
         result = newQVariant(item.lastMessageText)
       of ModelRole.LastMessageTimestamp:
         result = newQVariant(item.lastMessageTimestamp)
+      of ModelRole.LastOwnMessageTimestamp:
+        result = newQVariant(item.lastOwnMessageTimestamp)
       of ModelRole.CanPost:
         result = newQVariant(item.canPost)
 
@@ -140,6 +144,10 @@ QtObject:
   proc updateLastMessageTimestampOnChatItem*(self:Model, chatId: string, lastMessageTimestamp: int) =
     updateItemRolesAndNotify self.getItemIndexById(chatId):
       updateRole(lastMessageTimestamp)
+
+  proc updateLastOwnMessageTimestampOnChatItem*(self:Model, chatId: string, lastOwnMessageTimestamp: int) =
+    updateItemRolesAndNotify self.getItemIndexById(chatId):
+      updateRole(lastOwnMessageTimestamp)
 
   proc updateCanPostOnChatItem*(self:Model, chatId: string, canPost: bool) =
     updateItemRolesAndNotify self.getItemIndexById(chatId):

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -377,7 +377,6 @@ proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, pe
       else:
         self.controller.getMessagesParsedPlainText(chat.lastMessage, []),
     lastMessageTimestamp = chat.timestamp.int,
-    canPost = chat.canPost,
     # Own-send recency survives restarts by deriving from the persisted last
     # message; when someone else posted last, the live bump on sending success
     # (updateLastMessage) is the only source, so it starts unset.
@@ -386,6 +385,7 @@ proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, pe
         chat.timestamp.int
       else:
         0,
+    canPost = chat.canPost,
   )
 
 method buildChatSearchModel*(self: Module) =

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -378,6 +378,14 @@ proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, pe
         self.controller.getMessagesParsedPlainText(chat.lastMessage, []),
     lastMessageTimestamp = chat.timestamp.int,
     canPost = chat.canPost,
+    # Own-send recency survives restarts by deriving from the persisted last
+    # message; when someone else posted last, the live bump on sending success
+    # (updateLastMessage) is the only source, so it starts unset.
+    lastOwnMessageTimestamp =
+      if chat.lastMessage.`from` == singletonInstance.userProfile.getPubKey():
+        chat.timestamp.int
+      else:
+        0,
   )
 
 method buildChatSearchModel*(self: Module) =
@@ -453,3 +461,5 @@ method updateLastMessage*(self: Module, chatId, communityId: string, chatType: C
   )
   if lastMessageTimestamp > 0:
     self.view.chatSearchModel().updateLastMessageTimestampOnChatItem(chatId, lastMessageTimestamp)
+    if lastMessage.`from` == singletonInstance.userProfile.getPubKey():
+      self.view.chatSearchModel().updateLastOwnMessageTimestampOnChatItem(chatId, lastMessageTimestamp)

--- a/storybook/pages/RecentPostableDestinationsAdaptorPage.qml
+++ b/storybook/pages/RecentPostableDestinationsAdaptorPage.qml
@@ -21,6 +21,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 400,
+                lastOwnMessageTimestamp: 400,
                 canPost: true
             },
             {
@@ -33,6 +34,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 900,
+                lastOwnMessageTimestamp: 100,
                 canPost: true
             },
             {
@@ -45,6 +47,7 @@ SplitView {
                 sectionId: "community-1",
                 sectionName: "CryptoKitties",
                 lastMessageTimestamp: 1000,
+                lastOwnMessageTimestamp: 0,
                 canPost: false
             },
             {
@@ -57,6 +60,7 @@ SplitView {
                 sectionId: "community-1",
                 sectionName: "CryptoKitties",
                 lastMessageTimestamp: 700,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             }
         ]
@@ -79,8 +83,9 @@ SplitView {
             spacing: 4
 
             delegate: Label {
-                text: "%1 (%2) — lastMessageTimestamp: %3".arg(model.name)
-                        .arg(model.sectionName).arg(model.lastMessageTimestamp)
+                text: "%1 (%2) — own: %3, any: %4".arg(model.name)
+                        .arg(model.sectionName).arg(model.lastOwnMessageTimestamp)
+                        .arg(model.lastMessageTimestamp)
             }
         }
     }
@@ -96,8 +101,12 @@ SplitView {
                 Layout.fillWidth: true
                 wrapMode: Text.Wrap
                 text: "Source rows (toggle post rights, bump recency); the left "
-                      + "pane shows the adaptor output: postable only, most "
-                      + "recent first."
+                      + "pane shows the adaptor output: postable only, chats "
+                      + "the user sent to first (by own-send recency), then "
+                      + "never-sent-to ones by any-message recency. 'Send' "
+                      + "bumps both recency roles like a real send; 'Receive' "
+                      + "bumps only any-message recency and must not promote "
+                      + "the row above sent-to chats."
             }
 
             Repeater {
@@ -113,7 +122,16 @@ SplitView {
                     }
 
                     Button {
-                        text: "Bump"
+                        text: "Send"
+                        onClicked: {
+                            const bumped = model.lastMessageTimestamp + 1000
+                            destinationsModel.setProperty(index, "lastMessageTimestamp", bumped)
+                            destinationsModel.setProperty(index, "lastOwnMessageTimestamp", bumped)
+                        }
+                    }
+
+                    Button {
+                        text: "Receive"
                         onClicked: destinationsModel.setProperty(index, "lastMessageTimestamp",
                                                                  model.lastMessageTimestamp + 1000)
                     }

--- a/storybook/pages/SendMessageIntentDonorPage.qml
+++ b/storybook/pages/SendMessageIntentDonorPage.qml
@@ -24,6 +24,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 400,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             },
             {
@@ -36,6 +37,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 900,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             },
             {
@@ -48,6 +50,7 @@ SplitView {
                 sectionId: "community-1",
                 sectionName: "CryptoKitties",
                 lastMessageTimestamp: 1000,
+                lastOwnMessageTimestamp: 0,
                 canPost: false
             },
             {
@@ -60,6 +63,7 @@ SplitView {
                 sectionId: "community-1",
                 sectionName: "CryptoKitties",
                 lastMessageTimestamp: 700,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             },
             {
@@ -72,6 +76,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 300,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             }
         ]

--- a/storybook/pages/ShareDestinationPickerPanelPage.qml
+++ b/storybook/pages/ShareDestinationPickerPanelPage.qml
@@ -25,6 +25,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 400,
+                lastOwnMessageTimestamp: 400,
                 canPost: true
             },
             {
@@ -37,6 +38,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 900,
+                lastOwnMessageTimestamp: 100,
                 canPost: true
             },
             {
@@ -49,6 +51,7 @@ SplitView {
                 sectionId: "community-1",
                 sectionName: "CryptoKitties",
                 lastMessageTimestamp: 1000,
+                lastOwnMessageTimestamp: 0,
                 canPost: false
             },
             {
@@ -61,6 +64,7 @@ SplitView {
                 sectionId: "community-1",
                 sectionName: "CryptoKitties",
                 lastMessageTimestamp: 700,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             }
         ]

--- a/storybook/pages/SharePreviewPanelPage.qml
+++ b/storybook/pages/SharePreviewPanelPage.qml
@@ -4,6 +4,8 @@ import QtQuick.Layouts
 
 import Storybook
 
+import utils
+
 import mainui
 
 SplitView {
@@ -32,6 +34,12 @@ SplitView {
             height: 500
 
             destinationName: destinationNameField.text
+            destinationColor: destinationColorField.text
+            destinationEmoji: destinationEmojiField.text
+            destinationChatType: communityChannelCheckBox.checked
+                                 ? Constants.chatType.communityChat
+                                 : Constants.chatType.oneToOne
+            destinationSectionName: destinationSectionNameField.text
             text: "Look at this https://example.com/article"
             imagePaths: root.sampleImages.slice(0, imageCountSpinBox.value)
 
@@ -56,6 +64,32 @@ SplitView {
             TextField {
                 id: destinationNameField
                 text: "Design crew"
+            }
+            Label {
+                text: "Destination color"
+            }
+            TextField {
+                id: destinationColorField
+                text: "#7CDA00"
+            }
+            Label {
+                text: "Destination emoji"
+            }
+            TextField {
+                id: destinationEmojiField
+                text: ""
+            }
+            CheckBox {
+                id: communityChannelCheckBox
+                text: "Community channel"
+                checked: true
+            }
+            Label {
+                text: "Section name"
+            }
+            TextField {
+                id: destinationSectionNameField
+                text: "Design DAO"
             }
             Label {
                 text: "Shared images"

--- a/storybook/pages/SharePreviewPanelPage.qml
+++ b/storybook/pages/SharePreviewPanelPage.qml
@@ -11,30 +11,33 @@ SplitView {
 
     Logs { id: logs }
 
-    // Self-contained 1x1 PNG so the page works in isolation, standing in for
-    // the cached file paths the share intake delivers.
-    readonly property string sampleImage:
-        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    // Self-contained 1x1 PNGs so the page works in isolation, standing in for
+    // the cached file paths the share intake delivers. Distinct pixels because
+    // the chat input deduplicates identical entries.
+    readonly property var sampleImages: [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNg+M8AAAICAQB7CYF4AAAAAElFTkSuQmCC",
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC"
+    ]
 
     Pane {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
         SharePreviewPanel {
+            id: previewPanel
+
             anchors.centerIn: parent
             width: 400
             height: 500
 
             destinationName: destinationNameField.text
             text: "Look at this https://example.com/article"
-            imagePaths: {
-                const paths = []
-                for (let i = 0; i < imageCountSpinBox.value; i++)
-                    paths.push(root.sampleImage)
-                return paths
-            }
+            imagePaths: root.sampleImages.slice(0, imageCountSpinBox.value)
 
-            onSendRequested: (text) => logs.logEvent("SharePreviewPanel::sendRequested: " + text)
+            onSendRequested: (text, imagePaths) => logs.logEvent(
+                "SharePreviewPanel::sendRequested",
+                ["text", "imagePaths"], [text, JSON.stringify(imagePaths)])
             onBackRequested: logs.logEvent("SharePreviewPanel::backRequested")
             onCancelRequested: logs.logEvent("SharePreviewPanel::cancelRequested")
         }
@@ -60,8 +63,12 @@ SplitView {
             SpinBox {
                 id: imageCountSpinBox
                 from: 0
-                to: 10
+                to: root.sampleImages.length
                 value: 2
+            }
+            Button {
+                text: "Reset shared payload"
+                onClicked: previewPanel.reset()
             }
         }
     }

--- a/storybook/pages/ShareShortcutsPublisherPage.qml
+++ b/storybook/pages/ShareShortcutsPublisherPage.qml
@@ -22,6 +22,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 400,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             },
             {
@@ -34,6 +35,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 900,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             },
             {
@@ -46,6 +48,7 @@ SplitView {
                 sectionId: "community-1",
                 sectionName: "CryptoKitties",
                 lastMessageTimestamp: 1000,
+                lastOwnMessageTimestamp: 0,
                 canPost: false
             },
             {
@@ -58,6 +61,7 @@ SplitView {
                 sectionId: "community-1",
                 sectionName: "CryptoKitties",
                 lastMessageTimestamp: 700,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             },
             {
@@ -70,6 +74,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 300,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             },
             {
@@ -82,6 +87,7 @@ SplitView {
                 sectionId: "personal-section",
                 sectionName: "Chat",
                 lastMessageTimestamp: 200,
+                lastOwnMessageTimestamp: 0,
                 canPost: true
             }
         ]
@@ -159,9 +165,12 @@ SplitView {
                     }
 
                     Button {
-                        text: "Bump"
-                        onClicked: destinationsModel.setProperty(index, "lastMessageTimestamp",
-                                                                 model.lastMessageTimestamp + 1000)
+                        text: "Send"
+                        onClicked: {
+                            const bumped = model.lastMessageTimestamp + 1000
+                            destinationsModel.setProperty(index, "lastMessageTimestamp", bumped)
+                            destinationsModel.setProperty(index, "lastOwnMessageTimestamp", bumped)
+                        }
                     }
                 }
             }

--- a/storybook/qmlTests/tests/tst_RecentPostableDestinationsAdaptor.qml
+++ b/storybook/qmlTests/tests/tst_RecentPostableDestinationsAdaptor.qml
@@ -25,6 +25,7 @@ Item {
                     sectionId: "personal-section",
                     sectionName: "Chat",
                     lastMessageTimestamp: 400,
+                    lastOwnMessageTimestamp: 400,
                     canPost: true
                 },
                 {
@@ -33,6 +34,7 @@ Item {
                     sectionId: "personal-section",
                     sectionName: "Chat",
                     lastMessageTimestamp: 900,
+                    lastOwnMessageTimestamp: 100,
                     canPost: true
                 },
                 {
@@ -41,6 +43,7 @@ Item {
                     sectionId: "community-1",
                     sectionName: "CryptoKitties",
                     lastMessageTimestamp: 1000,
+                    lastOwnMessageTimestamp: 0,
                     canPost: false
                 },
                 {
@@ -49,6 +52,7 @@ Item {
                     sectionId: "community-1",
                     sectionName: "CryptoKitties",
                     lastMessageTimestamp: 700,
+                    lastOwnMessageTimestamp: 0,
                     canPost: true
                 }
             ]
@@ -70,15 +74,31 @@ Item {
             compare(ModelUtils.indexOf(model, "chatId", "channel-announcements"), -1)
         }
 
-        function test_sortsByRecencyMostRecentFirst() {
+        function test_ranksByOwnSendRecencyNotAnyMessageRecency() {
             const sourceModel = createTemporaryObject(destinationsModelComponent, root)
             const adaptor = createTemporaryObject(testComponent, root,
                                                   { sourceModel: sourceModel })
             const model = adaptor.model
 
-            compare(ModelUtils.get(model, 0).chatId, "chat-design-group")
-            compare(ModelUtils.get(model, 1).chatId, "channel-general")
-            compare(ModelUtils.get(model, 2).chatId, "chat-alice")
+            // the busy channel-general (lastMessageTimestamp 700, never sent
+            // to) must not outrank the chats the user actually sent to
+            compare(ModelUtils.get(model, 0).chatId, "chat-alice")
+            compare(ModelUtils.get(model, 1).chatId, "chat-design-group")
+            compare(ModelUtils.get(model, 2).chatId, "channel-general")
+        }
+
+        function test_neverSentToChatsFallBackToAnyMessageRecency() {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const adaptor = createTemporaryObject(testComponent, root,
+                                                  { sourceModel: sourceModel })
+            const model = adaptor.model
+
+            // both community channels have no own sends; once postable they
+            // rank after all sent-to chats, ordered by any-message recency
+            sourceModel.setProperty(2, "canPost", true)
+            compare(model.rowCount(), 4)
+            compare(ModelUtils.get(model, 2).chatId, "channel-announcements")
+            compare(ModelUtils.get(model, 3).chatId, "channel-general")
         }
 
         function test_reactsToPostRightsChanges() {
@@ -90,7 +110,6 @@ Item {
             // gaining post rights adds the destination
             sourceModel.setProperty(2, "canPost", true)
             compare(model.rowCount(), 4)
-            compare(ModelUtils.get(model, 0).chatId, "channel-announcements")
 
             // losing post rights removes it
             sourceModel.setProperty(2, "canPost", false)
@@ -98,14 +117,30 @@ Item {
             compare(ModelUtils.indexOf(model, "chatId", "channel-announcements"), -1)
         }
 
-        function test_reactsToRecencyChanges() {
+        function test_ownSendBumpsChatToTop() {
             const sourceModel = createTemporaryObject(destinationsModelComponent, root)
             const adaptor = createTemporaryObject(testComponent, root,
                                                   { sourceModel: sourceModel })
             const model = adaptor.model
 
-            sourceModel.setProperty(0, "lastMessageTimestamp", 2000)
+            // a successful send updates both recency roles on the source model
+            sourceModel.setProperty(3, "lastMessageTimestamp", 2000)
+            sourceModel.setProperty(3, "lastOwnMessageTimestamp", 2000)
+            compare(ModelUtils.get(model, 0).chatId, "channel-general")
+            compare(ModelUtils.get(model, 1).chatId, "chat-alice")
+        }
+
+        function test_anyMessageRecencyChangeDoesNotOutrankSentToChats() {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const adaptor = createTemporaryObject(testComponent, root,
+                                                  { sourceModel: sourceModel })
+            const model = adaptor.model
+
+            // someone else posting in the busy channel must not promote it
+            sourceModel.setProperty(3, "lastMessageTimestamp", 5000)
             compare(ModelUtils.get(model, 0).chatId, "chat-alice")
+            compare(ModelUtils.get(model, 1).chatId, "chat-design-group")
+            compare(ModelUtils.get(model, 2).chatId, "channel-general")
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_SendMessageIntentDonor.qml
+++ b/storybook/qmlTests/tests/tst_SendMessageIntentDonor.qml
@@ -39,6 +39,7 @@ Item {
                     sectionId: "personal-section",
                     sectionName: "Chat",
                     lastMessageTimestamp: 500,
+                    lastOwnMessageTimestamp: 0,
                     canPost: true
                 },
                 {
@@ -51,6 +52,7 @@ Item {
                     sectionId: "personal-section",
                     sectionName: "Chat",
                     lastMessageTimestamp: 900,
+                    lastOwnMessageTimestamp: 0,
                     canPost: true
                 },
                 {
@@ -63,6 +65,7 @@ Item {
                     sectionId: "community-1",
                     sectionName: "CryptoKitties",
                     lastMessageTimestamp: 1000,
+                    lastOwnMessageTimestamp: 0,
                     canPost: false
                 }
             ]

--- a/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
+++ b/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
@@ -181,6 +181,24 @@ Item {
             compare(sendRequestedSpy.signalArguments[0][1][0], root.redImage)
         }
 
+        function test_sendConvertsSingleSlashFileUrlToPlainPath() {
+            // Real file needed: the image validator sniffs content.
+            const absPath = Qt.resolvedUrl("../../../ui/StatusQ/src/assets/png/qr-scan-success.png")
+                              .toString().slice("file://".length)
+            const preview = createPreview({ text: "" })
+            const chatInput = findChild(preview, "statusChatInput")
+            const sendButton = findChild(preview, "statusChatInputSendButton")
+            verify(chatInput)
+
+            chatInput.selectImageString("file:" + absPath)
+            compare(chatInput.fileUrlsAndSources.length, 1)
+
+            mouseClick(sendButton)
+
+            compare(sendRequestedSpy.count, 1)
+            compare(sendRequestedSpy.signalArguments[0][1][0], absPath)
+        }
+
         function test_sendWithImagesEmitsEditedCaption() {
             const preview = createPreview({
                 imagePaths: [root.redImage, root.greenImage]

--- a/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
+++ b/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
@@ -1,6 +1,8 @@
 import QtQuick
 import QtTest
 
+import StatusQ.Core.Utils as SQUtils
+
 import mainui
 
 Item {
@@ -9,10 +11,15 @@ Item {
     width: 500
     height: 600
 
-    // Self-contained 1x1 PNG standing in for the cached file paths the share
+    // Self-contained 1x1 PNGs standing in for the cached file paths the share
     // intake delivers (no filesystem dependency, no Image load warnings).
-    readonly property string sampleImage:
-        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    // Distinct pixels because the chat input deduplicates identical entries.
+    readonly property string redImage:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+    readonly property string greenImage:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNg+M8AAAICAQB7CYF4AAAAAElFTkSuQmCC"
+    readonly property string blueImage:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC"
 
     Component {
         id: testComponent
@@ -49,8 +56,8 @@ Item {
             cancelRequestedSpy.clear()
         }
 
-        function createPreview() {
-            const preview = createTemporaryObject(testComponent, root)
+        function createPreview(properties = {}) {
+            const preview = createTemporaryObject(testComponent, root, properties)
             sendRequestedSpy.target = preview
             backRequestedSpy.target = preview
             cancelRequestedSpy.target = preview
@@ -58,35 +65,57 @@ Item {
             return preview
         }
 
+        // The chat input emits rich text; compare via its plain-text form,
+        // like the send pipeline does.
+        function plainText(text) {
+            return SQUtils.StringUtils.plainText(text)
+        }
+
+        function test_prefillsChatInputWithSharedText() {
+            const preview = createPreview()
+            const chatInput = findChild(preview, "statusChatInput")
+            verify(chatInput)
+
+            compare(chatInput.getPlainText(),
+                    "Look at this https://example.com/article")
+        }
+
         function test_sendEmitsEditedText() {
             const preview = createPreview()
-            const textArea = findChild(preview, "sharePreviewTextArea")
-            const sendButton = findChild(preview, "sharePreviewSendButton")
-            verify(textArea)
+            const chatInput = findChild(preview, "statusChatInput")
+            const sendButton = findChild(preview, "statusChatInputSendButton")
+            verify(chatInput)
             verify(sendButton)
-
-            compare(textArea.text, "Look at this https://example.com/article")
             verify(sendButton.enabled)
 
-            textArea.text = "Edited before sending"
+            chatInput.setText("Edited before sending")
             mouseClick(sendButton)
 
             compare(sendRequestedSpy.count, 1)
-            compare(sendRequestedSpy.signalArguments[0][0], "Edited before sending")
+            compare(plainText(sendRequestedSpy.signalArguments[0][0]),
+                    "Edited before sending")
+            compare(sendRequestedSpy.signalArguments[0][1].length, 0)
         }
 
-        function test_sendDisabledOnBlankText() {
+        function test_sendNotEmittedOnBlankText() {
             const preview = createPreview()
-            const textArea = findChild(preview, "sharePreviewTextArea")
-            const sendButton = findChild(preview, "sharePreviewSendButton")
-            verify(textArea)
+            const chatInput = findChild(preview, "statusChatInput")
+            const sendButton = findChild(preview, "statusChatInputSendButton")
+            verify(chatInput)
             verify(sendButton)
 
-            textArea.text = "   "
-            verify(!sendButton.enabled)
-
+            chatInput.setText("   ")
             mouseClick(sendButton)
+
             compare(sendRequestedSpy.count, 0)
+        }
+
+        function test_sendDisabledOnEmptyInput() {
+            const preview = createPreview({ text: "" })
+            const sendButton = findChild(preview, "statusChatInputSendButton")
+            verify(sendButton)
+
+            verify(!sendButton.enabled)
         }
 
         function test_backEmitsIntent() {
@@ -111,60 +140,115 @@ Item {
             compare(sendRequestedSpy.count, 0)
         }
 
-        function test_thumbnailsHiddenForTextShare() {
-            const preview = createPreview()
-            const thumbnails = findChild(preview, "sharePreviewThumbnailsList")
-            verify(thumbnails)
+        function test_sharedImagesAttachedToInput() {
+            const preview = createPreview({
+                imagePaths: [root.redImage, root.greenImage, root.blueImage]
+            })
+            const chatInput = findChild(preview, "statusChatInput")
+            verify(chatInput)
 
-            compare(thumbnails.count, 0)
-            verify(!thumbnails.visible)
+            compare(chatInput.fileUrlsAndSources.length, 3)
+            verify(chatInput.isImage)
         }
 
-        function test_thumbnailShownPerSharedImage() {
+        function test_noImagesAttachedForTextShare() {
             const preview = createPreview()
-            const thumbnails = findChild(preview, "sharePreviewThumbnailsList")
-            verify(thumbnails)
+            const chatInput = findChild(preview, "statusChatInput")
+            verify(chatInput)
 
-            preview.imagePaths = [root.sampleImage, root.sampleImage, root.sampleImage]
-            waitForRendering(preview)
-
-            compare(thumbnails.count, 3)
-            verify(thumbnails.visible)
-            const thumbnail = findChild(thumbnails, "sharePreviewThumbnail")
-            verify(thumbnail)
-            tryCompare(thumbnail, "status", Image.Ready)
+            compare(chatInput.fileUrlsAndSources.length, 0)
+            verify(!chatInput.isImage)
         }
 
         function test_sendEnabledWithImagesAndBlankCaption() {
-            const preview = createPreview()
-            const textArea = findChild(preview, "sharePreviewTextArea")
-            const sendButton = findChild(preview, "sharePreviewSendButton")
-            verify(textArea)
+            const preview = createPreview({
+                text: "",
+                imagePaths: [root.redImage]
+            })
+            const chatInput = findChild(preview, "statusChatInput")
+            const sendButton = findChild(preview, "statusChatInputSendButton")
+            verify(chatInput)
             verify(sendButton)
-
-            preview.imagePaths = [root.sampleImage]
-            textArea.text = ""
             verify(sendButton.enabled)
 
             mouseClick(sendButton)
 
             compare(sendRequestedSpy.count, 1)
-            compare(sendRequestedSpy.signalArguments[0][0], "")
+            compare(plainText(sendRequestedSpy.signalArguments[0][0]).trim(), "")
+            compare(sendRequestedSpy.signalArguments[0][1].length, 1)
+            compare(sendRequestedSpy.signalArguments[0][1][0], root.redImage)
         }
 
         function test_sendWithImagesEmitsEditedCaption() {
-            const preview = createPreview()
-            const textArea = findChild(preview, "sharePreviewTextArea")
-            const sendButton = findChild(preview, "sharePreviewSendButton")
-            verify(textArea)
+            const preview = createPreview({
+                imagePaths: [root.redImage, root.greenImage]
+            })
+            const chatInput = findChild(preview, "statusChatInput")
+            const sendButton = findChild(preview, "statusChatInputSendButton")
+            verify(chatInput)
             verify(sendButton)
 
-            preview.imagePaths = [root.sampleImage, root.sampleImage]
-            textArea.text = "Gallery caption"
+            chatInput.setText("Gallery caption")
             mouseClick(sendButton)
 
             compare(sendRequestedSpy.count, 1)
-            compare(sendRequestedSpy.signalArguments[0][0], "Gallery caption")
+            compare(plainText(sendRequestedSpy.signalArguments[0][0]),
+                    "Gallery caption")
+            compare(sendRequestedSpy.signalArguments[0][1].length, 2)
+        }
+
+        function test_sendCarriesOnlyRemainingImagesAfterRemoval() {
+            const preview = createPreview({
+                imagePaths: [root.redImage, root.greenImage]
+            })
+            const chatInput = findChild(preview, "statusChatInput")
+            const sendButton = findChild(preview, "statusChatInputSendButton")
+            verify(chatInput)
+            verify(sendButton)
+            compare(chatInput.fileUrlsAndSources.length, 2)
+
+            // Mirrors what the input's per-image close button does; the click
+            // handling itself belongs to StatusChatInputNew's own tests.
+            const urls = [...chatInput.fileUrlsAndSources]
+            urls.splice(0, 1)
+            chatInput.fileUrlsAndSources = urls
+
+            mouseClick(sendButton)
+
+            compare(sendRequestedSpy.count, 1)
+            compare(sendRequestedSpy.signalArguments[0][1].length, 1)
+            compare(sendRequestedSpy.signalArguments[0][1][0], root.greenImage)
+        }
+
+        function test_hostPropertyWritesReapplySharedPayload() {
+            const preview = createPreview()
+            const chatInput = findChild(preview, "statusChatInput")
+            verify(chatInput)
+
+            preview.text = "Replacement share"
+            preview.imagePaths = [root.blueImage]
+
+            compare(chatInput.getPlainText(), "Replacement share")
+            compare(chatInput.fileUrlsAndSources.length, 1)
+        }
+
+        function test_resetReappliesUnchangedSharedPayload() {
+            const preview = createPreview({
+                imagePaths: [root.redImage]
+            })
+            const chatInput = findChild(preview, "statusChatInput")
+            verify(chatInput)
+
+            // The user edits the text and detaches the image, then a new share
+            // with the identical payload restarts the flow (last-wins).
+            chatInput.setText("Edited by the user")
+            chatInput.fileUrlsAndSources = []
+
+            preview.reset()
+
+            compare(chatInput.getPlainText(),
+                    "Look at this https://example.com/article")
+            compare(chatInput.fileUrlsAndSources.length, 1)
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
+++ b/storybook/qmlTests/tests/tst_SharePreviewPanel.qml
@@ -3,6 +3,8 @@ import QtTest
 
 import StatusQ.Core.Utils as SQUtils
 
+import utils
+
 import mainui
 
 Item {
@@ -208,7 +210,7 @@ Item {
             compare(chatInput.fileUrlsAndSources.length, 2)
 
             // Mirrors what the input's per-image close button does; the click
-            // handling itself belongs to StatusChatInputNew's own tests.
+            // handling itself belongs to StatusChatInput's own tests.
             const urls = [...chatInput.fileUrlsAndSources]
             urls.splice(0, 1)
             chatInput.fileUrlsAndSources = urls
@@ -230,6 +232,69 @@ Item {
 
             compare(chatInput.getPlainText(), "Replacement share")
             compare(chatInput.fileUrlsAndSources.length, 1)
+        }
+
+        function test_headerShowsDestinationIdentity() {
+            const preview = createPreview({
+                destinationName: "design",
+                destinationColor: "#ff0000",
+                destinationEmoji: "⚽",
+                destinationChatType: Constants.chatType.communityChat,
+                destinationSectionName: "Design DAO"
+            })
+            const infoButton = findChild(preview, "sharePreviewChatInfoButton")
+            verify(infoButton)
+
+            compare(infoButton.title, "design")
+            compare(infoButton.subTitle, "Design DAO")
+            compare(infoButton.asset.color.toString(), "#ff0000")
+            compare(infoButton.asset.emoji, "⚽")
+        }
+
+        function test_headerHidesSectionSubtitleForNonCommunityChat() {
+            const preview = createPreview({
+                destinationName: "Alice",
+                destinationChatType: Constants.chatType.oneToOne,
+                destinationSectionName: "Messages"
+            })
+            const infoButton = findChild(preview, "sharePreviewChatInfoButton")
+            verify(infoButton)
+
+            compare(infoButton.subTitle, "")
+        }
+
+        function test_inputFillsHeightBelowHeader() {
+            const preview = createPreview()
+            const chatInput = findChild(preview, "statusChatInput")
+            verify(chatInput)
+
+            // The input reaches the panel's bottom (no dead spacer above a
+            // bottom-anchored input)...
+            const inputBottom = chatInput.mapToItem(preview, 0,
+                                                    chatInput.height).y
+            fuzzyCompare(inputBottom, preview.height, 1)
+
+            // ...and stretches over the whole space below the header instead
+            // of keeping its compact in-chat height
+            verify(chatInput.height > preview.height / 2)
+        }
+
+        function test_inputAutoFocusedWhenShown() {
+            const preview = createPreview()
+            const chatInput = findChild(preview, "statusChatInput")
+            verify(chatInput)
+
+            tryVerify(() => chatInput.textInput.activeFocus)
+
+            // Leaving and re-entering the preview step (the share flow hosts
+            // the panel in a StackLayout, which toggles visibility) focuses
+            // the input again — even after another step's control took the
+            // focus in between, like the picker's search box does
+            preview.visible = false
+            root.forceActiveFocus()
+            verify(!chatInput.textInput.activeFocus)
+            preview.visible = true
+            tryVerify(() => chatInput.textInput.activeFocus)
         }
 
         function test_resetReappliesUnchangedSharedPayload() {

--- a/storybook/qmlTests/tests/tst_ShareShortcutsPublisher.qml
+++ b/storybook/qmlTests/tests/tst_ShareShortcutsPublisher.qml
@@ -41,6 +41,7 @@ Item {
                     sectionId: "personal-section",
                     sectionName: "Chat",
                     lastMessageTimestamp: 500,
+                    lastOwnMessageTimestamp: 0,
                     canPost: true
                 },
                 {
@@ -53,6 +54,7 @@ Item {
                     sectionId: "personal-section",
                     sectionName: "Chat",
                     lastMessageTimestamp: 900,
+                    lastOwnMessageTimestamp: 0,
                     canPost: true
                 },
                 {
@@ -65,6 +67,7 @@ Item {
                     sectionId: "community-1",
                     sectionName: "CryptoKitties",
                     lastMessageTimestamp: 1000,
+                    lastOwnMessageTimestamp: 0,
                     canPost: false
                 },
                 {
@@ -77,6 +80,7 @@ Item {
                     sectionId: "community-1",
                     sectionName: "CryptoKitties",
                     lastMessageTimestamp: 700,
+                    lastOwnMessageTimestamp: 0,
                     canPost: true
                 },
                 {
@@ -89,6 +93,7 @@ Item {
                     sectionId: "personal-section",
                     sectionName: "Chat",
                     lastMessageTimestamp: 300,
+                    lastOwnMessageTimestamp: 0,
                     canPost: true
                 },
                 {
@@ -101,6 +106,7 @@ Item {
                     sectionId: "personal-section",
                     sectionName: "Chat",
                     lastMessageTimestamp: 200,
+                    lastOwnMessageTimestamp: 0,
                     canPost: true
                 }
             ]
@@ -156,9 +162,11 @@ Item {
             const { sourceModel, spy } = createPublisher()
             tryCompare(spy, "count", 1)
 
-            // Carol (least recent, not in the top 4) gets a successful send:
-            // she must enter the published set at the top.
+            // Carol (least recent, not in the top 4) gets a successful send
+            // (bumps both recency roles): she must enter the published set at
+            // the top.
             sourceModel.setProperty(5, "lastMessageTimestamp", 2000)
+            sourceModel.setProperty(5, "lastOwnMessageTimestamp", 2000)
 
             tryCompare(spy, "count", 2)
             const payload = lastPayload(spy)

--- a/test/nim/chat_search_model_test.nim
+++ b/test/nim/chat_search_model_test.nim
@@ -1,0 +1,73 @@
+import unittest, tables
+
+import nimqml
+
+import app/modules/main/app_search/io_interface
+import app/modules/main/app_search/models/[chat_search_item, chat_search_model]
+
+type
+  StubDelegate = ref object of io_interface.AccessInterface
+    buildRequested: bool
+
+method buildChatSearchModel(self: StubDelegate) =
+  self.buildRequested = true
+
+proc createTestItem(chatId: string, lastMessageTimestamp: int,
+    lastOwnMessageTimestamp: int, canPost: bool = true): ChatSearchItem =
+  return chat_search_item.initItem(
+    chatId,
+    name = "name-" & chatId,
+    color = "",
+    colorId = 0,
+    icon = "",
+    sectionId = "section",
+    sectionName = "Section",
+    emoji = "",
+    chatType = 1,
+    lastMessageText = "",
+    lastMessageTimestamp = lastMessageTimestamp,
+    canPost = canPost,
+    lastOwnMessageTimestamp = lastOwnMessageTimestamp,
+  )
+
+proc roleForName(model: chat_search_model.Model, name: string): int =
+  for role, roleName in model.roleNames().pairs:
+    if roleName == name:
+      return role
+  return -1
+
+proc intData(model: chat_search_model.Model, row: int, roleName: string): int =
+  let idx = model.createIndex(row, 0, nil)
+  return model.data(idx, roleForName(model, roleName)).intVal
+
+suite "chat search model - own message recency role":
+  setup:
+    let delegate = StubDelegate()
+    let model = chat_search_model.newModel(delegate)
+    model.setItems(@[
+      createTestItem("chat-a", lastMessageTimestamp = 400, lastOwnMessageTimestamp = 400),
+      createTestItem("chat-b", lastMessageTimestamp = 900, lastOwnMessageTimestamp = 100),
+      createTestItem("channel-c", lastMessageTimestamp = 1000, lastOwnMessageTimestamp = 0),
+    ])
+    check(model.rowCount() == 3)
+
+  test "exposes the lastOwnMessageTimestamp role":
+    check(roleForName(model, "lastOwnMessageTimestamp") != -1)
+
+  test "item data reports the own-send timestamp independently from any-message recency":
+    check(intData(model, 0, "lastMessageTimestamp") == 400)
+    check(intData(model, 0, "lastOwnMessageTimestamp") == 400)
+    check(intData(model, 1, "lastOwnMessageTimestamp") == 100)
+    check(intData(model, 2, "lastOwnMessageTimestamp") == 0)
+
+  test "updateLastOwnMessageTimestampOnChatItem bumps only the target chat":
+    model.updateLastOwnMessageTimestampOnChatItem("chat-b", 2000)
+    check(intData(model, 1, "lastOwnMessageTimestamp") == 2000)
+    check(intData(model, 0, "lastOwnMessageTimestamp") == 400)
+    check(intData(model, 2, "lastOwnMessageTimestamp") == 0)
+
+  test "updating an unknown chat is a no-op":
+    model.updateLastOwnMessageTimestampOnChatItem("missing", 2000)
+    check(intData(model, 0, "lastOwnMessageTimestamp") == 400)
+    check(intData(model, 1, "lastOwnMessageTimestamp") == 100)
+    check(intData(model, 2, "lastOwnMessageTimestamp") == 0)

--- a/test/nim/chat_search_model_test.nim
+++ b/test/nim/chat_search_model_test.nim
@@ -5,12 +5,13 @@ import nimqml
 import app/modules/main/app_search/io_interface
 import app/modules/main/app_search/models/[chat_search_item, chat_search_model]
 
+# Overridden because the base method raises; the model requests a lazy build
+# on first rowCount, but these tests populate items via setItems directly.
 type
   StubDelegate = ref object of io_interface.AccessInterface
-    buildRequested: bool
 
 method buildChatSearchModel(self: StubDelegate) =
-  self.buildRequested = true
+  discard
 
 proc createTestItem(chatId: string, lastMessageTimestamp: int,
     lastOwnMessageTimestamp: int, canPost: bool = true): ChatSearchItem =
@@ -26,8 +27,8 @@ proc createTestItem(chatId: string, lastMessageTimestamp: int,
     chatType = 1,
     lastMessageText = "",
     lastMessageTimestamp = lastMessageTimestamp,
-    canPost = canPost,
     lastOwnMessageTimestamp = lastOwnMessageTimestamp,
+    canPost = canPost,
   )
 
 proc roleForName(model: chat_search_model.Model, name: string): int =

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -320,8 +320,18 @@ QtObject {
                                              "itemId", chatId)
         const sectionModule = isPersonalSectionChat ? root.mainModuleInst.getChatSectionModule()
                                                     : getCommunitySectionModule(sectionId)
+        if (!sectionModule) {
+            console.warn("sendMessageToChat: no section module for section", sectionId)
+            return false
+        }
         sectionModule.prepareChatContentModuleForChatId(chatId)
         const chatContentModule = sectionModule.getChatContentModule()
+        if (!chatContentModule) {
+            // The section's chat content modules are built on its first
+            // activation — activate the destination before sending.
+            console.warn("sendMessageToChat: no chat content module for chat", chatId)
+            return false
+        }
 
         const textMsg = cleanMessageText(text)
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1146,12 +1146,22 @@ Item {
         // Send the shared content to the picked destination and land in that
         // chat. The cached image copies are NOT released here — the image-send
         // task consumes the files asynchronously and releases them once done.
+        // Activation must come BEFORE the send: it synchronously builds and
+        // loads the destination chat content module (community sections build
+        // their chats lazily on first activation), so the send finds the input
+        // area module and the destination's message model is already
+        // subscribed for the local echo — the sent message shows up in the
+        // chat view the moment the send is accepted, like an in-chat send.
         function completeShareFlow(sectionId: string, chatId: string, text: string) {
             const imagePaths = shareFlowLoader.sharedImagePaths
             shareFlowLoader.sharedImagePaths = []
             shareFlowLoader.item.close()
-            appMain.rootChatStore.sendMessageToChat(sectionId, chatId, text, imagePaths)
             rootStore.setActiveSectionChat(sectionId, chatId)
+            if (!appMain.rootChatStore.sendMessageToChat(sectionId, chatId, text, imagePaths)) {
+                // Nothing was sent, so the image-send task will never release
+                // the cached copies — release them here instead.
+                rootStore.releaseShareIntakeFiles(imagePaths)
+            }
         }
 
         // Cache lifecycle: drop the flow's cached shared-image copies (cancel

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1144,23 +1144,34 @@ Item {
         }
 
         // Send the shared content to the picked destination and land in that
-        // chat. The cached image copies are NOT released here — the image-send
-        // task consumes the files asynchronously and releases them once done.
+        // chat. imagePaths is the attachment list as it left the preview's
+        // chat input — the user can detach shared images there (and attach
+        // new ones); detached cached copies are released right away since no
+        // send will ever consume them. The sent files' cached copies are NOT
+        // released here — the image-send task consumes them asynchronously
+        // and releases them once done.
         // Activation must come BEFORE the send: it synchronously builds and
         // loads the destination chat content module (community sections build
         // their chats lazily on first activation), so the send finds the input
         // area module and the destination's message model is already
         // subscribed for the local echo — the sent message shows up in the
         // chat view the moment the send is accepted, like an in-chat send.
-        function completeShareFlow(sectionId: string, chatId: string, text: string) {
-            const imagePaths = shareFlowLoader.sharedImagePaths
+        function completeShareFlow(sectionId: string, chatId: string, text: string, imagePaths) {
+            const removedCached = shareFlowLoader.sharedImagePaths.filter(
+                                    path => !imagePaths.includes(path))
+            const keptCached = shareFlowLoader.sharedImagePaths.filter(
+                                 path => imagePaths.includes(path))
             shareFlowLoader.sharedImagePaths = []
+            if (removedCached.length > 0)
+                rootStore.releaseShareIntakeFiles(removedCached)
             shareFlowLoader.item.close()
             rootStore.setActiveSectionChat(sectionId, chatId)
             if (!appMain.rootChatStore.sendMessageToChat(sectionId, chatId, text, imagePaths)) {
                 // Nothing was sent, so the image-send task will never release
-                // the cached copies — release them here instead.
-                rootStore.releaseShareIntakeFiles(imagePaths)
+                // the cached copies — release them here instead. Guarded to
+                // the intake's own copies; user-attached files are not ours.
+                if (keptCached.length > 0)
+                    rootStore.releaseShareIntakeFiles(keptCached)
             }
         }
 
@@ -2997,7 +3008,9 @@ Item {
 
             function restart() {
                 shareFlowSteps.currentIndex = 0
-                sharePreviewPanel.text = shareFlowLoader.sharedText
+                // Re-push the shared payload into the preview's chat input
+                // even when it is identical to the replaced share's
+                sharePreviewPanel.reset()
                 applyPreselectedDestination()
             }
 
@@ -3043,9 +3056,12 @@ Item {
 
                     text: shareFlowLoader.sharedText
                     imagePaths: shareFlowLoader.sharedImagePaths
+                    emojiPopup: statusEmojiPopup.item
+                    stickersPopup: statusStickersPopupLoader.item
 
-                    onSendRequested: (text) => d.completeShareFlow(destinationSectionId,
-                                                                   destinationChatId, text)
+                    onSendRequested: (text, imagePaths) =>
+                        d.completeShareFlow(destinationSectionId,
+                                            destinationChatId, text, imagePaths)
                     onBackRequested: shareFlowSteps.currentIndex = 0
                     onCancelRequested: d.cancelShareFlow()
                 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1157,10 +1157,9 @@ Item {
         // subscribed for the local echo — the sent message shows up in the
         // chat view the moment the send is accepted, like an in-chat send.
         function completeShareFlow(sectionId: string, chatId: string, text: string, imagePaths) {
-            const removedCached = shareFlowLoader.sharedImagePaths.filter(
-                                    path => !imagePaths.includes(path))
-            const keptCached = shareFlowLoader.sharedImagePaths.filter(
-                                 path => imagePaths.includes(path))
+            const cachedPaths = shareFlowLoader.sharedImagePaths
+            const removedCached = cachedPaths.filter(path => !imagePaths.includes(path))
+            const keptCached = cachedPaths.filter(path => imagePaths.includes(path))
             shareFlowLoader.sharedImagePaths = []
             if (removedCached.length > 0)
                 rootStore.releaseShareIntakeFiles(removedCached)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2973,6 +2973,14 @@ Item {
             closePolicy: Popup.NoAutoClose
             padding: Theme.padding
 
+            background: StatusDialogBackground {
+                radius: appMain.isPortraitMode ? 0 : Theme.radius
+            }
+
+            Overlay.modal: Rectangle {
+                color: Theme.palette.backdropColor
+            }
+
             Component.onCompleted: applyPreselectedDestination()
 
             onClosed: shareFlowLoader.active = false

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2980,25 +2980,24 @@ Item {
         property var sharedImagePaths: []
         property string preselectedDestinationChatId
 
-        sourceComponent: Popup {
+        sourceComponent: StatusDialog {
             id: shareFlowPopup
 
-            parent: appMain
-            x: (appMain.width - width) / 2
-            y: (appMain.height - height) / 2
-            width: appMain.isPortraitMode ? appMain.width : 480
-            height: appMain.isPortraitMode ? appMain.height
-                                           : Math.min(640, appMain.height - 2 * Theme.bigPadding)
-            modal: true
+            // Portrait/mobile: the dialog's own bottom-sheet handling makes
+            // it fullscreen; otherwise ~480x640 centered (the content's
+            // implicit height, capped by the dialog to 80% of the window).
+            width: 480
+            fullScreenSheet: true
             closePolicy: Popup.NoAutoClose
-            padding: Theme.padding
+            standardButtons: Dialog.NoButton
 
-            background: StatusDialogBackground {
-                radius: appMain.isPortraitMode ? 0 : Theme.radius
-            }
-
-            Overlay.modal: Rectangle {
-                color: Theme.palette.backdropColor
+            // The steps carry their own header row (back/identity/close), so
+            // the fullscreen sheet is header-less — keep that row out of the
+            // notch/status-bar area (StatusDialog only safe-area-pads the
+            // bottom).
+            Binding on topPadding {
+                when: shareFlowPopup.bottomSheet
+                value: shareFlowPopup.padding + shareFlowPopup.parent.SafeArea.margins.top
             }
 
             Component.onCompleted: applyPreselectedDestination()
@@ -3017,7 +3016,13 @@ Item {
             // on the preview with it pre-selected. Falls back to the picker
             // when the chat is no longer among the postable destinations.
             function applyPreselectedDestination() {
-                const chatId = shareFlowLoader.preselectedDestinationChatId
+                showPreviewFor(shareFlowLoader.preselectedDestinationChatId)
+            }
+
+            // Land the flow on the preview step, passing the destination
+            // row's identity (avatar/name/section) into the panel so its
+            // header can render chat-header-style.
+            function showPreviewFor(chatId) {
                 if (chatId === "")
                     return
                 const destination = SQUtils.ModelUtils.getByKey(
@@ -3027,23 +3032,27 @@ Item {
                 sharePreviewPanel.destinationSectionId = destination.sectionId
                 sharePreviewPanel.destinationChatId = destination.chatId
                 sharePreviewPanel.destinationName = destination.name
+                sharePreviewPanel.destinationColor = destination.color
+                sharePreviewPanel.destinationColorId = destination.colorId
+                sharePreviewPanel.destinationIcon = destination.icon
+                sharePreviewPanel.destinationEmoji = destination.emoji
+                sharePreviewPanel.destinationChatType = destination.chatType
+                sharePreviewPanel.destinationSectionName = destination.sectionName
                 shareFlowSteps.currentIndex = 1
             }
 
-            StackLayout {
+            contentItem: StackLayout {
                 id: shareFlowSteps
-                anchors.fill: parent
+
+                implicitHeight: 640 - shareFlowPopup.topPadding
+                                - shareFlowPopup.bottomPadding
                 currentIndex: 0
 
                 ShareDestinationPickerPanel {
                     model: shareDestinationsAdaptor.model
 
-                    onDestinationPicked: (sectionId, chatId, name) => {
-                        sharePreviewPanel.destinationSectionId = sectionId
-                        sharePreviewPanel.destinationChatId = chatId
-                        sharePreviewPanel.destinationName = name
-                        shareFlowSteps.currentIndex = 1
-                    }
+                    onDestinationPicked: (sectionId, chatId, name) =>
+                        shareFlowPopup.showPreviewFor(chatId)
                     onCancelRequested: d.cancelShareFlow()
                 }
 

--- a/ui/app/mainui/adaptors/RecentPostableDestinationsAdaptor.qml
+++ b/ui/app/mainui/adaptors/RecentPostableDestinationsAdaptor.qml
@@ -8,12 +8,16 @@ import SortFilterProxyModel
   * Data-oriented adaptor producing the "recent postable destinations" model
   * (see CONTEXT.md): from a plain model of chats/channels it keeps only the
   * destinations the user can post to (1-1 chats, group chats, community
-  * channels with post rights) and orders them by recency of the last message.
+  * channels with post rights) and orders them by recency of the user's own
+  * last message — the chats the user actually sends to rank first, so a busy
+  * channel the user never posts in cannot outrank them. Destinations the user
+  * never posted in (lastOwnMessageTimestamp of 0) follow, ordered by recency
+  * of the last message from anyone.
   *
-  * Expected source roles: canPost (bool), lastMessageTimestamp (int) plus
-  * whatever display roles the consumer needs — all source roles pass through.
-  * Consumed by the share-flow destination picker; the direct-share shortcut
-  * publisher slice reuses it later.
+  * Expected source roles: canPost (bool), lastOwnMessageTimestamp (int),
+  * lastMessageTimestamp (int) plus whatever display roles the consumer needs
+  * — all source roles pass through. Consumed by the share-flow destination
+  * picker, the direct-share shortcut publisher and the iOS intent donor.
   */
 QObject {
     id: root
@@ -28,9 +32,19 @@ QObject {
             value: true
         }
 
-        sorters: RoleSorter {
-            roleName: "lastMessageTimestamp"
-            sortOrder: Qt.DescendingOrder
-        }
+        // Descending sort on the own-send timestamp ranks sent-to chats by the
+        // user's own recency and ties all never-sent-to chats (timestamp 0) at
+        // the bottom, where the secondary sorter falls back to any-message
+        // recency.
+        sorters: [
+            RoleSorter {
+                roleName: "lastOwnMessageTimestamp"
+                sortOrder: Qt.DescendingOrder
+            },
+            RoleSorter {
+                roleName: "lastMessageTimestamp"
+                sortOrder: Qt.DescendingOrder
+            }
+        ]
     }
 }

--- a/ui/app/mainui/panels/SharePreviewPanel.qml
+++ b/ui/app/mainui/panels/SharePreviewPanel.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import StatusQ.Controls
 import StatusQ.Core
 import StatusQ.Core.Theme
+import StatusQ
 
 import shared.status
 
@@ -99,11 +100,14 @@ Control {
         }
 
         // Inverse mapping: the host consumes plain paths (send + cache
-        // lifecycle), the input holds URLs.
+        // lifecycle), the input holds URLs. Not all of them come from
+        // toImageSource — the input's own picker returns a single-slash
+        // "file:/…" on mobile — so use the same helper the in-chat send does.
         function toImagePath(url) {
             const str = url.toString()
-            return str.startsWith("file://") ? str.slice("file://".length)
-                                             : str
+            return str.startsWith(Constants.dataImagePrefix)
+                    ? str
+                    : UrlUtils.convertUrlToLocalPath(str)
         }
 
         // The shared images go through the input's own validators (extension,

--- a/ui/app/mainui/panels/SharePreviewPanel.qml
+++ b/ui/app/mainui/panels/SharePreviewPanel.qml
@@ -129,7 +129,6 @@ Control {
             id: chatInput
 
             Layout.fillWidth: true
-            Layout.alignment: Qt.AlignBottom
 
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
@@ -143,7 +142,7 @@ Control {
                 // Images alone are sendable (empty caption); text shares need
                 // text. The toolbar send button enables on whitespace too, so
                 // guard here.
-                const imagePaths = [...chatInput.fileUrlsAndSources].map(
+                const imagePaths = chatInput.fileUrlsAndSources.map(
                                      url => d.toImagePath(url))
                 if (chatInput.getPlainText().trim() === "" && imagePaths.length === 0)
                     return

--- a/ui/app/mainui/panels/SharePreviewPanel.qml
+++ b/ui/app/mainui/panels/SharePreviewPanel.qml
@@ -8,19 +8,29 @@ import StatusQ.Core.Theme
 
 import shared.status
 
+import utils
+
 /**
   * Preview step of the share flow: hosts the real chat input
-  * (StatusChatInputNew) pre-filled with the shared text, with the shared
+  * (StatusChatInput) pre-filled with the shared text, with the shared
   * images attached to the input's image area — removable per image, exactly
   * like the in-chat attach flow. Send goes through the input's own send
-  * affordance. Takes data in (destination name, initial text, image paths)
-  * and emits intent signals out — no store access.
+  * affordance. Takes data in (destination identity, initial text, image
+  * paths) and emits intent signals out — no store access.
   */
 Control {
     id: root
 
-    /* Display name of the picked destination */
+    /* Identity of the picked destination, shown chat-header-style (avatar +
+       name + community name for channels); values come straight from the
+       destination picker model's roles */
     property string destinationName
+    property string destinationColor
+    property int destinationColorId
+    property string destinationIcon
+    property string destinationEmoji
+    property int destinationChatType: Constants.chatType.unknown
+    property string destinationSectionName
 
     /* The shared text (or image caption); pushed into the chat input, where
        the user edits it. Edits do not write back here. */
@@ -57,10 +67,26 @@ Control {
             d.attachSharedImages()
     }
 
-    Component.onCompleted: reset()
+    // Bring the software keyboard up without an extra tap whenever the
+    // preview becomes the visible step: the share flow's StackLayout toggles
+    // visibility on step changes, while the hosting dialog enables its
+    // content only once its enter transition finished (StatusDialog's
+    // `enabled: opened`) — focus grabs are no-ops until then.
+    onVisibleChanged: d.focusInputIfShown()
+    onEnabledChanged: d.focusInputIfShown()
+
+    Component.onCompleted: {
+        reset()
+        d.focusInputIfShown()
+    }
 
     QtObject {
         id: d
+
+        function focusInputIfShown() {
+            if (root.visible && root.enabled)
+                chatInput.forceInputActiveFocus()
+        }
 
         // Nim hands over plain absolute file paths; the input's image area
         // needs URLs. Already-formed URLs (file:, data:, qrc:, image:) pass
@@ -104,12 +130,29 @@ Control {
                 onClicked: root.backRequested()
             }
 
-            StatusBaseText {
+            // Read-only destination identity, rendered the way the chat
+            // header does (same component), minus its menu/action affordances
+            StatusChatInfoButton {
+                objectName: "sharePreviewChatInfoButton"
                 Layout.fillWidth: true
-                text: qsTr("Share to %1").arg(root.destinationName)
-                font.pixelSize: Theme.primaryTextFontSize
-                font.weight: Font.DemiBold
-                elide: Text.ElideRight
+                title: root.destinationName
+                subTitle: {
+                    if (root.destinationChatType === Constants.chatType.communityChat)
+                        return root.destinationSectionName
+                    return ""
+                }
+                type: root.destinationChatType
+                asset.name: root.destinationIcon
+                asset.isImage: root.destinationIcon !== ""
+                asset.isLetterIdenticon: root.destinationIcon === ""
+                asset.color: {
+                    if (root.destinationColor)
+                        return root.destinationColor
+                    return Utils.colorForColorId(Theme.palette, root.destinationColorId)
+                }
+                asset.emoji: root.destinationEmoji
+                asset.emojiSize: "24x24"
+                hoverEnabled: false
             }
 
             StatusFlatRoundButton {
@@ -120,16 +163,13 @@ Control {
             }
         }
 
-        Item {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-        }
-
-        StatusChatInputNew {
+        StatusChatInput {
             id: chatInput
 
             Layout.fillWidth: true
+            Layout.fillHeight: true
 
+            fillAvailableHeight: true
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
             chatInputPlaceholder: qsTr("Message")

--- a/ui/app/mainui/panels/SharePreviewPanel.qml
+++ b/ui/app/mainui/panels/SharePreviewPanel.qml
@@ -6,10 +6,14 @@ import StatusQ.Controls
 import StatusQ.Core
 import StatusQ.Core.Theme
 
+import shared.status
+
 /**
-  * Preview step of the share flow: the shared content — image thumbnails (if
-  * any) and the text/caption, editable before sending to the picked
-  * destination. Takes data in (destination name, initial text, image paths)
+  * Preview step of the share flow: hosts the real chat input
+  * (StatusChatInputNew) pre-filled with the shared text, with the shared
+  * images attached to the input's image area — removable per image, exactly
+  * like the in-chat attach flow. Send goes through the input's own send
+  * affordance. Takes data in (destination name, initial text, image paths)
   * and emits intent signals out — no store access.
   */
 Control {
@@ -18,26 +22,72 @@ Control {
     /* Display name of the picked destination */
     property string destinationName
 
-    /* The shared text (or image caption); editable by the user before sending */
-    property alias text: previewTextArea.text
+    /* The shared text (or image caption); pushed into the chat input, where
+       the user edits it. Edits do not write back here. */
+    property string text
 
-    /* Local paths (or image URLs) of the shared images; empty for text shares */
+    /* Local paths (or image URLs) of the shared images; empty for text
+       shares. Pushed into the chat input's image area. */
     property var imagePaths: []
 
-    signal sendRequested(string text)
+    /* Optional pass-through popups for the input's toolbar */
+    property var emojiPopup: null
+    property var stickersPopup: null
+
+    /* Final content as edited in the input: rich text (the send pipeline
+       plain-texts it) and the remaining attached images as plain paths */
+    signal sendRequested(string text, var imagePaths)
     signal backRequested()
     signal cancelRequested()
+
+    /* Re-applies the shared payload to the input even when the property
+       values did not change (last-wins replacement with identical payload) */
+    function reset() {
+        chatInput.setText(root.text)
+        d.attachSharedImages()
+    }
+
+    onTextChanged: {
+        if (chatInput)
+            chatInput.setText(root.text)
+    }
+
+    onImagePathsChanged: {
+        if (chatInput)
+            d.attachSharedImages()
+    }
+
+    Component.onCompleted: reset()
 
     QtObject {
         id: d
 
-        // Nim hands over plain absolute file paths; QML Image needs a URL.
-        // Already-formed URLs (file:, data:, qrc:, image:) pass through, which
-        // keeps the component previewable with self-contained test data.
+        // Nim hands over plain absolute file paths; the input's image area
+        // needs URLs. Already-formed URLs (file:, data:, qrc:, image:) pass
+        // through, which keeps the component previewable with self-contained
+        // test data.
         function toImageSource(path) {
             if (/^(file|data|qrc|image|https?):/.test(path))
                 return path
             return "file://" + path
+        }
+
+        // Inverse mapping: the host consumes plain paths (send + cache
+        // lifecycle), the input holds URLs.
+        function toImagePath(url) {
+            const str = url.toString()
+            return str.startsWith("file://") ? str.slice("file://".length)
+                                             : str
+        }
+
+        // The shared images go through the input's own validators (extension,
+        // size, quantity) — same limits as the in-chat attach flow; the
+        // validators surface their own warnings for rejected entries.
+        function attachSharedImages() {
+            chatInput.resetImageArea()
+            if (root.imagePaths.length > 0)
+                chatInput.validateImagesAndShowImageArea(
+                            root.imagePaths.map(path => toImageSource(path)))
         }
     }
 
@@ -70,57 +120,35 @@ Control {
             }
         }
 
-        StatusListView {
-            id: thumbnailsList
-            objectName: "sharePreviewThumbnailsList"
-
-            Layout.fillWidth: true
-            Layout.preferredHeight: 96
-            visible: count > 0
-
-            orientation: ListView.Horizontal
-            spacing: Theme.halfPadding
-            model: root.imagePaths
-
-            delegate: Rectangle {
-                width: 96
-                height: 96
-                radius: Theme.radius
-                color: Theme.palette.baseColor2
-                clip: true
-
-                Image {
-                    objectName: "sharePreviewThumbnail"
-                    anchors.fill: parent
-                    source: d.toImageSource(modelData)
-                    fillMode: Image.PreserveAspectCrop
-                    asynchronous: true
-                }
-            }
-        }
-
-        StatusScrollView {
+        Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            padding: 0
-
-            StatusTextArea {
-                id: previewTextArea
-                objectName: "sharePreviewTextArea"
-
-                width: parent.width
-                placeholderText: qsTr("Message")
-                wrapMode: TextEdit.Wrap
-            }
         }
 
-        StatusButton {
-            objectName: "sharePreviewSendButton"
-            Layout.alignment: Qt.AlignRight
-            text: qsTr("Send")
-            // Images alone are sendable (empty caption); text shares need text.
-            enabled: previewTextArea.text.trim().length > 0 || root.imagePaths.length > 0
-            onClicked: root.sendRequested(previewTextArea.text)
+        StatusChatInputNew {
+            id: chatInput
+
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignBottom
+
+            emojiPopup: root.emojiPopup
+            stickersPopup: root.stickersPopup
+            chatInputPlaceholder: qsTr("Message")
+
+            // Nobody is mentionable at this step (the panel is store-free and
+            // does not know the destination's members)
+            usersModel: ListModel {}
+
+            onSendMessageRequested: {
+                // Images alone are sendable (empty caption); text shares need
+                // text. The toolbar send button enables on whitespace too, so
+                // guard here.
+                const imagePaths = [...chatInput.fileUrlsAndSources].map(
+                                     url => d.toImagePath(url))
+                if (chatInput.getPlainText().trim() === "" && imagePaths.length === 0)
+                    return
+                root.sendRequested(chatInput.getTextWithPublicKeys(), imagePaths)
+            }
         }
     }
 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -72,6 +72,12 @@ Control {
 
     property string chatInputPlaceholder: qsTr("Type something")
 
+    /* When true the text area grows to fill the height given to the input
+       instead of capping at 200px — for hosts that hand the input all the
+       space between header and screen bottom (e.g. the share preview). The
+       in-chat usage keeps the default (false) and with it the 200px cap. */
+    property bool fillAvailableHeight: false
+
     property alias textInput: messageInputField
 
     // Background color of the surface the input sits on. Propagated to the text area so the
@@ -700,6 +706,7 @@ Control {
 
         ColumnLayout {
             Layout.fillWidth: true
+            Layout.fillHeight: root.fillAvailableHeight
             spacing: 0
 
             StatusChatInputReplyPanel {
@@ -750,6 +757,8 @@ Control {
 
             ColumnLayout {
                 id: inputLayout
+
+                Layout.fillHeight: root.fillAvailableHeight
 
                 RowLayout {
                     id: editModeTag
@@ -834,8 +843,15 @@ Control {
                     Layout.preferredHeight: messageInputField.implicitHeight
                                             + flickable.topMargin
                                             + flickable.bottomMargin
-                    Layout.maximumHeight: root.isEdit ? editMaxHeight : 200
                     Layout.fillWidth: true
+                    Layout.fillHeight: root.fillAvailableHeight
+                    Layout.maximumHeight: {
+                        if (root.isEdit)
+                            return editMaxHeight
+                        if (root.fillAvailableHeight)
+                            return Number.POSITIVE_INFINITY
+                        return 200
+                    }
 
                     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
                     ScrollBar.vertical.implicitWidth: Theme.halfPadding


### PR DESCRIPTION
Part of #21683. Part of #20439. Slice of the share epic — targets `feat/share-integration`, not `master`.

Polish pass bringing the share flow to its final UX.

- Share preview becomes a chat-style dialog: destination chat header, full-height chat input with the shared images attached, keyboard raised automatically, themed background/overlay
- Destinations ranked by the user's own recent sends, not any-message recency
- The destination chat is activated before sending, so the sent message appears instantly (local echo)
- Storybook pages and QML tests updated; Nim tests for the model changes

**How tested:** QML + Nim unit tests; device-verified on Galaxy S21 and iPhone 15 Pro Max.

**Stacked chain:** #21768 (feature branch → `master`) ← #21686 (core, merged) ← #21769 (Android target) ← #21770 (direct share) ← #21771 (iOS extension) ← #21772 (donations) ← #21773 (flow polish). Each PR is based on its predecessor's branch, so the diff shows only this PR's own commits. When a predecessor merges, this PR is retargeted and rebased. #21687 (media lifecycle) is independent and targets `master` directly.

