### PR TITLE
feat(news): update to V2 of the RSS feed

### DIFF
--- a/storybook/pages/NewsMessagePopupPage.qml
+++ b/storybook/pages/NewsMessagePopupPage.qml
@@ -45,7 +45,7 @@ SplitView {
             id: popup
             visible: true
             notification: notificationMock
-            onLinkClicked: logs.logEvent("NewsMessagesPopup::onLinkClicked")
+            onLinkClicked: link => logs.logEvent("NewsMessagesPopup::onLinkClicked " + link)
         }
     }
    
@@ -55,19 +55,41 @@ SplitView {
 
         logsView.logText: logs.logText
 
-        RowLayout {
-            spacing: 4
+        ColumnLayout {
+            spacing: 8
 
-            CheckBox {
-                id: hasImage
-                text: "Has Image"
-                checked: true
+            RowLayout {
+                spacing: 4
+
+                CheckBox {
+                    id: hasImage
+                    text: "Has Image"
+                    checked: true
+                }
+
+                StatusInput {
+                    id: linkLabelInput
+                    label: "linkLabel"
+                    text: "Read our blog post"
+                }
             }
 
             StatusInput {
-                id: linkLabelInput
-                label: "linkLabel"
-                text: "Read our blog post"
+                id: newsTitleInput
+                Layout.fillWidth: true
+                label: "newsTitle"
+                text: notificationMock.newsTitle
+                onTextChanged: notificationMock.newsTitle = newsTitleInput.text
+            }
+
+            TextArea {
+                id: newsContentInput
+                Layout.fillWidth: true
+                Layout.preferredHeight: 90
+                placeholderText: "newsContent"
+                text: notificationMock.newsContent
+                wrapMode: TextArea.Wrap
+                onTextChanged: notificationMock.newsContent = newsContentInput.text
             }
         }
     }

--- a/storybook/pages/NewsMessagePopupPage.qml
+++ b/storybook/pages/NewsMessagePopupPage.qml
@@ -57,6 +57,7 @@ SplitView {
 
         ColumnLayout {
             spacing: 8
+            width: parent.width
 
             RowLayout {
                 spacing: 4
@@ -88,7 +89,7 @@ SplitView {
                 Layout.preferredHeight: 90
                 placeholderText: "newsContent"
                 text: notificationMock.newsContent
-                wrapMode: TextArea.Wrap
+                wrapMode: TextEdit.Wrap
                 onTextChanged: notificationMock.newsContent = newsContentInput.text
             }
         }

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -41,14 +41,10 @@ StatusAdaptiveDialog {
     maximumWidthOverride: 480
     title: root.notification ? CoreUtils.StringUtils.plainText(root.notification.newsTitle) : ""
     subtitle: d.dateGroupLabel.text
-    leftHeaderComponent: Item {
-        implicitWidth: 40
-        implicitHeight: 40
-
-        StatusImage {
-            source: Assets.png("status")
-            anchors.fill: parent
-        }
+    leftHeaderComponent: StatusImage {
+        source: Assets.svg("status-logo")
+        width: 40
+        height: 40
     }
 
     Loader {
@@ -60,8 +56,6 @@ StatusAdaptiveDialog {
             activityCenterNotifications: root.activityCenterNotifications
         }
     }
-
-    headerActions.closeButton.onClicked: root.close()
 
     contentComponent: ColumnLayout {
         spacing: Theme.padding
@@ -86,10 +80,10 @@ StatusAdaptiveDialog {
         }
 
         StatusBaseText {
-            text: CoreUtils.StringUtils.plainText(root.notification.newsContent)
+            text: root.notification ? CoreUtils.StringUtils.plainText(root.notification.newsContent) : ""
             Layout.fillWidth: true
             wrapMode: Text.WordWrap
-            onLinkActivated: root.linkClicked(link)
+            onLinkActivated: link => root.linkClicked(link)
         }
     }
 

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
 import QtQml.Models
 
@@ -15,7 +14,7 @@ import AppLayouts.ActivityCenter.helpers
 import shared
 import utils
 
-StatusDialog {
+StatusAdaptiveDialog {
     id: root
 
     required property var notification
@@ -26,7 +25,7 @@ StatusDialog {
         id: d
 
         readonly property StatusDateGroupLabel dateGroupLabel : StatusDateGroupLabel {
-            messageTimestamp: notification ? notification.timestamp : 0
+            messageTimestamp: root.notification ? root.notification.timestamp : 0
             // Hidden label to get the string
             visible: false
         }
@@ -39,40 +38,36 @@ StatusDialog {
         }
     }
 
-    width: 480
-    padding: Theme.bigPadding
+    maximumWidthOverride: 480
+    title: root.notification ? CoreUtils.StringUtils.plainText(root.notification.newsTitle) : ""
+    subtitle: d.dateGroupLabel.text
+    leftHeaderComponent: Item {
+        implicitWidth: 40
+        implicitHeight: 40
 
-    header: StatusDialogHeader {
-        headline.title: CoreUtils.StringUtils.plainText(notification.newsTitle)
-        headline.subtitle: d.dateGroupLabel.text
-        actions.closeButton.onClicked: root.close()
-        leftComponent: Item {
-            width: 40
-            height: 40
-            StatusImage {
-                source: Assets.png("status")
-                anchors.fill: parent
-            }
+        StatusImage {
+            source: Assets.png("status")
+            anchors.fill: parent
         }
     }
 
-    ColumnLayout {
-        width: parent.width
-        height: parent.height
-        spacing: 0
+    Loader {
+        id: notificationModelEntryLoader
+        active: false // Only enabled if we do not have a notification and need to get it from the model
 
-        Loader {
-            id: notificationModelEntryLoader
-            active: false // Only enabled if we do not have a notification and need to get it from the model
-
-            sourceComponent: NotificationModelEntry {
-                notificationId: root.notification?.id ?? ""
-                activityCenterNotifications: root.activityCenterNotifications
-            }
+        sourceComponent: NotificationModelEntry {
+            notificationId: root.notification?.id ?? ""
+            activityCenterNotifications: root.activityCenterNotifications
         }
+    }
+
+    headerActions.closeButton.onClicked: root.close()
+
+    contentComponent: ColumnLayout {
+        spacing: Theme.padding
 
         Loader {
-            active: !!notification.newsImageUrl
+            active: !!root.notification && !!root.notification.newsImageUrl
 
             Layout.bottomMargin: active ? Theme.padding : 0
             Layout.fillWidth: true
@@ -81,30 +76,29 @@ StatusDialog {
             sourceComponent: StatusRoundedImage {
                 implicitWidth: parent.width
                 implicitHeight: image.implicitHeight
-                image.source: notification.newsImageUrl
+                image.source: root.notification ? root.notification.newsImageUrl : ""
                 image.fillMode: Image.PreserveAspectCrop
                 color: "transparent"
-                border.color: root.backgroundColor
+                border.color: Theme.palette.directColor8
                 border.width: 1
                 radius: 8
             }
         }
 
         StatusBaseText {
-            text: CoreUtils.StringUtils.plainText(notification.newsContent)
+            text: CoreUtils.StringUtils.plainText(root.notification.newsContent)
             Layout.fillWidth: true
-            Layout.fillHeight: true
             wrapMode: Text.WordWrap
-            elide: Text.ElideRight
             onLinkActivated: root.linkClicked(link)
         }
     }
+
     footer: StatusDialogFooter {
-        visible: !!notification.newsLink
+        visible: !!root.notification && !!root.notification.newsLink
 
         rightButtons: ObjectModel {
             StatusButton {
-                text: !!notification.newsLinkLabel ? notification.newsLinkLabel : qsTr("Visit the website")
+                text: root.notification && !!root.notification.newsLinkLabel ? root.notification.newsLinkLabel : qsTr("Visit the website")
                 icon.name: "external"
                 onClicked: root.linkClicked(root.notification.newsLink)
             }

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -43,7 +43,7 @@ StatusDialog {
     padding: Theme.bigPadding
 
     header: StatusDialogHeader {
-        headline.title: notification.newsTitle
+        headline.title: CoreUtils.StringUtils.plainText(notification.newsTitle)
         headline.subtitle: d.dateGroupLabel.text
         actions.closeButton.onClicked: root.close()
         leftComponent: Item {
@@ -91,11 +91,12 @@ StatusDialog {
         }
 
         StatusBaseText {
-            text: notification.newsContent
+            text: CoreUtils.StringUtils.plainText(notification.newsContent)
             Layout.fillWidth: true
             Layout.fillHeight: true
             wrapMode: Text.WordWrap
             elide: Text.ElideRight
+            onLinkActivated: root.linkClicked(link)
         }
     }
     footer: StatusDialogFooter {


### PR DESCRIPTION
### What does the PR do

Fixes #21844

- [feat(rss): support for content and title that can contain HTML entities](https://github.com/status-im/status-app/commit/61b798fba4dfb3995f81f09f2745a4cc67a06622)
- [feat(news): update news popup to AdaptiveDialog to get a scroll bar](https://github.com/status-im/status-app/commit/92ff3071f979c6b497ce2495e283d88bdae03043)
- [chore(status-go): up status-go to update to the V2 RSS feed](https://github.com/status-im/status-app/commit/4383ee13a640bd06c1bfd4e49a927c4551980f70)

One thing that doesn't look right is that the popup now **always** has a scrollbar. @noeliaSD I updated to use your AdaptiveDialog component to get the free scrollbar, but somehow, the text is always cropped, even if there is no image. Can you help please.

### Affected areas

- ui/imports/shared/popups/NewsMessagePopup.qml
- status-go (PR: https://github.com/status-im/status-go/pull/7689)

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Demo of getting a news on V2 RSS (I hardcoded the date to be able to fetch an old news):

[demo-news.webm](https://github.com/user-attachments/assets/0e9596df-4758-4fe2-a21f-0308f22dd60c)

Demo of a News with special characters, links and bullet points (in storybook):

<img width="490" height="599" alt="image" src="https://github.com/user-attachments/assets/38ab838f-c65e-40e1-b99a-84256f8ecc68" />

### Impact on end user

Cooler news

### How to test

Use the storybook

### Risk 

Low
