### PR TITLE
perf(mobile): QML ahead-of-time compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ nim-status-client*.tgz
 TODO
 resources.rcc
 ui/resources.qrc
+ui/resources_webscripts.qrc
 status-react-translations/
 /.update.timestamp
 notarization.log

--- a/Makefile
+++ b/Makefile
@@ -641,9 +641,9 @@ UI_RESOURCES := resources.rcc
 $(UI_RESOURCES): $(UI_SOURCES) | check-qt-dir compile-translations
 	echo -e $(BUILD_MSG) "resources.rcc"
 	rm -f ./resources.rcc
-	rm -f ./ui/resources.qrc
-	go run ui/generate-rcc.go -source=ui -output=ui/resources.qrc
-	rcc -binary $(RCC_PARAMS) ui/resources.qrc -o ./resources.rcc
+	rm -f ./ui/resources.qrc ./ui/resources_webscripts.qrc
+	go run ui/generate-rcc.go -source=ui -output=ui/resources.qrc -webscripts-output=ui/resources_webscripts.qrc
+	rcc -binary $(RCC_PARAMS) ui/resources.qrc ui/resources_webscripts.qrc -o ./resources.rcc
 
 rcc: $(UI_RESOURCES)
 

--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -264,6 +264,7 @@ clean-status-desktop-rcc:
 	@rm -f $(STATUS_DESKTOP_RCC)
 	@rm -f $(STATUS_DESKTOP)/resources.rcc
 	@rm -f $(STATUS_DESKTOP)/ui/resources.qrc
+	@rm -f $(STATUS_DESKTOP)/ui/resources_webscripts.qrc
 
 .PHONY: apk-fdroid
 apk-fdroid:

--- a/mobile/scripts/buildStatusQ.sh
+++ b/mobile/scripts/buildStatusQ.sh
@@ -29,6 +29,7 @@ cmake -S "${STATUSQ}" -B "${BUILD_DIR}" \
     -DSTATUSQ_BUILD_SANITY_CHECKER=OFF \
     -DSTATUSQ_BUILD_TESTS=OFF \
     -DSTATUSQ_STATIC_LIB=${STATIC_LIB} \
+    -DSTATUSQ_BUNDLE_QML=OFF \
     -DSTATUSQ_TESTMODE=$([[ "${STATUSQ_TESTMODE}" == "true" ]] && echo ON || echo OFF)
 
 make -C "${BUILD_DIR}" SCodes -j "$(nproc)"

--- a/mobile/scripts/gen_controls_shim.sh
+++ b/mobile/scripts/gen_controls_shim.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# qmlcachegen cannot follow QtQuick.Controls' optional style imports; expose one
+# concrete style under the module name "QtQuick.Controls" so the compiler can
+# resolve Controls-derived types. Compile-time only, nothing is shipped.
+set -eo pipefail
+
+QT_QML_DIR="$1"   # Qt qml import root, e.g. <qt>/android_arm64_v8a/qml
+OUT_DIR="$2"      # shim root; pass to qmlcachegen as -I <OUT_DIR>
+STYLE="${3:-Universal}"
+
+SRC="$QT_QML_DIR/QtQuick/Controls/$STYLE"
+DST="$OUT_DIR/QtQuick/Controls"
+
+[[ -d "$SRC" ]] || { echo "gen_controls_shim: style dir not found: $SRC" >&2; exit 1; }
+
+rm -rf "$DST"
+mkdir -p "$DST"
+cp -R "$SRC/." "$DST/"
+# Re-home the module; drop "prefer" so types resolve from this copy. Incomplete
+# styles keep their "import QtQuick.Controls.Basic auto" fallback line.
+sed -i.bak -e "s/^module QtQuick\.Controls\.$STYLE$/module QtQuick.Controls/" -e '/^prefer /d' "$DST/qmldir"
+rm -f "$DST/qmldir.bak"
+grep -q '^module QtQuick\.Controls$' "$DST/qmldir" || {
+    echo "gen_controls_shim: failed to rewrite module line in $DST/qmldir" >&2
+    exit 1
+}

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -2,6 +2,19 @@ TEMPLATE = app
 
 QT += quick gui qml webview svg widgets multimedia
 
+CONFIG += qtquickcompiler
+# Per-binding AOT stats, written next to each generated .cpp
+QMLCACHE_FLAGS += --dump-aot-stats --module-id=status
+# qtquickcompiler.prf passes no import paths; without these, in-repo modules don't AOT-compile
+QMLCACHE_FLAGS += -I $$PWD/../../ui -I $$PWD/../../ui/imports -I $$PWD/../../ui/app -I $$PWD/../../ui/StatusQ/src
+
+# qmlcachegen cannot follow QtQuick.Controls' optional style imports; expose the Universal
+# style under the plain Controls module name so Control-derived types AOT-compile
+QMLSHIM_DIR = $$OUT_PWD/qmlcontrols-shim
+SHIM_RESULT = $$system(bash $$PWD/../scripts/gen_controls_shim.sh $$[QT_INSTALL_QML] $$system_quote($$QMLSHIM_DIR) Universal 2>&1)
+!isEmpty(SHIM_RESULT): warning("gen_controls_shim: $$SHIM_RESULT")
+QMLCACHE_FLAGS += -I $$QMLSHIM_DIR
+
 BUILD_VARIANT = $$(BUILD_VARIANT)
 TARGET = Status
 equals(BUILD_VARIANT, "pr"): TARGET = StatusPR
@@ -23,9 +36,15 @@ equals(QT_MAJOR_VERSION, 6) {
 SOURCES += \
     sources/main.cpp
 
+# Browser user scripts run in the web engine, not the QML engine, so they must
+# not go through qmlcachegen (it rejects async/await and optional catch binding).
+WEBSCRIPTS_QRC = $$PWD/../../ui/resources_webscripts.qrc
+QTQUICK_COMPILER_SKIPPED_RESOURCES += $$WEBSCRIPTS_QRC
+
 # Add all status-desktop qrc files
 RESOURCES += \
-    $$PWD/../../ui/resources.qrc
+    $$PWD/../../ui/resources.qrc \
+    $$WEBSCRIPTS_QRC
 
 QML_IMPORT_PATH += $$PWD/../../ui/imports \
                    $$PWD/../../ui/app \

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -41,9 +41,17 @@ SOURCES += \
 WEBSCRIPTS_QRC = $$PWD/../../ui/resources_webscripts.qrc
 QTQUICK_COMPILER_SKIPPED_RESOURCES += $$WEBSCRIPTS_QRC
 
-# Add all status-desktop qrc files
+# StatusQ resources are bundled here instead of libStatusQ (STATUSQ_BUNDLE_QML=OFF)
+# so its QML goes through the Qt Quick Compiler too.
 RESOURCES += \
     $$PWD/../../ui/resources.qrc \
+    $$PWD/../../ui/StatusQ/src/statusq.qrc \
+    $$PWD/../../ui/StatusQ/src/assets/fonts/fonts.qrc \
+    $$PWD/../../ui/StatusQ/src/assets/img/img.qrc \
+    $$PWD/../../ui/StatusQ/src/assets/png/png.qrc \
+    $$PWD/../../ui/StatusQ/src/assets/png/png-mobile.qrc \
+    $$PWD/../../ui/StatusQ/src/assets/twemoji/twemoji.qrc \
+    $$PWD/../../ui/StatusQ/src/assets/twemoji/twemoji-svg.qrc \
     $$WEBSCRIPTS_QRC
 
 QML_IMPORT_PATH += $$PWD/../../ui/imports \

--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -104,7 +104,7 @@ SplitView {
 
         onObtainingPasswordSuccess: {
             loginScreen.setBiometricResponse(loginScreen.selectedProfileIsKeycard
-                                             ? ctrlPin.text : ctrlPassword.text)
+                                             ? ctrlPin.text : ctrlPassword.text, "")
         }
     }
 

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -126,24 +126,34 @@ else()
     set(LIB_TYPE SHARED)
 endif ()
 
+# When OFF, the application must bundle statusq.qrc and the asset qrcs itself
+# (e.g. to run the QML through the Qt Quick Compiler, which only sees app resources).
+option(STATUSQ_BUNDLE_QML "Embed StatusQ QML sources and assets into the library" ON)
+
 if (${STATUSQ_SHADOW_BUILD})
     add_definitions(-DBUNDLE_QML_RESOURCES)
-    set(STATUSQ_QRC_FILES src/statusq.qrc
-        src/assets/fonts/fonts.qrc
-        src/assets/img/img.qrc
-        src/assets/png/png.qrc
-        src/assets/twemoji/twemoji.qrc
-        src/assets/twemoji/twemoji-svg.qrc)
+    set(STATUSQ_QRC_FILES "")
 
-    # Platform-specific PNG bundles
-    if(ANDROID OR IOS)
+    if (${STATUSQ_BUNDLE_QML})
+        add_definitions(-DBUNDLE_STATUSQ_QML)
         list(APPEND STATUSQ_QRC_FILES
-            src/assets/png/png-mobile.qrc
-        )
-    else()
-        list(APPEND STATUSQ_QRC_FILES
-            src/assets/png/png-desktop.qrc
-        )
+            src/statusq.qrc
+            src/assets/fonts/fonts.qrc
+            src/assets/img/img.qrc
+            src/assets/png/png.qrc
+            src/assets/twemoji/twemoji.qrc
+            src/assets/twemoji/twemoji-svg.qrc)
+
+        # Platform-specific PNG bundles
+        if(ANDROID OR IOS)
+            list(APPEND STATUSQ_QRC_FILES
+                src/assets/png/png-mobile.qrc
+            )
+        else()
+            list(APPEND STATUSQ_QRC_FILES
+                src/assets/png/png-desktop.qrc
+            )
+        endif()
     endif()
 
     if (${STATUSQ_STATIC_LIB})

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -210,10 +210,11 @@ void registerStatusQTypes() {
 
 #ifdef BUNDLE_QML_RESOURCES
     Q_INIT_RESOURCE(TestConfig);
-    Q_INIT_RESOURCE(statusq);
 #if defined(STATUSQ_HAS_MOBILEWEBVIEW)
     Q_INIT_RESOURCE(customwebview);
 #endif
+#ifdef BUNDLE_STATUSQ_QML
+    Q_INIT_RESOURCE(statusq);
     Q_INIT_RESOURCE(fonts);
     Q_INIT_RESOURCE(img);
     Q_INIT_RESOURCE(png);
@@ -224,6 +225,7 @@ void registerStatusQTypes() {
 #endif
     Q_INIT_RESOURCE(twemoji);
     Q_INIT_RESOURCE(twemoji_svg);
+#endif
 #endif
 
     qtmt::registerQmlTypes();

--- a/ui/app/AppLayouts/Onboarding/LoginBySyncingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/LoginBySyncingFlow.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 

--- a/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -87,11 +89,11 @@ OnboardingStackView {
 
     signal skippedBiometricFlow()
 
-    function restart() {
+    function restart() : void {
         replace(null, loginAccountsModel.ModelCount.empty ? welcomePage : loginScreenComponent)
     }
 
-    function setBiometricResponse(secret: string, error = "") {
+    function setBiometricResponse(secret: string, error: string) : void {
         if (!loginScreen)
             return
 
@@ -101,7 +103,7 @@ OnboardingStackView {
     Connections {
         target: root.loginAccountsModel?.ModelCount ?? null
 
-        function onCountChanged() {
+        function onCountChanged() : void {
             d.showWelcomePageIfNoProfiles()
         }
     }
@@ -114,7 +116,7 @@ OnboardingStackView {
         property var manageProfilesDialog: null
 
 
-        function pushOrSkipBiometricsPage() {
+        function pushOrSkipBiometricsPage() : void {
             if (d.flow === Onboarding.OnboardingFlow.LoginWithSyncing
                     || d.flow === Onboarding.OnboardingFlow.LoginWithKeycard) {
                 root.skippedBiometricFlow()
@@ -129,24 +131,24 @@ OnboardingStackView {
             }
         }
 
-        function openPrivacyPolicyPopup() {
+        function openPrivacyPolicyPopup() : void {
             privacyPolicyPopup.createObject(root).open()
         }
 
-        function openTermsOfUsePopup() {
+        function openTermsOfUsePopup() : void {
             termsOfUsePopup.createObject(root).open()
         }
 
-        function openThirdpartyServicesPopup() {
+        function openThirdpartyServicesPopup() : void {
             thirdpartyServicesPopup.createObject(root).open()
         }
 
-        function openManageProfilesPopup() {
+        function openManageProfilesPopup() : void {
             d.manageProfilesDialog = manageProfilesPopup.createObject(root)
             d.manageProfilesDialog.open()
         }
 
-        function showWelcomePageIfNoProfiles() {
+        function showWelcomePageIfNoProfiles() : void {
             if (!root.loginAccountsModel?.ModelCount.empty)
                 return
 
@@ -156,7 +158,7 @@ OnboardingStackView {
             root.replace(null, welcomePage)
         }
 
-        function openDeleteMultiaccountConfirmationDialog(keyUid, username) {
+        function openDeleteMultiaccountConfirmationDialog(keyUid: string, username: string) : void {
             deleteMultiaccountConfirmationDialog.createObject(root, { keyUid, username }).open()
         }
     }
@@ -370,7 +372,7 @@ OnboardingStackView {
         id: onboardingKeycardStore
     }
 
-    function openKeycardPopup(flow, keyUid, keycardUid, cardMetadataName, cardMetadataWalletAccountsJson) {
+    function openKeycardPopup(flow: string, keyUid: string, keycardUid: string, cardMetadataName: string, cardMetadataWalletAccountsJson: string) : void {
         console.info("onboarding - openning keycard popup for flow: ", flow, " keyUid: ", keyUid, " keycardUid: ", keycardUid, " cardMetadataName: ", cardMetadataName, " cardMetadataWalletAccountsJson: ", cardMetadataWalletAccountsJson)
         keycardManagementPopupComponent.createObject(root, {
             flow: flow,
@@ -604,16 +606,20 @@ OnboardingStackView {
                     spacing: Theme.halfPadding
 
                     delegate: LoginUserSelectorDelegate {
-                        objectName: "manageProfilesDelegate-" + model.keyUid
+                        id: profileDelegate
+
+                        required property var model
+
+                        objectName: "manageProfilesDelegate-" + profileDelegate.model.keyUid
                         width: ListView.view.width
                         height: d.delegateHeight
-                        label: model.username
-                        image: model.thumbnailImage
-                        colorId: model.colorId
-                        keycardCreatedAccount: model.keycardCreatedAccount
+                        label: profileDelegate.model.username
+                        image: profileDelegate.model.thumbnailImage
+                        colorId: profileDelegate.model.colorId
+                        keycardCreatedAccount: profileDelegate.model.keycardCreatedAccount
                         keycardEnabled: true // We just care to show the icon here
                         managementMode: true
-                        onDeleteProfileRequested: d.openDeleteMultiaccountConfirmationDialog(model.keyUid, model.username)
+                        onDeleteProfileRequested: d.openDeleteMultiaccountConfirmationDialog(profileDelegate.model.keyUid, profileDelegate.model.username)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
@@ -111,6 +111,8 @@ OnboardingStackView {
     QtObject {
         id: d
 
+        readonly property int delegateHeight: 64
+
         property int flow
         property LoginScreen loginScreen: null
         property var manageProfilesDialog: null

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -56,12 +56,12 @@ Page {
     signal loginRequested(string keyUid, int method, var data)
     signal profileSelected(string keyUid)
 
-    function restartFlow() {
+    function restartFlow() : void {
         unload()
         onboardingFlow.restart()
     }
 
-    function unload() {
+    function unload() : void {
         onboardingFlow.clear()
         d.resetState()
     }
@@ -69,7 +69,7 @@ Page {
     // clear the stack and load the LoginScreen
     // the purpose is to return from main/splash screen in case of a late stage error
     // and use the below error handler (onAccountLoginError)
-    function unwindToLoginScreen() {
+    function unwindToLoginScreen() : void {
         restartFlow()
     }
 
@@ -94,7 +94,7 @@ Page {
 
         property bool thirdpartyServicesEnabled: true
 
-        function resetState() {
+        function resetState() : void {
             d.password = ""
             d.keycardPin = ""
             d.enableBiometrics = false
@@ -109,12 +109,12 @@ Page {
         readonly property var settings: Settings { /* https://bugreports.qt.io/browse/QTBUG-135039 */
             property bool keycardPromoShown // whether we've seen the keycard promo banner on KeycardIntroPage
 
-            function reset() {
+            function reset() : void {
                 keycardPromoShown = false
             }
         }
 
-        function finishFlow(flow) {
+        function finishFlow(flow: int) : void {
             const keyUid = onboardingFlow.loginScreen ? onboardingFlow.loginScreen.selectedProfileKeyId : ""
             const data = {
                 selectedProfileKeyUid: keyUid, // used to determine whether import seed phrase was done for the login or onboarding purpose
@@ -266,7 +266,7 @@ Page {
         target: onboardingFlow.topLevelItem
         ignoreUnknownSignals: true
 
-        function onRequestOpenLink(link: string) {
+        function onRequestOpenLink(link: string) : void {
             Qt.openUrlExternally(link)
         }
     }
@@ -275,7 +275,7 @@ Page {
     Connections {
         target: root.onboardingStore
 
-        function onAccountLoginError(error: string, wrongPassword: bool) {
+        function onAccountLoginError(error: string, wrongPassword: bool) : void {
             const loginScreen = onboardingFlow.loginScreen
 
             if (!loginScreen)
@@ -290,7 +290,7 @@ Page {
 
         function onGetCredentialRequestCompleted(status, secret) {
             if (status === Keychain.StatusSuccess)
-                onboardingFlow.setBiometricResponse(secret)
+                onboardingFlow.setBiometricResponse(secret, "")
             else if (status === Keychain.StatusNotFound)
                 onboardingFlow.setBiometricResponse("", qsTr("Credentials not found."))
             else if (status === Keychain.StatusFallbackSelected)

--- a/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
+++ b/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 

--- a/ui/app/AppLayouts/Onboarding/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/UseRecoveryPhraseFlow.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 
 import AppLayouts.Onboarding.pages

--- a/ui/app/AppLayouts/Onboarding/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding/components/LoginKeycardBox.qml
@@ -39,18 +39,18 @@ Control {
 
     readonly property alias pairingPassword: pairingPasswordInput.text
 
-    function clear() {
+    function clear() : void {
         d.wrongPin = false
         pinInputField.clearPin()
         pairingPasswordInput.clear()
     }
 
-    function markAsWrongPin() {
+    function markAsWrongPin() : void {
         d.wrongPin = true
         pinInputField.statesInitialization()
     }
 
-    function setPin(pin: string) {
+    function setPin(pin: string) : void {
         pinInputField.setPin(pin)
     }
 
@@ -65,6 +65,8 @@ Control {
     }
 
     background: Rectangle {
+        id: backgroundRect
+
         color: StatusColors.transparent
         border.width: 1
         border.color: Theme.palette.baseColor2
@@ -170,16 +172,14 @@ Control {
             name: "plugin"
             when: root.keycardState === Onboarding.KeycardState.PluginReader && !SQUtils.Utils.isMobile
             PropertyChanges {
-                target: infoText
-                text: qsTr("Plug in Keycard reader...")
+                infoText.text: qsTr("Plug in Keycard reader...")
             }
         },
         State {
             name: "insert"
             when: root.keycardState === Onboarding.KeycardState.InsertKeycard && !SQUtils.Utils.isMobile
             PropertyChanges {
-                target: infoText
-                text: qsTr("Tap or insert your Keycard...")
+                infoText.text: qsTr("Tap or insert your Keycard...")
             }
         },
         State {
@@ -196,8 +196,7 @@ Control {
             name: "reading"
             when: root.keycardState === Onboarding.KeycardState.ReadingKeycard && !SQUtils.Utils.isMobile
             PropertyChanges {
-                target: infoText
-                text: qsTr("Reading Keycard...")
+                infoText.text: qsTr("Reading Keycard...")
             }
         },
         // error states
@@ -206,9 +205,8 @@ Control {
             when: root.keycardState === Onboarding.KeycardState.NotKeycard
             extend: "notEmpty"
             PropertyChanges {
-                target: infoText
-                color: Theme.palette.dangerColor1
-                text: qsTr("This isn't a Keycard.<br>Remove card and insert a Keycard.")
+                infoText.color: Theme.palette.dangerColor1
+                infoText.text: qsTr("This isn't a Keycard.<br>Remove card and insert a Keycard.")
             }
         },
         State {
@@ -216,9 +214,8 @@ Control {
             when: root.isWrongKeycard
             extend: "notEmpty"
             PropertyChanges {
-                target: infoText
-                color: Theme.palette.dangerColor1
-                text: qsTr("Wrong Keycard for this profile")
+                infoText.color: Theme.palette.dangerColor1
+                infoText.text: qsTr("Wrong Keycard for this profile")
             }
         },
         State {
@@ -226,9 +223,8 @@ Control {
             when: root.keycardState === Onboarding.KeycardState.NoPCSCService && !SQUtils.Utils.isMobile
             extend: "notEmpty"
             PropertyChanges {
-                target: infoText
-                color: Theme.palette.dangerColor1
-                text: qsTr("Issue detecting Keycard.<br>Re-scan Keycard.")
+                infoText.color: Theme.palette.dangerColor1
+                infoText.text: qsTr("Issue detecting Keycard.<br>Re-scan Keycard.")
             }
         },
         State {
@@ -261,9 +257,8 @@ Control {
             when: root.keycardState === Onboarding.KeycardState.MaxPairingSlotsReached
             extend: "notEmpty"
             PropertyChanges {
-                target: infoText
-                color: Theme.palette.dangerColor1
-                text: qsTr("No free pairing slots on this Keycard.<br>You can use it with previously paired installations.")
+                infoText.color: Theme.palette.dangerColor1
+                infoText.text: qsTr("No free pairing slots on this Keycard.<br>You can use it with previously paired installations.")
             }
         },
         State {
@@ -271,18 +266,15 @@ Control {
             when: root.keycardState === Onboarding.KeycardState.BlockedPIN ||
                   root.keycardState === Onboarding.KeycardState.BlockedPUK
             PropertyChanges {
-                target: infoText
-                color: Theme.palette.dangerColor1
-                text: qsTr("Keycard blocked")
+                infoText.color: Theme.palette.dangerColor1
+                infoText.text: qsTr("Keycard blocked")
             }
             PropertyChanges {
-                target: unblockButton
-                visible: true
+                unblockButton.visible: true
             }
             PropertyChanges {
-                target: pinInputField
-                enabled: false
-                visible: false
+                pinInputField.enabled: false
+                pinInputField.visible: false
             }
         },
         State {
@@ -290,9 +282,8 @@ Control {
             when: root.keycardState === Onboarding.KeycardState.Empty
             extend: "notEmpty"
             PropertyChanges {
-                target: infoText
-                color: Theme.palette.dangerColor1
-                text: qsTr("The scanned Keycard is empty.<br>Scan the correct Keycard for this profile.")
+                infoText.color: Theme.palette.dangerColor1
+                infoText.text: qsTr("The scanned Keycard is empty.<br>Scan the correct Keycard for this profile.")
             }
         },
         State {
@@ -300,9 +291,8 @@ Control {
             extend: "notEmpty"
             when: root.keycardState === Onboarding.KeycardState.NotEmpty && d.wrongPin
             PropertyChanges {
-                target: infoText
-                color: Theme.palette.dangerColor1
-                text: qsTr("PIN incorrect. %n attempt(s) remaining.", "", root.keycardRemainingPinAttempts)
+                infoText.color: Theme.palette.dangerColor1
+                infoText.text: qsTr("PIN incorrect. %n attempt(s) remaining.", "", root.keycardRemainingPinAttempts)
             }
         },
         State {
@@ -310,9 +300,8 @@ Control {
             when: !!root.loginError
             extend: "notEmpty"
             PropertyChanges {
-                target: infoText
-                color: Theme.palette.dangerColor1
-                text: qsTr("Login failed. %1").arg("<a href='#details'>" + qsTr("Show details.") + "</a>")
+                infoText.color: Theme.palette.dangerColor1
+                infoText.text: qsTr("Login failed. %1").arg("<a href='#details'>" + qsTr("Show details.") + "</a>")
             }
         },
         // exit states
@@ -321,21 +310,17 @@ Control {
             // Mobile UnknownReaderState just means the keycard was never tapped, so we show the PIN input
             when: (root.keycardState === Onboarding.KeycardState.UnknownReaderState) || (root.keycardState === Onboarding.KeycardState.NotEmpty) && !d.wrongPin
             PropertyChanges {
-                target: infoText
-                text: qsTr("Enter Keycard PIN")
+                infoText.text: qsTr("Enter Keycard PIN")
             }
             PropertyChanges {
-                target: background
-                border.color: Theme.palette.primaryColor1
+                backgroundRect.border.color: Theme.palette.primaryColor1
             }
             PropertyChanges {
-                target: pinInputField
-                visible: true
-                enabled: true
+                pinInputField.visible: true
+                pinInputField.enabled: true
             }
             PropertyChanges {
-                target: touchIdIcon
-                visible: root.isBiometricsLogin
+                touchIdIcon.visible: root.isBiometricsLogin
             }
         }
     ]

--- a/ui/app/AppLayouts/Onboarding/components/LoginPasswordBox.qml
+++ b/ui/app/AppLayouts/Onboarding/components/LoginPasswordBox.qml
@@ -34,15 +34,15 @@ Control {
     signal biometricsRequested()
     signal loginRequested(string password)
 
-    function clear() {
+    function clear() : void {
         txtPassword.clear()
     }
 
-    function forceActiveFocus() {
+    function forceActiveFocus() : void {
         txtPassword.forceActiveFocus()
     }
 
-    function clearInputFocus() {
+    function clearInputFocus() : void {
         if (!txtPassword.activeFocus) {
             return
         }

--- a/ui/app/AppLayouts/Onboarding/components/SeedphraseVerifyInput.qml
+++ b/ui/app/AppLayouts/Onboarding/components/SeedphraseVerifyInput.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -103,12 +105,17 @@ StatusTextField {
                 }
             }
             delegate: StatusItemDelegate {
+                id: suggestionDelegate
+
+                required property string seedWord
+                required property int index
+
                 width: ListView.view.width
                 height: d.delegateHeight
-                text: model.seedWord
+                text: suggestionDelegate.seedWord
                 font.pixelSize: Theme.additionalTextSize
                 highlightColor: Theme.palette.primaryColor1
-                highlighted: hovered || index === suggestionsList.currentIndex
+                highlighted: hovered || suggestionDelegate.index === suggestionsList.currentIndex
                 onClicked: {
                     root.text = text
                     root.accepted()

--- a/ui/app/AppLayouts/Onboarding/controls/LoginUserSelector.qml
+++ b/ui/app/AppLayouts/Onboarding/controls/LoginUserSelector.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -28,7 +30,7 @@ Control {
     signal onboardingLoginFlowRequested()
     signal onboardingManageProfilesFlowRequested()
 
-    function setSelection(keyUid: string) {
+    function setSelection(keyUid: string) : void {
         let selection = keyUid
         if (!ModelUtils.contains(root.model, "keyUid", selection)) // get first item if not existing (or empty)
             selection = ModelUtils.get(root.model, 0, "keyUid")
@@ -41,7 +43,7 @@ Control {
     Connections {
         target: root.model?.ModelCount ?? null
 
-        function onCountChanged() {
+        function onCountChanged() : void {
             root.setSelection(root.selectedProfileKeyId)
         }
     }
@@ -88,14 +90,12 @@ Control {
             State {
                 when: currentEntry.available
                 PropertyChanges {
-                    target: userSelectorButton
-
-                    label: currentEntry.item.username
-                    image: currentEntry.item.thumbnailImage
-                    colorId: currentEntry.item.colorId
-                    keycardCreatedAccount: currentEntry.item.keycardCreatedAccount
-                    keycardLocked: root.currentKeycardLocked
-                    keycardEnabled: root.isKeycardEnabled
+                    userSelectorButton.label: currentEntry.item.username
+                    userSelectorButton.image: currentEntry.item.thumbnailImage
+                    userSelectorButton.colorId: currentEntry.item.colorId
+                    userSelectorButton.keycardCreatedAccount: currentEntry.item.keycardCreatedAccount
+                    userSelectorButton.keycardLocked: root.currentKeycardLocked
+                    userSelectorButton.keycardEnabled: root.isKeycardEnabled
                 }
             }
         ]
@@ -151,20 +151,24 @@ Control {
                         model: dropdownProfilesModel
 
                         LoginUserSelectorDelegate {
-                            readonly property bool hasProfileData: !!model.keyUid && !!model.username
+                            id: profileDelegate
+
+                            required property var model
+
+                            readonly property bool hasProfileData: !!profileDelegate.model.keyUid && !!profileDelegate.model.username
 
                             Layout.fillWidth: true
-                            Layout.preferredHeight: hasProfileData ? d.delegateHeight : 0
-                            visible: hasProfileData
-                            label: model.username
-                            image: model.thumbnailImage
-                            colorId: model.colorId
-                            keycardCreatedAccount: model.keycardCreatedAccount
+                            Layout.preferredHeight: profileDelegate.hasProfileData ? d.delegateHeight : 0
+                            visible: profileDelegate.hasProfileData
+                            label: profileDelegate.model.username
+                            image: profileDelegate.model.thumbnailImage
+                            colorId: profileDelegate.model.colorId
+                            keycardCreatedAccount: profileDelegate.model.keycardCreatedAccount
                             keycardEnabled: root.isKeycardEnabled
-                            enabled: !model.keycardCreatedAccount ? true : root.isKeycardEnabled
+                            enabled: !profileDelegate.model.keycardCreatedAccount ? true : root.isKeycardEnabled
                             onClicked: {
                                 dropdown.close()
-                                root.setSelection(model.keyUid)
+                                root.setSelection(profileDelegate.model.keyUid)
                             }
                         }
                     }

--- a/ui/app/AppLayouts/Onboarding/controls/LoginUserSelectorDelegate.qml
+++ b/ui/app/AppLayouts/Onboarding/controls/LoginUserSelectorDelegate.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls

--- a/ui/app/AppLayouts/Onboarding/controls/OnboardingButtonFrame.qml
+++ b/ui/app/AppLayouts/Onboarding/controls/OnboardingButtonFrame.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import Qt5Compat.GraphicalEffects

--- a/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseReveal.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseReveal.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -83,6 +85,11 @@ OnboardingPage {
                     Repeater {
                         model: d.mnemonicWords
                         delegate: Frame {
+                            id: wordFrame
+
+                            required property string modelData
+                            required property int index
+
                             Layout.fillWidth: true
                             Layout.fillHeight: true
                             padding: Theme.smallPadding
@@ -97,16 +104,16 @@ OnboardingPage {
                                 StatusBaseText {
                                     Layout.preferredWidth: idxMetrics.advanceWidth
                                     horizontalAlignment: Qt.AlignHCenter
-                                    text: index + 1
+                                    text: wordFrame.index + 1
                                     color: Theme.palette.baseColor1
                                     font: idxMetrics.font
                                 }
                                 StatusBaseText {
-                                    objectName: "seedWordText_" + (index+1)
+                                    objectName: "seedWordText_" + (wordFrame.index + 1)
                                     Layout.fillWidth: true
-                                    text: modelData
+                                    text: wordFrame.modelData
                                     Accessible.role: Accessible.StaticText
-                                    Accessible.name: SQUtils.Utils.formatAccessibleName(modelData, objectName)
+                                    Accessible.name: SQUtils.Utils.formatAccessibleName(wordFrame.modelData, objectName)
                                 }
                             }
                         }

--- a/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseVerify.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseVerify.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -79,6 +81,8 @@ OnboardingPage {
                     id: seedRepeater
                     model: d.verificationWordsMap
                     delegate: RowLayout {
+                        id: seedRow
+
                         required property var modelData
                         required property int index
 
@@ -91,22 +95,22 @@ OnboardingPage {
                         spacing: 12
                         StatusBaseText {
                             Layout.preferredWidth: 20
-                            text: modelData.seedWordNumber
+                            text: seedRow.modelData.seedWordNumber
                             horizontalAlignment: Text.AlignHCenter
                         }
                         SeedphraseVerifyInput {
-                            readonly property int seedWordIndex: modelData.seedWordNumber - 1 // 0 based idx in the mnemonic
+                            readonly property int seedWordIndex: seedRow.modelData.seedWordNumber - 1 // 0 based idx in the mnemonic
                             objectName: "seedInput_%1".arg(seedWordIndex)
                             Layout.fillWidth: true
                             id: seedInput
-                            valid: text.trim().toLowerCase() === modelData.seedWord
+                            valid: text.trim().toLowerCase() === seedRow.modelData.seedWord
                             seedSuggestions: d.seedSuggestions
-                            Component.onCompleted: if (index === 0) forceActiveFocus()
+                            Component.onCompleted: if (seedRow.index === 0) forceActiveFocus()
                             onAccepted: {
                                 if (seedRepeater.allValid) { // move to next page
                                     root.backupSeedphraseVerified()
                                 } else { // move to next field
-                                    const nextItem = seedRepeater.itemAt(index + 1) ?? seedRepeater.itemAt(0)
+                                    const nextItem = seedRepeater.itemAt(seedRow.index + 1) ?? seedRepeater.itemAt(0)
                                     if (!!nextItem) {
                                         nextItem.input.forceActiveFocus()
                                     }

--- a/ui/app/AppLayouts/Onboarding/pages/ConvertKeycardAccountPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/ConvertKeycardAccountPage.qml
@@ -23,84 +23,66 @@ OnboardingPage {
                 when: root.convertKeycardAccountState === Onboarding.ProgressState.InProgress
 
                 PropertyChanges {
-                    target: root
-                    title: qsTr("Re-encrypting your profile data")
+                    root.title: qsTr("Re-encrypting your profile data")
                 }
                 PropertyChanges {
-                    target: iconLoader
-                    sourceComponent: loadingIndicator
+                    iconLoader.sourceComponent: loadingIndicator
                 }
                 PropertyChanges {
-                    target: subtitle
-                    text: qsTr("Your data must be re-encrypted with your new password which may take some time.")
+                    subtitle.text: qsTr("Your data must be re-encrypted with your new password which may take some time.")
                 }
                 PropertyChanges {
-                    target: warningText
-                    visible: true
+                    warningText.visible: true
                 }
                 PropertyChanges {
-                    target: btnQuit
-                    visible: false
+                    btnQuit.visible: false
                 }
                 PropertyChanges {
-                    target: btnTryAgain
-                    visible: false
+                    btnTryAgain.visible: false
                 }
             },
             State {
                 when: root.convertKeycardAccountState === Onboarding.ProgressState.Success
 
                 PropertyChanges {
-                    target: root
-                    title: qsTr("Re-encryption complete")
+                    root.title: qsTr("Re-encryption complete")
                 }
                 PropertyChanges {
-                    target: iconLoader
-                    sourceComponent: successIcon
+                    iconLoader.sourceComponent: successIcon
                 }
                 PropertyChanges {
-                    target: subtitle
-                    text: qsTr("Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.")
+                    subtitle.text: qsTr("Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.")
                 }
                 PropertyChanges {
-                    target: warningText
-                    visible: false
+                    warningText.visible: false
                 }
                 PropertyChanges {
-                    target: btnQuit
-                    visible: true
+                    btnQuit.visible: true
                 }
                 PropertyChanges {
-                    target: btnTryAgain
-                    visible: false
+                    btnTryAgain.visible: false
                 }
             },
             State {
                 when: root.convertKeycardAccountState === Onboarding.ProgressState.Failed
 
                 PropertyChanges {
-                    target: root
-                    title: qsTr("Re-encryption failed")
+                    root.title: qsTr("Re-encryption failed")
                 }
                 PropertyChanges {
-                    target: iconLoader
-                    sourceComponent: failedIcon
+                    iconLoader.sourceComponent: failedIcon
                 }
                 PropertyChanges {
-                    target: subtitle
-                    text: qsTr("Your data must be re-encrypted with your new password which may take some time.")
+                    subtitle.text: qsTr("Your data must be re-encrypted with your new password which may take some time.")
                 }
                 PropertyChanges {
-                    target: warningText
-                    visible: true
+                    warningText.visible: true
                 }
                 PropertyChanges {
-                    target: btnQuit
-                    visible: false
+                    btnQuit.visible: false
                 }
                 PropertyChanges {
-                    target: btnTryAgain
-                    visible: true
+                    btnTryAgain.visible: true
                 }
             }
         ]

--- a/ui/app/AppLayouts/Onboarding/pages/CreatePasswordPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/CreatePasswordPage.qml
@@ -24,7 +24,7 @@ OnboardingPage {
     QtObject {
         id: d
 
-        function submit() {
+        function submit() : void {
             if (!passView.ready)
                 return
             root.setPasswordRequested(passView.newPswText)

--- a/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
@@ -55,7 +55,7 @@ OnboardingPage {
     signal changeLanguageRequested(string newLanguageCode)
     signal profileSelected(string keyUid)
 
-    function setBiometricResponse(secret: string, error = "") {
+    function setBiometricResponse(secret: string, error: string) : void {
         if (!root.isBiometricsLogin)
             return
 
@@ -109,7 +109,7 @@ OnboardingPage {
         readonly property int loginModelCount: root.loginAccountsModel.ModelCount.count
         onLoginModelCountChanged: setSelectedLoginUser()
 
-        function setSelectedLoginUser() {
+        function setSelectedLoginUser() : void {
             if (loginModelCount > 0) {
                 loginUserSelector.setSelection(root.lastSelectedProfileKeyUid)
                 if (!d.currentProfileIsKeycard)
@@ -118,12 +118,12 @@ OnboardingPage {
         }
 
 
-        function resetBiometricsResult() {
+        function resetBiometricsResult() : void {
             d.biometricsSuccessful = false
             d.biometricsFailed = false
         }
 
-        function doPasswordLogin(password: string) {
+        function doPasswordLogin(password: string) : void {
             if (password.length === 0)
                 return
 
@@ -132,7 +132,7 @@ OnboardingPage {
 
         property string lastPin: ""
 
-        function doKeycardLogin(pin: string) {
+        function doKeycardLogin(pin: string) : void {
             if (pin.length === 0)
                 return
 
@@ -169,7 +169,7 @@ OnboardingPage {
 
 
     // login errors reporting
-    function setAccountLoginError(error: string, wrongPassword: bool) {
+    function setAccountLoginError(error: string, wrongPassword: bool) : void {
         if (!error && !wrongPassword) {
             return
         }

--- a/ui/app/AppLayouts/Onboarding/pages/NewAccountLoginPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/NewAccountLoginPage.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -140,22 +142,22 @@ OnboardingPage {
     Loader {
         id: popupsLoader
         property bool waitingForPermission: false
-        function goToLoginWithSyncAck() {
+        function goToLoginWithSyncAck() : void {
             sourceComponent = loginWithSyncAck
             active = true
         }
 
-        function goToLocalNetworkPermissionDenied() {
+        function goToLocalNetworkPermissionDenied() : void {
             sourceComponent = localNetworkPermissionDeniedPopup
             active = true
         }
 
-        function goToNetworkCheck() {
+        function goToNetworkCheck() : void {
             sourceComponent = networkCheckPopup
             active = true
         }
 
-        function reset() {
+        function reset() : void {
             active = false
             sourceComponent = null
             waitingForPermission = false
@@ -191,7 +193,7 @@ OnboardingPage {
                         id: btnContinue
                         objectName: "btnContinue"
                         
-                        function tryAccept() {
+                        function tryAccept() : void {
                             if (localNetworkPermission.status === LocalNetworkPermission.Unknown) {
                                 popupsLoader.waitingForPermission = true
                                 localNetworkPermission.request()
@@ -348,7 +350,7 @@ OnboardingPage {
             }
             Connections {
                 target: netChecker
-                function onIsOnlineChanged() {
+                function onIsOnlineChanged() : void {
                     if (netChecker.isOnline) {
                         root.loginWithSyncingRequested()
                         close()

--- a/ui/app/AppLayouts/Onboarding/pages/SeedphrasePage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/SeedphrasePage.qml
@@ -23,7 +23,7 @@ OnboardingPage {
     signal seedphraseSubmitted(string seedphrase)
     signal seedphraseProvided(var seedPhrase)
 
-    function setSeedPhraseError(errorMessage: string) {
+    function setSeedPhraseError(errorMessage: string) : void {
         seedPanel.setError(errorMessage)
     }
 

--- a/ui/app/AppLayouts/Onboarding/pages/SyncProgressPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/SyncProgressPage.qml
@@ -23,77 +23,61 @@ OnboardingPage {
             name: "inprogress"
             when: root.syncState === Onboarding.LocalPairingState.Transferring || root.syncState === Onboarding.LocalPairingState.Idle
             PropertyChanges {
-                target: root
-                title: qsTr("Profile sync in progress...")
+                root.title: qsTr("Profile sync in progress...")
             }
             PropertyChanges {
-                target: subtitle
-                text: qsTr("Your profile data is being synced to this device")
+                subtitle.text: qsTr("Your profile data is being synced to this device")
             }
             PropertyChanges {
-                target: iconLoader
-                sourceComponent: loadingIndicator
+                iconLoader.sourceComponent: loadingIndicator
             }
             PropertyChanges {
-                target: image
-                source: Assets.png("onboarding/status_sync_progress")
+                image.source: Assets.png("onboarding/status_sync_progress")
             }
             PropertyChanges {
-                target: subImageText
-                text: qsTr("Please keep both devices switched on and connected to the same network until the sync is complete")
-                visible: true
+                subImageText.text: qsTr("Please keep both devices switched on and connected to the same network until the sync is complete")
+                subImageText.visible: true
             }
         },
         State {
             name: "success"
             when: root.syncState === Onboarding.LocalPairingState.Finished
             PropertyChanges {
-                target: root
-                title: qsTr("Profile synced")
+                root.title: qsTr("Profile synced")
             }
             PropertyChanges {
-                target: subtitle
-                text: qsTr("Your profile data has been synced to this device")
+                subtitle.text: qsTr("Your profile data has been synced to this device")
             }
             PropertyChanges {
-                target: iconLoader
-                sourceComponent: successIcon
+                iconLoader.sourceComponent: successIcon
             }
             PropertyChanges {
-                target: image
-                source: Assets.png("onboarding/status_sync_success")
+                image.source: Assets.png("onboarding/status_sync_success")
             }
             PropertyChanges {
-                target: loginButton
-                visible: true
+                loginButton.visible: true
             }
         },
         State {
             name: "failed"
             when: root.syncState === Onboarding.LocalPairingState.Error
             PropertyChanges {
-                target: root
-                title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Failed to pair devices") + "</font>"
+                root.title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Failed to pair devices") + "</font>"
             }
             PropertyChanges {
-                target: subtitle
-                text: qsTr("Try again and double-check the instructions")
+                subtitle.text: qsTr("Try again and double-check the instructions")
             }
             PropertyChanges {
-                target: iconLoader
-                sourceComponent: failedIcon
+                iconLoader.sourceComponent: failedIcon
             }
             PropertyChanges {
-                target: image
-                source: Assets.png("onboarding/status_sync_failed")
+                image.source: Assets.png("onboarding/status_sync_failed")
             }
             PropertyChanges {
-                target: tryAgainButton
-                visible: true
+                tryAgainButton.visible: true
             }
             PropertyChanges {
-                target: loginWithSeedphraseButton
-                visible: true
+                loginWithSeedphraseButton.visible: true
             }
         }
     ]

--- a/ui/app/AppLayouts/Onboarding/stores/OnboardingKeycardStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/OnboardingKeycardStore.qml
@@ -20,15 +20,15 @@ BaseKeycardManagementStore {
     readonly property Connections _onboardingConn: Connections {
         target: backend ?? null
 
-        function onKeycardAsyncLoginSuccess(dataJson) { root.keycardAsyncLoginSuccess(dataJson) }
-        function onKeycardAsyncLoginError(error) { root.keycardAsyncLoginError(error) }
+        function onKeycardAsyncLoginSuccess(dataJson: string) : void { root.keycardAsyncLoginSuccess(dataJson) }
+        function onKeycardAsyncLoginError(error: string) : void { root.keycardAsyncLoginError(error) }
     }
 
-    function prepare() {
+    function prepare() : void {
         d.onboardingModuleInst.prepareKeycardModule()
     }
 
-    function teardown() {
+    function teardown() : void {
         if (!backend) {
             console.error("onboarding - keycard management module was not created")
             return
@@ -37,7 +37,7 @@ BaseKeycardManagementStore {
         d.onboardingModuleInst.destroyKeycardModule()
     }
 
-    function startAsyncLogin(keyUid, pin, generateXPub, pairingPassword = "") {
+    function startAsyncLogin(keyUid: string, pin: string, generateXPub: bool, pairingPassword = "") {
         if (!backend) {
             console.error("onboarding - keycard management module was not created")
             return
@@ -45,15 +45,15 @@ BaseKeycardManagementStore {
         backend.startAsyncLogin(keyUid, pin, generateXPub, pairingPassword)
     }
 
-    function isMnemonicBackedUp() {
+    function isMnemonicBackedUp() : bool {
         return false
     }
 
-    function getMnemonic() {
+    function getMnemonic() : string {
         return ""
     }
 
-    function isKnownKeyUid(keyUid) {
+    function isKnownKeyUid(keyUid: string) : bool {
         const profile = StatusQUtils.ModelUtils.getByKey(d.loginAccountsModel, "keyUid", keyUid)
         if (!!profile) {
             return true
@@ -61,7 +61,7 @@ BaseKeycardManagementStore {
         return false
     }
 
-    function isKeypairMigratedToColdWallet(keyUid) {
+    function isKeypairMigratedToColdWallet(keyUid: string) : bool {
         const profile = StatusQUtils.ModelUtils.getByKey(d.loginAccountsModel, "keyUid", keyUid)
         if (!!profile && profile.keycardPairing.trim().length > 0) {
             return true

--- a/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
@@ -39,26 +39,26 @@ QtObject {
     readonly property string keycardCardMetadataName: d.onboardingModuleInst.keycardCardMetadataName
     readonly property string keycardCardMetadataWalletAccountsJson: d.onboardingModuleInst.keycardCardMetadataWalletAccountsJson
 
-    function finishOnboardingFlow(flow: int, data: Object) { // -> string
+    function finishOnboardingFlow(flow: int, data: Object) : string {
         return d.onboardingModuleInst.finishOnboardingFlow(flow, JSON.stringify(data))
     }
 
-    function loginRequested(keyUid: string, method: int, data: Object) { // -> void
+    function loginRequested(keyUid: string, method: int, data: Object) : void {
         d.onboardingModuleInst.loginRequested(keyUid, method, JSON.stringify(data))
     }
 
-    function deleteMultiaccountRequested(keyUid: string) {
+    function deleteMultiaccountRequested(keyUid: string) : void {
         d.onboardingModuleInst.requestDeleteMultiaccount(keyUid)
     }
 
-    function cleanupAfterMainTransition() {
+    function cleanupAfterMainTransition() : void {
         d.onboardingModuleInst.cleanupAfterMainTransition()
     }
 
     // password
     signal accountLoginError(string error, bool wrongPassword)
 
-    function getPasswordStrengthScore(password: string) { // -> int
+    function getPasswordStrengthScore(password: string) : int {
         return d.onboardingModuleInst.getPasswordStrengthScore(password, "") // The second argument is username
     }
 
@@ -75,7 +75,7 @@ QtObject {
     function validateLocalPairingConnectionString(connectionString: string) : bool {
         return d.onboardingModuleInst.validateLocalPairingConnectionString(connectionString)
     }
-    function inputConnectionStringForBootstrapping(connectionString: string) {
+    function inputConnectionStringForBootstrapping(connectionString: string) : void {
         d.onboardingModuleInst.inputConnectionStringForBootstrapping(connectionString)
     }
 }

--- a/ui/generate-rcc.go
+++ b/ui/generate-rcc.go
@@ -29,49 +29,96 @@ var qrcExtensions = map[string]bool{
 	".html": true,
 }
 
+var skippedDirs = map[string]bool{
+	"vendor":       true,
+	"tests":        true,
+	"StatusQ":      true,
+	"node_modules": true,
+	"build":        true,
+}
+
+// Scripts injected into web pages (WebEngine/WKWebView), never loaded by the QML
+// engine. They are written for a browser JS engine and use syntax qmlcachegen
+// cannot parse (async/await, optional catch binding), so they are emitted into a
+// separate .qrc that the build excludes from the Qt Quick Compiler.
+const webScriptsDir = "app/AppLayouts/Browser/provider/js"
+
+type qrcWriter struct {
+	file  *os.File
+	count int
+}
+
+func newQrcWriter(name string) *qrcWriter {
+	f, err := os.Create(name)
+	if err != nil {
+		log.Fatalf("Failed creating qrc file: %s", err)
+	}
+	f.WriteString("<!DOCTYPE RCC>\n")
+	f.WriteString("<RCC version=\"1.0\">\n")
+	f.WriteString("  <qresource>\n")
+	return &qrcWriter{file: f}
+}
+
+func (w *qrcWriter) add(path string) {
+	w.count++
+	w.file.WriteString("      <file>" + path + "</file>\n")
+}
+
+func (w *qrcWriter) close() {
+	w.file.WriteString("  </qresource>\n")
+	w.file.WriteString("</RCC>")
+	w.file.Close()
+}
+
 func main() {
 	sourceDirName := flag.String("source", "", "source dir containing ui files")
 	qrcFileName := flag.String("output", "resources.qrc", "output filename")
+	webScriptsQrcFileName := flag.String("webscripts-output", "", "output filename for browser user scripts; when empty they go into -output")
 	flag.Parse()
 	if flag.NFlag() == 0 {
 		flag.Usage()
 		return
 	}
 
-	qrcFile, err := os.Create(*qrcFileName)
-	if err != nil {
-		log.Fatalf("Failed creating qrc file: %s", err)
+	resources := newQrcWriter(*qrcFileName)
+	defer resources.close()
+
+	webScripts := resources
+	if *webScriptsQrcFileName != "" {
+		webScripts = newQrcWriter(*webScriptsQrcFileName)
+		defer webScripts.close()
 	}
-	defer qrcFile.Close()
 
-	qrcFile.WriteString("<!DOCTYPE RCC>\n")
-	qrcFile.WriteString("<RCC version=\"1.0\">\n")
-	qrcFile.WriteString("  <qresource>\n")
-
-	counter := 0
-	err = filepath.Walk(*sourceDirName,
+	err := filepath.Walk(*sourceDirName,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
-			if info.IsDir() && (info.Name() == "vendor" || info.Name() == "tests" || info.Name() == "StatusQ" || info.Name() == "node_modules") {
+			if info.IsDir() && skippedDirs[info.Name()] {
 				return filepath.SkipDir
 			}
 			if !info.IsDir() {
 				ext := filepath.Ext(path)
 				base := filepath.Base(path)
 				if qrcExtensions[ext] || base == "qmldir" {
-					counter++
 					fixedPath := strings.ReplaceAll(path, "\\", "/")
 					fixedPath = "./" + strings.TrimPrefix(fixedPath, *sourceDirName)
-					qrcFile.WriteString("      <file>" + fixedPath + "</file>\n")
+					if strings.Contains(fixedPath, webScriptsDir) {
+						webScripts.add(fixedPath)
+					} else {
+						resources.add(fixedPath)
+					}
 				}
 			}
 			return nil
 		})
+	if err != nil {
+		log.Fatalf("Failed walking %s: %s", *sourceDirName, err)
+	}
 
-	qrcFile.WriteString("  </qresource>\n")
-	qrcFile.WriteString("</RCC>")
-
-	fmt.Printf("%d resources added\n", counter)
+	if webScripts != resources {
+		fmt.Printf("%d resources added, %d web scripts added\n", resources.count, webScripts.count)
+	} else {
+		fmt.Printf("%d resources added\n", resources.count)
+	}
 }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -107,14 +109,14 @@ Window {
         }
     }
 
-    function contentLoaded() {
+    function contentLoaded() : void {
         if (SQUtils.Utils.isAndroid && !d.splashDismissed) {
             d.splashDismissed = true
             SystemUtils.setMainWindowReady()
         }
     }
 
-    function restoreAppState() {
+    function restoreAppState() : void {
         if (SQUtils.Utils.isMobile && applicationWindow.visibility !== Window.Windowed) {
             // just correct visibility on mobile
             applicationWindow.visibility = Window.Maximized
@@ -163,7 +165,7 @@ Window {
         applicationWindow.visibility = visibility
     }
 
-    function storeAppState() {
+    function storeAppState() : void {
         if (SQUtils.Utils.isMobile) // no point in storing geometry or visibility
             return
 
@@ -188,7 +190,7 @@ Window {
 
         readonly property bool macOSWindowed: SQUtils.Utils.isMacOS && applicationWindow.visibility !== Window.FullScreen
 
-        function restoreScreenAfterMinimizing() {
+        function restoreScreenAfterMinimizing() : void {
             if (Qt.platform.os !== SQUtils.Utils.windows || !lastMinimizedScreen)
                 return
 
@@ -197,7 +199,7 @@ Window {
             lastMinimizedScreen = null
         }
 
-        function restoreWindowState() {
+        function restoreWindowState() : void {
             if (SQUtils.Utils.isMobile) // no point in restoring window state
                 return
             restoreScreenAfterMinimizing()
@@ -220,7 +222,7 @@ Window {
         property bool showSkippedBiometricFlow: false
 
         property var keycardSimulatorWindow
-        function createKeycardSimulatorController() {
+        function createKeycardSimulatorController() : void {
             if (d.keycardSimulatorWindow)
                 return
             if (!localAppSettings || !localAppSettings.useSimulatedKeycard)
@@ -288,7 +290,7 @@ Window {
         id: windowsOsNotificationsConnection
         enabled: Qt.platform.os === SQUtils.Utils.windows
         target: Qt.platform.os === SQUtils.Utils.windows && typeof mainModule !== "undefined" ? mainModule : null
-        function onDisplayWindowsOsNotification(title, message) {
+        function onDisplayWindowsOsNotification(title: string, message: string) : void {
             systemTray.showMessage(title, message)
         }
     }
@@ -302,7 +304,7 @@ Window {
         running: false
     }
 
-    function moveToAppMain() {
+    function moveToAppMain() : void {
         d.appMainTriggered = true
     }
 
@@ -317,7 +319,7 @@ Window {
         target: SystemUtils
         enabled: SQUtils.Utils.isMacOS
 
-        function onQuit(spontaneous) {
+        function onQuit(spontaneous: bool) : void {
             if (spontaneous)
                 Qt.exit(0)
         }
@@ -326,7 +328,7 @@ Window {
     Connections {
         target: SystemUtils
         enabled: SQUtils.Utils.isMobile
-        function onShakeDetected() {
+        function onShakeDetected() : void {
             const nowMs = Date.now()
             if (nowMs - d.lastShakeShareMs < 3000) {
                 openShakeToSharePopup()
@@ -411,7 +413,7 @@ Window {
     Connections {
         target: singleInstance
 
-        function onSecondInstanceDetected() {
+        function onSecondInstanceDetected() : void {
             console.log("User attempted to run the second instance of the application")
             // activating this instance to give user visual feedback
             makeStatusAppActive()
@@ -420,7 +422,7 @@ Window {
 
     Connections {
         target: Application
-        function onAboutToQuit() {
+        function onAboutToQuit() : void {
             applicationWindow.storeAppState()
         }
     }
@@ -463,13 +465,13 @@ Window {
         }
     }
 
-    function makeStatusAppActive() {
+    function makeStatusAppActive() : void {
         d.restoreWindowState()
         applicationWindow.raise()
         applicationWindow.requestActivate()
     }
 
-    function openShakeToSharePopup() {
+    function openShakeToSharePopup() : void {
         shakeToShareLoader.active = true
     }
 
@@ -639,22 +641,22 @@ Window {
             target: startupOnboardingLoader.item
             ignoreUnknownSignals: true
 
-            function onAppReady() {
+            function onAppReady() : void {
                 applicationWindow.appIsReady = true
             }
-            function onStoreAppStateRequested() {
+            function onStoreAppStateRequested() : void {
                 applicationWindow.storeAppState()
             }
-            function onRequestMoveToAppMain() {
+            function onRequestMoveToAppMain() : void {
                 applicationWindow.moveToAppMain()
             }
-            function onBiometricFlowStarted() {
+            function onBiometricFlowStarted() : void {
                 applicationWindow.biometricFlowPending = true
             }
-            function onSkippedBiometricFlow(available) {
+            function onSkippedBiometricFlow(available: bool) : void {
                 d.showSkippedBiometricFlow = available
             }
-            function onProfileSelected(keyUid) {
+            function onProfileSelected(keyUid: string) : void {
                 localAppSettings.selectedProfileKeyUid = keyUid
             }
         }

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -36,6 +36,7 @@ QML_IMPORT_PATH = $$PWD/imports \
 QML_DESIGNER_IMPORT_PATH = $$PWD/imports
 
 RESOURCES += resources.qrc \
+            resources_webscripts.qrc \
             StatusQ/src/assets/fonts/fonts.qrc \
             StatusQ/src/assets/img/img.qrc \
             StatusQ/src/assets/png/png.qrc \


### PR DESCRIPTION
Iterates https://github.com/status-im/status-app/issues/21654

Wires qmlcachegen AOT into the mobile build and fixes what blocked it:

- import paths + a QtQuick.Controls style shim for qmlcachegen (it resolves no in-repo modules and cannot follow optional style imports on its own)
- StatusQ QML/assets move from libStatusQ into the app so they compile too (`STATUSQ_BUNDLE_QML=OFF`, desktop unchanged)
- Onboarding/main.qml made AOT-friendlier (`pragma ComponentBehavior: Bound`, ID-based `PropertyChanges`, type annotations)
- fixes an undefined delegate height surfaced by the work

Results: 48% of bindings AOT-compiled tree-wide (was 11%). Device cold start after install/update: **6.3s → 4.8s**; runtime QML compilation fully eliminated (warm == cold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)