### PR TITLE
fix(keycard): make packaged simulator work on Linux and Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ GIT_ROOT ?= $(shell git rev-parse --show-toplevel 2>/dev/null || echo .)
 	benches-nim \
 	status-go \
 	status-keycard-qt \
+	keycard-simulator \
+	keycard-simulator-bundle \
 	statusq-sanity-checker \
 	run-statusq-sanity-checker \
 	statusq-tests \
@@ -561,6 +563,14 @@ STATUSKEYCARD_QT_LINKNAME := $(patsubst lib%,%,$(basename $(STATUSKEYCARD_QT_DYL
 KEYCARD_SIM_SRC_DIR := $(STATUS_KEYCARD_QT_SOURCE_DIR)/test/keycard-simulator
 KEYCARD_SIM_RUNTIME_BITS := run.sh libs versions out
 
+keycard-simulator:
+	echo -e $(BUILD_MSG) "keycard-simulator (precompile)"
+	bash scripts/precompile-keycard-simulator.sh $(KEYCARD_SIM_SRC_DIR)
+
+keycard-simulator-bundle:
+	mkdir -p $(KEYCARD_SIM_DEST)
+	cp -R $(addprefix $(KEYCARD_SIM_SRC_DIR)/,$(KEYCARD_SIM_RUNTIME_BITS)) $(KEYCARD_SIM_DEST)/
+
 status-keycard-qt: $(STATUSKEYCARD_QT_LIB)
 $(STATUSKEYCARD_QT_LIB): | deps check-qt-dir
 	echo -e $(BUILD_MSG) "status-keycard-qt"
@@ -817,7 +827,13 @@ $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop
 	rm -rf pkg/*.AppImage
 	chmod -R u+w tmp || true
 
+ifeq ($(USE_SIMULATED_KEYCARD),true)
+	$(MAKE) keycard-simulator
+endif
 	scripts/init_app_dir.sh
+ifeq ($(USE_SIMULATED_KEYCARD),true)
+	$(MAKE) keycard-simulator-bundle KEYCARD_SIM_DEST=$(APP_DIR)/usr/share/keycard-simulator
+endif
 
 	echo -e $(BUILD_MSG) "AppImage"
 
@@ -897,13 +913,9 @@ $(STATUS_CLIENT_DMG): nim_status_client
 	cp status-macos.svg $(MACOS_OUTER_BUNDLE)/Contents/
 	cp -R resources.rcc $(MACOS_OUTER_BUNDLE)/Contents/
 
-# Precompile (JDK from nix) + bundle the keycard simulator into the app, before macdeployqt/signing
 ifeq ($(USE_SIMULATED_KEYCARD),true)
-	echo -e $(BUILD_MSG) "keycard-simulator (precompile + bundle)"
-	nix shell .#jdk -c bash -c 'cd $(KEYCARD_SIM_SRC_DIR) && ./build.sh'
-	mkdir -p $(MACOS_OUTER_BUNDLE)/Contents/Resources/keycard-simulator
-	cp -R $(addprefix $(KEYCARD_SIM_SRC_DIR)/,$(KEYCARD_SIM_RUNTIME_BITS)) \
-		$(MACOS_OUTER_BUNDLE)/Contents/Resources/keycard-simulator/
+	$(MAKE) keycard-simulator
+	$(MAKE) keycard-simulator-bundle KEYCARD_SIM_DEST=$(MACOS_OUTER_BUNDLE)/Contents/Resources/keycard-simulator
 endif
 
 	echo -e $(BUILD_MSG) "app"
@@ -963,6 +975,10 @@ $(STATUS_CLIENT_EXE): compile_windows_resources nim_status_client nim_windows_la
 	cp "$(shell which libwinpthread-1.dll)" $(OUTPUT)/bin/
 	cp "$(shell which libcrypto-3-x64.dll)" $(OUTPUT)/bin/
 	cp "$(shell which libssl-3-x64.dll)"    $(OUTPUT)/bin/
+ifeq ($(USE_SIMULATED_KEYCARD),true)
+	$(MAKE) keycard-simulator
+	$(MAKE) keycard-simulator-bundle KEYCARD_SIM_DEST=$(OUTPUT)/resources/keycard-simulator
+endif
 	echo -e $(BUILD_MSG) "deployable folder"
 	VCINSTALLDIR="$(VCINSTALLDIR)" windeployqt --compiler-runtime --qmldir ui --release \
 		tmp/windows/dist/Status/bin/Status.exe

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -222,6 +222,7 @@ def assembePath(List<String> extraPaths) {
       'C:/ProgramData/scoop/apps/openssl-lts/3.0.19/bin',
       'C:/ProgramData/scoop/apps/protobuf/3.20.1/bin',
       'C:/ProgramData/scoop/apps/inno-setup/6.7.0',
+      'C:/ProgramData/scoop/apps/temurin17-jdk/17.0.19-10/bin',
       'C:/ProgramData/scoop/apps/git/current/bin',
       'C:/ProgramData/scoop/shims',
       'C:/BuildTools/MSBuild/Current/Bin',

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,14 @@
 
   outputs = { self, nixpkgs }:
     let
-      darwinSystems = [ "aarch64-darwin" "x86_64-darwin" ];
-      forDarwin = f: nixpkgs.lib.genAttrs darwinSystems f;
+      systems = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems f;
     in {
-      packages = forDarwin (system:
+      packages = forAllSystems (system:
         let pkgs = nixpkgs.legacyPackages.${system};
         in {
+          jdk = pkgs.jdk; # keycard simulator precompile (USE_SIMULATED_KEYCARD packages)
+        } // nixpkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
           dmgbuild = pkgs.python3Packages.dmgbuild.overrideAttrs (old: rec {
             version = "1.6.7";
             src = pkgs.fetchPypi {
@@ -21,9 +23,6 @@
               hash = "sha256-Z2sXrNRIiZ9tSoOyGE4GV0gEROy2rJxJIoie+tnl2/s=";
             };
           });
-
-          # JDK to precompile the keycard simulator when packaging a USE_SIMULATED_KEYCARD build
-          jdk = pkgs.jdk;
         }
       );
     };

--- a/scripts/init_app_dir.sh
+++ b/scripts/init_app_dir.sh
@@ -25,19 +25,6 @@ copy_system_libs() {
   cp -P /usr/local/lib/x86_64-linux-gnu/libpcsclite*.so* "$dest/"
 }
 
-bundle_keycard_simulator() {
-  local dest="$1"
-  local src="vendor/status-keycard-qt/test/keycard-simulator"
-  if ! command -v javac >/dev/null 2>&1; then
-    echo "WARNING: javac not found; skipping keycard simulator bundle." >&2
-    return 0
-  fi
-  echo "Bundling keycard simulator (precompile + copy)..."
-  ( cd "$src" && ./build.sh )
-  mkdir -p "$dest"
-  cp -R "$src"/run.sh "$src"/libs "$src"/versions "$src"/out "$dest/"
-}
-
 DEST="${APP_DIR:?APP_DIR must be set}/usr"
 rm -rf "${APP_DIR}"
 
@@ -60,11 +47,6 @@ cp status.png "${DEST}/"
 
 copy_native_libs "${DEST}/lib"
 cp "${FCITX5_QT}" "${DEST}/plugins/platforminputcontexts/"
-
-if [[ "${USE_SIMULATED_KEYCARD:-}" == "true" ]]; then
-  # Bundled at usr/share/keycard-simulator; the app finds it at ../share relative to usr/bin.
-  bundle_keycard_simulator "${DEST}/share/keycard-simulator"
-fi
 
 # Qt WebEngine only (process + resources + locales)
 copy_qt_webengine() {

--- a/scripts/precompile-keycard-simulator.sh
+++ b/scripts/precompile-keycard-simulator.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Precompile keycard-simulator: nix JDK off-Windows; on Windows host javac (scoop).
+set -euo pipefail
+
+SRC_DIR="${1:?usage: $0 <keycard-simulator-dir>}"
+SRC_DIR="$(cd "$SRC_DIR" && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+is_windows() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_build() {
+  # Host JDK may be 17; --release 11 keeps bytecode runnable on any JRE >= 11 (same as build.sh).
+  local release="${JAVAC_RELEASE:-11}"
+  (
+    cd "$SRC_DIR"
+    mkdir -p out/core
+    echo "Compiling core (--release $release) ..."
+    "$JAVAC_BIN" --release "$release" -cp "libs/common/*" -d out/core \
+      src/im/status/keycardqt/sim/*.java
+    local vdir v out
+    local -a sources
+    for vdir in versions/*/; do
+      v="$(basename "$vdir")"
+      [[ -d "${vdir}src" && -d "${vdir}libs" ]] || continue
+      out="${vdir}out"
+      mkdir -p "$out"
+      echo "Compiling version $v (--release $release) ..."
+      mapfile -d '' sources < <(find "${vdir}src" -name '*.java' -print0)
+      "$JAVAC_BIN" --release "$release" \
+        -cp "out/core;libs/common/*;${vdir}libs/*" -d "$out" \
+        "${sources[@]}"
+    done
+  )
+}
+
+cd "$ROOT_DIR"
+
+if is_windows; then
+  if ! command -v javac >/dev/null 2>&1; then
+    echo "ERROR: javac not found; run scripts/windows_build_setup.ps1" >&2
+    exit 1
+  fi
+  JAVAC_BIN="$(command -v javac)"
+  run_build
+else
+  export PATH="/nix/var/nix/profiles/default/bin:${HOME:-}/.nix-profile/bin:${PATH:-}"
+  nix --extra-experimental-features 'nix-command flakes' shell .#jdk -c \
+    bash -c "cd '$SRC_DIR' && ./build.sh"
+fi
+
+test -d "$SRC_DIR/out"

--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -77,6 +77,7 @@ function Install-Dependencies {
     Scoop-Install 'status/inno-setup'    '6.7.0'
     Scoop-Install 'status/msys2'         '2025-12-13'
     Scoop-Install 'status/llvm'          '22.1.8'
+    Scoop-Install 'status/temurin17-jdk' '17.0.19-10'
 }
 
 function Install-MSYS2-Packages {

--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -153,6 +153,7 @@ export PATH=`"/c/BuildTools/MSBuild/Current/Bin:`$PATH`"
 export PATH=`"/c/BuildTools/VC/Tools/MSVC/14.44.35207/bin:`$PATH`"
 export PATH=`"/c/ProgramData/scoop/apps/openssl-lts/current/bin:`$PATH`"
 export PATH=`"/c/ProgramData/scoop/apps/inno-setup/current:`$PATH`"
+export PATH=`"/c/ProgramData/scoop/apps/temurin17-jdk/17.0.19-10/bin:`$PATH`"
 "@
 }
 

--- a/src/app_service/service/keycardV2/test_controller.nim
+++ b/src/app_service/service/keycardV2/test_controller.nim
@@ -14,10 +14,15 @@ when defined(useSimulatedKeycard):
   const
     KEYCARD_SIMULATOR_DEFAULT_VERSION = "3.2"
     KEYCARD_SIMULATOR_DEFAULT_SIMULATOR_ADDRESS = "127.0.0.1:9025"
-    # Subdirs (relative to the app executable) where packaging bundles the precompiled simulator:
-    #   macOS  Status.app/Contents/MacOS/nim_status_client -> ../Resources/keycard-simulator
-    #   Linux  AppDir/usr/bin/nim_status_client            -> ../share/keycard-simulator
-    KEYCARD_SIMULATOR_BUNDLED_SUBDIRS = ["../Resources/keycard-simulator", "../share/keycard-simulator"]
+    # Relative to the app executable:
+    #   macOS   ../Resources/keycard-simulator
+    #   Linux   ../share/keycard-simulator
+    #   Windows ../resources/keycard-simulator
+    KEYCARD_SIMULATOR_BUNDLED_SUBDIRS = [
+      "../Resources/keycard-simulator",
+      "../share/keycard-simulator",
+      "../resources/keycard-simulator",
+    ]
     KEYCARD_SIMULATOR_DEV_DIR = "vendor/status-keycard-qt/test/keycard-simulator"
 
   var ignoreKeycardLibSignals = false # used to avoid triggering of any keycard actions while setting up the test keycard
@@ -35,6 +40,76 @@ when defined(useSimulatedKeycard):
       if dirExists(candidate):
         return candidate
     return absolutePath(KEYCARD_SIMULATOR_DEV_DIR)
+
+  proc readMainClass(simDir, version: string): string =
+    let propsPath = simDir / "versions" / version / "version.properties"
+    if not fileExists(propsPath):
+      return ""
+    for line in lines(propsPath):
+      let t = line.strip()
+      if t.startsWith("mainClass="):
+        return t[len("mainClass=") .. ^1].strip()
+    return ""
+
+  proc buildClasspath(simDir, version: string): string =
+    var entries = @[simDir / "out" / "core", simDir / "versions" / version / "out"]
+    for jar in walkFiles(simDir / "libs" / "common" / "*"):
+      entries.add(jar)
+    for jar in walkFiles(simDir / "versions" / version / "libs" / "*"):
+      entries.add(jar)
+    entries.join($PathSep)
+
+  proc ensureSimulatorBuilt(simDir: string): string =
+    if dirExists(simDir / "out"):
+      return ""
+    when defined(windows):
+      return "keycard simulator not precompiled (out/ missing)"
+    else:
+      try:
+        let p = startProcess("/bin/bash", workingDir = simDir,
+          args = @["-c", "./build.sh"], options = {poParentStreams})
+        let code = p.waitForExit()
+        p.close()
+        if code != 0 or not dirExists(simDir / "out"):
+          return "keycard simulator build.sh failed"
+        return ""
+      except CatchableError as e:
+        return "failed to run build.sh: " & e.msg
+
+  # Windows: free leftover keycardqt on port; refuse if held by something else (like run.sh).
+  proc freeSimulatorPort(port: string): string =
+    when defined(windows):
+      try:
+        proc listeningPids(): seq[string] =
+          let (netOut, _) = execCmdEx("netstat -ano -p TCP")
+          for line in netOut.splitLines():
+            let parts = line.splitWhitespace()
+            if parts.len >= 5 and parts[0] == "TCP" and parts[^2] == "LISTENING" and
+                parts[1].endsWith(":" & port):
+              let pid = parts[^1]
+              if pid.len > 0 and pid != "0" and pid notin result:
+                result.add(pid)
+
+        let pids = listeningPids()
+        for pid in pids:
+          let (cmdOut, _) = execCmdEx(
+            "powershell -NoProfile -Command \"(Get-CimInstance Win32_Process -Filter 'ProcessId=" &
+            pid & "').CommandLine\"")
+          let cmd = cmdOut.strip()
+          if "keycardqt" in cmd.toLowerAscii():
+            info "Port held by previous simulator — stopping it", port = port, pid = pid
+            discard execCmdEx("taskkill /PID " & pid & " /F")
+          else:
+            return "port " & port & " is in use by a non-simulator process (pid " & pid & ")"
+        for _ in 0 ..< 20:
+          if listeningPids().len == 0:
+            break
+          sleep(200)
+        return ""
+      except CatchableError as e:
+        return "failed to check simulator port: " & e.msg
+    else:
+      return ""
 
   type
     LoadCardArg = ref object of QObjectTaskArg
@@ -70,21 +145,33 @@ when defined(useSimulatedKeycard):
         self.threadpool.teardown()
       self.QObject.delete
 
-    proc startSimulator*(self: KeycardTestController, version: string) {.slot.} =
+    proc startSimulator*(self: KeycardTestController, version: string): string {.slot.} =
       var safeVersion = ""
       for c in version:
         if c in {'0'..'9', '.'}: safeVersion.add(c)
       if safeVersion.len == 0:
         safeVersion = KEYCARD_SIMULATOR_DEFAULT_VERSION
+
       let simDir = resolveSimDir()
       if not dirExists(simDir):
-        error "keycard simulator directory not found; set STATUS_KEYCARD_SIM_DIR to " &
-          "'<status-desktop checkout>/vendor/status-keycard-qt/test/keycard-simulator'", dir = simDir
-        return
-      let port = getEnv("STATUS_KEYCARD_SIM_ENDPOINT", KEYCARD_SIMULATOR_DEFAULT_SIMULATOR_ADDRESS).rsplit(":", 1)[^1]
-      let launch =
-        if dirExists(simDir / "out"): "exec ./run.sh " & port & " " & safeVersion
-        else: "./build.sh && exec ./run.sh " & port & " " & safeVersion
+        error "keycard simulator directory not found", dir = simDir
+        return "keycard simulator directory not found; set STATUS_KEYCARD_SIM_DIR"
+
+      let buildErr = ensureSimulatorBuilt(simDir)
+      if buildErr.len > 0:
+        error "keycard simulator build failed", err = buildErr, dir = simDir
+        return buildErr
+
+      let mainClass = readMainClass(simDir, safeVersion)
+      if mainClass.len == 0:
+        error "keycard simulator mainClass missing", version = safeVersion, dir = simDir
+        return "missing mainClass for applet version " & safeVersion
+
+      var port = ""
+      for c in getEnv("STATUS_KEYCARD_SIM_ENDPOINT", KEYCARD_SIMULATOR_DEFAULT_SIMULATOR_ADDRESS).rsplit(":", 1)[^1]:
+        if c in {'0'..'9'}: port.add(c)
+      if port.len == 0:
+        port = "9025"
 
       if not self.simProcess.isNil and self.simProcess.running:
         self.simProcess.terminate()
@@ -95,12 +182,36 @@ when defined(useSimulatedKeycard):
       discard keycard_go.keycardTestUnplugReader()
 
       try:
-        self.simProcess = startProcess("/bin/bash",
-          args = @["-c", "cd '" & simDir & "' && " & launch],
-          options = {poParentStreams})
+        when defined(windows):
+          # Mirror run.sh: version/mainClass already validated above; free port then launch JVM.
+          let javaExe = findExe("java")
+          if javaExe.len == 0:
+            error "java not found for keycard simulator"
+            return "java not found in PATH; install a JRE >= 11"
+          let portErr = freeSimulatorPort(port)
+          if portErr.len > 0:
+            error "keycard simulator port unavailable", err = portErr, port = port
+            return portErr
+          let classpath = buildClasspath(simDir, safeVersion)
+          self.simProcess = startProcess(
+            javaExe,
+            workingDir = simDir,
+            args = @["-noverify", "-cp", classpath, mainClass, port],
+            options = {poParentStreams},
+          )
+        else:
+          # run.sh validates version props and frees a leftover simulator on the port.
+          self.simProcess = startProcess(
+            "/bin/bash",
+            workingDir = simDir,
+            args = @["./run.sh", port, safeVersion],
+            options = {poParentStreams},
+          )
         info "starting keycard simulator", dir = simDir, port = port, version = safeVersion
+        return ""
       except CatchableError as e:
         error "failed to start keycard simulator", err = e.msg
+        return "failed to start keycard simulator: " & e.msg
 
     proc createCard*(self: KeycardTestController, cardId: string) {.slot.} =
       info "creating a new keycard with id: ", cardId

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -164,6 +164,8 @@ cd test/e2e && source .venv/bin/activate
 pytest -m keycard -v
 ```
 
+Requires a **JRE ≥ 11** on `PATH` (packaged builds ship the simulator, but still start it with the host JVM).
+
 **1. Dev build** — from repo root:
 
 ```bash

--- a/ui/imports/shared/panels/KeycardSimulatorController.qml
+++ b/ui/imports/shared/panels/KeycardSimulatorController.qml
@@ -28,6 +28,7 @@ ApplicationWindow {
         id: d
 
         property bool simulatorStarted: false
+        property string simulatorError: ""
         property var cardIds: []
         property bool readerPlugged: false
         property bool cardInserted: false
@@ -118,10 +119,20 @@ ApplicationWindow {
             text: d.simulatorStarted ? qsTr("Restart Keycard Simulator")
                                      : qsTr("Start Keycard Simulator")
             onClicked: {
-                root.controller.startSimulator(d.selectedVersion)
-                d.simulatorStarted = true
-                d.resetState()
+                d.simulatorError = root.controller.startSimulator(d.selectedVersion)
+                d.simulatorStarted = !d.simulatorError
+                if (d.simulatorStarted)
+                    d.resetState()
             }
+        }
+        StatusBaseText {
+            objectName: "keycardSimStartError"
+            Layout.fillWidth: true
+            visible: !!d.simulatorError
+            wrapMode: Text.WordWrap
+            font.pixelSize: 12
+            color: Theme.palette.dangerColor1
+            text: d.simulatorError
         }
 
         Separator {}


### PR DESCRIPTION
### What does the PR do

## Summary
- Fix packaged `USE_SIMULATED_KEYCARD` builds on Linux and Windows: PR #21775 only bundled the simulator on macOS; Linux silently skipped without `javac`, and Windows had no packaging / bash-based launch.
- Bundle the precompiled keycard simulator into Linux AppImage and Windows packages.
- Add a cross-platform precompile script:
  - uses nix JDK when available;
  - uses the host `javac` as a fallback;
  - downloads portable Temurin 17 on Windows when Java is unavailable.
- Launch the simulator directly with the host JVM instead of relying on `/bin/bash` and `run.sh`.
- Add the Windows simulator resource path.
- Fail packaging when simulator compilation is unsuccessful.
- Display simulator startup errors in the controller UI.
- Document the JRE 11+ runtime requirement.

Closes #21871


Run on Linux on Jenkins

<img width="1744" height="1046" alt="image" src="https://github.com/user-attachments/assets/2f7852df-271b-45bf-94ee-554e298fc7b0" />

Run on Windows on Jenkins

<img width="1744" height="1046" alt="image" src="https://github.com/user-attachments/assets/d6dbc231-efc7-4398-bb78-7e505ea67698" />
