### PR TITLE
feat(browser): download records, history [2/5]

### DIFF
--- a/docs/adr/0006-browser-download-records.md
+++ b/docs/adr/0006-browser-download-records.md
@@ -1,0 +1,217 @@
+# ADR 0006: Browser downloads — Download Records over live library objects
+
+## Status
+
+Accepted
+
+- **Date**: 2026-07-29
+- **Amended**: 2026-07-30 — §6 (no close-confirmation; retention ownership and
+  bounds), §7 (profile match is mandatory), §8 (unreportable state must not gate
+  UI; allowlist limited to uniformly-rendered media; opening prefers our browser
+  and falls back to the OS; desktop copies a file path)
+- **Amended**: 2026-08-07 — §8 (in-page media playback is a Capability the Backend
+  answers at runtime, not a platform check or a deployment floor)
+- **Owners**: Status Desktop (browser)
+
+## Context
+
+Mobile had no downloads at all: `MobileWebViewAdapter.qml` never connected the
+backend's `downloadRequested` signal, and the download bar was gated off entirely
+(`sourceComponent: !root.isMobile ? downloadBar : null`). The MobileWebView
+library closed that gap upstream (its ADR 0005, shipped at `a09833d`): a Download
+is surfaced to the host as a `MobileWebViewDownload` with metadata only, the host
+supplies a **Download Target** and calls `accept(target)`, and the library then
+performs and tracks the transfer with pause/resume/cancel/retry.
+
+Two properties of that surface do not fit the download UI we have:
+
+- **Ownership is per Backend and terminal-bounded.** There is no cross-view
+  registry, and `DownloadRegistry` calls `download->deleteLater()` the moment a
+  Download reaches Completed, Cancelled, or Interrupted. Its comment reads "host
+  (DownloadsStore) may still hold a ref and call retry()", but a QML reference
+  does not keep a C++ `QObject` alive: one event-loop turn later the object is
+  gone and the QML variable reads as null. Anything the UI must still show or act
+  on *after* a download finishes cannot be the library's object.
+- **The host owns the destination.** Android scoped storage and the iOS sandbox
+  mean the library never picks a path; with no accept, a Download is cancelled.
+
+Meanwhile the existing store held raw platform objects in a `ListModel` *and* a
+parallel `downloads: []` JS array, because `ListModel.append(qobject)` copies
+property values and does not track later changes — so the model was effectively
+only supplying `count` and `index`.
+
+The mobile design then raised the bar past anything the old store could express:
+a downloads strip under the address bar, a full list inside the tabs/bookmarks
+panel, per-state menus (Show in folder / Pause / Resume / Cancel / Share file /
+Share URL / Open in Browser), duplicate-name suffixes (`(1)`, `(2)`), and — from
+the product discussion — a **durable** list, so that show-in-folder, copy-URL and
+retry still work later, with entries struck through once their file is gone.
+
+## Decision
+
+**A Download Record, owned by this layer, is the identity of a download; the
+library's Download object is a transient attachment to it.**
+
+1. **One platform-neutral seam.** `AbstractWebView` defines the Download shape;
+   both adapters map into it — `MobileWebViewDownload` on mobile,
+   `WebEngineDownloadRequest` on desktop. `DownloadState` keeps WebEngine's
+   numbering and adds `Paused = 5`, matching the library. No UI code branches on
+   which Backend produced a download.
+
+2. **Download Records own the list.** `DownloadsStore` holds Records as objects
+   (not `ListModel` rows), so delegates bind to a Record directly and the
+   parallel-array workaround disappears. A live Download attaches to its Record
+   while it exists and supplies progress and pause/resume/cancel; everything that
+   must survive the transfer lives on the Record.
+
+3. **Download History is persisted, in the same place as the Tab session.**
+   Records are written through the browser preferences key/value store under their
+   own category, debounced, and only on two events: Record creation and the
+   terminal transition. Progress is never persisted. The History is capped at 200
+   Records, oldest evicted — each write rewrites the whole JSON blob, so unbounded
+   growth is a real cost. A Record restored without a terminal state means the app
+   died mid-transfer; it is restored as **Interrupted**, because the library does
+   not survive process death and no progress will ever arrive for it.
+
+4. **Incognito downloads never enter Download History.** They appear in the
+   current session only. The library already refuses to register Incognito
+   downloads with the Android system Downloads UI precisely so that those URLs do
+   not leak; persisting source URL and target path host-side would undo that in the
+   most sensitive place. The file on disk stays — that was the user's explicit act.
+
+5. **The Download Target is fixed host policy**: the platform downloads location,
+   file name from the library's suggestion, collisions resolved with `(1)`, `(2)`
+   suffixes. No save-as picker: the design starts the transfer immediately and
+   shows a pill, and there is nowhere to store a per-download choice yet.
+
+6. **Retained Views instead of cancelled downloads.** A Web View whose Tab goes
+   away while it still owns a non-terminal Download is hidden and frozen rather
+   than destroyed, and destroyed once its downloads are terminal. The library
+   guarantees a Download keeps running while its view is frozen, so this is the
+   only option that neither lies about ownership nor breaks Inline Downloads,
+   whose bytes live in the originating Backend and cannot be re-issued elsewhere.
+   This matters most for the download-only Tab (`target=_blank` onto an
+   attachment), which the browser closes *itself* — there is no user to prompt.
+
+   **Closing a Tab never cancels a Download** — user-initiated or not. An earlier
+   draft asked for confirmation on user close and cancelled on confirm; that was
+   dropped, because the Download Pill and the Downloads List already offer Cancel
+   for every non-terminal Download, so the dialog asks a question the user can
+   answer better, later, and with more context. Cancelling stays an explicit act
+   on the download, never a side effect of tidying up tabs.
+
+   Retention rules:
+   - **One owner.** The component that creates Web Views destroys them
+     (`BrowserWebViewContext`), retained or not. `DownloadsStore` answers "does
+     this view still own non-terminal Downloads?" and signals when that becomes
+     false; only a Download Record ever attaches to a live Download object.
+   - **Retained Views take no new work.** A Retained View is not part of the Tab
+     set and is never chosen as the Backend for a new Download or a retry —
+     otherwise its retention could be extended indefinitely and "destroyed once
+     its Downloads are terminal" would stop being a reachable state.
+   - **Incognito Tabs are retained on the same terms.** The privacy boundary is
+     persistence (§4), not aborting a transfer the user explicitly asked for;
+     retention writes nothing.
+   - **No timeout and no cap.** Retention ends only when the Downloads it holds
+     reach a terminal state. A host-side timeout would report a live transfer as
+     dead; a stalled transfer is the Backend's to interrupt, and the user's to
+     cancel from the Pill.
+
+7. **Retry is a host-side re-issue**, not the library's `retry()`: the Record's
+   URL is downloaded again via `downloadUrl(url, fileName)` on a Backend with a
+   matching profile. Offered from the Record menu for Interrupted and Cancelled
+   Records, and on tap for Interrupted only — tapping a download the user
+   cancelled must not restart it. Inline Downloads get no retry at all; their
+   payload is not reproducible from a URL.
+
+   **The profile match is mandatory, never best-effort.** Re-issuing an Incognito
+   Record on a Standard Backend would give the new Record standard mode, and so
+   persist an Incognito source URL into Download History and — on Android —
+   register the file with the system Downloads UI, which the library refuses for
+   Incognito precisely to keep those URLs out. If no Backend with a matching mode
+   exists, retry is unavailable rather than downgraded.
+
+8. **Platform reach is reported, not assumed.** "Show in folder" exists on
+   Android only (via the system downloads view; the library registers completed
+   Standard-mode files with MediaStore) and is hidden on iOS, which has no folder
+   to show. "Share file" reuses the existing cross-platform share sheet
+   (`SystemUtilsInternal.sharePaths`). "Open in Browser" is gated on the Backend's
+   ability to render the file's type: images, plain text and HTML everywhere, PDF
+   only where the Backend renders PDF — the system Android WebView does not.
+
+   **The allowlist admits formats our Backends render.** Audio and video qualify
+   to the extent support is reliable in Chromium/WebEngine — MP3, WAV and WebM
+   are in; Ogg and Matroska stay out (platform media stack), and so do M4A/AAC
+   and MP4/H.264: the shipped Chromium is built without proprietary codecs, so
+   they fail with `DEMUXER_ERROR_NO_SUPPORTED_STREAMS` and would leave the user
+   on a dead player. A format left out is not a dead end: it opens in the OS
+   instead.
+
+   **Whether a page can play media at all is a Capability, not a platform check.**
+   The allowlist says which formats a Backend renders; the Backend still has to
+   say whether in-page playback works for it, and it answers at runtime. iOS is
+   the case that forces this — WebKit gained WebM/VP8/VP9 in 17.4 — and the
+   answer belongs in the library rather than in the app's deployment floor:
+   raising the floor would drop every older device to buy one format, and hiding
+   the question behind `isIOS` in the UI would state a platform fact the platform
+   is perfectly able to state itself. A "no" takes the same route an unlisted
+   format takes, out to the OS.
+
+   **Opening a finished Download prefers our own browser, and hands off when it
+   cannot render.** Tapping a Completed Record — from the Downloads List or its
+   Pill — loads it in a Tab when the type is on the allowlist, and otherwise asks
+   the OS to open it. The fallback is what makes the allowlist affordable: keeping
+   it narrow costs the user nothing, so there is never a reason to widen it by
+   guessing.
+
+   **The desktop file action copies a path, and says so.** Where mobile shares the
+   file itself through the system sheet, desktop has no file to hand anywhere — it
+   can only name the file's location. The action is therefore "Copy file path" and
+   yields the plain filesystem path, which the address bar already resolves to a
+   local file, so the copied text works both in our browser and in a terminal.
+
+   The corollary: **state the Backend cannot report must not gate UI.** The seam
+   can open and close the native find panel but is never told when the user
+   dismisses it, so "Find is open" is not a fact the host owns. Opening Find
+   therefore hides the Download Pill strip once, as an action, instead of latching
+   it hidden until some unrelated event happens to clear the flag.
+
+9. **Clear browsing data clears Records, not files.** Downloaded files are the
+   user's; the browsing trace is ours to erase.
+
+## Consequences
+
+### Positive
+
+- One download vocabulary from the seam up: the same store, Records, list and
+  menus serve desktop and mobile, and the desktop store loses its parallel-array
+  workaround.
+- The list is honest after a transfer ends, after a Tab closes, and after a
+  restart — none of which the library's object lifetime can span.
+- Downloads no longer die silently when the browser closes the tab that started
+  them, which was the most common mobile trigger.
+
+### Negative / trade-offs
+
+- **Retained Views are a real cost.** A hidden native WebView can outlive its Tab,
+  and its lifetime is now driven by download state. Leaks here are invisible to the
+  user, so ownership has to stay in one place. With no cap and no timeout, several
+  attachments opened in a row can leave several hidden native views alive at once;
+  that ceiling is set by user behaviour and by how quickly the Backend interrupts a
+  stalled transfer, not by us.
+- **Host-side retry loses the library's resume path.** A re-issued download starts
+  from zero rather than reusing WKDownload resume data or an HTTP `Range` request.
+  A follow-up upstream would fix the root cause: keep a terminal Download alive
+  until the host releases it, or expose `retryById()` on the Backend.
+- **The persisted Record format becomes a compatibility surface.** It must tolerate
+  reading what older builds wrote, and vice versa.
+- **On iOS the downloaded file is invisible outside the app.** Without
+  `UIFileSharingEnabled` (deliberately not enabled here — it exposes the whole app
+  sandbox and is a product decision, not a download feature) the only route to the
+  file is the share sheet.
+
+## Scope
+
+Out of scope for this decision: resuming a transfer after process death, a
+foreground download service, a save-as picker or per-download target, and any
+change to how the library itself transfers bytes.

--- a/storybook/qmlTests/tests/tst_BrowserDownloadOpenContext.qml
+++ b/storybook/qmlTests/tests/tst_BrowserDownloadOpenContext.qml
@@ -1,0 +1,194 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Internal
+
+import AppLayouts.Browser.adapters
+
+/**
+ * The open-a-downloaded-file seam (ADR 0006 §8): render/media allowlist and
+ * player-page assembly.
+ * Loads the real context; dependencies are the same narrow injected functions
+ * production wires in.
+ */
+Item {
+    id: root
+
+    readonly property url openContextUrl: Qt.resolvedUrl(
+        "../../../ui/app/AppLayouts/Browser/webview/BrowserDownloadOpenContext.qml")
+
+    TestCase {
+        name: "BrowserDownloadOpenContext"
+        when: windowShown
+
+        property var openedUrls: []
+
+        function createContext() {
+            openedUrls = []
+            const component = Qt.createComponent(root.openContextUrl)
+            verify(component.status === Component.Ready, component.errorString())
+            const ctx = createTemporaryObject(component, root)
+            ctx.mediaPlayerDirectory = "/tmp/status-player"
+            ctx.ensureDirectoryFn = function(path) { return true }
+            ctx.writeTextFileFn = function(path, data) { return true }
+            ctx.openUrlFn = (url) => openedUrls.push(String(url))
+            return ctx
+        }
+
+        /// A Completed Download Record shape (target under /tmp/downloads).
+        function completed(mime, name) {
+            return {
+                mimeType: mime,
+                fileName: name,
+                state: AbstractWebView.DownloadState.DownloadCompleted,
+                missingFile: false,
+                targetPath: "/tmp/downloads/" + name
+            }
+        }
+
+        function test_canOpenInBrowser_allowlist_andPdfGate() {
+            const ctx = createContext()
+
+            const pngRec = completed("image/png", "a.png")
+            const pdfRec = completed("application/pdf", "a.pdf")
+            const binRec = completed("application/octet-stream", "a.bin")
+
+            verify(ctx.canOpenInBrowser(pngRec, false))
+            verify(!ctx.canOpenInBrowser(pdfRec, false))
+            verify(ctx.canOpenInBrowser(pdfRec, true))
+            verify(!ctx.canOpenInBrowser(binRec, true))
+            pngRec.missingFile = true
+            verify(!ctx.canOpenInBrowser(pngRec, false))
+        }
+
+        function test_canOpenInBrowser_requiresCompleted() {
+            const ctx = createContext()
+            const rec = completed("image/png", "a.png")
+            rec.state = AbstractWebView.DownloadState.DownloadInProgress
+            verify(!ctx.canOpenInBrowser(rec, false))
+            verify(!ctx.canOpenInBrowser(null, false))
+        }
+
+        function test_canOpenInBrowser_mediaAllowlist_andExclusions() {
+            const ctx = createContext()
+
+            verify(ctx.canOpenInBrowser(completed("audio/mpeg", "a.mp3"), false))
+            verify(ctx.canOpenInBrowser(completed("audio/wav", "a.wav"), false))
+            verify(ctx.canOpenInBrowser(completed("video/webm", "a.webm"), false))
+
+            // No proprietary codecs in the shipped Chromium: H.264/AAC would load a
+            // player that cannot decode, so they go to the OS like Ogg and Matroska.
+            verify(!ctx.canOpenInBrowser(completed("audio/mp4", "a.m4a"), true))
+            verify(!ctx.canOpenInBrowser(completed("audio/aac", "a.aac"), true))
+            verify(!ctx.canOpenInBrowser(completed("video/mp4", "a.mp4"), true))
+            verify(!ctx.canOpenInBrowser(completed("audio/ogg", "a.ogg"), true))
+            verify(!ctx.canOpenInBrowser(completed("video/x-matroska", "a.mkv"), true))
+
+            // Media playback is a Backend Capability, never a platform check.
+            compare(ctx.inBrowserMediaPlaybackSupported,
+                    BrowserBackendCapabilities.inPageMediaPlaybackSupported)
+
+            // Backend without in-page playback: media leaves the in-browser
+            // route; images still render.
+            ctx.inBrowserMediaPlaybackSupported = false
+            verify(!ctx.canOpenInBrowser(completed("audio/mpeg", "b.mp3"), false))
+            verify(!ctx.canOpenInBrowser(completed("video/webm", "b.webm"), false))
+            verify(ctx.canOpenInBrowser(completed("image/png", "b.png"), false))
+        }
+
+        function test_mediaPlayerPage_writesPlayerForMedia_reusesPerTarget() {
+            const ctx = createContext()
+
+            let written = null
+            ctx.writeTextFileFn = function(path, data) {
+                written = { path: path, data: data }
+                return true
+            }
+
+            const rec = completed("video/webm", "sample 30s (2).webm")
+
+            const url = String(ctx.mediaPlayerPageUrl(rec))
+            verify(url.startsWith("file:///tmp/status-player/player-"))
+            verify(url.endsWith(".html"))
+
+            verify(!!written)
+            verify(written.data.indexOf("<video ") >= 0)
+            verify(written.data.indexOf("<audio ") < 0)
+            // Spaces are percent-encoded — a raw space would break the src.
+            verify(written.data.indexOf('src="file:///') >= 0)
+            verify(written.data.indexOf("sample%2030s%20(2).webm") >= 0)
+            verify(written.data.indexOf('.webm" controls') >= 0)
+
+            // Replaying the same target reuses one page instead of piling up temp files.
+            written = null
+            compare(String(ctx.mediaPlayerPageUrl(rec)), url)
+            verify(!!written)
+            compare(written.path, "/tmp/status-player/player-" + url.split("player-")[1].replace(".html", "") + ".html")
+        }
+
+        function test_mediaPlayerPage_audioTag_andEmptyWhenUnusable() {
+            const ctx = createContext()
+
+            let data = ""
+            ctx.writeTextFileFn = function(path, text) { data = text; return true }
+
+            const mp3 = completed("audio/mpeg", "tune.mp3")
+            verify(String(ctx.mediaPlayerPageUrl(mp3)).length > 0)
+            verify(data.indexOf("<audio ") >= 0)
+            verify(data.indexOf("<video ") < 0)
+            // The name is shown — an audio page is otherwise an empty void.
+            verify(data.indexOf("tune.mp3") >= 0)
+            // A codec the build lacks must say so instead of leaving a dead control.
+            verify(data.indexOf('id="failed"') >= 0)
+            // Assets came from media_player.html/.js, fully substituted.
+            verify(data.indexOf("min(90%, 520px)") >= 0)
+            verify(data.indexOf('addEventListener("error"') >= 0)
+            verify(data.indexOf("__") < 0)
+
+            // Non-media never gets a page — it navigates to the file directly.
+            compare(String(ctx.mediaPlayerPageUrl(completed("application/pdf", "a.pdf"))), "")
+
+            // A failed write leaves the caller to fall back to the OS handler.
+            ctx.writeTextFileFn = function() { return false }
+            compare(String(ctx.mediaPlayerPageUrl(completed("video/webm", "clip.webm"))), "")
+
+            // Missing file blocks both routes.
+            ctx.writeTextFileFn = function(path, text) { return true }
+            const gone = completed("video/webm", "gone.webm")
+            gone.missingFile = true
+            compare(String(ctx.mediaPlayerPageUrl(gone)), "")
+
+            // An unreadable page asset must not write a half-built page.
+            let written = false
+            ctx.writeTextFileFn = function(path, text) { written = true; return true }
+            ctx._mediaPlayerTemplateCache = ""
+            ctx.readTextFileFn = function(path) { return "" }
+            compare(String(ctx.mediaPlayerPageUrl(completed("audio/mpeg", "b.mp3"))), "")
+            verify(!written)
+        }
+
+        function test_openInBrowser_routeChoice_playerNavigateOrOsHandoff() {
+            const ctx = createContext()
+
+            // Media route: a generated player page, never the file itself.
+            verify(ctx.openInBrowser(completed("video/webm", "clip.webm"), false))
+            compare(openedUrls.length, 1)
+            verify(openedUrls[0].startsWith("file:///tmp/status-player/player-"))
+            verify(openedUrls[0].endsWith(".html"))
+
+            // Static route: direct navigation to the Download Target.
+            verify(ctx.openInBrowser(completed("image/png", "photo.png"), false))
+            compare(openedUrls.length, 2)
+            verify(openedUrls[1].indexOf("photo.png") >= 0)
+
+            // Not renderable here → false: the caller hands off to the OS.
+            verify(!ctx.openInBrowser(completed("application/octet-stream", "a.bin"), true))
+            compare(openedUrls.length, 2)
+
+            // No player page (write failed) → false, same OS handoff.
+            ctx.writeTextFileFn = function() { return false }
+            verify(!ctx.openInBrowser(completed("video/webm", "b.webm"), false))
+            compare(openedUrls.length, 2)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_DownloadsStore.qml
+++ b/storybook/qmlTests/tests/tst_DownloadsStore.qml
@@ -1,0 +1,943 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Browser.adapters
+
+import utils
+
+/**
+ * DownloadsStore seam: Download Records own list identity; a fake live Download
+ * attaches for progress and can be destroyed without losing the Record.
+ * Loads the real store (stubs are empty by architecture guide).
+ * See ADR 0006.
+ */
+Item {
+    id: root
+
+    // Real store — stubs/AppLayouts/Browser/stores/DownloadsStore is an empty QtObject.
+    readonly property url downloadsStoreUrl: Qt.resolvedUrl(
+        "../../../ui/app/AppLayouts/Browser/stores/DownloadsStore.qml")
+
+    Component {
+        id: fakeDownloadComponent
+
+        QtObject {
+            property url url: "https://example.com/report.pdf"
+            property string downloadFileName: "report.pdf"
+            property string downloadDirectory: "/tmp/downloads"
+            property string suggestedFileName: downloadFileName
+            property string mimeType: "application/pdf"
+            property double receivedBytes: 0
+            property double totalBytes: 1000
+            property int state: AbstractWebView.DownloadState.DownloadRequested
+            property bool isPaused: false
+            property bool isInline: false
+            property bool offTheRecord: false
+            property string errorString: ""
+            property string destinationPath: downloadDirectory + "/" + downloadFileName
+            property bool accepted: false
+            // When true, cancel() leaves isPaused set — WebEngine can do this.
+            property bool leavePausedOnCancel: false
+
+            function accept() { accepted = true }
+            function cancel() {
+                if (!leavePausedOnCancel)
+                    isPaused = false
+                state = AbstractWebView.DownloadState.DownloadCancelled
+            }
+            function pause() {
+                isPaused = true
+                // WebEngine-shaped: stay InProgress while paused; isPaused carries the pause.
+                state = AbstractWebView.DownloadState.DownloadInProgress
+            }
+            function resume() {
+                isPaused = false
+                state = AbstractWebView.DownloadState.DownloadInProgress
+            }
+
+            function advance(bytes) {
+                receivedBytes = bytes
+                isPaused = false
+                state = AbstractWebView.DownloadState.DownloadInProgress
+            }
+
+            function complete() {
+                receivedBytes = totalBytes
+                isPaused = false
+                state = AbstractWebView.DownloadState.DownloadCompleted
+            }
+        }
+    }
+
+    Component {
+        id: fakeMobileDownloadComponent
+
+        QtObject {
+            property url url: "https://example.com/a.bin"
+            property string suggestedFileName: "a.bin"
+            property string mimeType: "application/octet-stream"
+            property double receivedBytes: 0
+            property double totalBytes: -1
+            property int state: AbstractWebView.DownloadState.DownloadRequested
+            property bool isPaused: false
+            property bool isInline: false
+            property string destinationPath: ""
+            property string acceptedPath: ""
+
+            // Mobile-shaped: accept requires a Download Target path.
+            function accept(path) {
+                acceptedPath = path
+                destinationPath = path
+            }
+            function cancel() {}
+            function pause() {}
+            function resume() {}
+        }
+    }
+
+    Component {
+        id: fakePreferencesComponent
+
+        QtObject {
+            property var _preferences: ({})
+
+            function put(category, key, value) {
+                _preferences[category + "\0" + key] = String(value)
+            }
+            function get(category, key) {
+                return _preferences[category + "\0" + key] || ""
+            }
+            function getDownloadHistoryRaw() {
+                return get(BrowserPreferenceKeys.downloadsHistoryCategory,
+                           BrowserPreferenceKeys.keyDownloadRecords)
+            }
+            function setDownloadHistoryRaw(raw) {
+                put(BrowserPreferenceKeys.downloadsHistoryCategory,
+                    BrowserPreferenceKeys.keyDownloadRecords, raw || "[]")
+            }
+            function clearDownloadHistoryRaw() {
+                setDownloadHistoryRaw("[]")
+            }
+        }
+    }
+
+    Component {
+        id: fakeViewComponent
+        QtObject {
+            property bool offTheRecord: false
+            property bool retained: false
+            property bool htmlPageLoaded: false
+            property string title: ""
+        }
+    }
+
+    TestCase {
+        name: "DownloadsStore"
+        when: windowShown
+
+        /// The one platform seam (DownloadsStore.platform) as a single fake object.
+        function fakePlatform(overrides) {
+            const platform = {
+                fileExists: function(path) { return false },
+                ensureDirectory: function(path) { return true },
+                sharePaths: function(paths) {},
+                shareText: function(text) {},
+                copyText: function(text) {},
+                showInFolder: function(path) {},
+                preferShareSheet: false,
+                showInFolderSupported: true
+            }
+            return Object.assign(platform, overrides || {})
+        }
+
+        function createStore() {
+            const component = Qt.createComponent(root.downloadsStoreUrl)
+            verify(component.status === Component.Ready, component.errorString())
+            const store = createTemporaryObject(component, root)
+            store.platform = fakePlatform()
+            return store
+        }
+
+        function test_createRecord_fromLiveDownload() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+
+            const record = store.addDownload(live)
+
+            verify(!!record)
+            compare(store.downloadModel.length, 1)
+            compare(store.downloadModel[0], record)
+            compare(record.url, live.url)
+            compare(record.fileName, "report.pdf")
+            compare(record.downloadDirectory, "/tmp/downloads")
+            compare(record.state, AbstractWebView.DownloadState.DownloadRequested)
+            compare(record.receivedBytes, 0)
+            compare(record.totalBytes, 1000)
+            compare(record.liveDownload, live)
+        }
+
+        function test_progressBinding_fromLiveDownload() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+
+            live.advance(400)
+
+            compare(record.receivedBytes, 400)
+            compare(record.state, AbstractWebView.DownloadState.DownloadInProgress)
+            compare(record.isPaused, false)
+        }
+
+        function test_recordSurvives_afterLiveDownloadDestroyed() {
+            const store = createStore()
+            const live = fakeDownloadComponent.createObject(root)
+            const record = store.addDownload(live)
+
+            live.advance(700)
+            live.complete()
+
+            compare(record.state, AbstractWebView.DownloadState.DownloadCompleted)
+            compare(record.receivedBytes, 1000)
+
+            live.destroy()
+            wait(0)
+
+            compare(record.liveDownload, null)
+            compare(record.state, AbstractWebView.DownloadState.DownloadCompleted)
+            compare(record.receivedBytes, 1000)
+            compare(record.fileName, "report.pdf")
+            compare(record.downloadDirectory, "/tmp/downloads")
+            compare(store.downloadModel.length, 1)
+            compare(store.downloadModel[0], record)
+        }
+
+        function test_pauseResumeCancel_forwardedToLive() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+
+            live.advance(100)
+            record.pause()
+            compare(record.state, AbstractWebView.DownloadState.DownloadPaused)
+            compare(record.isPaused, true)
+
+            record.resume()
+            compare(record.state, AbstractWebView.DownloadState.DownloadInProgress)
+            compare(record.isPaused, false)
+
+            record.cancel()
+            compare(record.state, AbstractWebView.DownloadState.DownloadCancelled)
+        }
+
+        function test_cancel_whilePaused_clearsResumeUi() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.leavePausedOnCancel = true
+            const record = store.addDownload(live)
+
+            live.advance(100)
+            record.pause()
+            compare(record.state, AbstractWebView.DownloadState.DownloadPaused)
+            compare(record.isPaused, true)
+
+            record.cancel()
+            compare(record.state, AbstractWebView.DownloadState.DownloadCancelled)
+            compare(record.isPaused, false)
+        }
+
+        function test_cancel_afterLiveDestroyed_updatesRecord() {
+            const store = createStore()
+            const live = fakeDownloadComponent.createObject(root)
+            const record = store.addDownload(live)
+
+            live.advance(50)
+            live.destroy()
+            wait(0)
+
+            compare(record.liveDownload, null)
+            record.cancel()
+            compare(record.state, AbstractWebView.DownloadState.DownloadCancelled)
+            compare(record.isPaused, false)
+        }
+
+        function test_downloadModel_isArrayNotObjectModel() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            store.addDownload(live)
+
+            // ObjectModel crashes ListView (QQuickItem::x on QtObject). Must be a JS array.
+            verify(Array.isArray(store.downloadModel))
+            compare(typeof store.downloadModel.append, "undefined")
+        }
+
+        function test_resolveDownloadTarget_usesDownloadsDirAndSuggestedName() {
+            const store = createStore()
+            store.downloadsDirectory = "/tmp/status-downloads"
+            store.platform.fileExists = function(path) { return false }
+
+            compare(store._resolveDownloadTarget("report.pdf"),
+                    "/tmp/status-downloads/report.pdf")
+        }
+
+        function test_resolveDownloadTarget_addsCollisionSuffixes() {
+            const store = createStore()
+            store.downloadsDirectory = "/tmp/status-downloads"
+            store.platform.fileExists = function(path) {
+                return path === "/tmp/status-downloads/report.pdf"
+                    || path === "/tmp/status-downloads/report (1).pdf"
+            }
+
+            compare(store._resolveDownloadTarget("report.pdf"),
+                    "/tmp/status-downloads/report (2).pdf")
+        }
+
+        function test_resolveDownloadTarget_skipsTargetsClaimedByRecords() {
+            const store = createStore()
+            store.downloadsDirectory = "/tmp/status-downloads"
+            store.platform.fileExists = function(path) { return false }
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            record.downloadDirectory = "/tmp/status-downloads"
+            record.fileName = "report.pdf"
+
+            compare(store._resolveDownloadTarget("report.pdf"),
+                    "/tmp/status-downloads/report (1).pdf")
+        }
+
+        function test_acceptLiveDownload_mobileShaped_passesTargetPath() {
+            const store = createStore()
+            store.downloadsDirectory = "/tmp/status-downloads"
+            store.platform.fileExists = function(path) { return false }
+
+            const live = createTemporaryObject(fakeMobileDownloadComponent, root)
+            const record = store.addDownload(live)
+            store.acceptLiveDownload(live, record)
+
+            compare(live.acceptedPath, "/tmp/status-downloads/a.bin")
+            compare(record.fileName, "a.bin")
+            compare(record.downloadDirectory, "/tmp/status-downloads")
+            compare(record.targetPath, "/tmp/status-downloads/a.bin")
+        }
+
+        function test_syncFromLive_acceptedDestinationBeatsSuggestedName() {
+            const store = createStore()
+            store.downloadsDirectory = "/tmp/status-downloads"
+            store.platform.fileExists = function(path) {
+                return path === "/tmp/status-downloads/a.bin"
+            }
+
+            const live = createTemporaryObject(fakeMobileDownloadComponent, root)
+            const record = store.addDownload(live)
+            store.acceptLiveDownload(live, record)
+            compare(live.acceptedPath, "/tmp/status-downloads/a (1).bin")
+
+            // Mobile keeps suggestedFileName at the unsuffixed name after accept;
+            // progress must not revert the Record to it.
+            compare(live.suggestedFileName, "a.bin")
+            live.receivedBytes = 10
+
+            compare(record.fileName, "a (1).bin")
+            compare(record.targetPath, "/tmp/status-downloads/a (1).bin")
+        }
+
+        function test_acceptLiveDownload_webEngineShaped_setsDirAndAccepts() {
+            const store = createStore()
+            store.downloadsDirectory = "/tmp/status-downloads"
+            store.platform.fileExists = function(path) { return false }
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            store.acceptLiveDownload(live, record)
+
+            verify(live.accepted)
+            compare(live.downloadDirectory, "/tmp/status-downloads")
+            compare(live.downloadFileName, "report.pdf")
+            compare(record.fileName, "report.pdf")
+            compare(record.downloadDirectory, "/tmp/status-downloads")
+        }
+
+        function createStoreWithPrefs() {
+            const prefs = createTemporaryObject(fakePreferencesComponent, root)
+            const store = createStore()
+            store.preferencesStore = prefs
+            store.historySaveDebounceMs = 0
+            store.historyCap = 200
+            store.downloadsDirectory = "/tmp/status-downloads"
+            store.platform.fileExists = function(path) { return false }
+            return store
+        }
+
+        function flushHistory(store) {
+            store.saveDownloadHistoryNow()
+        }
+
+        function test_history_persistsOnCreateAndTerminal_notProgress() {
+            const store = createStoreWithPrefs()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            store.acceptLiveDownload(live, record)
+            flushHistory(store)
+
+            const savedAfterCreate = JSON.parse(store.preferencesStore.getDownloadHistoryRaw() || "[]")
+            compare(savedAfterCreate.length, 1)
+            compare(savedAfterCreate[0].fileName, "report.pdf")
+
+            live.advance(400)
+            flushHistory(store)
+            const savedMid = JSON.parse(store.preferencesStore.getDownloadHistoryRaw() || "[]")
+            // Progress must not be written into History.
+            compare(savedMid[0].receivedBytes, undefined)
+
+            live.complete()
+            flushHistory(store)
+            const savedDone = JSON.parse(store.preferencesStore.getDownloadHistoryRaw() || "[]")
+            compare(savedDone[0].state, AbstractWebView.DownloadState.DownloadCompleted)
+            compare(savedDone[0].fileName, "report.pdf")
+            compare(savedDone[0].downloadDirectory, "/tmp/status-downloads")
+        }
+
+        function test_history_excludesIncognito() {
+            const store = createStoreWithPrefs()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            record.offTheRecord = true
+            store.acceptLiveDownload(live, record)
+            live.complete()
+            flushHistory(store)
+
+            const saved = JSON.parse(store.preferencesStore.getDownloadHistoryRaw() || "[]")
+            compare(saved.length, 0)
+            compare(store.downloadModel.length, 1) // still session-visible
+        }
+
+        function test_history_restore_incompleteBecomesInterrupted() {
+            const prefs = createTemporaryObject(fakePreferencesComponent, root)
+            prefs.setDownloadHistoryRaw(JSON.stringify([{
+                url: "https://example.com/x.bin",
+                fileName: "x.bin",
+                downloadDirectory: "/tmp/status-downloads",
+                mimeType: "application/octet-stream",
+                isInline: false,
+                startTime: new Date().toISOString(),
+                state: AbstractWebView.DownloadState.DownloadInProgress,
+                totalBytes: 500,
+                errorString: ""
+            }]))
+
+            const store = createStore()
+            store.preferencesStore = prefs
+            store.platform.fileExists = function(path) { return false }
+            store.restoreDownloadHistory()
+
+            compare(store.downloadModel.length, 1)
+            compare(store.downloadModel[0].fileName, "x.bin")
+            compare(store.downloadModel[0].state, AbstractWebView.DownloadState.DownloadInterrupted)
+            compare(store.downloadModel[0].liveDownload, null)
+        }
+
+        function test_history_capEvictsOldest() {
+            const store = createStoreWithPrefs()
+            store.historyCap = 2
+
+            for (let i = 0; i < 3; ++i) {
+                const live = createTemporaryObject(fakeDownloadComponent, root)
+                live.downloadFileName = "f" + i + ".bin"
+                live.suggestedFileName = live.downloadFileName
+                const record = store.addDownload(live)
+                store.acceptLiveDownload(live, record)
+                live.complete()
+            }
+            flushHistory(store)
+
+            const saved = JSON.parse(store.preferencesStore.getDownloadHistoryRaw() || "[]")
+            compare(saved.length, 2)
+            compare(saved[0].fileName, "f1.bin")
+            compare(saved[1].fileName, "f2.bin")
+        }
+
+        function test_clearDownloadHistory_clearsRecordsKeepsSessionFilesUntouched() {
+            const store = createStoreWithPrefs()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            store.acceptLiveDownload(live, record)
+            live.complete()
+            flushHistory(store)
+            compare(JSON.parse(store.preferencesStore.getDownloadHistoryRaw() || "[]").length, 1)
+
+            store.clearDownloadHistory()
+            compare(store.downloadModel.length, 0)
+            compare(store.downloadStripModel.length, 0)
+            compare(JSON.parse(store.preferencesStore.getDownloadHistoryRaw() || "[]").length, 0)
+        }
+
+        function test_clearDownloadHistory_keepsRunningDownloads() {
+            const store = createStoreWithPrefs()
+            const running = createTemporaryObject(fakeDownloadComponent, root)
+            const runningRec = store.addDownload(running)
+            store.acceptLiveDownload(running, runningRec)
+            running.advance(400)
+
+            const done = createTemporaryObject(fakeDownloadComponent, root)
+            done.downloadFileName = "done.bin"
+            done.suggestedFileName = done.downloadFileName
+            const doneRec = store.addDownload(done)
+            store.acceptLiveDownload(done, doneRec)
+            done.complete()
+
+            store.clearDownloadHistory()
+
+            compare(store.downloadModel.length, 1)
+            compare(store.downloadModel[0], runningRec)
+            compare(runningRec.liveDownload, running)
+
+            running.complete()
+            compare(runningRec.state, AbstractWebView.DownloadState.DownloadCompleted)
+        }
+
+        // --- Download Pill strip (session-only) ---
+
+        function test_strip_newDownload_prependsNewestFirst() {
+            const store = createStore()
+            const live1 = createTemporaryObject(fakeDownloadComponent, root)
+            live1.downloadFileName = "older.pdf"
+            const live2 = createTemporaryObject(fakeDownloadComponent, root)
+            live2.downloadFileName = "newer.pdf"
+            const older = store.addDownload(live1)
+            const newer = store.addDownload(live2)
+
+            verify(Array.isArray(store.downloadStripModel))
+            compare(store.downloadStripModel.length, 2)
+            compare(store.downloadStripModel[0], newer)
+            compare(store.downloadStripModel[1], older)
+        }
+
+        function test_strip_restoreHistory_doesNotPopulateStrip() {
+            const prefs = createTemporaryObject(fakePreferencesComponent, root)
+            prefs.setDownloadHistoryRaw(JSON.stringify([{
+                url: "https://example.com/old.bin",
+                fileName: "old.bin",
+                downloadDirectory: "/tmp/status-downloads",
+                mimeType: "application/octet-stream",
+                isInline: false,
+                startTime: new Date().toISOString(),
+                state: AbstractWebView.DownloadState.DownloadCompleted,
+                totalBytes: 10,
+                errorString: ""
+            }]))
+
+            const store = createStore()
+            store.preferencesStore = prefs
+            store.platform.fileExists = function(path) { return false }
+            store.restoreDownloadHistory()
+
+            compare(store.downloadModel.length, 1)
+            compare(store.downloadStripModel.length, 0)
+        }
+
+        function test_strip_dismissRecordFromStrip_removesOnlyFromStrip() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            live.complete()
+
+            compare(store.downloadStripModel.length, 1)
+            store.dismissRecordFromStrip(record)
+
+            compare(store.downloadStripModel.length, 0)
+            compare(store.downloadModel.length, 1)
+            compare(store.downloadModel[0], record)
+        }
+
+        function test_strip_dismissRecord_byIdentity() {
+            const store = createStore()
+            const live1 = createTemporaryObject(fakeDownloadComponent, root)
+            live1.downloadFileName = "a.pdf"
+            const live2 = createTemporaryObject(fakeDownloadComponent, root)
+            live2.downloadFileName = "b.pdf"
+            const a = store.addDownload(live1)
+            const b = store.addDownload(live2)
+            // Strip is newest-first: [b, a]
+            compare(store.downloadStripModel[0], b)
+            compare(store.downloadStripModel[1], a)
+
+            store.dismissRecordFromStrip(a)
+
+            compare(store.downloadStripModel.length, 1)
+            compare(store.downloadStripModel[0], b)
+            compare(store.downloadModel.length, 2)
+        }
+
+        // --- Downloads List policy: Missing File, retry, open, share ---
+
+        function test_reattachForRetry_keepsIdentity_andMovesNewest() {
+            const store = createStore()
+            const otherLive = createTemporaryObject(fakeDownloadComponent, root)
+            otherLive.downloadFileName = "other.bin"
+            otherLive.url = "https://example.com/other.bin"
+            const other = store.addDownload(otherLive)
+
+            const cancelledLive = createTemporaryObject(fakeDownloadComponent, root)
+            cancelledLive.downloadFileName = "clip.webm"
+            cancelledLive.url = "https://example.com/clip.webm"
+            const record = store.addDownload(cancelledLive)
+            cancelledLive.cancel()
+            compare(record.state, AbstractWebView.DownloadState.DownloadCancelled)
+            compare(store.downloadModel.length, 2)
+
+            const retryLive = createTemporaryObject(fakeDownloadComponent, root)
+            retryLive.downloadFileName = "clip.webm"
+            retryLive.url = "https://example.com/clip.webm"
+            retryLive.state = AbstractWebView.DownloadState.DownloadInProgress
+            const reused = store.reattachForRetry(record, retryLive, null)
+            store.acceptLiveDownload(retryLive, reused)
+
+            compare(reused, record)
+            compare(store.downloadModel.length, 2)
+            compare(store.downloadModel[0], other)
+            compare(store.downloadModel[1], record)
+            compare(store.downloadStripModel[0], record)
+            compare(record.liveDownload, retryLive)
+            compare(record.state, AbstractWebView.DownloadState.DownloadInProgress)
+            compare(store.downloadsListModel[0], record)
+        }
+
+        function test_reattachForRetry_declinesRecordDroppedFromHistory() {
+            const store = createStore()
+            const cancelledLive = createTemporaryObject(fakeDownloadComponent, root)
+            cancelledLive.downloadFileName = "clip.webm"
+            cancelledLive.url = "https://example.com/clip.webm"
+            const record = store.addDownload(cancelledLive)
+            cancelledLive.cancel()
+            compare(record.state, AbstractWebView.DownloadState.DownloadCancelled)
+
+            // Clearing History drops the Record and queues it for destroy().
+            store.clearDownloadHistory()
+            compare(store.downloadModel.length, 0)
+
+            const retryLive = createTemporaryObject(fakeDownloadComponent, root)
+            retryLive.downloadFileName = "clip.webm"
+            retryLive.url = "https://example.com/clip.webm"
+            retryLive.state = AbstractWebView.DownloadState.DownloadInProgress
+
+            // Declined, so the dying Record is never resurrected into the model.
+            compare(store.reattachForRetry(record, retryLive, null), null)
+            compare(store.downloadModel.length, 0)
+            compare(store.downloadStripModel.length, 0)
+        }
+
+        function test_downloadsList_newestFirst() {
+            const store = createStore()
+            const live1 = createTemporaryObject(fakeDownloadComponent, root)
+            live1.downloadFileName = "old.bin"
+            const live2 = createTemporaryObject(fakeDownloadComponent, root)
+            live2.downloadFileName = "new.bin"
+            store.addDownload(live1)
+            store.addDownload(live2)
+
+            const list = store.downloadsListModel
+            compare(list.length, 2)
+            compare(list[0].fileName, "new.bin")
+            compare(list[1].fileName, "old.bin")
+            // Underlying History order unchanged (oldest first for cap eviction).
+            compare(store.downloadModel[0].fileName, "old.bin")
+        }
+
+        function test_missingFile_lazyProbe_setsFlagOnCompleted() {
+            const store = createStore()
+            store.platform.fileExists = function(path) {
+                return path !== "/tmp/downloads/gone.pdf"
+            }
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.downloadFileName = "gone.pdf"
+            live.downloadDirectory = "/tmp/downloads"
+            const record = store.addDownload(live)
+            live.complete()
+
+            compare(record.missingFile, false)
+            store.refreshMissingFiles()
+            compare(record.missingFile, true)
+        }
+
+        function test_missingFile_notFlaggedWhileInProgress() {
+            const store = createStore()
+            store.platform.fileExists = function(path) { return false }
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            live.advance(10)
+
+            store.refreshMissingFiles()
+            compare(record.missingFile, false)
+        }
+
+        function test_retryEligibility_menuAndTap_rules() {
+            const store = createStore()
+
+            const interrupted = createTemporaryObject(fakeDownloadComponent, root)
+            const interruptedRec = store.addDownload(interrupted)
+            interruptedRec.state = AbstractWebView.DownloadState.DownloadInterrupted
+            interruptedRec.isInline = false
+
+            const cancelled = createTemporaryObject(fakeDownloadComponent, root)
+            const cancelledRec = store.addDownload(cancelled)
+            cancelledRec.state = AbstractWebView.DownloadState.DownloadCancelled
+            cancelledRec.isInline = false
+
+            const inlineInterrupted = createTemporaryObject(fakeDownloadComponent, root)
+            const inlineRec = store.addDownload(inlineInterrupted)
+            inlineRec.state = AbstractWebView.DownloadState.DownloadInterrupted
+            inlineRec.isInline = true
+
+            const completed = createTemporaryObject(fakeDownloadComponent, root)
+            const completedRec = store.addDownload(completed)
+            completed.complete()
+
+            verify(store.canRetryFromMenu(interruptedRec))
+            verify(store.canRetryFromTap(interruptedRec))
+            verify(store.canRetryFromMenu(cancelledRec))
+            verify(!store.canRetryFromTap(cancelledRec))
+            verify(!store.canRetryFromMenu(inlineRec))
+            verify(!store.canRetryFromTap(inlineRec))
+            verify(!store.canRetryFromMenu(completedRec))
+            verify(!store.canRetryFromTap(completedRec))
+        }
+
+        function test_canShareFile_requiresCompletedPresentFile() {
+            const store = createStore()
+            store.platform.fileExists = function(path) { return true }
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            live.complete()
+            store.refreshMissingFiles()
+
+            verify(store.canShareFile(record))
+            record.missingFile = true
+            verify(!store.canShareFile(record))
+        }
+
+        function test_shareFile_invokesPlatformSharePaths() {
+            const store = createStore()
+            store.platform.preferShareSheet = true
+            let shared = []
+            store.platform.sharePaths = function(paths) { shared = paths.slice() }
+            store.platform.fileExists = function(path) { return true }
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.downloadDirectory = "/tmp/downloads"
+            live.downloadFileName = "report.pdf"
+            const record = store.addDownload(live)
+            live.complete()
+            store.refreshMissingFiles()
+
+            verify(store.shareFile(record))
+            compare(shared.length, 1)
+            compare(shared[0], "/tmp/downloads/report.pdf")
+        }
+
+        function test_shareFile_desktop_copiesPath() {
+            const store = createStore()
+            store.platform.preferShareSheet = false
+            let copied = ""
+            let shared = []
+            store.platform.copyText = function(text) { copied = text }
+            store.platform.sharePaths = function(paths) { shared = paths.slice() }
+            store.platform.fileExists = function(path) { return true }
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.downloadDirectory = "/tmp/downloads"
+            live.downloadFileName = "report.pdf"
+            const record = store.addDownload(live)
+            live.complete()
+            store.refreshMissingFiles()
+
+            verify(store.shareFile(record))
+            compare(copied, "/tmp/downloads/report.pdf")
+            compare(shared.length, 0)
+        }
+
+        function test_shareUrl_mobile_usesShareText_desktop_copies() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.url = "https://example.com/report.pdf"
+            const record = store.addDownload(live)
+
+            store.platform.preferShareSheet = true
+            let sharedText = ""
+            store.platform.shareText = function(text) { sharedText = text }
+            verify(store.shareUrl(record))
+            compare(sharedText, "https://example.com/report.pdf")
+
+            store.platform.preferShareSheet = false
+            let copied = ""
+            store.platform.copyText = function(text) { copied = text }
+            verify(store.shareUrl(record))
+            compare(copied, "https://example.com/report.pdf")
+        }
+
+        function test_canShowInFolder_desktopAndroid_notIos() {
+            const store = createStore()
+            store.platform.fileExists = function(path) { return true }
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            live.complete()
+            store.refreshMissingFiles()
+
+            store.platform.showInFolderSupported = true
+            verify(store.canShowInFolder(record))
+            store.platform.showInFolderSupported = false
+            verify(!store.canShowInFolder(record))
+            store.platform.showInFolderSupported = true
+            record.missingFile = true
+            verify(!store.canShowInFolder(record))
+        }
+
+        function test_openDirectoryForRecord_callsPlatformShowInFolder_withTargetPath() {
+            const store = createStore()
+            store.platform.fileExists = function(path) { return true }
+            store.platform.showInFolderSupported = true
+            let shownPath = ""
+            store.platform.showInFolder = function(path) { shownPath = path }
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            live.complete()
+            store.refreshMissingFiles()
+
+            store.openDirectoryForRecord(record)
+            compare(shownPath, record.targetPath)
+
+            // iOS / unsupported: no-op
+            shownPath = "unchanged"
+            store.platform.showInFolderSupported = false
+            store.openDirectoryForRecord(record)
+            compare(shownPath, "unchanged")
+        }
+
+        function test_canShowInFolder_incognitoCompleted_stillAllowed() {
+            // ADR 0006: Incognito Records stay session-only and are not registered
+            // with the Android Downloads UI, but Show in folder remains available
+            // for the on-disk file (Desktop reveal / Android Downloads app).
+            const store = createStore()
+            store.platform.fileExists = function(path) { return true }
+            store.platform.showInFolderSupported = true
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.offTheRecord = true
+            const record = store.addDownload(live)
+            live.complete()
+            store.refreshMissingFiles()
+            verify(!!record.offTheRecord)
+            verify(store.canShowInFolder(record))
+        }
+
+        function test_sourceUrl_forShareCopy() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.url = "https://example.com/report.pdf"
+            const record = store.addDownload(live)
+
+            compare(store.sourceUrlString(record), "https://example.com/report.pdf")
+            verify(store.canShareUrl(record))
+            record.missingFile = true
+            verify(store.canShareUrl(record)) // URL actions remain for Missing File
+        }
+
+        // Record bytes are doubles: a 32-bit counter would wrap here. The
+        // wording built from them is covered in tst_DownloadPill.
+        function test_recordBytes_survivesFilesOver2GiB() {
+            const store = createStore()
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.totalBytes = 3 * 1024 * 1024 * 1024      // 3 GiB > 2^31
+            live.receivedBytes = 2.5 * 1024 * 1024 * 1024
+            const record = store.addDownload(live)
+            live.advance(live.receivedBytes)
+
+            compare(record.totalBytes, 3 * 1024 * 1024 * 1024)
+            compare(record.receivedBytes, 2.5 * 1024 * 1024 * 1024)
+        }
+
+        // ADR 0006 §6 — Retained View ownership seam
+        function test_viewHasNonTerminalDownloads_tracksOriginatingView() {
+            const store = createStore()
+            const viewA = createTemporaryObject(fakeViewComponent, root)
+            const viewB = createTemporaryObject(fakeViewComponent, root)
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+
+            verify(!store.viewHasNonTerminalDownloads(viewA))
+
+            const record = store.addDownload(live, viewA)
+            compare(record.originatingView, viewA)
+            verify(store.viewHasNonTerminalDownloads(viewA))
+            verify(!store.viewHasNonTerminalDownloads(viewB))
+            verify(!store.viewHasNonTerminalDownloads(null))
+
+            live.complete()
+            verify(!store.viewHasNonTerminalDownloads(viewA))
+        }
+
+        function test_viewDownloadsCleared_emitsWhenLastNonTerminalEnds() {
+            const store = createStore()
+            const view = createTemporaryObject(fakeViewComponent, root)
+            const live1 = createTemporaryObject(fakeDownloadComponent, root)
+            const live2 = createTemporaryObject(fakeDownloadComponent, root)
+            live2.downloadFileName = "other.bin"
+            live2.suggestedFileName = "other.bin"
+            live2.destinationPath = "/tmp/downloads/other.bin"
+
+            let clearedCount = 0
+            let clearedView = null
+            store.viewDownloadsCleared.connect(function(v) {
+                clearedCount += 1
+                clearedView = v
+            })
+
+            const r1 = store.addDownload(live1, view)
+            const r2 = store.addDownload(live2, view)
+            verify(store.viewHasNonTerminalDownloads(view))
+
+            live1.complete()
+            compare(clearedCount, 0)
+            verify(store.viewHasNonTerminalDownloads(view))
+
+            live2.complete()
+            compare(clearedCount, 1)
+            compare(clearedView, view)
+            verify(!store.viewHasNonTerminalDownloads(view))
+            verify(r1.isTerminal && r2.isTerminal)
+        }
+
+        function test_addDownload_stampsOffTheRecord_fromHostView() {
+            const store = createStore()
+            const view = createTemporaryObject(fakeViewComponent, root)
+            view.offTheRecord = true
+            const live = createTemporaryObject(fakeMobileDownloadComponent, root)
+            // Mobile download has no offTheRecord / view — host view is the source of truth.
+            const record = store.addDownload(live, view)
+            verify(record.offTheRecord)
+            compare(record.originatingView, view)
+        }
+
+        function test_viewDownloadsCleared_notEmittedForUnrelatedView() {
+            const store = createStore()
+            const viewA = createTemporaryObject(fakeViewComponent, root)
+            const viewB = createTemporaryObject(fakeViewComponent, root)
+            const liveA = createTemporaryObject(fakeDownloadComponent, root)
+            const liveB = createTemporaryObject(fakeDownloadComponent, root)
+            liveB.downloadFileName = "b.bin"
+            liveB.suggestedFileName = "b.bin"
+            liveB.destinationPath = "/tmp/downloads/b.bin"
+
+            let clearedViews = []
+            store.viewDownloadsCleared.connect(function(v) {
+                clearedViews.push(v)
+            })
+
+            store.addDownload(liveA, viewA)
+            store.addDownload(liveB, viewB)
+            liveA.complete()
+
+            compare(clearedViews.length, 1)
+            compare(clearedViews[0], viewA)
+            verify(store.viewHasNonTerminalDownloads(viewB))
+        }
+    }
+}

--- a/storybook/stubs/AppLayouts/Browser/stores/BrowserPreferencesStore.qml
+++ b/storybook/stubs/AppLayouts/Browser/stores/BrowserPreferencesStore.qml
@@ -32,4 +32,18 @@ BrowserPreferencesStoreBase {
         }
         _preferences = nextPreferences
     }
+
+    function getDownloadHistoryRaw() {
+        return get(BrowserPreferenceKeys.downloadsHistoryCategory,
+                   BrowserPreferenceKeys.keyDownloadRecords)
+    }
+
+    function setDownloadHistoryRaw(raw) {
+        put(BrowserPreferenceKeys.downloadsHistoryCategory,
+            BrowserPreferenceKeys.keyDownloadRecords, raw || "[]")
+    }
+
+    function clearDownloadHistoryRaw() {
+        setDownloadHistoryRaw("[]")
+    }
 }

--- a/storybook/stubs/AppLayouts/Browser/stores/DownloadsStore.qml
+++ b/storybook/stubs/AppLayouts/Browser/stores/DownloadsStore.qml
@@ -1,3 +1,5 @@
 import QtQml
 
+// Empty stub — Storybook/pages and QML tests mock DownloadsStore inline when needed.
+// Real implementation: ui/app/AppLayouts/Browser/stores/DownloadsStore.qml
 QtObject {}

--- a/ui/app/AppLayouts/Browser/CONTEXT.md
+++ b/ui/app/AppLayouts/Browser/CONTEXT.md
@@ -1,0 +1,78 @@
+# Browser — Context Glossary
+
+The in-app browser: tabs, navigation, favourites, and downloads, on desktop
+(Qt WebEngine) and mobile (the MobileWebView library). Definitions only — no
+implementation details.
+
+Terms owned by the library rather than by this layer (Storage Profile, Standard
+and Incognito mode, Clearing, Freeze, Download, Download Request, Download
+Target, Download State, Inline Download) are defined in the MobileWebView
+glossary and are not repeated here.
+
+## Browsing
+
+### Tab
+One entry in the tab strip, backed by exactly one Web View for its lifetime.
+Closing a Tab destroys its Web View unless the view is Retained, and never
+cancels that view's Downloads.
+
+### Web View
+The surface that loads and renders one page and owns that page's navigation
+history. Its capabilities (zoom, find, dev tools, incognito, site-data clearing)
+vary by platform and are reported rather than assumed.
+_Avoid_: webview instance, browser view, page.
+
+### Backend
+The platform engine behind a Web View: Qt WebEngine on desktop, MobileWebView on
+mobile. Which Backend is in use is never a UI concern — only its reported
+capabilities are.
+
+### Session
+The set of open Tabs, their order, and the active Tab, persisted so the browser
+reopens where the user left it. Opt-in; independent of Download History.
+
+## Downloads
+
+### Download Record
+This layer's own record of one download: source URL, file name, Download Target,
+size, start time, and final Download State. A Record outlives the library's
+Download object and is the identity the Downloads List and Download History are
+built from.
+_Avoid_: download item, download entry, download model.
+
+### Download History
+The persisted set of Download Records, restored on launch and capped in size,
+oldest evicted first and never a Record whose Download is still non-terminal.
+Holds Records only — never file bytes, and never Records from Incognito Tabs.
+_Avoid_: downloads log, saved downloads.
+
+### Downloads List
+The full, scrollable view of Download Records, newest first, with the per-Record
+actions (open, show in folder, share, retry, pause/resume, cancel). Lives as the
+third section of the Open tabs overview on both Desktop and Mobile — never as its
+own Tab.
+_Avoid_: downloads panel, downloads modal, Downloads Page, downloads tab,
+download view.
+
+### Download Pill
+The compact strip entry shown while a download is worth surfacing in-line: file
+name, progress or terminal status, one primary action, and a menu. Lives for the
+browsing session only, is never restored from Download History, and never
+outlives its Record's place in the Downloads List.
+_Avoid_: download chip, download tab, download bar item.
+
+### Retained View
+A Web View kept alive, hidden and frozen, after its Tab is gone, because it still
+owns a non-terminal Download. Destroyed once every Download it owns reaches a
+terminal state. Exists only when destroying the Web View would abort those
+Downloads — today that is the Mobile Backend; a Backend that keeps Downloads
+alive after view destruction does not create Retained Views. Incognito Tabs are
+retained on the same terms: retention keeps a transfer the user asked for alive
+and persists nothing. A Retained View is not part of the Tab set and never takes
+on new Downloads — it only finishes the ones it already owns.
+_Avoid_: zombie tab, orphan view, background tab.
+
+### Missing File
+A Download Record whose Download Target no longer exists on disk. Still a valid
+Record — its source URL remains actionable — but it cannot be opened or shared.
+_Avoid_: broken download, deleted download.

--- a/ui/app/AppLayouts/Browser/stores/DownloadRecord.qml
+++ b/ui/app/AppLayouts/Browser/stores/DownloadRecord.qml
@@ -1,0 +1,177 @@
+import QtQuick
+
+import AppLayouts.Browser.adapters
+
+/**
+ * Host-owned Download Record (see Browser CONTEXT / ADR 0006).
+ * A live Backend Download may attach for progress; the Record survives after it is gone.
+ */
+QtObject {
+    id: root
+
+    property url url
+    property string fileName: ""
+    property string downloadDirectory: ""
+    property string mimeType: ""
+    property bool isInline: false
+    property var startTime: new Date()
+    property string errorString: ""
+    // Incognito Downloads stay session-visible but never enter Download History.
+    property bool offTheRecord: false
+    // Lazily probed when the Downloads List is shown (or app returns to foreground).
+    property bool missingFile: false
+
+    property int state: AbstractWebView.DownloadState.DownloadRequested
+    // double, not int: files over 2 GiB overflow a 32-bit QML int.
+    property double receivedBytes: 0
+    property double totalBytes: -1
+    property bool isPaused: false
+
+    // Transient Backend download (WebEngineDownloadRequest / MobileWebViewDownload). May become null.
+    property var liveDownload: null
+
+    // Host Web View that started this Download (LazyWebViewAdapter). Used for
+    // Retained View ownership (ADR 0006 §6); never persisted.
+    property var originatingView: null
+
+    signal terminalReached()
+
+    readonly property string targetPath: {
+        if (!root.downloadDirectory)
+            return root.fileName
+        if (root.downloadDirectory.endsWith("/") || root.downloadDirectory.endsWith("\\"))
+            return root.downloadDirectory + root.fileName
+        return root.downloadDirectory + "/" + root.fileName
+    }
+
+    readonly property bool isTerminal: root.isTerminalState(root.state)
+
+    /// Prefer this over `isTerminal` inside onStateChanged — the binding can lag.
+    function isTerminalState(state) {
+        return state === AbstractWebView.DownloadState.DownloadCompleted
+            || state === AbstractWebView.DownloadState.DownloadCancelled
+            || state === AbstractWebView.DownloadState.DownloadInterrupted
+    }
+
+    onStateChanged: {
+        if (root.isTerminalState(root.state))
+            root.terminalReached()
+    }
+
+    readonly property Connections _liveBindings: Connections {
+        target: root.liveDownload
+        enabled: !!root.liveDownload
+        // WebEngine vs mobile Backend expose different path properties.
+        ignoreUnknownSignals: true
+
+        function onStateChanged() { root.syncFromLive() }
+        function onReceivedBytesChanged() { root.syncFromLive() }
+        function onTotalBytesChanged() { root.syncFromLive() }
+        function onIsPausedChanged() { root.syncFromLive() }
+        function onDownloadDirectoryChanged() { root.syncFromLive() }
+        function onDownloadFileNameChanged() { root.syncFromLive() }
+        function onDestinationPathChanged() { root.syncFromLive() }
+    }
+
+    onLiveDownloadChanged: {
+        if (!root.liveDownload)
+            return
+        root.syncFromLive()
+    }
+
+    function attach(download) {
+        if (!download)
+            return
+        root.liveDownload = download
+        root.syncFromLive()
+    }
+
+    function detach() {
+        root.liveDownload = null
+    }
+
+    function syncFromLive() {
+        const d = root.liveDownload
+        if (!d)
+            return
+
+        if (d.url !== undefined && d.url.toString() !== "")
+            root.url = d.url
+
+        // The accepted target wins: mobile leaves suggestedFileName unsuffixed.
+        if (d.downloadFileName)
+            root.fileName = d.downloadFileName
+        else if (!root.fileName && d.suggestedFileName)
+            root.fileName = d.suggestedFileName
+
+        if (d.downloadDirectory)
+            root.downloadDirectory = d.downloadDirectory
+        else if (d.destinationPath) {
+            const path = String(d.destinationPath)
+            const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"))
+            if (slash >= 0) {
+                root.downloadDirectory = path.substring(0, slash)
+                root.fileName = path.substring(slash + 1)
+            }
+        }
+
+        if (d.mimeType !== undefined && d.mimeType !== "")
+            root.mimeType = d.mimeType
+        if (d.isInline !== undefined)
+            root.isInline = !!d.isInline
+        if (d.errorString !== undefined)
+            root.errorString = d.errorString || ""
+
+        if (d.receivedBytes !== undefined)
+            root.receivedBytes = d.receivedBytes
+        if (d.totalBytes !== undefined)
+            root.totalBytes = d.totalBytes
+
+        // Terminal Backend state always wins. WebEngine can leave isPaused true
+        // after cancel(); preferring pause would stick the Record on Resume forever.
+        if (d.state !== undefined && root.isTerminalState(d.state)) {
+            root.state = d.state
+            root.isPaused = false
+            return
+        }
+
+        // Normalize to AbstractWebView seam: WebEngine keeps InProgress while paused;
+        // expose DownloadPaused = 5 when isPaused is set.
+        if (d.isPaused)
+            root.state = AbstractWebView.DownloadState.DownloadPaused
+        else if (d.state !== undefined)
+            root.state = d.state
+
+        root.isPaused = root.state === AbstractWebView.DownloadState.DownloadPaused
+            || !!(d.isPaused)
+    }
+
+    function pause() {
+        if (root.liveDownload && root.liveDownload.pause)
+            root.liveDownload.pause()
+    }
+
+    function resume() {
+        if (root.liveDownload && root.liveDownload.resume)
+            root.liveDownload.resume()
+    }
+
+    function cancel() {
+        if (root.liveDownload && root.liveDownload.cancel) {
+            root.liveDownload.cancel()
+            root.syncFromLive()
+            // If the Backend has not flipped state yet (or left isPaused set),
+            // force Cancelled so UI cannot stay on Resume + 0 bytes.
+            if (!root.isTerminalState(root.state)) {
+                root.isPaused = false
+                root.state = AbstractWebView.DownloadState.DownloadCancelled
+            }
+            return
+        }
+        // Live object already gone: keep the Record actionable for the session.
+        if (!root.isTerminal) {
+            root.isPaused = false
+            root.state = AbstractWebView.DownloadState.DownloadCancelled
+        }
+    }
+}

--- a/ui/app/AppLayouts/Browser/stores/DownloadsStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/DownloadsStore.qml
@@ -1,29 +1,571 @@
+import QtCore
 import QtQuick
-import StatusQ
 
+import StatusQ
+import StatusQ.Core
+import StatusQ.Core.Utils as SQUtils
+import StatusQ.Internal
+
+import utils
+
+import AppLayouts.Browser.adapters
+
+/**
+ * Owns Download Records for the browser (see Browser CONTEXT / ADR 0006).
+ * Live Backend downloads attach to Records; the list identity is the Record.
+ * Download History persists via preferencesStore (create + terminal only).
+ *
+ * downloadModel is a JS array of DownloadRecord objects (not ObjectModel):
+ * ObjectModel treats entries as visual QQuickItems and crashes ListView.
+ */
 QtObject {
     id: root
 
-    property ListModel downloadModel : ListModel {
-        property var downloads: []
+    // Array of DownloadRecord; reassigned on change so ListView refreshes.
+    property var downloadModel: []
+
+    // Session-only Download Pill strip. Never restored from Download History (ADR 0006).
+    property var downloadStripModel: []
+
+    /// Newest-first list for the Downloads overview. Recomputes when downloadModel
+    /// changes so an open TabsBookmarksOverviewModal stays live (not a createObject snapshot).
+    readonly property var downloadsListModel: {
+        const src = downloadModel
+        const list = []
+        for (let i = src.length - 1; i >= 0; --i)
+            list.push(src[i])
+        return list
     }
 
-    function getDownload(index) {
-        return downloadModel.downloads[index]
+    // Browser preferences (same mechanism as Tab Session). Optional in unit tests.
+    property var preferencesStore: null
+
+    property int historyCap: 200
+    property int historySaveDebounceMs: 700
+
+    // Host Download Target policy: platform downloads location (overridable in tests).
+    property string downloadsDirectory: {
+        const loc = StandardPaths.writableLocation(StandardPaths.DownloadLocation)
+        return loc ? String(loc).replace("file://", "") : ""
     }
 
-    function addDownload(download) {
-        downloadModel.append(download);
-        downloadModel.downloads.push(download);
+    /// The one platform seam: filesystem, share/clipboard, and the two platform
+    /// facts the store branches on. Production injects nothing — the default
+    /// wraps SystemUtils / ShareUtils / ClipboardUtils; tests inject one fake:
+    /// - fileExists(path) → bool — disk existence probe (Missing File, collisions)
+    /// - ensureDirectory(path) → bool — create the downloads directory
+    /// - sharePaths([path]) — mobile share sheet for files
+    /// - shareText(text) — mobile share sheet for text/URL
+    /// - copyText(text) — desktop Copy file path / Copy URL
+    /// - showInFolder(path) — desktop reveals file; Android opens system Downloads UI
+    /// - preferShareSheet: bool — mobile → share sheet; desktop → copy
+    /// - showInFolderSupported: bool — Desktop + Android; hidden on iOS
+    ///   (ADR 0006)
+    property var platform: ({
+        fileExists: function(path) { return SystemUtils.fileExists(path) },
+        ensureDirectory: function(path) { return SystemUtils.ensureDirectory(path) },
+        sharePaths: function(paths) { SystemUtils.sharePaths(paths) },
+        shareText: function(text) { ShareUtils.shareText(text) },
+        copyText: function(text) { ClipboardUtils.setText(text) },
+        showInFolder: function(path) { SystemUtils.showInFolder(path) },
+        preferShareSheet: SQUtils.Utils.isMobile,
+        showInFolderSupported: !SQUtils.Utils.isIOS
+    })
+
+    readonly property url _downloadRecordUrl: Qt.resolvedUrl("DownloadRecord.qml")
+
+    /// Emitted when a host Web View no longer owns any non-terminal Downloads.
+    /// BrowserWebViewContext destroys Retained Views on this signal (ADR 0006 §6).
+    signal viewDownloadsCleared(var view)
+
+    readonly property Timer _historySaveTimer: Timer {
+        interval: Math.max(0, root.historySaveDebounceMs)
+        repeat: false
+        onTriggered: root.saveDownloadHistoryNow()
     }
 
-    function openFile(index) {
-        const filePath = `${downloadModel.downloads[index].downloadDirectory}/${downloadModel.downloads[index].downloadFileName}`
-        Qt.openUrlExternally(UrlUtils.urlFromUserInput(filePath))
+    /// hostView is the host Web View (LazyWebViewAdapter) that owns this Download.
+    /// Required for Retained View ownership; Backend download.view is unreliable on mobile.
+    function addDownload(download, hostView) {
+        const component = Qt.createComponent(_downloadRecordUrl)
+        if (component.status !== Component.Ready) {
+            console.error("DownloadsStore: failed to load DownloadRecord:", component.errorString())
+            return null
+        }
+        const record = component.createObject(root)
+        record.attach(download)
+        if (hostView)
+            record.originatingView = hostView
+        else if (download && download.view)
+            record.originatingView = download.view
+
+        if (hostView && hostView.offTheRecord !== undefined)
+            record.offTheRecord = !!hostView.offTheRecord
+        else if (download) {
+            if (download.offTheRecord !== undefined)
+                record.offTheRecord = !!download.offTheRecord
+            else if (download.view && download.view.offTheRecord !== undefined)
+                record.offTheRecord = !!download.view.offTheRecord
+        }
+        record.terminalReached.connect(function() {
+            root.scheduleSaveDownloadHistory()
+            root._maybeEmitViewDownloadsCleared(record.originatingView)
+        })
+        downloadModel = downloadModel.concat([record])
+        // Newest pills first — strip shifts existing items right (animated in the view).
+        downloadStripModel = [record].concat(downloadStripModel)
+        root.enforceHistoryCap()
+        root.scheduleSaveDownloadHistory()
+        return record
     }
 
-    function openDirectory(index) {
-        const dirPath = downloadModel.downloads[index].downloadDirectory
-        Qt.openUrlExternally(UrlUtils.urlFromUserInput(dirPath))
+    /// Retry: re-bind a new live Backend Download onto an existing Interrupted/Cancelled
+    /// Record so History / overview keep one identity (no duplicate Cancelled + InProgress).
+    function reattachForRetry(record, download, hostView) {
+        if (!record || !download)
+            return null
+        // Dropped by clear/evict, so already queued for destroy() — reattaching
+        // would resurrect a dying QObject. The caller starts a fresh Record.
+        if (downloadModel.indexOf(record) < 0)
+            return null
+
+        record.errorString = ""
+        record.missingFile = false
+        record.startTime = new Date()
+        record.receivedBytes = 0
+        record.isPaused = false
+        record.state = AbstractWebView.DownloadState.DownloadRequested
+
+        if (hostView)
+            record.originatingView = hostView
+        else if (download.view)
+            record.originatingView = download.view
+
+        if (hostView && hostView.offTheRecord !== undefined)
+            record.offTheRecord = !!hostView.offTheRecord
+
+        record.attach(download)
+
+        // Newest in History (oldest-first array → append).
+        const rest = []
+        for (let i = 0; i < downloadModel.length; ++i) {
+            if (downloadModel[i] !== record)
+                rest.push(downloadModel[i])
+        }
+        downloadModel = rest.concat([record])
+
+        // Front of the session strip.
+        dismissRecordFromStrip(record)
+        downloadStripModel = [record].concat(downloadStripModel)
+
+        return record
+    }
+
+    /// True while any Download Record for this host Web View is still non-terminal.
+    function viewHasNonTerminalDownloads(view) {
+        if (!view)
+            return false
+        for (let i = 0; i < downloadModel.length; ++i) {
+            const record = downloadModel[i]
+            if (!record || record.originatingView !== view)
+                continue
+            // Read state via isTerminalState — isTerminal can lag behind
+            // onStateChanged when called from a terminalReached handler.
+            if (record.isTerminalState) {
+                if (!record.isTerminalState(record.state))
+                    return true
+            } else if (!record.isTerminal) {
+                return true
+            }
+        }
+        return false
+    }
+
+    function _maybeEmitViewDownloadsCleared(view) {
+        if (!view)
+            return
+        if (!root.viewHasNonTerminalDownloads(view))
+            root.viewDownloadsCleared(view)
+    }
+
+    /// Remove a Record from the Download Pill strip only (History / downloadModel unchanged).
+    function dismissRecordFromStrip(record) {
+        if (!record)
+            return
+        for (let i = 0; i < downloadStripModel.length; ++i) {
+            if (downloadStripModel[i] === record) {
+                const next = downloadStripModel.slice()
+                next.splice(i, 1)
+                downloadStripModel = next
+                return
+            }
+        }
+    }
+
+    function clearDownloadStrip() {
+        downloadStripModel = []
+    }
+
+    function openRecord(record) {
+        if (!record || record.missingFile)
+            return
+        Qt.openUrlExternally(UrlUtils.urlFromUserInput(record.targetPath))
+    }
+
+    function openDirectoryForRecord(record) {
+        if (!record || !canShowInFolder(record))
+            return
+        // Prefer the file path so desktop can reveal/select it; Android opens
+        // the system Downloads UI and ignores the path.
+        const path = record.targetPath || record.downloadDirectory
+        if (!path)
+            return
+        if (root.platform && root.platform.showInFolder)
+            root.platform.showInFolder(path)
+    }
+
+    /// Lazy Missing File probe for Completed Records (list shown / app foreground).
+    function refreshMissingFiles() {
+        for (let i = 0; i < downloadModel.length; ++i) {
+            const record = downloadModel[i]
+            if (!record)
+                continue
+            if (record.state !== AbstractWebView.DownloadState.DownloadCompleted) {
+                record.missingFile = false
+                continue
+            }
+            const path = record.targetPath
+            record.missingFile = !(path && root.platform && root.platform.fileExists
+                                   && root.platform.fileExists(path))
+        }
+    }
+
+    function canRetryFromMenu(record) {
+        if (!record || record.isInline)
+            return false
+        return record.state === AbstractWebView.DownloadState.DownloadInterrupted
+            || record.state === AbstractWebView.DownloadState.DownloadCancelled
+    }
+
+    function canRetryFromTap(record) {
+        if (!record || record.isInline)
+            return false
+        return record.state === AbstractWebView.DownloadState.DownloadInterrupted
+    }
+
+    function canShareFile(record) {
+        if (!record || record.missingFile)
+            return false
+        return record.state === AbstractWebView.DownloadState.DownloadCompleted
+            && !!record.targetPath
+    }
+
+    function canShowInFolder(record) {
+        if (!root.platform || !root.platform.showInFolderSupported || !record || record.missingFile)
+            return false
+        return record.state === AbstractWebView.DownloadState.DownloadCompleted
+            && !!record.targetPath
+    }
+
+    function canShareUrl(record) {
+        return !!record && sourceUrlString(record).length > 0
+    }
+
+    function sourceUrlString(record) {
+        if (!record || record.url === undefined || record.url === null)
+            return ""
+        return String(record.url)
+    }
+
+    /// Mobile: system share sheet. Desktop: copy the Download Target path.
+    function shareFile(record) {
+        if (!canShareFile(record))
+            return false
+        const path = record.targetPath
+        if (root.platform.preferShareSheet) {
+            if (root.platform.sharePaths)
+                root.platform.sharePaths([path])
+        } else if (root.platform.copyText) {
+            root.platform.copyText(path)
+        }
+        return true
+    }
+
+    /// Mobile: system share sheet. Desktop: copy the source URL.
+    function shareUrl(record) {
+        return shareUrlString(sourceUrlString(record))
+    }
+
+    /// Same share-vs-copy policy for a raw URL (link long-press menu).
+    function shareUrlString(url) {
+        const text = String(url || "")
+        if (!text)
+            return false
+        if (root.platform.preferShareSheet) {
+            if (root.platform.shareText)
+                root.platform.shareText(text)
+        } else if (root.platform.copyText) {
+            root.platform.copyText(text)
+        }
+        return true
+    }
+
+    // Formatting (elideFileName) lives in
+    // webview/DownloadFormatUtils.js — pure functions, imported by the pill.
+
+    /// Sanitize a suggested file name and resolve a free Download Target under downloadsDirectory.
+    /// Collisions with existing files or in-session Records get "(1)", "(2)", … suffixes.
+    function _resolveDownloadTarget(suggestedFileName) {
+        const dir = root.downloadsDirectory.replace(/[/\\]+$/, "")
+        if (root.platform && root.platform.ensureDirectory)
+            root.platform.ensureDirectory(dir)
+
+        let name = String(suggestedFileName || "").trim()
+        if (!name)
+            name = "download.bin"
+        name = name.replace(/[\\/]/g, "_")
+
+        let candidate = _joinPath(dir, name)
+        let n = 1
+        while (_pathTaken(candidate)) {
+            candidate = _joinPath(dir, _withCollisionSuffix(name, n))
+            n += 1
+            if (n > 1000)
+                break
+        }
+        return candidate
+    }
+
+    /// Accept the live Backend download into a resolved Download Target and update the Record.
+    /// Mobile-shaped: accept(path). WebEngine-shaped: set downloadDirectory/fileName then accept().
+    function acceptLiveDownload(download, record) {
+        if (!download)
+            return ""
+
+        const suggested = download.suggestedFileName || download.downloadFileName || "download.bin"
+        const target = _resolveDownloadTarget(suggested)
+        const parts = _splitPath(target)
+
+        if (record) {
+            record.downloadDirectory = parts.dir
+            record.fileName = parts.fileName
+        }
+
+        if (download.downloadDirectory !== undefined) {
+            // WebEngineDownloadRequest
+            download.downloadDirectory = parts.dir
+            download.downloadFileName = parts.fileName
+            download.accept()
+        } else {
+            // MobileWebViewDownload
+            download.accept(target)
+        }
+
+        if (record)
+            record.syncFromLive()
+
+        return target
+    }
+
+    function scheduleSaveDownloadHistory() {
+        if (!preferencesStore)
+            return
+        if (historySaveDebounceMs <= 0) {
+            saveDownloadHistoryNow()
+            return
+        }
+        _historySaveTimer.restart()
+    }
+
+    function saveDownloadHistoryNow() {
+        if (!preferencesStore || !preferencesStore.setDownloadHistoryRaw)
+            return
+
+        let persistable = []
+        for (let i = 0; i < downloadModel.length; ++i) {
+            const record = downloadModel[i]
+            if (!record || record.offTheRecord)
+                continue
+            persistable.push(serializeRecord(record))
+        }
+        if (persistable.length > historyCap)
+            persistable = persistable.slice(persistable.length - historyCap)
+
+        preferencesStore.setDownloadHistoryRaw(JSON.stringify(persistable))
+    }
+
+    function restoreDownloadHistory() {
+        if (!preferencesStore || !preferencesStore.getDownloadHistoryRaw)
+            return
+
+        const raw = preferencesStore.getDownloadHistoryRaw()
+        if (!raw)
+            return
+
+        let parsed = []
+        try {
+            parsed = JSON.parse(raw)
+        } catch (e) {
+            console.warn("DownloadsStore: invalid Download History JSON")
+            return
+        }
+        if (!Array.isArray(parsed))
+            return
+
+        const component = Qt.createComponent(_downloadRecordUrl)
+        if (component.status !== Component.Ready) {
+            console.error("DownloadsStore: failed to load DownloadRecord:", component.errorString())
+            return
+        }
+
+        const restored = []
+        for (let i = 0; i < parsed.length; ++i) {
+            const dto = parsed[i]
+            if (!dto)
+                continue
+            const record = component.createObject(root)
+            applyDto(record, dto)
+            if (!record.isTerminal) {
+                record.state = AbstractWebView.DownloadState.DownloadInterrupted
+                record.isPaused = false
+            }
+            record.terminalReached.connect(function() {
+                root.scheduleSaveDownloadHistory()
+            })
+            restored.push(record)
+        }
+
+        // Restore replaces the list; dropped Records die unless still running.
+        const kept = []
+        for (let i = 0; i < downloadModel.length; ++i) {
+            const previous = downloadModel[i]
+            if (previous && !root._destroyRecord(previous))
+                kept.push(previous)
+        }
+        downloadModel = restored.concat(kept)
+        enforceHistoryCap()
+    }
+
+    /// Destroy a Record: as createObject(root) children they outlive removal
+    /// from downloadModel. Returns false for one still driving a Download.
+    function _destroyRecord(record) {
+        if (!record || !record.isTerminal)
+            return false
+        dismissRecordFromStrip(record)
+        record.detach()
+        record.destroy()
+        return true
+    }
+
+    /// Clear Download History Records only — files on disk are left alone (ADR 0006).
+    function clearDownloadHistory() {
+        // Non-terminal Records stay — they still drive a Retained View (§6).
+        const kept = []
+        for (let i = 0; i < downloadModel.length; ++i) {
+            const record = downloadModel[i]
+            if (record && !root._destroyRecord(record))
+                kept.push(record)
+        }
+        downloadModel = kept
+        downloadStripModel = []
+        if (preferencesStore && preferencesStore.clearDownloadHistoryRaw)
+            preferencesStore.clearDownloadHistoryRaw()
+        else if (preferencesStore && preferencesStore.setDownloadHistoryRaw)
+            preferencesStore.setDownloadHistoryRaw("[]")
+    }
+
+    function enforceHistoryCap() {
+        // Only terminal Records are evictable — a running Download keeps its Record.
+        let persistableIndexes = []
+        for (let i = 0; i < downloadModel.length; ++i) {
+            const record = downloadModel[i]
+            if (record && !record.offTheRecord && record.isTerminal)
+                persistableIndexes.push(i)
+        }
+        if (persistableIndexes.length <= historyCap)
+            return
+
+        const removeCount = persistableIndexes.length - historyCap
+        const drop = {}
+        for (let r = 0; r < removeCount; ++r)
+            drop[persistableIndexes[r]] = true
+
+        const next = []
+        for (let i = 0; i < downloadModel.length; ++i) {
+            if (drop[i])
+                root._destroyRecord(downloadModel[i])
+            else
+                next.push(downloadModel[i])
+        }
+        downloadModel = next
+    }
+
+    function serializeRecord(record) {
+        return {
+            url: String(record.url || ""),
+            fileName: record.fileName || "",
+            downloadDirectory: record.downloadDirectory || "",
+            mimeType: record.mimeType || "",
+            isInline: !!record.isInline,
+            startTime: record.startTime instanceof Date
+                       ? record.startTime.toISOString()
+                       : String(record.startTime || ""),
+            state: record.state,
+            totalBytes: record.totalBytes,
+            errorString: record.errorString || ""
+            // receivedBytes intentionally omitted — progress is never persisted
+        }
+    }
+
+    function applyDto(record, dto) {
+        record.url = dto.url || ""
+        record.fileName = dto.fileName || ""
+        record.downloadDirectory = dto.downloadDirectory || ""
+        record.mimeType = dto.mimeType || ""
+        record.isInline = !!dto.isInline
+        record.startTime = dto.startTime ? new Date(dto.startTime) : new Date()
+        record.state = dto.state !== undefined
+                      ? dto.state
+                      : AbstractWebView.DownloadState.DownloadInterrupted
+        record.totalBytes = dto.totalBytes !== undefined ? dto.totalBytes : -1
+        record.errorString = dto.errorString || ""
+        record.receivedBytes = 0
+        record.isPaused = false
+        record.offTheRecord = false
+        record.liveDownload = null
+    }
+
+    function _pathTaken(path) {
+        if (root.platform && root.platform.fileExists && root.platform.fileExists(path))
+            return true
+        for (let i = 0; i < downloadModel.length; ++i) {
+            const record = downloadModel[i]
+            if (record && record.targetPath === path)
+                return true
+        }
+        return false
+    }
+
+    function _joinPath(dir, fileName) {
+        if (!dir)
+            return fileName
+        if (dir.endsWith("/") || dir.endsWith("\\"))
+            return dir + fileName
+        return dir + "/" + fileName
+    }
+
+    function _splitPath(path) {
+        const s = String(path)
+        const slash = Math.max(s.lastIndexOf("/"), s.lastIndexOf("\\"))
+        if (slash < 0)
+            return { dir: "", fileName: s }
+        return { dir: s.substring(0, slash), fileName: s.substring(slash + 1) }
+    }
+
+    function _withCollisionSuffix(fileName, n) {
+        const dot = fileName.lastIndexOf(".")
+        if (dot <= 0)
+            return fileName + " (" + n + ")"
+        return fileName.substring(0, dot) + " (" + n + ")" + fileName.substring(dot)
     }
 }

--- a/ui/app/AppLayouts/Browser/stores/qmldir
+++ b/ui/app/AppLayouts/Browser/stores/qmldir
@@ -3,4 +3,5 @@ BrowserWalletStore 1.0 BrowserWalletStore.qml
 BrowserActivityStore 1.0 BrowserActivityStore.qml
 BookmarksStore 1.0 BookmarksStore.qml
 DownloadsStore 1.0 DownloadsStore.qml
+DownloadRecord 1.0 DownloadRecord.qml
 BrowserPreferencesStore 1.0 BrowserPreferencesStore.qml

--- a/ui/app/AppLayouts/Browser/webview/BrowserDownloadOpenContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserDownloadOpenContext.qml
@@ -1,0 +1,198 @@
+import QtCore
+import QtQuick
+
+import StatusQ
+import StatusQ.Core
+import StatusQ.Internal
+
+import utils
+
+import AppLayouts.Browser.adapters
+
+import "DownloadFormatUtils.js" as DownloadFormatUtils
+
+/**
+ * The open-a-downloaded-file seam (ADR 0006 §8): one place that knows which
+ * Download Records our Backends can render and how the player page for local
+ * media is assembled. Which file:// URLs may be reached is not decided here —
+ * the Backend owns that policy (see ProfileManager / browserprofileutils.cpp).
+ *
+ * Composed inside BrowserDownloadsContext. Dependencies are narrow injected
+ * functions — never a store reference; supportsPdf (a Backend Capability) is
+ * a plain per-call input.
+ *
+ * openInBrowser() makes the open-route choice: a generated player page for
+ * media, a direct navigation for everything else, both via openUrlFn. A false
+ * return means "not renderable here" — the caller hands the file to the OS.
+ */
+QtObject {
+    id: root
+
+    /// Opens a URL in the browser; injected by the owner.
+    property var openUrlFn: function(url) {
+        console.warn("BrowserDownloadOpenContext: openUrlFn not set")
+    }
+
+    // Text file writer; production uses StringUtils, tests inject a fake.
+    property var writeTextFileFn: function(path, data) {
+        return StringUtils.writeTextFile(path, data)
+    }
+
+    // Text file reader; reads qrc: and file: alike. Tests inject a fake.
+    property var readTextFileFn: function(path) {
+        return StringUtils.readTextFile(path)
+    }
+
+    // Directory create; injectable so Storybook/unit tests need not stub SystemUtils.
+    property var ensureDirectoryFn: function(path) {
+        return SystemUtils.ensureDirectory(path)
+    }
+
+    // Backend Capability, not a platform check. Injectable for QML tests.
+    property bool inBrowserMediaPlaybackSupported:
+        BrowserBackendCapabilities.inPageMediaPlaybackSupported
+
+    // Player pages for downloaded media (see mediaPlayerPageUrl); temp, disposable.
+    // The subdirectory name is also an allowed root of the Backend's local-browsing
+    // policy — keep in sync with kMediaPlayerDirName in browserprofileutils.cpp.
+    property string mediaPlayerDirectory: {
+        const loc = StandardPaths.writableLocation(StandardPaths.TempLocation)
+        return loc ? String(loc).replace("file://", "").replace(/[/\\]+$/, "") + "/status-browser-player" : ""
+    }
+
+    // Player page assets, substituted and inlined by _mediaPlayerHtml.
+    readonly property url mediaPlayerTemplateUrl:
+        Qt.resolvedUrl("player/media_player.html")
+    readonly property url mediaPlayerScriptUrl:
+        Qt.resolvedUrl("player/media_player.js")
+
+    property string _mediaPlayerTemplateCache: ""
+
+    /// Open-in-Browser gate for a Record: Completed, still on disk, and a type
+    /// on the shared allowlist (DownloadFormatUtils / ADR 0006 §8). supportsPdf
+    /// is the Backend Capability, evaluated by the caller at call time.
+    function canOpenInBrowser(record, supportsPdf) {
+        if (!record || record.missingFile)
+            return false
+        if (record.state !== AbstractWebView.DownloadState.DownloadCompleted)
+            return false
+        return DownloadFormatUtils.canOpenInBrowser(
+                    record.mimeType, record.fileName, supportsPdf,
+                    root.inBrowserMediaPlaybackSupported)
+    }
+
+    /// The in-browser open route, or false for the OS handoff.
+    /// Media goes through a player page: navigating to local audio/video makes
+    /// WebEngine download it again instead of playing it. No page, no
+    /// in-browser route.
+    function openInBrowser(record, supportsPdf) {
+        if (!canOpenInBrowser(record, supportsPdf))
+            return false
+        const path = record.targetPath
+        if (!path)
+            return false
+
+        if (DownloadFormatUtils.isPlayableMedia(record.mimeType, record.fileName)) {
+            const page = mediaPlayerPageUrl(record)
+            if (!page)
+                return false
+            root.openUrlFn(page)
+            return true
+        }
+
+        root.openUrlFn(UrlUtils.urlFromUserInput(path))
+        return true
+    }
+
+    /// Write (and reuse) a player page for a downloaded media Record and return its
+    /// file URL, or "" when it cannot be written.
+    ///
+    /// A top-level navigation to local audio/video is turned into a fresh Download by
+    /// WebEngine (net::ERR_ABORTED), which re-saves the file as "name (1)" instead of
+    /// playing it. The same file inside a file:// page plays fine, so we hand the tab
+    /// a one-element page instead of the media itself.
+    function mediaPlayerPageUrl(record) {
+        if (!record || record.missingFile
+                || !DownloadFormatUtils.isPlayableMedia(record.mimeType, record.fileName))
+            return ""
+        const path = String(record.targetPath || "")
+        if (!path)
+            return ""
+
+        const dir = root.mediaPlayerDirectory
+        if (!dir)
+            return ""
+        if (root.ensureDirectoryFn)
+            root.ensureDirectoryFn(dir)
+
+        const html = _mediaPlayerHtml(record, path)
+        if (!html)
+            return ""
+
+        // One page per target path: replaying a file reuses it instead of piling up.
+        const pagePath = _joinPath(dir, "player-" + _pathKey(path) + ".html")
+        if (!root.writeTextFileFn(pagePath, html))
+            return ""
+        return UrlUtils.urlFromUserInput(pagePath)
+    }
+
+    /// media_player.html with its placeholders filled in, or "" when the asset is
+    /// unreadable. Function replacements throughout: a file name may contain "$&".
+    function _mediaPlayerHtml(record, path) {
+        const template = _mediaPlayerTemplate()
+        if (!template)
+            return ""
+
+        const tag = DownloadFormatUtils.isVideoMedia(record.mimeType, record.fileName)
+                    ? "video" : "audio"
+        const name = StringUtils.escapeHtml(String(record.fileName || ""))
+        // Every path segment is percent-encoded, so the src carries no quote to escape.
+        const src = _fileUrlForPage(path)
+        const failed = StringUtils.escapeHtml(
+                         qsTr("This file cannot be played here. Open it with another app."))
+
+        return template
+            .replace(/__TAG__/g, () => tag)
+            .replace(/__SRC__/g, () => src)
+            .replace(/__NAME__/g, () => name)
+            .replace(/__FAILED__/g, () => failed)
+    }
+
+    /// media_player.html with media_player.js inlined, read once per session.
+    /// One page beats a page plus a sibling script copied into the temp directory.
+    function _mediaPlayerTemplate() {
+        if (root._mediaPlayerTemplateCache)
+            return root._mediaPlayerTemplateCache
+
+        const html = String(root.readTextFileFn(root.mediaPlayerTemplateUrl) || "")
+        if (!html)
+            return ""
+        const script = String(root.readTextFileFn(root.mediaPlayerScriptUrl) || "")
+        root._mediaPlayerTemplateCache = html.replace(/__SCRIPT__/g, () => script)
+        return root._mediaPlayerTemplateCache
+    }
+
+    /// Absolute path → file URL safe to inline in HTML. Drive letters keep their colon
+    /// so Windows targets stay valid ("C:/x" → "file:///C:/x").
+    function _fileUrlForPage(path) {
+        const encoded = String(path).replace(/\\/g, "/").split("/")
+            .map(segment => /^[A-Za-z]:$/.test(segment) ? segment : encodeURIComponent(segment))
+            .join("/")
+        return encoded.startsWith("/") ? "file://" + encoded : "file:///" + encoded
+    }
+
+    function _pathKey(path) {
+        let hash = 5381
+        for (let i = 0; i < path.length; ++i)
+            hash = ((hash << 5) + hash + path.charCodeAt(i)) >>> 0
+        return hash.toString(16)
+    }
+
+    function _joinPath(dir, fileName) {
+        if (!dir)
+            return fileName
+        if (dir.endsWith("/") || dir.endsWith("\\"))
+            return dir + fileName
+        return dir + "/" + fileName
+    }
+}

--- a/ui/app/AppLayouts/Browser/webview/DownloadFormatUtils.js
+++ b/ui/app/AppLayouts/Browser/webview/DownloadFormatUtils.js
@@ -1,0 +1,98 @@
+.pragma library
+
+// Pure format predicates for Download Records (ADR 0006 §8).
+//
+// Every input is a plain value — (mimeType, fileName, supportsPdf, …) — with
+// no QML object access, so BrowserDownloadOpenContext and QML components can
+// share one allowlist. supportsPdf is the Backend's PDF-rendering Capability;
+// mediaPlaybackSupported is the platform's in-page playback gate. Both are
+// passed in, never probed here.
+
+/// Open-in-Browser allowlist: types our Backends render (ADR 0006 §8).
+/// Images, plain text, HTML; PDF when the Backend supports it; media per
+/// isPlayableMedia, gated by mediaPlaybackSupported (false on iOS: WebKit
+/// rejects file:// media inside a file:// player page). Everything else is
+/// handed to the OS.
+///
+/// Order matters and is behavior: a name ending in ".pdf" resolves on the
+/// PDF branch even if its MIME type would also match media.
+function canOpenInBrowser(mimeType, fileName, supportsPdf, mediaPlaybackSupported = true) {
+    const mime = String(mimeType || "").toLowerCase()
+    const name = String(fileName || "").toLowerCase()
+
+    if (mime.startsWith("image/") || /\.(png|jpe?g|gif|webp|bmp|svg)$/.test(name))
+        return true
+    if (mime === "text/plain" || mime === "text/html" || mime === "application/xhtml+xml"
+            || /\.(txt|html?|xhtml)$/.test(name))
+        return true
+    if (mime === "application/pdf" || name.endsWith(".pdf"))
+        return !!supportsPdf
+    return !!mediaPlaybackSupported && isPlayableMedia(mimeType, fileName)
+}
+
+/// Media our Backends can decode — and only inside a page (WebEngine turns a
+/// top-level navigation to local media into a fresh Download instead of
+/// playing it; see BrowserDownloadOpenContext.mediaPlayerPageUrl).
+///
+/// MP4/M4A/AAC are deliberately absent: the shipped Chromium is built without
+/// proprietary codecs (a WebEngine build quirk), so H.264/AAC fail with
+/// DEMUXER_ERROR_NO_SUPPORTED_STREAMS and would leave the user staring at a
+/// dead player. They go to the OS instead, as do Ogg and Matroska. Revisit if
+/// the build ever gains those codecs.
+function isPlayableMedia(mimeType, fileName) {
+    const mime = String(mimeType || "").toLowerCase()
+    const name = String(fileName || "").toLowerCase()
+
+    if (mime === "audio/mpeg" || mime === "audio/mp3" || name.endsWith(".mp3"))
+        return true
+    if (mime === "audio/wav" || mime === "audio/x-wav" || mime === "audio/wave"
+            || name.endsWith(".wav"))
+        return true
+    if (mime === "video/webm" || mime === "audio/webm" || name.endsWith(".webm"))
+        return true
+    return false
+}
+
+/// Audio/video split for the player page: audio/* is never video; video/* and
+/// bare ".webm" get a <video> element (WebEngine renders webm video there,
+/// and an audio-only webm still plays in a <video> tag).
+function isVideoMedia(mimeType, fileName) {
+    const mime = String(mimeType || "").toLowerCase()
+    const name = String(fileName || "").toLowerCase()
+    if (mime.startsWith("audio/"))
+        return false
+    return mime.startsWith("video/") || name.endsWith(".webm")
+}
+
+/// Middle-elide the base name, then keep the extension (pill + list).
+function elideFileName(fileName, maxLength) {
+    if (!fileName)
+        return ""
+    const s = String(fileName)
+    const limit = Number(maxLength)
+    if (!(limit > 0) || s.length <= limit)
+        return s
+
+    const lastDot = s.lastIndexOf(".")
+    if (lastDot <= 0) {
+        if (limit <= 1)
+            return "…"
+        return s.substring(0, limit - 1) + "…"
+    }
+
+    const ext = s.substring(lastDot)
+    const base = s.substring(0, lastDot)
+    const budget = limit - ext.length
+    if (budget <= 1) {
+        if (ext.length >= limit)
+            return s.substring(0, Math.max(0, limit - 1)) + "…"
+        return "…" + ext
+    }
+    if (base.length <= budget)
+        return base + ext
+
+    const keep = budget - 1
+    const head = Math.ceil(keep / 2)
+    const tail = Math.floor(keep / 2)
+    return base.substring(0, head) + "…" + base.substring(base.length - tail) + ext
+}

--- a/ui/app/AppLayouts/Browser/webview/player/media_player.html
+++ b/ui/app/AppLayouts/Browser/webview/player/media_player.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<!--
+  Player page for a downloaded media Record
+  (BrowserDownloadOpenContext.mediaPlayerPageUrl).
+  Navigating a tab straight to local audio/video makes WebEngine download the file
+  again instead of playing it, so the Record is handed this page instead.
+
+  BrowserDownloadOpenContext._mediaPlayerHtml fills in the dunder placeholders below (TAG is
+  video or audio, SRC the percent-encoded file URL, NAME the escaped file name,
+  FAILED the escaped message, SCRIPT the contents of media_player.js). Do not
+  spell those tokens out here — this comment is substituted too.
+-->
+<html>
+<head>
+<meta charset="utf-8">
+<title>__NAME__</title>
+<style>
+  /* Only body is the flex container: making html one too shrinks body to its
+     content width, and the media control collapses along with it. */
+  html, body {
+    margin: 0;
+    height: 100%;
+    background: #000;
+    color: #fff;
+    font: 14px -apple-system, system-ui, sans-serif;
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+  }
+
+  #name {
+    max-width: 90%;
+    opacity: 0.7;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  video {
+    max-width: 100%;
+    max-height: 80%;
+  }
+
+  /* Chromium falls back to a collapsed control below ~250px. */
+  audio {
+    width: min(90%, 520px);
+  }
+</style>
+</head>
+<body>
+  <div id="name">__NAME__</div>
+  <__TAG__ id="media" src="__SRC__" controls autoplay></__TAG__>
+  <div id="failed" hidden>__FAILED__</div>
+  <script>__SCRIPT__</script>
+</body>
+</html>

--- a/ui/app/AppLayouts/Browser/webview/player/media_player.js
+++ b/ui/app/AppLayouts/Browser/webview/player/media_player.js
@@ -1,0 +1,19 @@
+// Media page behaviour for media_player.html.
+//
+// Playback itself needs no script — the element is rendered with `controls`, so
+// the page still works with JavaScript disabled. This only replaces a control
+// that cannot decode its source with a readable line: BrowserDownloadOpenContext
+// keeps undecodable types off the in-browser route, but a truncated or
+// mislabelled file still reaches us.
+
+(function () {
+    var media = document.getElementById("media")
+    var failed = document.getElementById("failed")
+    if (!media || !failed)
+        return
+
+    media.addEventListener("error", function () {
+        media.hidden = true
+        failed.hidden = false
+    })
+})()

--- a/ui/app/AppLayouts/Browser/webview/qmldir
+++ b/ui/app/AppLayouts/Browser/webview/qmldir
@@ -3,6 +3,8 @@ BrowserSavedSessionContext 1.0 BrowserSavedSessionContext.qml
 BrowserOverlayContext 1.0 BrowserOverlayContext.qml
 BrowserFavoritesContext 1.0 BrowserFavoritesContext.qml
 BrowserDialogsContext 1.0 BrowserDialogsContext.qml
+BrowserDownloadOpenContext 1.0 BrowserDownloadOpenContext.qml
 BrowserDownloadsContext 1.0 BrowserDownloadsContext.qml
+DownloadFormatUtils 1.0 DownloadFormatUtils.js
 SnapshotPersister 1.0 SnapshotPersister.qml
 BrowserSessionUtils 1.0 BrowserSessionUtils.js

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2485,6 +2485,13 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     </message>
 </context>
 <context>
+    <name>BrowserDownloadOpenContext</name>
+    <message>
+        <source>This file cannot be played here. Open it with another app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserLandscapeToolbar</name>
     <message>
         <source>Back</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2494,6 +2494,13 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
     </message>
 </context>
 <context>
+    <name>BrowserDownloadOpenContext</name>
+    <message>
+        <source>This file cannot be played here. Open it with another app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserLandscapeToolbar</name>
     <message>
         <source>Back</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2486,6 +2486,13 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
     </message>
 </context>
 <context>
+    <name>BrowserDownloadOpenContext</name>
+    <message>
+        <source>This file cannot be played here. Open it with another app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserLandscapeToolbar</name>
     <message>
         <source>Back</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2477,6 +2477,13 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     </message>
 </context>
 <context>
+    <name>BrowserDownloadOpenContext</name>
+    <message>
+        <source>This file cannot be played here. Open it with another app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserLandscapeToolbar</name>
     <message>
         <source>Back</source>

--- a/ui/imports/utils/BrowserPreferenceKeys.qml
+++ b/ui/imports/utils/BrowserPreferenceKeys.qml
@@ -5,7 +5,9 @@ import QtQuick
 QtObject {
     readonly property string snapshotsCategory: "BrowserSnapshots"
     readonly property string settingsCategory: "BrowserSettings"
+    readonly property string downloadsHistoryCategory: "BrowserDownloadsHistory"
     readonly property string keyOpenTabs: "openTabs"
     readonly property string keyCurrentTabIndex: "currentTabIndex"
     readonly property string keyRestoreOpenTabs: "restoreOpenTabs"
+    readonly property string keyDownloadRecords: "records"
 }

--- a/ui/imports/utils/BrowserPreferencesStoreBase.qml
+++ b/ui/imports/utils/BrowserPreferencesStoreBase.qml
@@ -90,4 +90,19 @@ QtObject {
         snapshotsCache = nextCache
         purge(BrowserPreferenceKeys.snapshotsCategory, list)
     }
+
+    function getDownloadHistoryRaw() {
+        return get(BrowserPreferenceKeys.downloadsHistoryCategory,
+                   BrowserPreferenceKeys.keyDownloadRecords)
+    }
+
+    function setDownloadHistoryRaw(raw) {
+        put(BrowserPreferenceKeys.downloadsHistoryCategory,
+            BrowserPreferenceKeys.keyDownloadRecords,
+            raw || "[]")
+    }
+
+    function clearDownloadHistoryRaw() {
+        setDownloadHistoryRaw("[]")
+    }
 }


### PR DESCRIPTION
Downloads domain: Records, history, and the open seam (ADR 0006):

* `DownloadRecord` — host-side identity of one download, outlives the Backend object
* `DownloadsStore` — auto-accept into the OS Downloads folder, "(1)" collision suffixes, capped persisted history (never Incognito)
* One injected `platform` object for all system calls (share, clipboard, show-in-folder)
* `BrowserDownloadOpenContext` — how a finished file opens: in browser / generated player page for audio-video / OS handoff; local-file guard exception
* `DownloadFormatUtils` — file-name eliding and status wording in one place
* ADR 0006 + Browser CONTEXT glossary
* Tests: tst_DownloadsStore, tst_BrowserDownloadOpenContext

App-inert until PR 5/5. Part of #21376