### PR TITLE
feat(browser): downloads context [3/5]

### DIFF
--- a/storybook/qmlTests/tests/tst_BrowserDisconnectDapp.qml
+++ b/storybook/qmlTests/tests/tst_BrowserDisconnectDapp.qml
@@ -76,7 +76,6 @@ Item {
             property int currentIndex: 0
             readonly property int count: 2
             function createEmptyTab() {}
-            function createDownloadTab() {}
             function removeTab() {}
         }
     }
@@ -88,7 +87,6 @@ Item {
             property int currentIndex: 0
             readonly property int count: 1
             function createEmptyTab() {}
-            function createDownloadTab() {}
             function removeTab() {}
         }
     }
@@ -126,6 +124,7 @@ Item {
             downloadsStore: QtObject {}
             determineRealURLFn: function(url) { return url }
             downloadRequestHandler: function() {}
+            linkLongPressHandler: function() {}
             sslErrorHandler: function() {}
             jsDialogHandler: function() {}
             findTextFinishedHandler: function() {}

--- a/storybook/qmlTests/tests/tst_BrowserDownloadsContext.qml
+++ b/storybook/qmlTests/tests/tst_BrowserDownloadsContext.qml
@@ -1,0 +1,709 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Browser.adapters
+import AppLayouts.Browser.stores as BrowserStores
+import AppLayouts.Browser.webview
+
+/**
+ * BrowserDownloadsContext orchestration:
+ * Find in page XOR Download Pill strip on mobile.
+ * Uses the typed DownloadsStore stub (Storybook import path) with a minimal
+ * session strip API — same pattern as BrowserLayoutPage.
+ */
+Item {
+    id: root
+    width: 400
+    height: 400
+
+    readonly property url downloadsContextUrl: Qt.resolvedUrl(
+        "../../../ui/app/AppLayouts/Browser/webview/BrowserDownloadsContext.qml")
+
+    Component {
+        id: mockStoreComponent
+
+        BrowserStores.DownloadsStore {
+            property var downloadModel: []
+            property var downloadStripModel: []
+            property int openRecordCalls: 0
+            // false → mediaPlayerPageUrl fails, as when the temp page cannot be written.
+            property bool playerPageWritable: true
+            property var lastOpenedRecord: null
+            property int dismissCalls: 0
+
+            function addDownload(download, hostView) {
+                const record = {
+                    url: download ? download.url : "",
+                    fileName: download ? (download.downloadFileName || download.suggestedFileName || "") : "",
+                    mimeType: download ? (download.mimeType || "") : "",
+                    state: download ? download.state : 0,
+                    originatingView: hostView || (download ? download.view : null),
+                    offTheRecord: !!(hostView && hostView.offTheRecord),
+                    isInline: false,
+                    missingFile: false,
+                    targetPath: download && download.targetPath
+                                ? download.targetPath
+                                : "/tmp/downloads/" + (download ? (download.downloadFileName || "file.bin") : "file.bin"),
+                    isTerminal: false,
+                    liveDownload: download || null
+                }
+                downloadModel = downloadModel.concat([record])
+                downloadStripModel = [record].concat(downloadStripModel)
+                return record
+            }
+            function reattachForRetry(record, download, hostView) {
+                if (!record || !download)
+                    return null
+                record.url = download.url
+                record.fileName = download.downloadFileName || download.suggestedFileName || record.fileName
+                record.mimeType = download.mimeType || record.mimeType
+                record.state = download.state
+                record.missingFile = false
+                record.errorString = ""
+                record.liveDownload = download
+                record.originatingView = hostView || download.view || record.originatingView
+                const rest = []
+                for (let i = 0; i < downloadModel.length; ++i) {
+                    if (downloadModel[i] !== record)
+                        rest.push(downloadModel[i])
+                }
+                downloadModel = rest.concat([record])
+                dismissRecordFromStrip(record)
+                downloadStripModel = [record].concat(downloadStripModel)
+                return record
+            }
+            function acceptLiveDownload(download, record) {}
+            function clearDownloadStrip() { downloadStripModel = [] }
+            // The one platform seam facts capabilitiesFor composes.
+            property var platform: ({
+                preferShareSheet: true,
+                showInFolderSupported: false
+            })
+            function canShareFile(record) {
+                if (!record || record.missingFile)
+                    return false
+                return record.state === AbstractWebView.DownloadState.DownloadCompleted
+                    && !!record.targetPath
+            }
+            function canShareUrl(record) {
+                return !!record && sourceUrlString(record).length > 0
+            }
+            function canShowInFolder(record) {
+                if (!platform.showInFolderSupported || !record || record.missingFile)
+                    return false
+                return record.state === AbstractWebView.DownloadState.DownloadCompleted
+                    && !!record.targetPath
+            }
+            function canRetryFromMenu(record) {
+                if (!record || record.isInline)
+                    return false
+                return record.state === AbstractWebView.DownloadState.DownloadInterrupted
+                    || record.state === AbstractWebView.DownloadState.DownloadCancelled
+            }
+            function canRetryFromTap(record) {
+                if (!record || record.isInline)
+                    return false
+                return record.state === AbstractWebView.DownloadState.DownloadInterrupted
+            }
+            function sourceUrlString(record) {
+                return record && record.url ? String(record.url) : ""
+            }
+            // Counter lives inside a var object: in-place mutation emits no
+            // change signal, so counting from inside a capabilities binding
+            // cannot invalidate that same binding (no read-write loop).
+            readonly property var refreshStats: ({ calls: 0 })
+            function refreshMissingFiles() { refreshStats.calls += 1 }
+            function openRecord(record) {
+                openRecordCalls += 1
+                lastOpenedRecord = record
+            }
+            function dismissRecordFromStrip(record) {
+                dismissCalls += 1
+                const next = []
+                for (let i = 0; i < downloadStripModel.length; ++i) {
+                    if (downloadStripModel[i] !== record)
+                        next.push(downloadStripModel[i])
+                }
+                downloadStripModel = next
+            }
+        }
+    }
+
+    Component {
+        id: fakeDownloadComponent
+
+        QtObject {
+            property url url: "https://example.com/report.pdf"
+            property string downloadFileName: "report.pdf"
+            property string suggestedFileName: downloadFileName
+            property string mimeType: "application/pdf"
+            property string targetPath: ""
+            property int state: AbstractWebView.DownloadState.DownloadRequested
+            property var view: null
+        }
+    }
+
+    Component {
+        id: fakeTabComponent
+
+        QtObject {
+            // htmlPageLoaded/title stay on the stub on purpose: the close path must
+            // read pristinePopup only, so the tests can vary them freely.
+            property bool htmlPageLoaded: false
+            property string title: ""
+            property bool pristinePopup: false
+            property bool offTheRecord: false
+            property bool retained: false
+            property int downloadUrlCalls: 0
+            property string lastDownloadUrl: ""
+            property string lastSuggestedName: ""
+
+            function downloadUrl(url, suggestedFileName) {
+                downloadUrlCalls += 1
+                lastDownloadUrl = String(url)
+                lastSuggestedName = suggestedFileName || ""
+            }
+        }
+    }
+
+    Component {
+        id: fakeRecordComponent
+
+        // Notifiable Download Record stand-in — property changes must re-trigger
+        // bindings that call capabilitiesFor (the no-stale-menu guarantee).
+        QtObject {
+            property url url: "https://example.com/photo.png"
+            property string fileName: "photo.png"
+            property string mimeType: "image/png"
+            property string targetPath: "/tmp/downloads/photo.png"
+            property int state: AbstractWebView.DownloadState.DownloadInterrupted
+            property bool missingFile: false
+            property bool isInline: false
+        }
+    }
+
+    Component {
+        id: capsHolderComponent
+
+        QtObject {
+            property var record: null
+            property var caps: null
+        }
+    }
+
+    TestCase {
+        name: "BrowserDownloadsContext"
+        when: windowShown
+
+        property int findHiddenCount: 0
+        property var tabs: []
+        property var removedIndexes: []
+        property var openedUrls: []
+        property bool supportsPdf: false
+
+        function createStore() {
+            return createTemporaryObject(mockStoreComponent, root)
+        }
+
+        function createContext(store) {
+            findHiddenCount = 0
+            tabs = []
+            removedIndexes = []
+            openedUrls = []
+            supportsPdf = false
+            const component = Qt.createComponent(root.downloadsContextUrl)
+            verify(component.status === Component.Ready, component.errorString())
+            const ctx = createTemporaryObject(component, root, {
+                downloadsStore: store,
+                getWebViewFn: function(index) { return tabs[index] || null },
+                getTabsCountFn: function() { return tabs.length },
+                removeViewFn: function(index) { removedIndexes.push(index) },
+                hideFindUiFn: function() { findHiddenCount += 1 },
+                openUrlFn: function(url) { openedUrls.push(String(url)) },
+                supportsPdfFn: function() { return supportsPdf }
+            })
+            // The internal open seam runs for real; keep its filesystem side
+            // hermetic (playerPageWritable simulates a write failure).
+            ctx._openContext.mediaPlayerDirectory = "/tmp/status-player"
+            ctx._openContext.ensureDirectoryFn = function(path) { return true }
+            ctx._openContext.writeTextFileFn = function(path, data) { return store.playerPageWritable }
+            return ctx
+        }
+
+        function test_stripHidden_whileNoSessionPills() {
+            const store = createStore()
+            const ctx = createContext(store)
+            verify(!ctx.stripVisible, "empty strip model → no strip")
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            ctx.handleDownloadRequest(live)
+            verify(ctx.stripVisible, "first download shows the strip")
+
+            store.clearDownloadStrip()
+            verify(!ctx.stripVisible, "emptying the model hides the strip by derivation")
+        }
+
+        function test_closingFind_restoresStrip_onlyWhenPillsRemain() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            ctx.handleDownloadRequest(live)
+
+            ctx.setFindOpen(true)
+            verify(!ctx.stripVisible)
+
+            ctx.setFindOpen(false)
+            verify(ctx.stripVisible)
+
+            store.clearDownloadStrip()
+            ctx.setFindOpen(true)
+            ctx.setFindOpen(false)
+            verify(!ctx.stripVisible)
+        }
+
+        function test_newDownload_hidesFind_andShowsStrip() {
+            const store = createStore()
+            const ctx = createContext(store)
+            ctx.setFindOpen(true)
+            verify(!ctx.stripVisible)
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const before = findHiddenCount
+            ctx.handleDownloadRequest(live)
+
+            verify(findHiddenCount > before,
+                   "handleDownloadRequest actively closes the open Find UI")
+            verify(ctx.stripVisible)
+            compare(store.downloadStripModel.length, 1)
+
+            // Find is treated as closed: closing it again is a no-op input.
+            ctx.setFindOpen(false)
+            verify(ctx.stripVisible)
+        }
+
+        function test_newDownload_doesNotTouchFindUi_whenFindClosed() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const before = findHiddenCount
+            ctx.handleDownloadRequest(live)
+            compare(findHiddenCount, before,
+                    "no hideFindUiFn call when Find was not open")
+        }
+
+        function test_userDismissedStrip_staysHidden_untilNewDownload() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            ctx.handleDownloadRequest(live)
+            verify(ctx.stripVisible)
+
+            ctx.dismissStrip()
+            verify(!ctx.stripVisible, "close button hides the strip while pills remain")
+
+            // A Find round-trip does not resurrect a user-dismissed strip.
+            ctx.setFindOpen(true)
+            ctx.setFindOpen(false)
+            verify(!ctx.stripVisible)
+
+            // The next download clears the dismissal and re-shows the strip.
+            const nextLive = createTemporaryObject(fakeDownloadComponent, root)
+            nextLive.url = "https://example.com/other.bin"
+            nextLive.downloadFileName = "other.bin"
+            ctx.handleDownloadRequest(nextLive)
+            verify(ctx.stripVisible)
+        }
+
+        // ADR 0006 §6 — download-only Tab auto-close uses hostView
+        function test_downloadOnlyTab_autoCloses_viaHostView() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const host = createTemporaryObject(fakeTabComponent, root)
+            host.pristinePopup = true
+            tabs = [host]
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            // No Backend download.view (mobile-shaped)
+            ctx.handleDownloadRequest(live, host)
+
+            compare(removedIndexes.length, 1)
+            compare(removedIndexes[0], 0)
+            compare(store.downloadModel[0].originatingView, host)
+        }
+
+        function test_downloadOnlyTab_doesNotAutoClose_whenPageLoaded() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const host = createTemporaryObject(fakeTabComponent, root)
+            host.pristinePopup = false
+            host.htmlPageLoaded = true
+            host.title = "Example"
+            tabs = [host]
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            ctx.handleDownloadRequest(live, host)
+
+            compare(removedIndexes.length, 0)
+        }
+
+        // A Tab doing a real navigation can raise a Download before its first
+        // title/load update — that Tab is the user's page, never download-only.
+        function test_downloadOnlyTab_doesNotAutoClose_whenNavigatingTabDownloadsBeforeTitle() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const host = createTemporaryObject(fakeTabComponent, root)
+            host.pristinePopup = false
+            host.htmlPageLoaded = false
+            host.title = ""
+            tabs = [host]
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            ctx.handleDownloadRequest(live, host)
+
+            compare(removedIndexes.length, 0, "a navigating Tab must survive its own Download")
+        }
+
+        // A download-only popup whose blank document set a title is still a popup
+        // that never committed a page — the title must not keep it open.
+        function test_downloadOnlyTab_autoCloses_whenPopupHasStrayTitle() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const host = createTemporaryObject(fakeTabComponent, root)
+            host.pristinePopup = true
+            host.title = "about:blank"
+            tabs = [host]
+
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            ctx.handleDownloadRequest(live, host)
+
+            compare(removedIndexes.length, 1, "a stray title must not keep a download-only Tab open")
+            compare(removedIndexes[0], 0)
+        }
+
+        function test_retry_requiresMatchingProfile_noFallback() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const standardTab = createTemporaryObject(fakeTabComponent, root)
+            standardTab.offTheRecord = false
+            tabs = [standardTab]
+
+            const record = {
+                url: "https://example.com/a.bin",
+                fileName: "a.bin",
+                state: AbstractWebView.DownloadState.DownloadInterrupted,
+                offTheRecord: true,
+                isInline: false
+            }
+
+            verify(!ctx.retryRecord(record))
+            compare(standardTab.downloadUrlCalls, 0)
+
+            const otrTab = createTemporaryObject(fakeTabComponent, root)
+            otrTab.offTheRecord = true
+            tabs = [standardTab, otrTab]
+            verify(ctx.retryRecord(record))
+            compare(otrTab.downloadUrlCalls, 1)
+            compare(otrTab.lastDownloadUrl, "https://example.com/a.bin")
+        }
+
+        function test_retry_skipsRetainedViews() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const retainedTab = createTemporaryObject(fakeTabComponent, root)
+            retainedTab.offTheRecord = false
+            retainedTab.retained = true
+            tabs = [retainedTab]
+
+            const record = {
+                url: "https://example.com/a.bin",
+                fileName: "a.bin",
+                state: AbstractWebView.DownloadState.DownloadInterrupted,
+                offTheRecord: false,
+                isInline: false
+            }
+
+            verify(!ctx.retryRecord(record))
+            compare(retainedTab.downloadUrlCalls, 0)
+        }
+
+        function test_retry_reattachesSameRecord_noDuplicate() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const tab = createTemporaryObject(fakeTabComponent, root)
+            tabs = [tab]
+
+            const cancelledLive = createTemporaryObject(fakeDownloadComponent, root)
+            cancelledLive.url = "https://example.com/clip.webm"
+            cancelledLive.downloadFileName = "clip.webm"
+            cancelledLive.state = AbstractWebView.DownloadState.DownloadCancelled
+            const record = store.addDownload(cancelledLive, tab)
+            record.state = AbstractWebView.DownloadState.DownloadCancelled
+            compare(store.downloadModel.length, 1)
+
+            verify(ctx.retryRecord(record))
+            compare(tab.downloadUrlCalls, 1)
+            compare(ctx._pendingRetry, record)
+
+            const retryLive = createTemporaryObject(fakeDownloadComponent, root)
+            retryLive.url = "https://example.com/clip.webm"
+            retryLive.downloadFileName = "clip.webm"
+            retryLive.state = AbstractWebView.DownloadState.DownloadInProgress
+            ctx.handleDownloadRequest(retryLive, tab)
+
+            compare(store.downloadModel.length, 1)
+            compare(store.downloadModel[0], record)
+            compare(record.liveDownload, retryLive)
+            compare(record.state, AbstractWebView.DownloadState.DownloadInProgress)
+            verify(!ctx._pendingRetry)
+            compare(store.downloadStripModel.length, 1)
+            compare(store.downloadStripModel[0], record)
+        }
+
+        function test_retry_armIsOneShot_droppedByUnrelatedRequest() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const tab = createTemporaryObject(fakeTabComponent, root)
+            tabs = [tab]
+
+            const cancelledLive = createTemporaryObject(fakeDownloadComponent, root)
+            cancelledLive.url = "https://example.com/clip.webm"
+            cancelledLive.downloadFileName = "clip.webm"
+            cancelledLive.state = AbstractWebView.DownloadState.DownloadCancelled
+            const record = store.addDownload(cancelledLive, tab)
+            record.state = AbstractWebView.DownloadState.DownloadCancelled
+
+            verify(ctx.retryRecord(record))
+            compare(ctx._pendingRetry, record)
+
+            // An unrelated download consumes the arm without matching…
+            const otherLive = createTemporaryObject(fakeDownloadComponent, root)
+            otherLive.url = "https://example.com/other.bin"
+            otherLive.downloadFileName = "other.bin"
+            ctx.handleDownloadRequest(otherLive, tab)
+            verify(!ctx._pendingRetry)
+            compare(store.downloadModel.length, 2)
+
+            // …so a later same-URL download is a fresh Record, not a reattach.
+            const laterLive = createTemporaryObject(fakeDownloadComponent, root)
+            laterLive.url = "https://example.com/clip.webm"
+            laterLive.downloadFileName = "clip.webm"
+            ctx.handleDownloadRequest(laterLive, tab)
+            compare(store.downloadModel.length, 3)
+            compare(record.state, AbstractWebView.DownloadState.DownloadCancelled)
+            verify(record.liveDownload !== laterLive)
+        }
+
+        function test_retry_armExpires_whenNoRequestArrives() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const tab = createTemporaryObject(fakeTabComponent, root)
+            tabs = [tab]
+
+            const cancelledLive = createTemporaryObject(fakeDownloadComponent, root)
+            cancelledLive.url = "https://example.com/clip.webm"
+            cancelledLive.downloadFileName = "clip.webm"
+            cancelledLive.state = AbstractWebView.DownloadState.DownloadCancelled
+            const record = store.addDownload(cancelledLive, tab)
+            record.state = AbstractWebView.DownloadState.DownloadCancelled
+
+            verify(ctx.retryRecord(record))
+            compare(ctx._pendingRetry, record)
+
+            ctx._pendingRetryExpiry.stop()
+            ctx._pendingRetryExpiry.interval = 20
+            ctx._pendingRetryExpiry.start()
+            tryVerify(() => !ctx._pendingRetry, 1000,
+                      "retry arm should expire without a matching request")
+
+            // The download that finally arrives with the same URL is new.
+            const laterLive = createTemporaryObject(fakeDownloadComponent, root)
+            laterLive.url = "https://example.com/clip.webm"
+            laterLive.downloadFileName = "clip.webm"
+            ctx.handleDownloadRequest(laterLive, tab)
+            compare(store.downloadModel.length, 2)
+            verify(record.liveDownload !== laterLive)
+        }
+
+        function test_openCompleted_prefersBrowser_forRenderableType() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const record = {
+                fileName: "track.mp3",
+                mimeType: "audio/mpeg",
+                state: AbstractWebView.DownloadState.DownloadCompleted,
+                missingFile: false,
+                targetPath: "/tmp/downloads/track.mp3"
+            }
+
+            verify(ctx.openCompletedRecord(record))
+            compare(openedUrls.length, 1)
+            // Media opens through a generated player page (one per Download Target).
+            verify(openedUrls[0].startsWith("file:///tmp/status-player/player-"))
+            verify(openedUrls[0].endsWith(".html"))
+            compare(store.openRecordCalls, 0)
+        }
+
+        function test_openCompleted_fallsBackToOs_forNonRenderableType() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const record = {
+                fileName: "clip.mkv",
+                mimeType: "video/x-matroska",
+                state: AbstractWebView.DownloadState.DownloadCompleted,
+                missingFile: false,
+                targetPath: "/tmp/downloads/clip.mkv"
+            }
+
+            verify(ctx.openCompletedRecord(record))
+            compare(openedUrls.length, 0)
+            compare(store.openRecordCalls, 1)
+            compare(store.lastOpenedRecord, record)
+        }
+
+        // Per-mime routing (webm player page, write-failure → false) is pinned at
+        // the open seam in tst_BrowserDownloadOpenContext; openCompletedRecord is
+        // mime-agnostic, so one player-page case and one OS-fallback case suffice.
+        function test_openCompleted_missingFile_blocksBothRoutes() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const record = {
+                fileName: "gone.mp3",
+                mimeType: "audio/mpeg",
+                state: AbstractWebView.DownloadState.DownloadCompleted,
+                missingFile: true,
+                targetPath: "/tmp/downloads/gone.mp3"
+            }
+
+            verify(!ctx.openCompletedRecord(record))
+            compare(openedUrls.length, 0)
+            compare(store.openRecordCalls, 0)
+        }
+
+        function test_pillClick_completed_opensThenDismisses() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.downloadFileName = "photo.png"
+            live.mimeType = "image/png"
+            live.state = AbstractWebView.DownloadState.DownloadCompleted
+            const record = store.addDownload(live)
+            record.state = AbstractWebView.DownloadState.DownloadCompleted
+            record.fileName = "photo.png"
+            record.mimeType = "image/png"
+
+            ctx.handlePillClicked(record)
+            compare(openedUrls.length, 1)
+            compare(store.dismissCalls, 1)
+            compare(store.downloadStripModel.length, 0)
+            verify(!ctx.stripVisible, "last pill gone → strip hides by derivation")
+        }
+
+        function test_listClick_completed_opensSameAsPill() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            live.downloadFileName = "archive.bin"
+            live.mimeType = "application/octet-stream"
+            const record = store.addDownload(live)
+            record.state = AbstractWebView.DownloadState.DownloadCompleted
+            record.fileName = "archive.bin"
+            record.mimeType = "application/octet-stream"
+
+            // OS open still counts as opened → overview closes on true.
+            verify(ctx.openDownloadFromList(record))
+            compare(openedUrls.length, 0)
+            compare(store.openRecordCalls, 1)
+            compare(store.lastOpenedRecord, record)
+        }
+
+        function test_listClick_interrupted_retries_reportsNothingOpened() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const live = createTemporaryObject(fakeDownloadComponent, root)
+            const record = store.addDownload(live)
+            record.state = AbstractWebView.DownloadState.DownloadInterrupted
+            record.fileName = "a.bin"
+
+            // Retry restarts in place — overview stays open.
+            verify(!ctx.openDownloadFromList(record))
+        }
+
+        // --- capabilitiesFor: the one capability vocabulary ---
+
+        function test_capabilitiesFor_composesStoreOpenSeamAndPlatform() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const record = createTemporaryObject(fakeRecordComponent, root, {
+                state: AbstractWebView.DownloadState.DownloadCompleted
+            })
+
+            const before = store.refreshStats.calls
+            const caps = ctx.capabilitiesFor(record, null)
+            verify(store.refreshStats.calls > before,
+                   "Missing File refresh happens inside capabilitiesFor, not at call sites")
+
+            verify(caps.openInBrowser, "renderable Completed type composes the open seam")
+            verify(caps.shareFile)
+            verify(caps.shareUrl)
+            verify(!caps.showInFolder, "platform.showInFolderSupported is false here")
+            verify(!caps.retry)
+            verify(!caps.dismiss)
+            verify(!caps.downloadsEntry, "list menus never get the Downloads entry")
+            verify(caps.useShareLabels, "platform.preferShareSheet flows through")
+
+            compare(ctx.capabilitiesFor(record, { showDismiss: true }).dismiss, true)
+
+            // Pill strip opens ask for the Downloads entry.
+            const stripCaps = ctx.capabilitiesFor(record, { showDismiss: true, showDownloadsEntry: true })
+            compare(stripCaps.downloadsEntry, true)
+        }
+
+        function test_capabilitiesFor_interrupted_onlyRetryAndUrl() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const record = createTemporaryObject(fakeRecordComponent, root)
+
+            const caps = ctx.capabilitiesFor(record, null)
+            verify(caps.retry)
+            verify(caps.shareUrl)
+            verify(!caps.openInBrowser)
+            verify(!caps.shareFile)
+        }
+
+        /// A binding on capabilitiesFor re-derives when the Record changes —
+        /// the structural replacement for populateRecordMenu ordering.
+        function test_capabilitiesFor_bindingUpdates_whenRecordChanges() {
+            const store = createStore()
+            const ctx = createContext(store)
+            const interrupted = createTemporaryObject(fakeRecordComponent, root)
+            const holder = createTemporaryObject(capsHolderComponent, root, {
+                record: interrupted
+            })
+            holder.caps = Qt.binding(function() {
+                return ctx.capabilitiesFor(holder.record, { showDismiss: true })
+            })
+
+            verify(holder.caps.retry)
+            verify(!holder.caps.shareFile)
+
+            // The same Record completes (e.g. after Retry) — no repopulate call.
+            interrupted.state = AbstractWebView.DownloadState.DownloadCompleted
+            verify(!holder.caps.retry, "capabilities follow the record's state")
+            verify(holder.caps.shareFile)
+            verify(holder.caps.openInBrowser)
+
+            // Swapping the record identity re-derives too.
+            const other = createTemporaryObject(fakeRecordComponent, root, {
+                fileName: "other.bin",
+                mimeType: "application/octet-stream",
+                targetPath: ""
+            })
+            holder.record = other
+            verify(holder.caps.retry)
+            verify(!holder.caps.shareFile, "no target path → no share")
+
+            // Break the binding before teardown destroys ctx/store under it.
+            holder.caps = null
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_BrowserRetainedViews.qml
+++ b/storybook/qmlTests/tests/tst_BrowserRetainedViews.qml
@@ -1,0 +1,229 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Browser.adapters
+import AppLayouts.Browser.webview
+
+/**
+ * Retained Views (ADR 0006 §6): closing a Tab that still owns non-terminal
+ * Downloads keeps its Web View alive; only viewDownloadsCleared ends that.
+ * Fake views suffice — the context touches just retained/focus/parent/detachView.
+ */
+Item {
+    id: root
+
+    width: 400
+    height: 400
+
+    // Appended on destruction, so we never probe a dangling handle.
+    property var destroyedViewNames: []
+
+    Component {
+        id: hostStackComponent
+
+        Item { width: 1; height: 1 }
+    }
+
+    Component {
+        id: fakeWebViewComponent
+
+        Item {
+            id: fakeView
+
+            property string viewName: ""
+            property bool offTheRecord: false
+            property bool retained: false
+            property int detachCalls: 0
+
+            function detachView() { detachCalls += 1 }
+
+            Component.onDestruction: root.destroyedViewNames =
+                root.destroyedViewNames.concat([fakeView.viewName])
+        }
+    }
+
+    Component {
+        id: downloadsStoreComponent
+
+        // Minimal DownloadsStore seam BrowserWebViewContext reads for retention.
+        QtObject {
+            id: store
+
+            signal viewDownloadsCleared(var view)
+
+            property var busyViews: []
+
+            function viewHasNonTerminalDownloads(view) {
+                return !!view && store.busyViews.indexOf(view) !== -1
+            }
+
+            // The view's last Download went terminal, so the signal fires.
+            function finishDownloadsFor(view) {
+                const next = []
+                for (let i = 0; i < store.busyViews.length; ++i) {
+                    if (store.busyViews[i] !== view)
+                        next.push(store.busyViews[i])
+                }
+                store.busyViews = next
+                store.viewDownloadsCleared(view)
+            }
+        }
+    }
+
+    Component {
+        id: tabsModelComponent
+
+        QtObject {
+            id: tabsModel
+
+            property int currentIndex: 0
+            property int count: 2
+            property var removedIndexes: []
+
+            function createEmptyTab() {}
+            function removeTab(index) {
+                tabsModel.removedIndexes = tabsModel.removedIndexes.concat([index])
+                tabsModel.count = Math.max(0, tabsModel.count - 1)
+                if (tabsModel.currentIndex >= tabsModel.count)
+                    tabsModel.currentIndex = Math.max(0, tabsModel.count - 1)
+            }
+        }
+    }
+
+    Component {
+        id: browserWebViewContextComponent
+
+        BrowserWebViewContext {
+            required property Item hostStack
+            required property var tabsModelRef
+            required property var downloadsStoreRef
+
+            thirdpartyServicesEnabled: true
+            isDebugEnabled: false
+            isMobile: true
+            hasPopups: false
+            browserSettings: QtObject {}
+            connectorController: null
+            dappsEnabled: false
+            hostStackLayout: hostStack
+            tabsModel: tabsModelRef
+            defaultProfileParams: ProfileParams {
+                userId: ""
+                userAgent: ""
+                scripts: []
+                offTheRecord: false
+            }
+            otrProfileParams: ProfileParams {
+                userId: ""
+                userAgent: ""
+                scripts: []
+                offTheRecord: true
+            }
+            bookmarksStore: QtObject {}
+            downloadsStore: downloadsStoreRef
+            determineRealURLFn: function(url) { return url }
+            downloadRequestHandler: function() {}
+            linkLongPressHandler: function() {}
+            sslErrorHandler: function() {}
+            jsDialogHandler: function() {}
+            findTextFinishedHandler: function() {}
+            savedSessionContext: QtObject {
+                function seedWebView() {}
+            }
+        }
+    }
+
+    TestCase {
+        name: "BrowserRetainedViews"
+        when: windowShown
+
+        property Item hostStack: null
+        property var store: null
+        property var tabsModel: null
+        property BrowserWebViewContext webViewContext: null
+        property var firstView: null
+        property var secondView: null
+
+        function init() {
+            root.destroyedViewNames = []
+
+            hostStack = createTemporaryObject(hostStackComponent, root)
+            store = createTemporaryObject(downloadsStoreComponent, root)
+            tabsModel = createTemporaryObject(tabsModelComponent, root)
+
+            // Two tabs: the "last tab" branch would build a real Web View.
+            firstView = createTemporaryObject(fakeWebViewComponent, hostStack,
+                                              { viewName: "first" })
+            secondView = createTemporaryObject(fakeWebViewComponent, hostStack,
+                                               { viewName: "second" })
+
+            webViewContext = createTemporaryObject(browserWebViewContextComponent, root, {
+                hostStack: hostStack,
+                tabsModelRef: tabsModel,
+                downloadsStoreRef: store
+            })
+        }
+
+        // Closing never cancels: the view stays alive, out of the Tab set (§6).
+        function test_closingTab_retainsViewWithNonTerminalDownloads() {
+            store.busyViews = [firstView]
+
+            webViewContext.removeView(0)
+
+            compare(tabsModel.removedIndexes.length, 1, "the tab is still closed")
+            compare(tabsModel.removedIndexes[0], 0)
+
+            verify(firstView.retained, "the view is marked Retained")
+            compare(firstView.parent, null,
+                    "a Retained View leaves the host stack so children stay 1:1 with tabs")
+            compare(firstView.detachCalls, 0,
+                    "detachView() would abort the transfer — never on the retain path")
+            compare(root.destroyedViewNames.length, 0, "the view is not destroyed")
+
+            compare(webViewContext._retainedViews.length, 1)
+            compare(webViewContext._retainedViews[0], firstView)
+        }
+
+        // Clearing ends the retention: it leaves _retainedViews and dies.
+        function test_viewDownloadsCleared_dropsAndDestroysRetainedView() {
+            store.busyViews = [firstView]
+            webViewContext.removeView(0)
+            compare(webViewContext._retainedViews.length, 1)
+
+            store.finishDownloadsFor(firstView)
+
+            compare(webViewContext._retainedViews.length, 0,
+                    "the cleared view leaves _retainedViews")
+            tryVerify(() => root.destroyedViewNames.indexOf("first") !== -1, 1000,
+                      "the cleared Retained View is destroyed")
+            compare(root.destroyedViewNames.indexOf("second"), -1,
+                    "the still-open tab's view is untouched")
+        }
+
+        // Nothing to finish → the ordinary close path, destroyed right away.
+        function test_closingTab_destroysViewWithoutNonTerminalDownloads() {
+            store.busyViews = []
+
+            webViewContext.removeView(0)
+
+            verify(!firstView.retained)
+            compare(webViewContext._retainedViews.length, 0)
+            compare(firstView.detachCalls, 1, "the ordinary close path detaches")
+            tryVerify(() => root.destroyedViewNames.indexOf("first") !== -1, 1000,
+                      "a view with no non-terminal Downloads is destroyed on close")
+        }
+
+        // A cleared signal for a view that was never retained must not destroy it.
+        function test_viewDownloadsCleared_ignoresUnknownView() {
+            store.busyViews = [firstView]
+            webViewContext.removeView(0)
+
+            store.finishDownloadsFor(secondView)
+
+            compare(webViewContext._retainedViews.length, 1,
+                    "an unrelated view does not drop the Retained View")
+            compare(webViewContext._retainedViews[0], firstView)
+            compare(root.destroyedViewNames.length, 0)
+        }
+    }
+}

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -280,7 +280,7 @@ StatusSectionLayout {
     }
 
     invertedLayout: height > width
-    showFooter: false
+    showFooter: downloadsContext.stripVisible
     headerPadding: 0
     backgroundColor: Theme.palette.statusAppNavBar.backgroundColor
 
@@ -303,10 +303,9 @@ StatusSectionLayout {
     BrowserDownloadsContext {
         id: downloadsContext
         downloadsStore: root.downloadsStore
-        tabsModel: tabs
+        getTabsCountFn: () => tabs.count
         getWebViewFn: (index) => webViewContext.getWebView(index)
         removeViewFn: (index) => webViewContext.removeView(index)
-        setFooterVisibleFn: (visible) => root.showFooter = visible
     }
 
     BrowserWebViewContext {
@@ -327,6 +326,9 @@ StatusSectionLayout {
         downloadsStore: root.downloadsStore
         determineRealURLFn: (url) => root.browserRootStore.determineRealURL(url)
         downloadRequestHandler: (download) => downloadsContext.handleDownloadRequest(download)
+        // The long-press menu itself arrives with the Downloads UI; until then
+        // the Backend signal has nowhere to go.
+        linkLongPressHandler: (linkUrl, imageUrl, position, hostView) => {}
         sslErrorHandler: (error) => {
                              error.defer()
                              sslDialog.enqueue(error)
@@ -905,7 +907,7 @@ StatusSectionLayout {
                 downloadsContext.openDownloadFromList(downloadComplete, index)
             }
             onAddNewDownloadTab: _internal.addNewDownloadTab()
-            onClose: root.showFooter = false
+            onClose: downloadsContext.dismissStrip()
         }
     }
 }

--- a/ui/app/AppLayouts/Browser/webview/BrowserDownloadsContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserDownloadsContext.qml
@@ -1,39 +1,283 @@
 import QtQuick
 
+import QtModelsToolkit
+
+import StatusQ
+import StatusQ.Core.Utils as SQUtils
+
+import AppLayouts.Browser.adapters
+import AppLayouts.Browser.stores as BrowserStores
+
+/**
+ * Orchestrates Download Requests and list/pill actions (ADR 0006).
+ * Retry is a host-side re-issue via Backend downloadUrl on a matching profile —
+ * not library retry() (live object is usually already gone). The next matching
+ * downloadRequested reattaches onto the same Record (no duplicate History row).
+ */
 QtObject {
     id: root
 
-    required property var downloadsStore
-    required property var tabsModel
+    required property BrowserStores.DownloadsStore downloadsStore
     required property var getWebViewFn
+    required property var getTabsCountFn
     required property var removeViewFn
-    required property var setFooterVisibleFn
 
-    function handleDownloadRequest(download) {
+    // Mobile Find XOR strip: actively closes the Find UI when a new Download
+    // starts. Closing Find is an action on the Find UI, not derivable state.
+    property var hideFindUiFn: function() {}
+
+    /// Find XOR Download Pill strip (mobile).
+    /// The one derived view of strip visibility: session pills exist, Find is
+    /// closed, and the user has not dismissed the strip. BrowserLayout binds
+    /// its footer/strip to this — nothing writes visibility imperatively.
+    readonly property bool stripVisible: stripPresenter.stripVisible
+
+    // Presenter over the three inputs. findOpen / userDismissed change only
+    // via setFindOpen, dismissStrip and handleDownloadRequest; model emptiness
+    // is observed from the store.
+    readonly property QtObject _stripPresenter: QtObject {
+        id: stripPresenter
+
+        property bool findOpen: false
+        property bool userDismissed: false
+
+        // A JS array today, possibly a QML model later: count for models,
+        // length for arrays. Both re-evaluate on change.
+        readonly property int pillCount: {
+            const model = root.downloadsStore?.downloadStripModel
+            return model?.ModelCount?.count ?? model?.length ?? 0
+        }
+
+        readonly property bool stripVisible: !findOpen && !userDismissed
+            && pillCount > 0
+    }
+
+    // One-shot Record armed by retryRecord for the reattach; consumed (or dropped)
+    // by the next downloadRequested and expired by timer so a failed retry can
+    // never capture a later unrelated download of the same URL.
+    property var _pendingRetry: null
+
+    readonly property Timer _pendingRetryExpiry: Timer {
+        interval: 10000
+        onTriggered: root._pendingRetry = null
+    }
+
+    property var openUrlFn: function(url) {
+        console.warn("BrowserDownloadsContext: openUrlFn not set")
+    }
+
+    // Backend PDF-rendering Capability. BrowserLayout overrides with
+    // BrowserBackendCapabilities.pdfViewerSupported; tests inject their own.
+    property var supportsPdfFn: function() { return false }
+
+    /// The open-a-downloaded-file seam (ADR 0006 §8): format allowlist, player
+    /// pages, local-URL guard exception. Internal composition — BrowserLayout
+    /// talks to this context only; the seam sees narrow injected functions,
+    /// never the store.
+    readonly property BrowserDownloadOpenContext _openContext: BrowserDownloadOpenContext {
+        openUrlFn: (url) => root.openUrlFn(url)
+    }
+
+    /// Find UI open/close hook (mobile call sites). Opening Find hides the
+    /// strip; closing Find restores it only when session pills remain and the
+    /// user did not dismiss the strip (all derived — see stripVisible).
+    function setFindOpen(open) {
+        stripPresenter.findOpen = !!open
+    }
+
+    /// Strip close button: hidden until the next download starts.
+    function dismissStrip() {
+        stripPresenter.userDismissed = true
+    }
+
+    /// hostView is the host Web View (LazyWebViewAdapter) that raised the request.
+    /// Prefer it over Backend download.view (missing on mobile; wrong identity on desktop).
+    function handleDownloadRequest(download, hostView) {
         if (!download)
             return
 
-        downloadsStore.addDownload(download)
-        download.accept()
-        setFooterVisibleFn(true)
+        // One-shot: whatever this request is, the retry arm does not outlive it.
+        const pending = root._pendingRetry
+        root._pendingRetry = null
+        root._pendingRetryExpiry.stop()
 
-        // Close tabs that were opened only to trigger a download.
-        if (!download.view)
+        let record = null
+        if (pending && root._urlsMatch(pending.url, download.url)
+                && typeof downloadsStore.reattachForRetry === "function") {
+            record = downloadsStore.reattachForRetry(pending, download, hostView)
+            // Reattach declined: track as new rather than accept untracked —
+            // a duplicate History row beats a lost Download.
+            if (!record)
+                record = downloadsStore.addDownload(download, hostView)
+        } else {
+            record = downloadsStore.addDownload(download, hostView)
+        }
+        downloadsStore.acceptLiveDownload(download, record)
+
+        // New download dismisses Find and re-shows the strip (Find XOR),
+        // expressed as presenter input changes; hideFindUiFn additionally
+        // closes the actual Find UI (not derivable from state).
+        if (stripPresenter.findOpen)
+            hideFindUiFn()
+        stripPresenter.findOpen = false
+        stripPresenter.userDismissed = false
+
+        // Download-only Tab (target=_blank attachment): leave the strip via removeView,
+        // which retains the Web View on mobile while Downloads are non-terminal.
+        const view = hostView || (record ? record.originatingView : null) || download.view
+        if (!view)
             return
 
-        for (var i = 0; i < tabsModel.count; ++i) {
+        const count = getTabsCountFn()
+        for (var i = 0; i < count; ++i) {
             var tab = getWebViewFn(i)
-            if (tab === download.view && !tab.htmlPageLoaded && tab.title === "") {
+            // Only a Tab a page opened that never committed a page of its own —
+            // marked at creation, never guessed from title or load state.
+            if (tab === view && tab.pristinePopup) {
                 removeViewFn(i)
                 break
             }
         }
     }
 
-    function openDownloadFromList(downloadComplete, index) {
-        if (downloadComplete)
-            return downloadsStore.openFile(index)
+    /// true if the file opened (caller closes the overview). false on retry.
+    function openDownloadFromList(record) {
+        if (!record)
+            return false
 
-        downloadsStore.openDirectory(index)
+        if (downloadsStore.canRetryFromTap(record)) {
+            retryRecord(record)
+            return false
+        }
+
+        if (record.state === AbstractWebView.DownloadState.DownloadCompleted)
+            return openCompletedRecord(record)
+        return false
+    }
+
+    function handlePillClicked(record) {
+        if (!record)
+            return
+
+        if (downloadsStore.canRetryFromTap(record)) {
+            retryRecord(record)
+            return
+        }
+
+        if (record.state === AbstractWebView.DownloadState.DownloadCompleted) {
+            openCompletedRecord(record)
+            // Dropping the last pill empties the strip model — stripVisible
+            // observes emptiness, so the strip hides by derivation.
+            downloadsStore.dismissRecordFromStrip(record)
+        }
+    }
+
+    /// Prefer our browser when the type is renderable; otherwise hand off to the OS.
+    /// Missing File blocks both routes (ADR 0006 §8).
+    function openCompletedRecord(record) {
+        if (!record)
+            return false
+        if (openInBrowserRecord(record))
+            return true
+        if (record.missingFile)
+            return false
+        // iOS: openUrlExternally ignores file:// — use the share sheet.
+        if (SQUtils.Utils.isIOS)
+            return shareFileRecord(record)
+        downloadsStore.openRecord(record)
+        return true
+    }
+
+    function shareFileRecord(record) {
+        downloadsStore.refreshMissingFiles()
+        return downloadsStore.shareFile(record)
+    }
+
+    function shareUrlRecord(record) {
+        return downloadsStore.shareUrl(record)
+    }
+
+    function openInBrowserRecord(record) {
+        downloadsStore.refreshMissingFiles()
+        return _openContext.openInBrowser(record, supportsPdfFn())
+    }
+
+    function retryRecord(record) {
+        if (!downloadsStore.canRetryFromMenu(record) && !downloadsStore.canRetryFromTap(record))
+            return false
+        const url = downloadsStore.sourceUrlString(record)
+        if (!url)
+            return false
+
+        const webView = root._webViewForRetry(record)
+        if (!webView || !webView.downloadUrl) {
+            console.warn("BrowserDownloadsContext: no Backend available for retry")
+            return false
+        }
+        root._pendingRetry = record
+        root._pendingRetryExpiry.restart()
+        webView.downloadUrl(url, record.fileName || "")
+        return true
+    }
+
+    function _urlsMatch(a, b) {
+        const left = String(a || "")
+        const right = String(b || "")
+        return left.length > 0 && left === right
+    }
+
+    function refreshMissingFiles() {
+        downloadsStore.refreshMissingFiles()
+    }
+
+    // Missing File markers go stale while the app is backgrounded (files can
+    // be removed externally); refresh when it returns to the foreground.
+    readonly property Connections _appActiveRefresh: Connections {
+        target: Qt.application
+        function onStateChanged() {
+            if (Qt.application.state === Qt.ApplicationActive)
+                root.refreshMissingFiles()
+        }
+    }
+
+    /// The one capability vocabulary for a Download Record menu:
+    /// store predicates + the open seam's canOpenInBrowser + the platform
+    /// share-vs-copy fact. BIND it at the call site
+    /// (capabilities: ctx.capabilitiesFor(menu.record, options)) so a stale
+    /// menu is structurally impossible — the Missing File refresh happens here,
+    /// never at call sites. options.showDismiss — pill strip session dismiss.
+    /// options.showDownloadsEntry — pill strip "Downloads" entry;
+    /// list menus never pass it — the user is already in the Downloads List.
+    function capabilitiesFor(record, options) {
+        downloadsStore.refreshMissingFiles()
+        return {
+            openInBrowser: _openContext.canOpenInBrowser(record, supportsPdfFn()),
+            shareFile: downloadsStore.canShareFile(record),
+            shareUrl: downloadsStore.canShareUrl(record),
+            showInFolder: downloadsStore.canShowInFolder(record),
+            retry: downloadsStore.canRetryFromMenu(record),
+            dismiss: !!(options && options.showDismiss),
+            downloadsEntry: !!(options && options.showDownloadsEntry),
+            useShareLabels: !!(downloadsStore.platform && downloadsStore.platform.preferShareSheet)
+        }
+    }
+
+    /// Retry Backend must match the Record profile (ADR 0006 §7) and must be a
+    /// live Tab Web View — never a Retained View (ADR 0006 §6).
+    function _webViewForRetry(record) {
+        const count = getTabsCountFn ? getTabsCountFn() : 0
+        const wantOtr = !!record.offTheRecord
+        for (let i = 0; i < count; ++i) {
+            const tab = getWebViewFn(i)
+            if (!tab || !tab.downloadUrl)
+                continue
+            if (tab.retained)
+                continue
+            const otr = tab.offTheRecord !== undefined ? !!tab.offTheRecord
+                        : (tab.profileParams ? !!tab.profileParams.offTheRecord : false)
+            if (otr === wantOtr)
+                return tab
+        }
+        return null
     }
 }

--- a/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
@@ -66,8 +66,7 @@ QtObject {
         return BrowserSessionUtils.displayTitle(webView, recordForWebView(webView), {
             isStartPage: !!isStartPage,
             startPageLabel: qsTr("Start Page"),
-            emptyLabel: qsTr("New Tab"),
-            downloadsLabel: qsTr("Downloads")
+            emptyLabel: qsTr("New Tab")
         })
     }
 

--- a/ui/app/AppLayouts/Browser/webview/BrowserSessionUtils.js
+++ b/ui/app/AppLayouts/Browser/webview/BrowserSessionUtils.js
@@ -42,9 +42,6 @@ function displayTitle(webView, persistedRecord, labels) {
     if (!webView)
         return fallback
 
-    if (webView.isDownloadView)
-        return labels.downloadsLabel || fallback
-
     const resolved = resolveTitle(webView.title || "", persistedRecord)
     if (resolved)
         return resolved

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -39,7 +39,10 @@ QtObject {
     }
 
     required property var determineRealURLFn
+    /// (download, hostView) — hostView is the LazyWebViewAdapter that raised the request.
     required property var downloadRequestHandler
+    /// (linkUrl, imageUrl, position, hostView) — long-press menu (mobile Backends).
+    required property var linkLongPressHandler
     required property var sslErrorHandler
     required property var jsDialogHandler
     required property var findTextFinishedHandler
@@ -47,16 +50,17 @@ QtObject {
 
     enum ContentMode {
         WebContent = 0,
-        DownloadContent,
         EmptyContent
     }
+
+    // Retained Views: host Web Views kept alive (hidden + frozen) after Tab close
+    // while they still own non-terminal Downloads. Not part of the Tab set.
+    property var _retainedViews: []
 
     readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? (getCurrentWebView() ?? null) : null
     readonly property int currentContentMode: {
         if (!currentWebView)
             return BrowserWebViewContext.ContentMode.EmptyContent
-        if (currentWebView.isDownloadView)
-            return BrowserWebViewContext.ContentMode.DownloadContent
         if (!currentWebView.url?.toString())
             return BrowserWebViewContext.ContentMode.EmptyContent
         return BrowserWebViewContext.ContentMode.WebContent
@@ -76,8 +80,7 @@ QtObject {
         focusOnNewTab = focusOnNewTab && !createAsStartPage
 
         var webview = webViewAdapterComponent.createObject(hostStackLayout, {
-            profileParams: profileParams,
-            isDownloadView: false
+            profileParams: profileParams
         })
         if (!webview) {
             console.error("[Browser] Failed to create webview")
@@ -100,22 +103,6 @@ QtObject {
         if ((focusOnNewTab || createAsStartPage) && webview.url.toString() && typeof webview.ensureLoaded === "function")
             webview.ensureLoaded()
 
-        return webview
-    }
-
-    function createDownloadTab(profileParams) {
-        var webview = webViewAdapterComponent.createObject(hostStackLayout, {
-            profileParams: profileParams,
-            isDownloadView: true
-        })
-        if (!webview) {
-            console.error("[Browser] Failed to create download webview")
-            return null
-        }
-
-        tabsModel.createDownloadTab()
-        webview.uid = SQUtils.Utils.uuid()
-        webview.ensureLoaded()
         return webview
     }
 
@@ -270,25 +257,87 @@ QtObject {
         tabsModel.removeTab(index)
         if (!view)
             return
+
+        // Mobile Backend aborts Downloads when the Web View is destroyed.
+        // Retain (hide + freeze) until DownloadsStore reports the view is clear.
+        // Desktop WebEngine keeps transfers alive after view destruction — no retain.
+        // Closing never cancels a Download (ADR 0006 §6).
+        const shouldRetain = root.isMobile
+            && !!downloadsStore
+            && typeof downloadsStore.viewHasNonTerminalDownloads === "function"
+            && downloadsStore.viewHasNonTerminalDownloads(view)
+
+        if (shouldRetain) {
+            view.retained = true
+            view.focus = false
+            // Reparent out of the StackLayout so children stay 1:1 with tabs.
+            // visible/freeze follow `retained` bindings on the adapter.
+            // Do not detachView()/stop() — that would abort the transfer.
+            view.parent = null
+            _retainedViews = _retainedViews.concat([view])
+            return
+        }
+
+        root._destroyWebView(view)
+    }
+
+    function _destroyWebView(view) {
+        if (!view)
+            return
         view.visible = false
         view.enabled = false
         view.focus = false
-        view.detachView()
+        if (typeof view.detachView === "function")
+            view.detachView()
         view.parent = null
         view.destroy()
+    }
+
+    function _destroyRetainedView(view) {
+        if (!view)
+            return
+        const next = []
+        let found = false
+        for (let i = 0; i < _retainedViews.length; ++i) {
+            if (_retainedViews[i] === view)
+                found = true
+            else
+                next.push(_retainedViews[i])
+        }
+        if (!found)
+            return
+        _retainedViews = next
+        root._destroyWebView(view)
+    }
+
+    readonly property Connections _retainedDownloadsConnections: Connections {
+        target: root.downloadsStore
+        ignoreUnknownSignals: true
+        function onViewDownloadsCleared(view) {
+            root._destroyRetainedView(view)
+        }
     }
 
     readonly property var webViewAdapterComponent: Component {
         LazyWebViewAdapter {
             id: lazyView
 
+            // StackLayout never sizes a child that was added while the layout was
+            // hidden, and neither forceLayout() nor re-setting currentIndex repairs
+            // it — the view stays 0x0 and renders nothing (issue 21282). Size to the
+            // host instead of relying on the layout to do it.
+            width: root.hostStackLayout.width
+            height: root.hostStackLayout.height
+
             // On mobile, only the active tab must be visible; native WKWebView
             // subviews share the same UIKit window and ignore QML z-order,
             // so StackLayout alone cannot hide inactive tabs reliably.
-            visible: root.isMobile ? StackLayout.isCurrentItem : true
+            // Retained Views stay hidden regardless of StackLayout current item.
+            visible: retained ? false
+                     : (root.isMobile ? StackLayout.isCurrentItem : true)
             enabled: visible
-            // Freeze native webview while QML popup is shown
-            freeze: root.isMobile && root.hasPopups
+            // Freeze while a QML popup is shown, or while Retained for Downloads.
+            freeze: root.isMobile && (root.hasPopups || retained)
 
             readonly property ConnectorBridge bridge: ConnectorBridge {
                 connectorController: root.dappsEnabled ? root.connectorController : null
@@ -312,9 +361,25 @@ QtObject {
             onNewWindowRequested: (makeCurrent, requestedUrl, callback) => {
                 var profileParams = root.currentWebView ? root.currentWebView.profileParams : root.defaultProfileParams
                 var tab = root.createEmptyTab(profileParams, false, makeCurrent, requestedUrl)
+                // Born from a page, nothing loaded in it yet: the Tab is download-only
+                // until it commits a page of its own (ADR 0006 §6).
+                if (tab)
+                    tab.pristinePopup = true
                 callback(tab)
             }
-            onDownloadRequested: (download) => root.downloadRequestHandler(download)
+            onDownloadRequested: (download) => {
+                // Retained Views finish only the Downloads they already own (ADR 0006 §6).
+                if (lazyView.retained) {
+                    if (download && download.cancel)
+                        download.cancel()
+                    return
+                }
+                root.downloadRequestHandler(download, lazyView)
+            }
+            onLinkLongPressed: (linkUrl, imageUrl, position) => {
+                if (!lazyView.retained)
+                    root.linkLongPressHandler(linkUrl, imageUrl, position, lazyView)
+            }
             onCertificateError: (error) => root.sslErrorHandler(error)
             onJavaScriptDialogRequested: (request) => root.jsDialogHandler(request)
             onFindTextFinished: (result) => root.findTextFinishedHandler(result)

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2631,10 +2631,6 @@ Do you wish to override the security check and continue?</source>
         <source>New Tab</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>BrowserSettingsMenu</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2641,10 +2641,6 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <source>New Tab</source>
         <translation type="unfinished">Nová karta</translation>
     </message>
-    <message>
-        <source>Downloads</source>
-        <translation type="unfinished">Stažené soubory</translation>
-    </message>
 </context>
 <context>
     <name>BrowserSettingsMenu</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2633,10 +2633,6 @@ Do you wish to override the security check and continue?</source>
         <source>New Tab</source>
         <translation type="unfinished">Nueva pestaña</translation>
     </message>
-    <message>
-        <source>Downloads</source>
-        <translation type="unfinished">Descargas</translation>
-    </message>
 </context>
 <context>
     <name>BrowserSettingsMenu</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2624,10 +2624,6 @@ Do you wish to override the security check and continue?</source>
         <source>New Tab</source>
         <translation type="unfinished">새 탭</translation>
     </message>
-    <message>
-        <source>Downloads</source>
-        <translation type="unfinished">다운로드</translation>
-    </message>
 </context>
 <context>
     <name>BrowserSettingsMenu</name>


### PR DESCRIPTION
Downloads orchestration and Retained Web Views:

* `BrowserDownloadsContext` — accepts download requests, builds Records, host-side retry (one-shot arm with expiry)
* `capabilitiesFor(record)` — single source of menu enablement
* Strip visibility as one derived value: downloads present, Find in page closed, not user-dismissed
* Retained Web Views: a view that still owns a running download survives its tab, hidden, until the download ends
* Long-press seam on BrowserWebViewContext
* Tests: tst_BrowserDownloadsContext

App-inert until PR 5/5. Part of #21376