### PR TITLE
test(e2e_appium): repair message locators for ChatText, xfail context-menu tests on #21846

### DIFF
--- a/test/e2e_appium/core/device_context.py
+++ b/test/e2e_appium/core/device_context.py
@@ -240,25 +240,33 @@ class DeviceContext:
                     # SHARE_PROFILE_BUTTON poll below.
                     time.sleep(2.0)
 
-                # Dismiss backup-recovery popup that may overlay
-                # Messages section. mobile:clickGesture with elementId
-                # — element.click() has the same BS-portrait mis-routing.
-                for dismiss_attempt in range(1, 4):
-                    skip_el = app.find_element_safe(chat_locators.BACKUP_SKIP_BUTTON, timeout=2)
-                    if skip_el is None:
-                        break
-                    self.logger.info(
-                        "Dismissing backup popup via clickGesture (attempt %d)",
-                        dismiss_attempt,
-                    )
-                    try:
-                        self.driver.execute_script(
-                            "mobile: clickGesture",
-                            {"elementId": skip_el.id},
+                # Dismiss the first-run popups that overlay the Messages
+                # section. Introduce-yourself comes first: AppMain shows it
+                # instead of the backup popup while the profile has no display
+                # name, which is always the case for e2e-created profiles.
+                # mobile:clickGesture with elementId — element.click() has the
+                # same BS-portrait mis-routing.
+                for popup_name, skip_locator in (
+                    ("introduce-yourself", chat_locators.INTRODUCE_SKIP_BUTTON),
+                    ("backup", chat_locators.BACKUP_SKIP_BUTTON),
+                ):
+                    for dismiss_attempt in range(1, 4):
+                        skip_el = app.find_element_safe(skip_locator, timeout=2)
+                        if skip_el is None:
+                            break
+                        self.logger.info(
+                            "Dismissing %s popup via clickGesture (attempt %d)",
+                            popup_name,
+                            dismiss_attempt,
                         )
-                    except Exception as exc:
-                        self.logger.debug("clickGesture on Skip suppressed: %s", exc)
-                    time.sleep(1.0)  # popup dismiss animation
+                        try:
+                            self.driver.execute_script(
+                                "mobile: clickGesture",
+                                {"elementId": skip_el.id},
+                            )
+                        except Exception as exc:
+                            self.logger.debug("clickGesture on Skip suppressed: %s", exc)
+                        time.sleep(1.0)  # popup dismiss animation
 
                 time.sleep(1.0)  # let any final overlay settle before polling
 

--- a/test/e2e_appium/locators/messaging/chat_locators.py
+++ b/test/e2e_appium/locators/messaging/chat_locators.py
@@ -103,7 +103,7 @@ class ChatLocators(BaseLocators):
     def message_text(content: str) -> tuple:
         escaped = content.replace('"', '\\"')
         xpath = (
-            "//android.widget.EditText"
+            "//*[contains(@resource-id,'StatusTextMessage_chatText')]"
             f"[contains(@content-desc,\"{escaped}\")]"
         )
         return BaseLocators.xpath(xpath)
@@ -112,20 +112,23 @@ class ChatLocators(BaseLocators):
     def message_text_exact(content: str) -> tuple:
         escaped = content.replace('"', '\\"')
         xpath = (
-            "//android.widget.EditText"
+            "//*[contains(@resource-id,'StatusTextMessage_chatText')]"
             f"[@content-desc=\"{escaped}\"]"
         )
         return BaseLocators.xpath(xpath)
 
     @staticmethod
     def message_content_desc_any(content: str) -> tuple:
-        """Match any element whose content-desc contains the message text.
+        """Match any element in the message list carrying the message text.
 
-        Broader fallback for devices where the sent message renders as
-        a different element type than ``EditText``.
+        Broad fallback for layouts where the message text node type differs;
+        scoped to the message delegates so chat headers cannot match.
         """
         escaped = content.replace('"', '\\"')
-        return BaseLocators.xpath(f"//*[contains(@resource-id,'chatMessageViewDelegate')]//*[contains(@content-desc,\"{escaped}\")]")
+        return BaseLocators.xpath(
+            f"//*[contains(@resource-id,'chatMessageViewDelegate')]"
+            f"//*[contains(@content-desc,\"{escaped}\") or contains(@text,\"{escaped}\")]"
+        )
 
     # Reply preview bar shown above the chat input when replying.
     # QML: StatusChatInputReplyArea (objectName "statusChatInputReplyArea")
@@ -167,7 +170,7 @@ class ChatLocators(BaseLocators):
         """Locator for a message that contains both the content and '(edited)' indicator."""
         escaped = content.replace('"', '\\"')
         return BaseLocators.xpath(
-            f"//android.widget.EditText[contains(@content-desc,'{escaped}') "
+            f"//*[contains(@resource-id,'StatusTextMessage_chatText')][contains(@content-desc,'{escaped}') "
             f"and contains(@content-desc,'(edited)')]"
         )
 

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -175,6 +175,34 @@ class App(BasePage):
         self.logger.info("Backup banner dismissed: %s", gone)
         return gone
 
+    def dismiss_introduce_yourself_popup(self) -> bool:
+        """Skip the first-run "Introduce yourself" popup if it is showing.
+
+        AppMain opens it on the first navigation into a chat section whenever
+        the profile has no display name — always true for e2e-created profiles,
+        which never set one — and returns early when it does, so the backup
+        popup stays hidden until this one has been dismissed.
+        """
+        from locators.messaging.chat_locators import ChatLocators
+
+        skip = self.find_element_safe(ChatLocators.INTRODUCE_SKIP_BUTTON, timeout=1)
+        if skip is None:
+            return False
+        try:
+            self.driver.execute_script("mobile: clickGesture", {"elementId": skip.id})
+        except Exception as exc:
+            self.logger.debug("Introduce-yourself skip tap failed: %s", exc)
+            return False
+        gone = self.wait_for_condition(
+            lambda: not self.is_element_visible(
+                ChatLocators.INTRODUCE_SKIP_BUTTON, timeout=1
+            ),
+            timeout=5,
+            poll_interval=0.5,
+        )
+        self.logger.info("Introduce-yourself popup skipped: %s", gone)
+        return gone
+
     def _ensure_main_nav_visible(self) -> bool:
         """Ensure the left navigation bar is visible.
 
@@ -188,6 +216,7 @@ class App(BasePage):
         if self.is_element_visible(self.locators.LEFT_NAV_ANY, timeout=1):
             return self.is_element_visible(self.locators.LEFT_NAV_SETTINGS, timeout=5)
 
+        self.dismiss_introduce_yourself_popup()
         self.dismiss_backup_banner()
 
         # Phase 1: unwind deep navigation stack via back button

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -212,10 +212,17 @@ class App(BasePage):
         return self.is_element_visible(self.locators.LEFT_NAV_SETTINGS, timeout=5)
 
     # Locator for the drawer swipe-indicator handle visible in portrait mode.
+    # The rendered handle is a narrow strip (~12-16px) at the left edge. It is
+    # not clickable and its class varies by device, so match on geometry only:
+    # left edge, non-degenerate, narrow. Zero-rect phantom nav nodes (present
+    # while the drawer is closed) fail the x2 > x1 condition.
     NAV_DRAWER_HANDLE = (
         "xpath",
-        "//android.view.View[@clickable='true' and @bounds]"
-        "[number(substring-before(substring-after(@bounds,'['),','))<=10]",
+        "//*[@bounds]"
+        "[number(substring-before(substring-after(@bounds,'['),','))<=10]"
+        "[number(substring-before(substring-after(@bounds,']['),','))"
+        " > number(substring-before(substring-after(@bounds,'['),','))]"
+        "[number(substring-before(substring-after(@bounds,']['),','))<=40]",
     )
 
     def _open_nav_drawer(self) -> bool:
@@ -274,18 +281,20 @@ class App(BasePage):
                 except Exception as e:
                     self.logger.debug("Strategy 2 (W3C actions) failed: %s", e)
 
-            # Strategy 3: coordinate-based drag from left-centre area
-            try:
-                self.driver.execute_script("mobile: dragGesture", {
-                    "startX": int(w * 0.08),
-                    "startY": int(h * 0.5),
-                    "endX": int(w * 0.7),
-                    "endY": int(h * 0.5),
-                })
-                if self.is_element_visible(self.locators.LEFT_NAV_ANY, timeout=3):
-                    return True
-            except Exception as e:
-                self.logger.debug("Strategy 3 (coordinate drag) failed: %s", e)
+            # Strategy 3: coordinate drag from the true edge, inside the strip's
+            # vertical band (~0.62-0.81 of height across known devices)
+            for frac_y in (0.72, 0.5):
+                try:
+                    self.driver.execute_script("mobile: dragGesture", {
+                        "startX": max(4, int(w * 0.01)),
+                        "startY": int(h * frac_y),
+                        "endX": int(w * 0.7),
+                        "endY": int(h * frac_y),
+                    })
+                    if self.is_element_visible(self.locators.LEFT_NAV_ANY, timeout=3):
+                        return True
+                except Exception as e:
+                    self.logger.debug("Strategy 3 (coordinate drag) failed: %s", e)
 
             return False
         except Exception as e:

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -142,6 +142,39 @@ class App(BasePage):
 
         return False
 
+    # The backup-reminder banner overlays the top strip and shifts the drawer
+    # layout, which defeats the nav-arrival retries. Its close control is not
+    # exposed to accessibility, so its position is derived from the action
+    # button's rect: the close cross sits centred between the button's right
+    # edge and the screen edge.
+    BACKUP_BANNER_ACTION = (
+        "xpath",
+        "//*[contains(@resource-id,'mainWindow.actionButton')]"
+        "[@content-desc='Back up now']",
+    )
+
+    def dismiss_backup_banner(self) -> bool:
+        """Close the backup-reminder banner if it is showing."""
+        button = self.find_element_safe(self.BACKUP_BANNER_ACTION, timeout=1)
+        if button is None:
+            return False
+        rect = button.rect
+        width = self.driver.get_window_size()["width"]
+        x = (rect["x"] + rect["width"] + width) // 2
+        y = rect["y"] + rect["height"] // 2
+        try:
+            self.driver.execute_script("mobile: clickGesture", {"x": x, "y": y})
+        except Exception as exc:
+            self.logger.debug("Backup banner dismiss tap failed: %s", exc)
+            return False
+        gone = self.wait_for_condition(
+            lambda: not self.is_element_visible(self.BACKUP_BANNER_ACTION, timeout=1),
+            timeout=5,
+            poll_interval=0.5,
+        )
+        self.logger.info("Backup banner dismissed: %s", gone)
+        return gone
+
     def _ensure_main_nav_visible(self) -> bool:
         """Ensure the left navigation bar is visible.
 
@@ -154,6 +187,8 @@ class App(BasePage):
 
         if self.is_element_visible(self.locators.LEFT_NAV_ANY, timeout=1):
             return self.is_element_visible(self.locators.LEFT_NAV_SETTINGS, timeout=5)
+
+        self.dismiss_backup_banner()
 
         # Phase 1: unwind deep navigation stack via back button
         for _ in range(5):


### PR DESCRIPTION
### What does the PR do

Repairs the mobile e2e suite after the chat text integration (#21456). Three commits:

1. **Locator repair.** #21456 moved message text from `EditText` nodes to `TextView` nodes under the `StatusTextMessage_chatText` object name. The message locators anchored on the widget class, so every message-content lookup broke (12 failures in nightly run 215). They now anchor on the resource id, class-agnostic. The broad fallback locator was unscoped and could match the chat header; it is now scoped to the message delegates. The edited-indicator locator used the same class and gets the same fix. Verified against a live device dump on master `fd90ae`: the tests find the message elements again.

2. **Expected-fail on #21846.** With the locators fixed, the tests still cannot pass: the context menu itself does not open on long-press on the phone layout (#21846, regression from the same integration). Both context-menu test classes are marked `xfail` referencing the issue, so the nightly stays sensitive to everything else. They will report `xpass` when the menu is fixed — the cue to remove the marker.

3. **Backup-banner guard.** The backup-reminder banner shifts the drawer layout and defeated the nav-arrival retries (the other nightly-215 signature: the group-chat fixture died on 4 straight Messages-nav attempts, landing on Settings). The banner close control is not exposed to accessibility, so the guard derives its position from the action button rect and verifies the banner is gone. Dismissal mechanism verified on device.

### Affected areas

Mobile e2e tests only. No app code.
