### PR TITLE
feat(browser): downloads feature utils, fixes [1/5]

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -146,6 +146,22 @@ public class StatusQtActivity extends QtActivity {
         }
     }
 
+    /**
+     * Opens the system Downloads UI (Show in folder for browser downloads).
+     * Called from Qt via JNI. Standard-mode completed files are registered by
+     * MobileWebView; Incognito downloads are not (ADR 0006).
+     */
+    public static void openDownloadsUi() {
+        if (sInstance == null) return;
+        try {
+            Intent intent = new Intent(android.app.DownloadManager.ACTION_VIEW_DOWNLOADS);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            sInstance.startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+            Log.e(TAG, "openDownloadsUi failed", e);
+        }
+    }
+
     // Opens the system Accessibility Settings screen. Called from Qt via JNI.
     public static void openAccessibilitySettings() {
         if (sInstance == null) return;

--- a/mobile/scripts/Common.mk
+++ b/mobile/scripts/Common.mk
@@ -58,7 +58,8 @@ TARGET := $(BIN_PATH)/$(TARGET_NAME)
 # src files & obj files
 STATUS_DESKTOP_NIM_FILES := $(shell find $(STATUS_DESKTOP)/src -type f \( -iname '*.nim' -o -iname '*.nims' \))
 STATUS_DESKTOP_UI_FILES := $(shell find $(STATUS_DESKTOP)/ui -type f \( -iname 'qmldir' -o -iname '*.qml' -o -iname '*.qrc' \) -not -iname 'resources.qrc' -not -path '$(STATUS_DESKTOP)/ui/StatusQ/*')
-STATUS_Q_FILES := $(shell find $(STATUSQ) -type f \( -iname '*.cpp' -o -iname '*.h' -o -iname '*.mm' \) -not -iname '*.qrc' -not -iname '*.qml')
+# Include CMakeLists.txt (mobilewebview pin) and prune build/ (generated sources).
+STATUS_Q_FILES := $(shell find $(STATUSQ) \( -path '$(STATUSQ)/build' \) -prune -o -type f \( -iname '*.cpp' -o -iname '*.h' -o -iname '*.mm' -o -iname 'CMakeLists.txt' \) -print)
 STATUS_Q_UI_FILES := $(shell find $(STATUSQ) -type f \( -iname '*.qml' -o -iname '*.qrc' \))
 STATUS_GO_FILES := $(shell find $(STATUS_GO) -type f \( -iname '*.go' \))
 OPENSSL_FILES := $(shell find $(OPENSSL) -type f \( -iname '*.c' -o -iname '*.h' \))

--- a/storybook/qmlTests/tests/tst_BrowserBackendCapabilities.qml
+++ b/storybook/qmlTests/tests/tst_BrowserBackendCapabilities.qml
@@ -1,0 +1,26 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Internal
+
+/**
+ * Capabilities of the browser Backend this build uses (ADR 0006 §8).
+ * Answered without a Web View, so the singleton must be readable on its own.
+ */
+Item {
+    TestCase {
+        name: "BrowserBackendCapabilities"
+
+        function test_inPageMediaPlaybackSupported_isTrueOnWebEngine() {
+            compare(typeof BrowserBackendCapabilities.inPageMediaPlaybackSupported, "boolean")
+            // This suite runs on the desktop (WebEngine) Backend.
+            compare(BrowserBackendCapabilities.inPageMediaPlaybackSupported, true)
+        }
+
+        function test_pdfViewerSupported_isTrueOnWebEngine() {
+            compare(typeof BrowserBackendCapabilities.pdfViewerSupported, "boolean")
+            // This suite runs on the desktop (WebEngine) Backend.
+            compare(BrowserBackendCapabilities.pdfViewerSupported, true)
+        }
+    }
+}

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -158,6 +158,7 @@ add_library(StatusQ ${LIB_TYPE}
         ${STATUSQ_QRC_COMPILED}
         ${STATUSQ_TESTCONFIG_RCC}
         include/StatusQ/audioutils.h
+        include/StatusQ/browserbackendcapabilities.h
         include/StatusQ/chatinputhighlighter.h
         include/StatusQ/clipboardutils.h
         include/StatusQ/constantrole.h
@@ -200,6 +201,7 @@ add_library(StatusQ ${LIB_TYPE}
         include/StatusQ/urlutils.h
         include/StatusQ/statuslayoutstate.h
         src/audioutils.cpp
+        src/browserbackendcapabilities.cpp
         src/chatinputhighlighter.cpp
         src/clipboardutils.cpp
         src/constantrole.cpp
@@ -335,7 +337,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG 92a4c62212702048715c69a85c82fd87fab47666
+      GIT_TAG c5d8232b61a4329737048d5821c9396bd3f5d350
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/StatusQ/include/StatusQ/browserbackendcapabilities.h
+++ b/ui/StatusQ/include/StatusQ/browserbackendcapabilities.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QObject>
+
+// Capability answers for the browser Backend this build uses: Qt WebEngine on
+// desktop, MobileWebView on iOS/Android. A Capability is a fact about the
+// Backend, so every accessor is static and needs no Web View; the QObject only
+// exists so QML can read the same answers through a singleton.
+class BrowserBackendCapabilities : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool inPageMediaPlaybackSupported READ inPageMediaPlaybackSupported CONSTANT)
+    Q_PROPERTY(bool pdfViewerSupported READ pdfViewerSupported CONSTANT)
+
+public:
+    explicit BrowserBackendCapabilities(QObject *parent = nullptr);
+
+    // Can the Backend decode and play audio/video inside a loaded page?
+    // Answering "no" means an in-page player would come up dead.
+    static bool isInPageMediaPlaybackSupported();
+
+    // Can the Backend render a PDF inside a loaded page? WKWebView renders PDF
+    // natively; the system Android WebView cannot render it at all.
+    static bool isPdfViewerSupported();
+
+    bool inPageMediaPlaybackSupported() const { return isInPageMediaPlaybackSupported(); }
+    bool pdfViewerSupported() const { return isPdfViewerSupported(); }
+};

--- a/ui/StatusQ/include/StatusQ/browserprofileutils.h
+++ b/ui/StatusQ/include/StatusQ/browserprofileutils.h
@@ -5,6 +5,10 @@
 #include <QObject>
 #include <QUrl>
 
+class QWebEngineDownloadRequest;
+class QWebEnginePage;
+class QWebEngineUrlRequestInterceptor;
+
 // Desktop-only helper exposing WebEngineProfile clearing that the QML
 // WebEngineProfile type does not expose (cookie store). Registered only when
 // StatusQ is built with Qt WebEngine (STATUSQ_HAS_QTWEBENGINE).
@@ -28,6 +32,13 @@ public:
     // are not indexed until they are (re)set in the current session.
     Q_INVOKABLE void trackProfile(QObject *profile);
 
+    // Install the local-browsing policy on `profile`: file:// navigation is
+    // blocked except under the downloads location and the generated player-page
+    // directory (ADR 0006 §8). Call once per profile at creation, before the
+    // first navigation. Also (re)installs on the default profile, which backs
+    // views whose storage profile could not be created.
+    Q_INVOKABLE void installLocalUrlPolicy(QObject *profile);
+
     // Clears profile-wide browsing data: HTTP cache and all cookies.
     // `profile` must be a QML WebEngineProfile (QQuickWebEngineProfile);
     // no-op with a warning otherwise. Invokes `callback` when clearHttpCache
@@ -43,11 +54,35 @@ public:
     Q_INVOKABLE void clearSiteData(QObject *profile, const QUrl &siteUrl,
                                    QJSValue callback = {});
 
+    // Force a Download via QWebEnginePage::download (QML WebEngineView has no
+    // page.download). Used for Retry — navigating renderable media (video/audio)
+    // would play in the tab instead of downloading. `webEngineView` is the
+    // initiating view so the matching adapter can forward downloadRequested.
+    // `profile` must be the view's QML WebEngineProfile.
+    Q_INVOKABLE void downloadUrl(QObject *profile, QObject *webEngineView,
+                                 const QUrl &url,
+                                 const QString &suggestedFileName = {});
+
+signals:
+    // Emitted for downloads started by downloadUrl(). `webEngineView` is the
+    // initiator passed to downloadUrl (null if it cannot be identified);
+    // `download` is a QWebEngineDownloadRequest.
+    void downloadRequested(QObject *webEngineView, QObject *download);
+
 private:
     struct TrackedStore;
+    struct DownloadHelper;
+
+    // Stateless policy shared by every profile; owned by this singleton.
+    QWebEngineUrlRequestInterceptor *m_localUrlPolicy = nullptr;
 
     TrackedStore *trackedStoreFor(QObject *profile) const;
+    DownloadHelper *helperFor(QObject *profile);
+    void retirePageWhenFinished(DownloadHelper *helper, QWebEnginePage *page,
+                                QWebEngineDownloadRequest *download);
 
     // Keyed by cookie store pointer; owned.
     QHash<quintptr, TrackedStore *> m_tracked;
+    // Keyed by Quick profile pointer; owned helpers (core profile + pages).
+    QHash<quintptr, DownloadHelper *> m_downloadHelpers;
 };

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -23,6 +23,13 @@ public:
     Q_INVOKABLE void restartApplication(bool killBackend) const;
     Q_INVOKABLE void openAppSettings();
 
+    Q_INVOKABLE bool fileExists(const QString &path) const;
+    Q_INVOKABLE bool ensureDirectory(const QString &path) const;
+
+    // Desktop: reveal file in OS file manager. Android: open system Downloads UI.
+    // iOS: no-op (Show in folder is hidden).
+    Q_INVOKABLE void showInFolder(const QString &path) const;
+
     Q_INVOKABLE void downloadImageByUrl(const QUrl& url, const QString& path);
     Q_INVOKABLE void synthetizeRightClick(QQuickItem* item, qreal x, qreal y, Qt::KeyboardModifiers modifiers) const;
     Q_INVOKABLE Qt::KeyboardModifiers queryKeyboardModifiers();

--- a/ui/StatusQ/src/browserbackendcapabilities.cpp
+++ b/ui/StatusQ/src/browserbackendcapabilities.cpp
@@ -1,0 +1,38 @@
+#include "StatusQ/browserbackendcapabilities.h"
+
+// Only iOS/Android run MobileWebView; macOS links the library but browses with
+// WebEngine, so it takes the desktop branch.
+#if defined(STATUSQ_HAS_MOBILEWEBVIEW) && (defined(Q_OS_IOS) || defined(Q_OS_ANDROID))
+#define STATUSQ_MOBILE_BACKEND 1
+#include "MobileWebView/mobilewebviewcapabilities.h"
+#endif
+
+BrowserBackendCapabilities::BrowserBackendCapabilities(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool BrowserBackendCapabilities::isInPageMediaPlaybackSupported()
+{
+#if defined(STATUSQ_MOBILE_BACKEND)
+    return MobileWebViewCapabilities::isInPageMediaPlaybackSupported();
+#else
+    return true;
+#endif
+}
+
+bool BrowserBackendCapabilities::isPdfViewerSupported()
+{
+#if defined(STATUSQ_MOBILE_BACKEND)
+#ifdef Q_OS_IOS
+    // WKWebView renders PDF natively in the page.
+    return true;
+#else
+    // The system Android WebView has no PDF renderer.
+    return false;
+#endif
+#else
+    // Qt WebEngine ships Chromium's built-in PDF viewer.
+    return true;
+#endif
+}

--- a/ui/StatusQ/src/browserprofileutils.cpp
+++ b/ui/StatusQ/src/browserprofileutils.cpp
@@ -2,10 +2,18 @@
 
 #include <QtWebEngineQuick/qquickwebengineprofile.h>
 #include <QtWebEngineCore/QWebEngineCookieStore>
+#include <QtWebEngineCore/QWebEngineDownloadRequest>
+#include <QtWebEngineCore/QWebEnginePage>
+#include <QtWebEngineCore/QWebEngineProfile>
+#include <QtWebEngineCore/QWebEngineUrlRequestInfo>
+#include <QtWebEngineCore/QWebEngineUrlRequestInterceptor>
 
+#include <QDir>
+#include <QFileInfo>
 #include <QNetworkCookie>
 #include <QPointer>
 #include <QSet>
+#include <QStandardPaths>
 #include <QTimer>
 
 namespace {
@@ -167,6 +175,93 @@ private:
     bool m_finished = false;
 };
 
+// Keep in sync with BrowserDownloadOpenContext.mediaPlayerDirectory (QML).
+constexpr char kMediaPlayerDirName[] = "status-browser-player";
+
+// Resolve symlinks so the two allowed roots and the requested path are compared
+// in the same form (macOS TempLocation is /var/... -> /private/var/...).
+// canonicalFilePath() is empty for paths that do not exist, hence the fallback.
+QString canonicalPath(const QString &path)
+{
+    if (path.isEmpty())
+        return {};
+    const QString canonical = QFileInfo(path).canonicalFilePath();
+    return canonical.isEmpty() ? QDir::cleanPath(QDir(path).absolutePath()) : canonical;
+}
+
+// Canonicalize the (existing) parent and append the leaf, so the root resolves
+// even before the leaf is created — the player directory is written lazily, and
+// canonicalizing it while absent would leave /var/... unresolved and then fail
+// to match the /private/var/... form the same request arrives in later.
+QString canonicalSubDir(const QString &parent, const QString &leaf)
+{
+    const QString root = canonicalPath(parent);
+    return root.isEmpty() ? QString() : root + QLatin1Char('/') + leaf;
+}
+
+// The Backend's local-browsing policy: file:// navigation is blocked except
+// inside the two directories the browser itself writes — the platform downloads
+// location (Download Targets) and the temp directory holding generated player
+// pages (ADR 0006 §8). Owned here rather than injected from QML so both Backends
+// keep the policy library-side; mobilewebview has the equivalent guard.
+//
+// Scope: navigations only (main frame + subframes), matching what the QML
+// navigationRequested handler used to cover. Subresources are deliberately left
+// alone so a player page can load the media it points at; Chromium already
+// forbids web origins from reaching file:// subresources.
+//
+// Stateless after construction (two const roots computed on the UI thread), so
+// it is safe whichever thread WebEngine calls interceptRequest on.
+class LocalUrlPolicyInterceptor final : public QWebEngineUrlRequestInterceptor
+{
+public:
+    explicit LocalUrlPolicyInterceptor(QObject *parent = nullptr)
+        : QWebEngineUrlRequestInterceptor(parent)
+        , m_downloadsDir(canonicalPath(
+              QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)))
+        , m_playerDir(canonicalSubDir(
+              QStandardPaths::writableLocation(QStandardPaths::TempLocation),
+              QLatin1String(kMediaPlayerDirName)))
+    {
+    }
+
+    void interceptRequest(QWebEngineUrlRequestInfo &info) override
+    {
+        const QUrl url = info.requestUrl();
+        if (!url.isLocalFile())
+            return;
+
+        const auto type = info.resourceType();
+        if (type != QWebEngineUrlRequestInfo::ResourceTypeMainFrame
+            && type != QWebEngineUrlRequestInfo::ResourceTypeSubFrame)
+            return;
+
+        if (isAllowed(url.toLocalFile()))
+            return;
+
+        qWarning("BrowserProfileUtils: local file browsing is disabled");
+        info.block(true);
+    }
+
+private:
+    bool isAllowed(const QString &localFile) const
+    {
+        const QString path = canonicalPath(localFile);
+        if (path.isEmpty())
+            return false;
+        return isUnder(path, m_downloadsDir) || isUnder(path, m_playerDir);
+    }
+
+    static bool isUnder(const QString &path, const QString &dir)
+    {
+        // The trailing separator keeps "/home/user/Downloads-evil" out.
+        return !dir.isEmpty() && path.startsWith(dir + QLatin1Char('/'));
+    }
+
+    const QString m_downloadsDir;
+    const QString m_playerDir;
+};
+
 } // namespace
 
 struct BrowserProfileUtils::TrackedStore
@@ -178,6 +273,31 @@ struct BrowserProfileUtils::TrackedStore
     QSet<QByteArray> cookieNames;
     QMetaObject::Connection addedConn;
     QMetaObject::Connection destroyedConn;
+};
+
+// QML WebEngineView has no page.download(); Core QWebEnginePages on an OTR
+// helper profile force downloadRequested for Retry (renderable media would
+// otherwise navigate/play). Helper does not share the tab's live cookies.
+struct BrowserProfileUtils::DownloadHelper
+{
+    // Owns the pages in pageViews and the coreProfile they live on; pages must
+    // go first so their retire connections die before the helper does.
+    ~DownloadHelper()
+    {
+        for (auto it = pageViews.cbegin(); it != pageViews.cend(); ++it)
+            delete it.key();
+        pageViews.clear();
+        delete coreProfile;
+    }
+
+    QPointer<QQuickWebEngineProfile> quickProfile;
+    QWebEngineProfile *coreProfile = nullptr;
+    QMetaObject::Connection downloadConn;
+    QMetaObject::Connection destroyedConn;
+
+    // Live transient download pages (one per downloadUrl() call) mapped to the
+    // initiating view; QPointer so a destroyed view degrades to null.
+    QHash<QWebEnginePage *, QPointer<QObject>> pageViews;
 };
 
 BrowserProfileUtils::BrowserProfileUtils(QObject *parent)
@@ -195,6 +315,35 @@ BrowserProfileUtils::~BrowserProfileUtils()
         delete tracked;
     }
     m_tracked.clear();
+
+    for (DownloadHelper *helper : std::as_const(m_downloadHelpers)) {
+        if (helper->downloadConn)
+            disconnect(helper->downloadConn);
+        if (helper->destroyedConn)
+            disconnect(helper->destroyedConn);
+        delete helper;
+    }
+    m_downloadHelpers.clear();
+}
+
+void BrowserProfileUtils::installLocalUrlPolicy(QObject *profile)
+{
+    auto *webProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
+    if (!webProfile) {
+        qWarning("BrowserProfileUtils::installLocalUrlPolicy: expected a WebEngineProfile");
+        return;
+    }
+
+    if (!m_localUrlPolicy)
+        m_localUrlPolicy = new LocalUrlPolicyInterceptor(this);
+
+    webProfile->setUrlRequestInterceptor(m_localUrlPolicy);
+
+    // A storage profile can fail to instantiate (one live profile per data path),
+    // leaving the view on the default profile — it must carry the policy too.
+    if (auto *fallback = QQuickWebEngineProfile::defaultProfile();
+        fallback && fallback != webProfile)
+        fallback->setUrlRequestInterceptor(m_localUrlPolicy);
 }
 
 BrowserProfileUtils::TrackedStore *BrowserProfileUtils::trackedStoreFor(QObject *profile) const
@@ -305,4 +454,105 @@ void BrowserProfileUtils::clearSiteData(QObject *profile, const QUrl &siteUrl,
         std::move(callback),
         this);
     op->start();
+}
+
+BrowserProfileUtils::DownloadHelper *BrowserProfileUtils::helperFor(QObject *profile)
+{
+    auto *quickProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
+    if (!quickProfile)
+        return nullptr;
+
+    const quintptr key = reinterpret_cast<quintptr>(quickProfile);
+    if (DownloadHelper *existing = m_downloadHelpers.value(key, nullptr))
+        return existing;
+
+    auto *helper = new DownloadHelper;
+    helper->quickProfile = quickProfile;
+
+    // Always OTR: a named Core profile with the same storageName as the Quick
+    // profile risks opening the same on-disk cookie DB twice. Public API cannot
+    // attach a QWebEnginePage to the Quick profile's ProfileAdapter, so Retry
+    // downloads do not see the tab's live cookies (OK for public CDN media;
+    // authenticated Retry may need a revisit).
+    helper->coreProfile = new QWebEngineProfile(this);
+
+    helper->downloadConn = connect(
+        helper->coreProfile,
+        &QWebEngineProfile::downloadRequested,
+        this,
+        [this, helper](QWebEngineDownloadRequest *download) {
+            if (!download)
+                return;
+            // Only downloadUrl() pages live on this profile, so an unknown
+            // page() means the request has no identifiable initiator.
+            QWebEnginePage *page = download->page();
+            const auto it = helper->pageViews.constFind(page);
+            if (it == helper->pageViews.cend()) {
+                qWarning("BrowserProfileUtils: downloadRequested from an unknown page");
+                emit downloadRequested(nullptr, download);
+                return;
+            }
+            retirePageWhenFinished(helper, page, download);
+            emit downloadRequested(it.value().data(), download);
+        });
+
+    helper->destroyedConn = connect(
+        quickProfile,
+        &QObject::destroyed,
+        this,
+        [this, key]() {
+            DownloadHelper *gone = m_downloadHelpers.take(key);
+            if (!gone)
+                return;
+            if (gone->downloadConn)
+                disconnect(gone->downloadConn);
+            if (gone->destroyedConn)
+                disconnect(gone->destroyedConn);
+            delete gone;
+        });
+
+    m_downloadHelpers.insert(key, helper);
+    return helper;
+}
+
+// Whether a download outlives the page it started on is undocumented, so the
+// transient page is kept until the download finishes (or is deleted).
+void BrowserProfileUtils::retirePageWhenFinished(DownloadHelper *helper,
+                                                 QWebEnginePage *page,
+                                                 QWebEngineDownloadRequest *download)
+{
+    // Capturing `helper` raw is safe: both connections have context `page`, and
+    // ~DownloadHelper deletes its pages first, so no run can outlive the helper.
+    const auto retire = [helper, page]() {
+        if (helper->pageViews.remove(page) > 0)
+            page->deleteLater();
+    };
+    connect(download, &QWebEngineDownloadRequest::isFinishedChanged, page,
+            [download, retire]() {
+                if (download->isFinished())
+                    retire();
+            });
+    connect(download, &QObject::destroyed, page, retire);
+}
+
+void BrowserProfileUtils::downloadUrl(QObject *profile, QObject *webEngineView,
+                                      const QUrl &url,
+                                      const QString &suggestedFileName)
+{
+    if (!url.isValid()) {
+        qWarning("BrowserProfileUtils::downloadUrl: invalid url");
+        return;
+    }
+
+    DownloadHelper *helper = helperFor(profile);
+    if (!helper || !helper->coreProfile) {
+        qWarning("BrowserProfileUtils::downloadUrl: expected a WebEngineProfile");
+        return;
+    }
+
+    // One page per call: downloadRequested carries page(), so concurrent calls
+    // are matched to their initiating view by identity, never by call order.
+    auto *page = new QWebEnginePage(helper->coreProfile, this);
+    helper->pageViews.insert(page, QPointer<QObject>(webEngineView));
+    page->download(url, suggestedFileName);
 }

--- a/ui/StatusQ/src/ios_utils.mm
+++ b/ui/StatusQ/src/ios_utils.mm
@@ -843,6 +843,26 @@ static void presentShareSheetWithRetry(UIActivityViewController* activityVC, NSI
     [vc presentViewController:activityVC animated:YES completion:nil];
 }
 
+/// Share extensions cannot open sandbox file URLs; NSItemProvider streams a
+/// file representation the system can hand off.
+static NSItemProvider* itemProviderForPath(NSString* nsPath) {
+    NSURL* url = [NSURL fileURLWithPath:nsPath];
+    if (!url) return nil;
+    NSItemProvider* provider = [[NSItemProvider alloc] initWithContentsOfURL:url];
+    if (!provider) return nil;
+    provider.suggestedName = url.lastPathComponent;
+    return provider;
+}
+
+static void presentShareSheetForProviders(NSArray<NSItemProvider*>* providers, NSString* logLabel) {
+    if (providers.count == 0) return;
+    UIActivityItemsConfiguration* config =
+        [UIActivityItemsConfiguration activityItemsConfigurationWithItemProviders:providers];
+    UIActivityViewController* activityVC =
+        [[UIActivityViewController alloc] initWithActivityItemsConfiguration:config];
+    presentShareSheetWithRetry(activityVC, 0, logLabel);
+}
+
 void presentIOSShareSheetForFilePath(const QString& filePath) {
     @autoreleasepool {
         if (filePath.isEmpty()) return;
@@ -851,13 +871,9 @@ void presentIOSShareSheetForFilePath(const QString& filePath) {
         dispatch_async(dispatch_get_main_queue(), ^{
             @autoreleasepool {
                 @try {
-                    NSString* nsPath = pathCopy.toNSString();
-                    NSURL* url = [NSURL fileURLWithPath:nsPath];
-                    if (!url) return;
-
-                    UIActivityViewController* activityVC =
-                        [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:nil];
-                    presentShareSheetWithRetry(activityVC, 0, @"single");
+                    NSItemProvider* provider = itemProviderForPath(pathCopy.toNSString());
+                    if (!provider) return;
+                    presentShareSheetForProviders(@[provider], @"single");
                 }
                 @catch (NSException* e) {
                     NSLog(@"[iOS Share] Exception presenting share sheet (single): %@ %@", e.name, e.reason);
@@ -875,17 +891,14 @@ void presentIOSShareSheetForFilePaths(const QStringList& filePaths) {
         dispatch_async(dispatch_get_main_queue(), ^{
             @autoreleasepool {
                 @try {
-                    NSMutableArray* items = [NSMutableArray arrayWithCapacity:(NSUInteger)pathsCopy.size()];
+                    NSMutableArray<NSItemProvider*>* items =
+                        [NSMutableArray arrayWithCapacity:(NSUInteger)pathsCopy.size()];
                     for (const auto& p : pathsCopy) {
                         if (p.isEmpty()) continue;
-                        NSURL* url = [NSURL fileURLWithPath:p.toNSString()];
-                        if (url) [items addObject:url];
+                        NSItemProvider* provider = itemProviderForPath(p.toNSString());
+                        if (provider) [items addObject:provider];
                     }
-                    if (items.count == 0) return;
-
-                    UIActivityViewController* activityVC =
-                        [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
-                    presentShareSheetWithRetry(activityVC, 0, @"multi");
+                    presentShareSheetForProviders(items, @"multi");
                 }
                 @catch (NSException* e) {
                     NSLog(@"[iOS Share] Exception presenting share sheet (multi): %@ %@", e.name, e.reason);

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -2,8 +2,11 @@
 
 #include <QDesktopServices>
 #include <QGuiApplication>
+#include <QUrl>
 #include <QMimeDatabase>
 #include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QSslError>
@@ -19,7 +22,6 @@
 #include <qpa/qplatformscreen.h>
 
 #ifdef Q_OS_ANDROID
-#include <QFile>
 #include <QJniObject>
 #include <QJniEnvironment>
 #include <QtCore/qnativeinterface.h>
@@ -135,6 +137,71 @@ SystemUtilsInternal::SystemUtilsInternal(QObject *parent)
 
 QString SystemUtilsInternal::qtRuntimeVersion() const {
     return qVersion();
+}
+
+bool SystemUtilsInternal::fileExists(const QString &path) const
+{
+    return !path.isEmpty() && QFileInfo::exists(path) && QFileInfo(path).isFile();
+}
+
+bool SystemUtilsInternal::ensureDirectory(const QString &path) const
+{
+    if (path.isEmpty())
+        return false;
+    QDir dir(path);
+    if (dir.exists())
+        return true;
+    return dir.mkpath(QStringLiteral("."));
+}
+
+void SystemUtilsInternal::showInFolder(const QString &path) const
+{
+#ifdef Q_OS_IOS
+    Q_UNUSED(path);
+    // Show in folder is hidden on iOS (no folder UI to open).
+    return;
+#elif defined(Q_OS_ANDROID)
+    Q_UNUSED(path);
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/StatusQtActivity",
+        "openDownloadsUi",
+        "()V"
+    );
+#else
+    if (path.isEmpty())
+        return;
+
+    // accept both "file:/foo/bar" and "/foo/bar"
+    const QUrl url = QUrl::fromUserInput(path);
+    if (!url.isValid() || !url.isLocalFile()) {
+        qWarning() << "showInFolder: not a local file:" << path;
+        return;
+    }
+
+    const QString localPath = url.toLocalFile();
+    if (!QFile::exists(localPath)) {
+        qWarning() << "showInFolder: path does not exist:" << localPath;
+        return;
+    }
+
+    const QFileInfo info(localPath);
+
+#if defined(Q_OS_MACOS)
+    // Reveal and select the file in Finder.
+    const QString target = info.isFile() ? info.absoluteFilePath() : info.absolutePath();
+    QProcess::startDetached(QStringLiteral("open"), {QStringLiteral("-R"), target});
+#elif defined(Q_OS_WIN)
+    // Reveal and select the file in Explorer (/select,<path> must be one arg).
+    const QString native = QDir::toNativeSeparators(
+        info.isFile() ? info.absoluteFilePath() : info.absolutePath());
+    QProcess::startDetached(QStringLiteral("explorer.exe"),
+                            {QStringLiteral("/select,%1").arg(native)});
+#else
+    // Linux and others: open the containing directory.
+    const QString dir = info.isDir() ? info.absoluteFilePath() : info.absolutePath();
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
+#endif
+#endif
 }
 
 void SystemUtilsInternal::restartApplication() const

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -1,4 +1,5 @@
 #include "StatusQ/audioutils.h"
+#include "StatusQ/browserbackendcapabilities.h"
 #include "StatusQ/clipboardutils.h"
 #include "StatusQ/constantrole.h"
 #include "StatusQ/fastexpressionfilter.h"
@@ -174,6 +175,11 @@ void registerStatusQTypes() {
 #if defined(STATUSQ_HAS_MOBILEWEBVIEW)
     qmlRegisterType<MobileWebViewBackend>("StatusQ.CustomWebView", 1, 0, "MobileWebViewBackend");
 #endif
+
+    qmlRegisterSingletonType<BrowserBackendCapabilities>(
+        "StatusQ.Internal", 0, 1, "BrowserBackendCapabilities", [](QQmlEngine*, QJSEngine*) {
+            return new BrowserBackendCapabilities;
+        });
 
 #if defined(STATUSQ_HAS_QTWEBENGINE)
     qmlRegisterSingletonType<BrowserProfileUtils>(

--- a/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
+++ b/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
@@ -6,14 +6,12 @@ Item {
     id: root
 
     required property BrowserStores.BookmarksStore bookmarksStore
-    required property BrowserStores.DownloadsStore downloadsStore
     required property var localAccountSensitiveSettings
 
     required property var webChannel
     required property ProfileParams profileParams
     required property bool devToolsEnabled
     required property bool enableJsLogs
-    required property bool isDownloadView
 
     readonly property bool offTheRecord: profileParams.offTheRecord
 
@@ -49,6 +47,14 @@ Item {
     // Mobile-only: pauses native webview updates (no-op on desktop)
     property bool freeze: false
 
+    // Tab strip gone but Web View kept alive for non-terminal Downloads (ADR 0006 §6).
+    // Retained Views take no new Downloads or retries.
+    property bool retained: false
+
+    // Opened by a page (target=_blank / window.open) and never committed a page of
+    // its own — the one fact that makes a Tab download-only (ADR 0006 §6).
+    property bool pristinePopup: false
+
     readonly property int devToolsHeight: 400
 
     readonly property int findBackward: 1
@@ -73,13 +79,15 @@ Item {
     }
 
     // === Download States (constants for cross-platform compatibility) ===
-    // These map to WebEngineDownloadRequest.DownloadState enum on desktop
+    // WebEngine-shaped numbering (0–4); Paused = 5 matches MobileWebViewDownload.
+    // Both adapters map Backend downloads into this seam — UI never branches on Backend.
     enum DownloadState {
         DownloadRequested = 0,
         DownloadInProgress = 1,
         DownloadCompleted = 2,
         DownloadCancelled = 3,
-        DownloadInterrupted = 4
+        DownloadInterrupted = 4,
+        DownloadPaused = 5
     }
 
     // === JavaScript Dialog Types (constants for cross-platform compatibility) ===
@@ -94,6 +102,9 @@ Item {
     signal linkHovered(string hoveredUrl)
     signal windowCloseRequested()
     signal downloadRequested(var download)
+    /// Long-press on a link/image (mobile Backends; WebEngine has its own menu).
+    /// Either URL may be empty, never both. position is view-local logical px.
+    signal linkLongPressed(url linkUrl, url imageUrl, point position)
     signal devToolsToggled(bool enabled)
 
     // Signals to be handled at Layout level
@@ -135,4 +146,10 @@ Item {
     function detachView() {}
 
     function triggerWebAction(action) { console.warn("AbstractWebView: triggerWebAction not implemented") }
+
+    /// Host-side re-issue of a Download (Retry). MobileWebView: backend.downloadUrl;
+    /// WebEngine: BrowserProfileUtils → QWebEnginePage::download (not navigate).
+    function downloadUrl(url, suggestedFileName) {
+        console.warn("AbstractWebView: downloadUrl not implemented")
+    }
 }

--- a/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
@@ -31,6 +31,9 @@ AbstractWebView {
     property string title: ""
     property url icon: ""
     property bool htmlPageLoaded: false
+    // A committed page load ends "pristine" for good — from here the Tab shows a
+    // page of its own, so no Download may close it.
+    onHtmlPageLoadedChanged: if (htmlPageLoaded) root.pristinePopup = false
     readonly property bool loading: loader.item ? loader.item.loading : false
     readonly property bool canGoBack: loader.item ? loader.item.canGoBack : false
     readonly property bool canGoForward: loader.item ? loader.item.canGoForward : false
@@ -64,11 +67,9 @@ AbstractWebView {
             profileParams:                 Qt.binding(() => root.profileParams),
             uid:                           Qt.binding(() => root.uid),
             bookmarksStore:                Qt.binding(() => root.bookmarksStore),
-            downloadsStore:                Qt.binding(() => root.downloadsStore),
             webChannel:                    Qt.binding(() => root.webChannel),
             enableJsLogs:                  Qt.binding(() => root.enableJsLogs),
             localAccountSensitiveSettings: Qt.binding(() => root.localAccountSensitiveSettings),
-            isDownloadView:                Qt.binding(() => root.isDownloadView),
             devToolsEnabled:               Qt.binding(() => root.devToolsEnabled),
             freeze:                        Qt.binding(() => root.freeze),
         }
@@ -132,6 +133,15 @@ AbstractWebView {
             loader.item.detachView()
     }
 
+    /// Host-side Retry — ensure the Backend is loaded, then forward.
+    function downloadUrl(url, suggestedFileName) {
+        ensureLoaded()
+        if (loader.item && loader.item.downloadUrl)
+            loader.item.downloadUrl(url, suggestedFileName || "")
+        else
+            console.warn("LazyWebViewAdapter: downloadUrl unavailable")
+    }
+
     onUrlChanged: {
         if (loader.item && loader.item.url !== url)
             loader.item.url = url
@@ -164,6 +174,9 @@ AbstractWebView {
         function onLinkHovered(hoveredUrl)             { root.linkHovered(hoveredUrl) }
         function onWindowCloseRequested()              { root.windowCloseRequested() }
         function onDownloadRequested(download)         { root.downloadRequested(download) }
+        function onLinkLongPressed(linkUrl, imageUrl, position) {
+            root.linkLongPressed(linkUrl, imageUrl, position)
+        }
         function onNewWindowRequested(makeCurrent, requestedUrl, callback) {
             root.newWindowRequested(makeCurrent, requestedUrl, callback)
         }

--- a/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
@@ -65,6 +65,14 @@ AbstractWebView {
 
         // clearSiteData reloads natively (cache-bypass); clearProfileData does not.
         function onClearProfileDataCompleted() { backend.reload() }
+
+        function onDownloadRequested(download) {
+            root.downloadRequested(download)
+        }
+
+        function onLinkLongPressed(linkUrl, imageUrl, position) {
+            root.linkLongPressed(linkUrl, imageUrl, position)
+        }
     }
 
     function rebuildHistoryModel() {
@@ -83,6 +91,14 @@ AbstractWebView {
 
     function loadUrl(newUrl) {
         backend.loadUrl(newUrl)
+    }
+
+    /// Host-side Retry (ADR 0006): re-issue via Backend downloadUrl on this profile.
+    function downloadUrl(url, suggestedFileName) {
+        if (backend.downloadUrl)
+            backend.downloadUrl(url, suggestedFileName || "")
+        else
+            console.warn("MobileWebViewAdapter: backend.downloadUrl unavailable")
     }
 
     function goBack() {

--- a/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
+++ b/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
@@ -55,9 +55,21 @@ QtObject {
                 profileParams.offTheRecord,
                 key)
             p = prototype.instance()
+            // Qt allows one live profile per data path and returns null on collision,
+            // which happens while a previous Browser instance is still being torn down.
+            // Returning null keeps the Web View on the default profile; dereferencing
+            // it here would abort before the cache write and crash the render path.
+            if (!p) {
+                console.error("ProfileManager: no profile for", key,
+                              "- another profile still holds this data path")
+                return null
+            }
             // Live cookie index for per-site clear (Qt 6 loadAllCookies is a no-op
             // for re-emitting existing cookies — see BrowserProfileUtils).
             BrowserProfileUtils.trackProfile(p)
+            // Backend-owned local-browsing policy (ADR 0006 §8): only the
+            // downloads and player-page directories are reachable via file://.
+            BrowserProfileUtils.installLocalUrlPolicy(p)
             if (!root.defaultHttpUserAgent)
                 root.defaultHttpUserAgent = p.httpUserAgent
             root.profiles[key] = p

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -48,6 +48,16 @@ AbstractWebView {
     function stop() { webView.stop() }
     function forceReload() { webView.triggerWebAction(WebEngineView.ReloadAndBypassCache) }
 
+    /// Host-side Retry: force Download via BrowserProfileUtils (QWebEnginePage::download).
+    /// Navigating renderable media (video/audio) would play in the tab instead.
+    function downloadUrl(url, suggestedFileName) {
+        if (!root.profile) {
+            console.warn("WebViewAdapter: downloadUrl requires a profile")
+            return
+        }
+        BrowserProfileUtils.downloadUrl(root.profile, webView, url, suggestedFileName || "")
+    }
+
     // Native per-site cookies, then site_utils.js for current-origin DOM + reload.
     function clearSiteData() {
         if (root.clearing || !root.profile)
@@ -163,12 +173,15 @@ AbstractWebView {
         settings.autoLoadIconsForPage: root.localAccountSensitiveSettings.autoLoadIconsForPage
         settings.touchIconsEnabled: root.localAccountSensitiveSettings.touchIconsEnabled
         settings.webRTCPublicInterfacesOnly: root.localAccountSensitiveSettings.webRTCPublicInterfacesOnly
-        settings.pdfViewerEnabled: root.localAccountSensitiveSettings.pdfViewerEnabled
+        settings.pdfViewerEnabled: true
         settings.focusOnNavigationEnabled: true
         settings.forceDarkMode: Application.styleHints.colorScheme === Qt.ColorScheme.Dark
 
         webChannel: root.webChannel
-        profile: root.profile
+        // Never null: a view with no profile aborts the render path. ProfileManager
+        // yields null only while a previous Browser still holds the data path, and
+        // the default profile keeps this view renderable until it is torn down.
+        profile: root.profile ?? WebEngine.defaultProfile
 
         onQuotaRequested: function(request) {
             if (request.requestedSize <= 5 * 1024 * 1024)
@@ -214,12 +227,6 @@ AbstractWebView {
             if (progress >= 10)
                 webView.htmlPageLoaded = true
         }
-        onNavigationRequested: function(request) {
-            if (request.url.toString().startsWith("file:/")) {
-                console.log("Local file browsing is disabled")
-                request.reject()
-            }
-        }
         onJavaScriptConsoleMessage: function(level, message, lineNumber, sourceID) {
             const isOurScript = ScriptUtils.isOurInjectedScript(sourceID, root.profile)
             if (isOurScript || root.enableJsLogs)
@@ -254,6 +261,16 @@ AbstractWebView {
                 return
             // For viewless downloads, only visible adapter forwards to avoid fan-out.
             if (!download?.view && !root.visible)
+                return
+            root.downloadRequested(download)
+        }
+    }
+
+    // Retry downloads start on a helper Core profile (not this Quick profile).
+    Connections {
+        target: BrowserProfileUtils
+        function onDownloadRequested(webEngineView, download) {
+            if (webEngineView !== webView)
                 return
             root.downloadRequested(download)
         }

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -301,7 +301,6 @@ QtObject {
             webChannel: bridge.channel
 
             bookmarksStore: root.bookmarksStore
-            downloadsStore: root.downloadsStore
             profileManager: root.profileManager
             enableJsLogs: root.isDebugEnabled
             localAccountSensitiveSettings: root.browserSettings


### PR DESCRIPTION
Extend the cross-platform web view seam for downloads (ADR 0006):

* Download states incl. synthesized Paused; `downloadUrl()` for host-side retry
* `linkLongPressed` signal (mobile long-press on links/images)
* `supportsPdfViewer` capability flag
* `retained` flag for Web Views kept alive after their tab closes
* Adapters surface Backend download requests per web view (WebEngine + MobileWebView)
* ProfileManager: fix render-path crash on profile teardown
* StatusQ C++: BrowserProfileUtils (downloadUrl), SystemUtilsInternal (fileExists, ensureDirectory, showInFolder, sharePaths); Android system Downloads registration
* Bump mobilewebview to `debb2c8c` (downloads backend + pause/resume race guard)

App-inert until PR 5/5. 
Part of #21376