### PR TITLE
fix(ProfileButton): update UserStatusContextMenu

### DIFF
--- a/storybook/pages/PrimaryNavSidebarPage.qml
+++ b/storybook/pages/PrimaryNavSidebarPage.qml
@@ -158,12 +158,13 @@ SplitView {
 
             selfContactDetails: ContactDetails {
                 publicKey: "0xdeadbeef"
-                compressedPubKey: "zxDeadBeef"
-                displayName: "John Doe"
-                icon: ModelsData.icons.rarible
+                compressedPubKey: "zx3shDeadBeef"
+                preferredDisplayName: "John Doe"
+                largeImage: ModelsData.icons.dribble
                 colorId: 7
                 usesDefaultName: false
                 onlineStatus: Constants.currentUserStatus.automatic
+                bio: "Core developer <john.doe@acme.org> Lorem ipsum dolor sit amet"
             }
 
             getEmojiHashFn: function(pubKey) { // <- root.utilsStore.getEmojiHash(pubKey)
@@ -266,6 +267,7 @@ SplitView {
             onViewProfileRequested: function(pubKey) {
                 logs.logEvent("onViewProfileRequested", ["pubKey"], arguments) // <- Global.openProfilePopup(pubKey)
             }
+            onShareOwnProfileRequested: logs.logEvent("onShareOwnProfileRequested", [], arguments)
         }
     }
 

--- a/test/e2e/gui/components/online_identifier.py
+++ b/test/e2e/gui/components/online_identifier.py
@@ -18,7 +18,7 @@ class OnlineIdentifier(QObject):
         self.automatic_button = Button(names.userContextmenu_AutomaticButton)
         self.view_my_profile_button = Button(names.userContextMenu_ViewMyProfileAction)
         self.copy_link_to_profile_button = QObject(names.userContextMenu_CopyLinkToProfile)
-        self.user_name_text_label = TextLabel(names.userLabel_StyledText)
+        self.user_name_text_label = TextLabel(names.userStatusDisplayName)
 
     @property
     @allure.step('Get user name')

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -162,9 +162,6 @@ contactRequest_Send_Button = {"container": statusDesktop_mainWindow_overlay,
 # User Status Profile Menu
 onlineIdentifier = {"container": statusDesktop_mainWindow_overlay, "objectName": "UserStatusContextMenu",
                     "type": "PopupItem", "visible": True}
-onlineIdentifierProfileHeader = {"container": statusDesktop_mainWindow_overlay,
-                                 "objectName": "onlineIdentifierProfileHeader", "type": "ProfileHeader",
-                                 "visible": True}
 userContextmenu_AlwaysActiveButton = {"container": statusDesktop_mainWindow_overlay,
                                       "objectName": "userStatusMenuAlwaysOnlineAction", "type": "StatusMenuItem",
                                       "visible": True}
@@ -180,8 +177,8 @@ userContextMenu_ViewMyProfileAction = {"container": statusDesktop_mainWindow_ove
 userContextMenu_CopyLinkToProfile = {"container": statusDesktop_mainWindow_overlay,
                                      "objectName": "userStatusCopyLinkAction", "type": "StatusMenuItem",
                                      "visible": True}
-userLabel_StyledText = {"container": statusDesktop_mainWindow_overlay, "type": "StyledText", "unnamed": 1,
-                        "visible": True}
+userStatusDisplayName = {"container": onlineIdentifier, "objectName": "userStatusDisplayName",
+                         "type": "StatusBaseText", "visible": True}
 
 # My Profile Popup (online identifier)
 ProfileDialogView = {"container": statusDesktop_mainWindow_overlay, "id": "profileView", "type": "ProfileDialogView",

--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -1,5 +1,5 @@
 import QtQuick
-import Qt5Compat.GraphicalEffects
+import QtQuick.Effects
 import QtQuick.Controls as QC
 import QtQml
 
@@ -90,6 +90,8 @@ QC.Popup {
        // Keeping a small gap at the top lets users tap to return to the underlying dialog
        // instead of closing the entire flow.
        readonly property real bottomSheetHeightRatio: 0.85
+
+       readonly property int cornerRadius: root.Theme.radius
     }
 
     // workaround for QTBUG-142248
@@ -136,16 +138,20 @@ QC.Popup {
 
     background: Rectangle {
        color: Theme.palette.statusMenu.backgroundColor
-       radius: Theme.radius
-       border.color: "transparent"
-       layer.enabled: true
-       layer.effect: DropShadow {
-           source: root.background
-           horizontalOffset: 0
-           verticalOffset: 4
-           radius: 12
-           samples: 25
-           spread: 0.2
+       topLeftRadius: d.cornerRadius
+       topRightRadius: d.cornerRadius
+       bottomLeftRadius: root.bottomSheet ? 0 : d.cornerRadius
+       bottomRightRadius: root.bottomSheet ? 0 : d.cornerRadius
+
+       RectangularShadow {
+           anchors.fill: parent
+           anchors.margins: -d.cornerRadius
+           z: parent.z - 1
+           topLeftRadius: parent.topLeftRadius
+           topRightRadius: parent.topRightRadius
+           bottomLeftRadius: parent.bottomLeftRadius
+           bottomRightRadius: parent.bottomRightRadius
+           spread: 0.1
            color: Theme.palette.dropShadow
        }
     }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -188,6 +188,14 @@ Dialog {
 
     background: StatusDialogBackground {
         id: background
+        Binding on bottomLeftRadius {
+            value: 0
+            when: root.bottomSheet
+        }
+        Binding on bottomRightRadius {
+            value: 0
+            when: root.bottomSheet
+        }
     }
 
     Connections {
@@ -221,6 +229,7 @@ Dialog {
         visible: rightButtons
                  && root.standardButtons & (rejectRoleFlags | noRoleFlags | acceptRoleFlags
                                             | yesRoleFlags | Dialog.ApplyRole)
+        bottomSheet: root.bottomSheet
 
         rightButtons: ObjectModel {
             StatusButton {

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogBackground.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogBackground.qml
@@ -7,7 +7,10 @@ Rectangle {
     id: root
 
     color: Theme.palette.statusModal.backgroundColor
-    radius: Theme.radius
+    topLeftRadius: Theme.radius
+    topRightRadius: Theme.radius
+    bottomLeftRadius: Theme.radius
+    bottomRightRadius: Theme.radius
 
     signal closeRequested()
 

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogFooter.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogFooter.qml
@@ -15,6 +15,7 @@ Control {
     property ObjectModel errorTags
     property color color: Theme.palette.statusModal.backgroundColor
     property bool dropShadowEnabled
+    property bool bottomSheet
 
     spacing: Theme.defaultHalfPadding
     padding: Theme.defaultPadding
@@ -22,7 +23,10 @@ Control {
 
     background: Rectangle {
         color: root.color
-        radius: Theme.radius
+        bottomLeftRadius: root.bottomSheet ? 0 : Theme.radius
+        bottomRightRadius: root.bottomSheet ? 0 : Theme.radius
+        topLeftRadius: 0
+        topRightRadius: 0
 
         layer.enabled: root.dropShadowEnabled
         layer.effect: DropShadow {
@@ -30,14 +34,6 @@ Control {
             verticalOffset: -2
             samples: 37
             color: Theme.palette.dropShadow
-        }
-
-        // cover for the top rounded corners
-        Rectangle {
-            width: parent.width
-            height: parent.radius
-            anchors.top: parent.top
-            color: parent.color
         }
 
         StatusDialogDivider {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusAction.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusAction.qml
@@ -20,8 +20,8 @@ Action {
     property bool visibleOnDisabled: false
 
     property StatusAssetSettings assetSettings: StatusAssetSettings {
-        width: 18
-        height: 18
+        width: root.icon.width
+        height: root.icon.height
         rotation: 0
         isLetterIdenticon: false
         imgIsIdenticon: false
@@ -34,6 +34,8 @@ Action {
         Theme.fontSizeOffset: root.Theme.fontSizeOffset
     }
 
+    icon.width: 18
+    icon.height: 18
     icon.color: {
         if (!root.enabled)
             return root.Theme.palette.baseColor1

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -25,14 +25,17 @@ MenuItem {
 
     font.pixelSize: d.fontSettings ? d.fontSettings.pixelSize : d.defaultFontSettings.pixelSize
 
+    icon.width: 18
+    icon.height: 18
+
     QtObject {
         id: d
 
         readonly property bool isSubMenu: !!root.subMenu
-        readonly property bool isStatusSubMenu: isSubMenu && root.subMenu.toString().startsWith("StatusMenu_")
+        readonly property bool isStatusSubMenu: isSubMenu && (root.subMenu instanceof StatusMenu)
         readonly property bool subMenuOpened: isSubMenu && root.subMenu.opened
         readonly property bool hasAction: !!root.action
-        readonly property bool isStatusAction: d.hasAction && root.action.toString().startsWith("StatusAction_")
+        readonly property bool isStatusAction: d.hasAction && (root.action instanceof StatusAction)
         readonly property bool isStatusDangerAction: (d.isStatusAction && root.action.type === StatusAction.Type.Danger) ||
                                                      (d.isStatusSubMenu && root.subMenu.type === StatusAction.Type.Danger)
         readonly property bool isStatusSuccessAction: (d.isStatusAction && root.action.type === StatusAction.Type.Success) ||
@@ -81,8 +84,8 @@ MenuItem {
                                                              : d.defaultFontSettings
 
         readonly property StatusAssetSettings defaultAssetSettings: StatusAssetSettings {
-            width: 18
-            height: 18
+            width: root.icon.width
+            height: root.icon.height
             rotation: 0
             // Link to standard Qt properties. Not because it's a good idea,
             // but because it we use it in some places and it will make refactor easier.
@@ -95,9 +98,8 @@ MenuItem {
         }
 
         readonly property StatusFontSettings defaultFontSettings: StatusFontSettings {
-            pixelSize: root.Theme.additionalTextSize
-            bold: false
-            italic: false
+            bold: root.font.bold
+            italic: root.font.italic
         }
     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -230,9 +230,9 @@ Item {
                 publicKey: appMain.profileStore.pubKey
                 compressedPubKey: appMain.profileStore.compressedPubKey
                 displayName: appMain.profileStore.displayName
-                ensName: appMain.profileStore.name
+                ensName: appMain.profileStore.preferredName
                 ensVerified: !!ensName && Utils.isValidEns(ensName)
-                preferredDisplayName: appMain.profileStore.preferredName
+                preferredDisplayName: appMain.profileStore.name // returns ENS, or display name, or alias
                 alias: appMain.profileStore.username
                 usesDefaultName: appMain.profileStore.usesDefaultName
                 icon: appMain.profileStore.icon

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -66,7 +66,7 @@ Control {
     // Portrait mobile drawer on Browser: keep sidebar open while overlay popups are shown.
     readonly property bool keepOpenWhenPopups: SQUtils.Utils.isMobile && !root.alwaysVisible && root.browserSectionActive
 
-    required property bool acVisible // FIXME AC should not be a section
+    required property bool acVisible
     required property bool acHasUnseenNotifications // ActivityCenterStore.hasUnseenNotifications
     required property int acUnreadNotificationsCount // ActivityCenterStore.unreadNotificationsCount
 
@@ -269,13 +269,14 @@ Control {
                     Layout.alignment: Qt.AlignHCenter
                     Layout.topMargin: root.spacing
                     loading: root.profileLoading
-                    name: root.selfContactDetails.displayName
+                    name: root.selfContactDetails.preferredDisplayName
                     pubKey: root.selfContactDetails.publicKey
                     compressedPubKey: root.selfContactDetails.compressedPubKey
-                    iconSource: root.selfContactDetails.icon
+                    iconSource: root.selfContactDetails.largeImage
                     colorId: root.selfContactDetails.colorId
                     currentUserStatus: root.selfContactDetails.onlineStatus
                     usesDefaultName: root.selfContactDetails.usesDefaultName
+                    bio: root.selfContactDetails.bio
 
                     getEmojiHashFn: root.getEmojiHashFn
                     getLinkToProfileFn: root.getLinkToProfileFn

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -18231,6 +18231,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>UserStatusContextMenu</name>
     <message>
+        <source>Copy Chat Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy link to profile</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -18326,6 +18326,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>UserStatusContextMenu</name>
     <message>
+        <source>Copy Chat Key</source>
+        <translation type="unfinished">Kopírovat klíč chatu</translation>
+    </message>
+    <message>
         <source>Copy link to profile</source>
         <translation>Kopírovat odkaz na profil</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -18259,6 +18259,10 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
 <context>
     <name>UserStatusContextMenu</name>
     <message>
+        <source>Copy Chat Key</source>
+        <translation type="unfinished">Copiar clave de chat</translation>
+    </message>
+    <message>
         <source>Copy link to profile</source>
         <translation>Copiar enlace al perfil</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -18184,6 +18184,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>UserStatusContextMenu</name>
     <message>
+        <source>Copy Chat Key</source>
+        <translation type="unfinished">채팅 키 복사</translation>
+    </message>
+    <message>
         <source>Copy link to profile</source>
         <translation>프로필 링크 복사</translation>
     </message>

--- a/ui/imports/shared/controls/ProfileButton.qml
+++ b/ui/imports/shared/controls/ProfileButton.qml
@@ -19,6 +19,7 @@ StatusIconTabButton {
     required property string iconSource
     required property int colorId
     required property int currentUserStatus
+    property string bio
 
     property bool loading: false
     property var getLinkToProfileFn: function(pubKey) { console.error("IMPLEMENT ME"); return "" }
@@ -80,10 +81,12 @@ StatusIconTabButton {
         id: userStatusContextMenu
         objectName: "userStatusContextMenu"
 
+        directParent: root
+
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
 
-        y: root.y - userStatusContextMenu.height + root.height
-        x: root.x + root.width + 5
+        relativeY: root.y - userStatusContextMenu.height + root.height
+        relativeX: root.x + root.width + 8
 
         compressedPubKey: root.compressedPubKey
         emojiHash: root.getEmojiHashFn(root.pubKey)
@@ -91,8 +94,8 @@ StatusIconTabButton {
         name: root.name
         headerIcon: root.iconSource
         usesDefaultName: root.usesDefaultName
+        bio: root.bio
 
-        isCurrentUser: true
         currentUserStatus: root.currentUserStatus
 
         onViewProfileRequested: root.viewProfileRequested(root.pubKey)

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -55,6 +55,7 @@ StatusDropdown {
                 imageHeight: imageWidth
             }
             StatusBaseText {
+                objectName: "userStatusDisplayName"
                 Layout.fillWidth: true
                 font.bold: true
                 font.pixelSize: Theme.fontSize(20)

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -1,108 +1,194 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Controls
+import StatusQ.Components
 import StatusQ.Popups
 import StatusQ.Core.Utils as SQUtils
 
-import shared.controls.chat
+import shared.controls
 import shared.controls.chat.menuItems
-import shared.panels
 import utils
 
-StatusMenu {
+StatusDropdown {
     id: root
 
-    property alias compressedPubKey: header.compressedPubKey
-    property alias emojiHash: header.emojiHash
-    property alias name: header.displayName
-    property alias headerIcon: header.icon
-    property alias colorId: header.colorId
-    property alias usesDefaultName: header.usesDefaultName
-    property alias isCurrentUser: header.isCurrentUser
+    required property string compressedPubKey
+    required property var emojiHash
+    required property string name
+    required property string headerIcon
+    required property int colorId
+    required property bool usesDefaultName
+    required property string bio
 
-    // Constants.currentUserStatus
-    property int currentUserStatus
+    property int currentUserStatus: Constants.currentUserStatus.unknown
 
     signal viewProfileRequested
     signal copyLinkRequested
     signal shareOwnProfileRequested
     signal setCurrentUserStatusRequested(int status)
 
-    ProfileHeader {
-        id: header
+    implicitWidth: 400
+    padding: 0
+    bottomPadding: root.bottomSheet ? 0 : Theme.halfPadding
 
-        objectName: 'onlineIdentifierProfileHeader'
+    contentItem: ColumnLayout {
+        spacing: 0
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.margins: Theme.defaultPadding
+            Layout.bottomMargin: Theme.halfPadding
+            spacing: Theme.halfPadding
 
-        width: parent.width
-    }
+            StatusUserImage {
+                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                name: root.name
+                usesDefaultName: root.usesDefaultName
+                image: root.headerIcon
+                userColor: Utils.colorForColorId(Theme.palette, root.colorId)
+                interactive: false
+                onlineStatus: root.currentUserStatus
+                imageWidth: 60
+                imageHeight: imageWidth
+            }
+            StatusBaseText {
+                Layout.fillWidth: true
+                font.bold: true
+                font.pixelSize: Theme.fontSize(20)
+                elide: Text.ElideRight
+                text: SQUtils.Emoji.parse(root.name, SQUtils.Emoji.size.middle)
+            }
 
-    StatusMenuSeparator {}
+            RowLayout {
+                Layout.fillWidth: true
+                StatusBaseText {
+                    color: Theme.palette.baseColor1
+                    text: Utils.getElidedPk(root.compressedPubKey)
+                    HoverHandler {
+                        id: keyHoverHandler
+                    }
+                    StatusToolTip {
+                        text: root.compressedPubKey
+                        visible: keyHoverHandler.hovered
+                    }
+                }
+                CopyButton {
+                    Layout.leftMargin: -4
+                    Layout.preferredWidth: 16
+                    Layout.preferredHeight: 16
+                    textToCopy: root.compressedPubKey
+                    StatusToolTip {
+                        text: qsTr("Copy Chat Key")
+                        visible: parent.hovered
+                    }
+                }
+            }
 
-    ViewProfileMenuItem {
-        objectName: "userStatusViewMyProfileAction"
-        onTriggered: {
-            root.viewProfileRequested()
-            root.close()
+            StatusBaseText {
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+                maximumLineCount: 1
+                text: root.bio
+            }
+
+            EmojiHash {
+                Layout.fillWidth: true
+                emojiHash: root.emojiHash
+                oneRow: true
+            }
+        }
+
+        StatusMenuSeparator {
+            Layout.fillWidth: true
+        }
+
+        ActionWrapper {
+            action: ViewProfileMenuItem {
+                objectName: "userStatusViewMyProfileAction"
+                onTriggered: {
+                    root.viewProfileRequested()
+                    root.close()
+                }
+            }
+        }
+
+        ActionWrapper {
+            visible: !SQUtils.Utils.isMobile
+            action: StatusAction {
+                objectName: "userStatusCopyLinkAction"
+                text: qsTr("Copy link to profile")
+                icon.name: "copy"
+                onTriggered: {
+                    root.copyLinkRequested()
+                    root.close()
+                }
+            }
+        }
+
+        ActionWrapper {
+            visible: SQUtils.Utils.isMobile
+            action: StatusAction {
+                objectName: "userStatusShareProfileAction"
+                text: qsTr("Invite contacts")
+                icon.name: "add-contact"
+                onTriggered: {
+                    root.shareOwnProfileRequested()
+                    root.close()
+                }
+            }
+        }
+
+        StatusMenuSeparator {
+            Layout.fillWidth: true
+        }
+
+        ActionWrapper {
+            font.bold: checked
+            action: OnlineStatusAction {
+                objectName: "userStatusMenuAlwaysOnlineAction"
+                userStatus: Constants.currentUserStatus.alwaysOnline
+                text: qsTr("Always online")
+                icon.name: "statuses/online"
+            }
+        }
+
+        ActionWrapper {
+            font.bold: checked
+            action: OnlineStatusAction {
+                objectName: "userStatusMenuInactiveAction"
+                userStatus: Constants.currentUserStatus.inactive
+                text: qsTr("Inactive")
+                icon.name: "statuses/inactive"
+            }
+        }
+
+        ActionWrapper {
+            font.bold: checked
+            action: OnlineStatusAction {
+                objectName: "userStatusMenuAutomaticAction"
+                userStatus: Constants.currentUserStatus.automatic
+                text: qsTr("Set status automatically")
+                icon.name: "statuses/automatic"
+            }
         }
     }
 
-    StatusAction {
-        objectName: "userStatusCopyLinkAction"
-        enabled: !SQUtils.Utils.isMobile
-        text: qsTr("Copy link to profile")
-        icon.name: "copy"
-        onTriggered: {
-            root.copyLinkRequested()
-            root.close()
-        }
+    component ActionWrapper: StatusMenuItem {
+        Layout.fillWidth: true
+        horizontalPadding: Theme.defaultSmallPadding
     }
 
-    StatusAction {
-        objectName: "userStatusShareProfileAction"
-        enabled: root.isCurrentUser && SQUtils.Utils.isMobile
-        text: qsTr("Invite contacts")
-        icon.name: "add-contact"
+    component OnlineStatusAction: StatusAction {
+        required property int userStatus
+        icon.color: "transparent"
+        icon.width: 12
+        icon.height: 12
+        checked: userStatus === root.currentUserStatus
         onTriggered: {
-            root.shareOwnProfileRequested()
-            root.close()
-        }
-    }
-
-    StatusMenuSeparator {}
-
-    StatusAction {
-        objectName: "userStatusMenuAlwaysOnlineAction"
-        text: qsTr("Always online")
-        assetSettings.name: "statuses/online"
-        assetSettings.width: 12
-        assetSettings.height: 12
-        assetSettings.color: "transparent"
-        fontSettings.bold: root.currentUserStatus === Constants.currentUserStatus.alwaysOnline
-        onTriggered: {
-            root.setCurrentUserStatusRequested(Constants.currentUserStatus.alwaysOnline)
-            root.close()
-        }
-    }
-
-    StatusAction {
-        objectName: "userStatusMenuInactiveAction"
-        text: qsTr("Inactive")
-        assetSettings.name: "statuses/inactive"
-        assetSettings.width: 12
-        assetSettings.height: 12
-        assetSettings.color: "transparent"
-        fontSettings.bold: root.currentUserStatus === Constants.currentUserStatus.inactive
-        onTriggered: {
-            root.setCurrentUserStatusRequested(Constants.currentUserStatus.inactive)
-            root.close()
-        }
-    }
-
-    StatusAction {
-        objectName: "userStatusMenuAutomaticAction"
-        text: qsTr("Set status automatically")
-        assetSettings.name: "statuses/automatic"
-        assetSettings.color: "transparent"
-        fontSettings.bold: root.currentUserStatus === Constants.currentUserStatus.automatic
-        onTriggered: {
-            root.setCurrentUserStatusRequested(Constants.currentUserStatus.automatic)
+            root.setCurrentUserStatusRequested(userStatus)
             root.close()
         }
     }

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -147,7 +147,6 @@ StatusDropdown {
         }
 
         ActionWrapper {
-            font.bold: checked
             action: OnlineStatusAction {
                 objectName: "userStatusMenuAlwaysOnlineAction"
                 userStatus: Constants.currentUserStatus.alwaysOnline
@@ -157,7 +156,6 @@ StatusDropdown {
         }
 
         ActionWrapper {
-            font.bold: checked
             action: OnlineStatusAction {
                 objectName: "userStatusMenuInactiveAction"
                 userStatus: Constants.currentUserStatus.inactive
@@ -167,7 +165,6 @@ StatusDropdown {
         }
 
         ActionWrapper {
-            font.bold: checked
             action: OnlineStatusAction {
                 objectName: "userStatusMenuAutomaticAction"
                 userStatus: Constants.currentUserStatus.automatic
@@ -184,10 +181,12 @@ StatusDropdown {
 
     component OnlineStatusAction: StatusAction {
         required property int userStatus
+        checkable: true
         icon.color: "transparent"
         icon.width: 12
         icon.height: 12
         checked: userStatus === root.currentUserStatus
+        fontSettings.bold: checked
         onTriggered: {
             root.setCurrentUserStatusRequested(userStatus)
             root.close()

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -1272,7 +1272,7 @@ QtObject {
     }
 
     function isChatKey(value) {
-        return (startsWith0x(value) && isHex(value) && value.length === 132) || globalUtilsInst.isCompressedPubKey(value)
+        return (startsWith0x(value) && isHex(value) && value.length === 132) || globalUtilsInst?.isCompressedPubKey(value)
     }
 
     function isEnsVerified(publicKey) {


### PR DESCRIPTION
### What does the PR do

- align it with the current Figma, same UI and information as in ProfileDialog
- fix the ENS name vs. preferred display name error for own contact details
- StatusDropdown/StatusDialog: use the more modern and performant RectangularShadow, and drop the bottom left/right radii when in bottomSheet mode; no more hollow bottom corners
- StatusAction/StatusMenuItem: revert `instanceof` workarounds for 6.9, allow to choose and override default asset settings in place
- update TS files and the SB page

Fixes #20770

### Affected areas

PrimaryNavSidebar/ProfileButton/UserStatusMenu

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Floating user menu:
<img width="2716" height="1778" alt="image" src="https://github.com/user-attachments/assets/b8625d69-5939-48bc-b2cf-9f3ce87f0cbc" />

Bottom sheet menu:
<img width="764" height="1778" alt="image" src="https://github.com/user-attachments/assets/139d9244-a1db-4057-87c2-0f1bbf311f1b" />


### Impact on end user

Better UX

### How to test

- click the Profile button in the main Sidebar

### Risk 

low
