### PR TITLE
feat: fast password change with optional rekey

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -214,8 +214,8 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.aboutService = about_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.advancedService = advanced_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.dappPermissionsService = dapp_permissions_service.newService()
-  result.privacyService = privacy_service.newService(statusFoundation.events, result.settingsService,
-  result.accountsService)
+  result.privacyService = privacy_service.newService(statusFoundation.events, statusFoundation.threadpool,
+    result.settingsService, result.accountsService)
   result.savedAddressService = saved_address_service.newService(statusFoundation.threadpool, statusFoundation.events,
     result.networkService, result.settingsService)
   result.followingAddressService = following_address_service.newService(statusFoundation.threadpool, statusFoundation.events,
@@ -500,7 +500,8 @@ proc buildAndRegisterUserProfile(self: AppController) =
 
   let loggedInAccount = self.accountsService.getLoggedInAccount()
 
-  singletonInstance.userProfile.setFixedData(alias, loggedInAccount.keyUid, pubKey, loggedInAccount.keycardPairing.len > 0)
+  singletonInstance.userProfile.setFixedData(alias, loggedInAccount.keyUid, pubKey, loggedInAccount.keycardPairing.len > 0,
+    self.privacyService.isProfileMigratedToDEKEncryption())
   singletonInstance.userProfile.setDisplayName(displayName)
   singletonInstance.userProfile.setPreferredName(preferredName)
   singletonInstance.userProfile.setThumbnailImage(loggedInAccount.images.thumbnail)

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -13,6 +13,8 @@ QtObject:
     keyUid: string
     pubKey: string
     migratedToColdWallet: bool
+    migratedToDEKEncryption: bool
+
     # fields which may change during runtime
     displayName: string
     preferredName: string
@@ -33,11 +35,13 @@ QtObject:
   proc delete*(self: UserProfile) =
     self.QObject.delete
 
-  proc setFixedData*(self: UserProfile, username: string, keyUid: string, pubKey: string, migratedToColdWallet: bool) =
+  proc setFixedData*(self: UserProfile, username: string, keyUid: string, pubKey: string, migratedToColdWallet: bool,
+    migratedToDEKEncryption: bool) =
     self.username = username
     self.keyUid = keyUid
     self.pubKey = pubKey
     self.migratedToColdWallet = migratedToColdWallet
+    self.migratedToDEKEncryption = migratedToDEKEncryption
 
   proc getKeyUid*(self: UserProfile): string {.slot.} =
     self.keyUid
@@ -55,10 +59,25 @@ QtObject:
   QtProperty[string] compressedPubKey:
     read = getCompressedPubKey
 
+  proc migratedToColdWalletChanged*(self: UserProfile) {.signal.}
+
   proc getMigratedToColdWallet*(self: UserProfile): bool {.slot.} =
     self.migratedToColdWallet
+
+  proc setMigratedToColdWallet*(self: UserProfile, value: bool) =
+    if self.migratedToColdWallet == value:
+      return
+    self.migratedToColdWallet = value
+    self.migratedToColdWalletChanged()
+
   QtProperty[bool] migratedToColdWallet:
     read = getMigratedToColdWallet
+    notify = migratedToColdWalletChanged
+
+  proc getMigratedToDEKEncryption*(self: UserProfile): bool {.slot.} =
+    self.migratedToDEKEncryption
+  QtProperty[bool] migratedToDEKEncryption:
+    read = getMigratedToDEKEncryption
 
   proc getUsingBiometricLogin*(self: UserProfile): bool {.slot.} =
     if(not main_constants.SUPPORTS_FINGERPRINT):

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -46,8 +46,11 @@ proc init*(self: Controller) =
 proc isMnemonicBackedUp*(self: Controller): bool =
   return self.privacyService.isMnemonicBackedUp()
 
-proc changePassword*(self: Controller, password: string, newPassword: string) =
-  self.privacyService.changePassword(password, newPassword)
+proc changePassword*(self: Controller, password: string, newPassword: string, rekey: bool) =
+  self.privacyService.changePassword(password, newPassword, rekey)
+
+proc isProfileMigratedToDEKEncryption*(self: Controller): bool =
+  return self.privacyService.isProfileMigratedToDEKEncryption()
 
 proc getMnemonic*(self: Controller): string =
   return self.privacyService.getMnemonic()

--- a/src/app/modules/main/profile_section/privacy/io_interface.nim
+++ b/src/app/modules/main/profile_section/privacy/io_interface.nim
@@ -25,7 +25,10 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method isMnemonicBackedUp*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method changePassword*(self: AccessInterface, password: string, newPassword: string) {.base.} =
+method changePassword*(self: AccessInterface, password: string, newPassword: string, rekey: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method isProfileMigratedToDEKEncryption*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getMnemonic*(self: AccessInterface): string {.base.} =

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -49,8 +49,11 @@ method viewDidLoad*(self: Module) =
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
-method changePassword*(self: Module, password: string, newPassword: string) =
-  self.controller.changePassword(password, newPassword)
+method changePassword*(self: Module, password: string, newPassword: string, rekey: bool) =
+  self.controller.changePassword(password, newPassword, rekey)
+
+method isProfileMigratedToDEKEncryption*(self: Module): bool =
+  return self.controller.isProfileMigratedToDEKEncryption()
 
 method isMnemonicBackedUp*(self: Module): bool =
   return self.controller.isMnemonicBackedUp()

--- a/src/app/modules/main/profile_section/privacy/view.nim
+++ b/src/app/modules/main/profile_section/privacy/view.nim
@@ -16,8 +16,11 @@ QtObject:
   proc load*(self: View) =
     self.delegate.viewDidLoad()
 
-  proc changePassword*(self: View, password: string, newPassword: string) {.slot.} =
-    self.delegate.changePassword(password, newPassword)
+  proc changePassword*(self: View, password: string, newPassword: string, rekey: bool) {.slot.} =
+    self.delegate.changePassword(password, newPassword, rekey)
+
+  proc isProfileMigratedToDEKEncryption*(self: View): bool {.slot.} =
+    return self.delegate.isProfileMigratedToDEKEncryption()
 
   proc passwordChanged(self: View, success: bool, errorMsg: string) {.signal.}
   proc emitPasswordChangedSignal*(self: View, success: bool, errorMsg: string) =

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -119,6 +119,9 @@ proc loginKeycard*(self: Controller, keyUid: string, pin: string, pairingPasswor
 proc getPasswordStrengthScore*(self: Controller, password, userName: string): int =
   return self.generalService.getPasswordStrengthScore(password, userName)
 
+proc isProfileMigratedToDEKEncryption*(self: Controller, keyUid: string): bool =
+  return self.accountsService.isProfileMigratedToDEKEncryption(keyUid)
+
 proc validMnemonic*(self: Controller, mnemonic: string): bool =
   let (_, err) = self.accountsService.validateMnemonic(mnemonic)
   return err.len == 0

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -37,6 +37,9 @@ method loginKeycard*(self: AccessInterface, keyUid: string, pin: string, pairing
 method getPasswordStrengthScore*(self: AccessInterface, password, userName: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method isProfileMigratedToDEKEncryption*(self: AccessInterface, keyUid: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method validMnemonic*(self: AccessInterface, mnemonic: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -180,6 +180,9 @@ method loginKeycard*[T](self: Module[T], keyUid: string, pin: string, pairingPas
 method getPasswordStrengthScore*[T](self: Module[T], password, userName: string): int =
   self.controller.getPasswordStrengthScore(password, userName)
 
+method isProfileMigratedToDEKEncryption*[T](self: Module[T], keyUid: string): bool =
+  self.controller.isProfileMigratedToDEKEncryption(keyUid)
+
 method validMnemonic*[T](self: Module[T], mnemonic: string): bool =
   self.controller.validMnemonic(mnemonic)
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -133,17 +133,7 @@ method cleanupAfterMainTransition*[T](self: Module[T]) =
 method onMainFailedToLoad*[T](self: Module[T]) =
   self.view.accountLoginError("Failed to load main module, please restart the app and try again.", wrongPassword = false)
 
-method load*[T](self: Module[T]) =
-  singletonInstance.engine.setRootContextProperty("onboardingModule", self.viewVariant)
-  self.controller.init()
-
-  let loggedInAccount = self.accountsService.fetchLoggedInAccount()
-  self.resumeLogin = loggedInAccount.isValid()
-  if self.resumeLogin:
-    self.controller.setLoggedInAccount(loggedInAccount)
-    self.finishAppLoading2()
-    return
-
+proc buildLoginAccountsModel[T](self: Module[T]): bool =
   var openedAccounts: seq[AccountDto]
   var accountsLoadFailed = false
   try:
@@ -168,6 +158,20 @@ method load*[T](self: Module[T]) =
       ))
 
     self.view.setLoginAccountsModelItems(items)
+  return accountsLoadFailed
+
+method load*[T](self: Module[T]) =
+  singletonInstance.engine.setRootContextProperty("onboardingModule", self.viewVariant)
+  self.controller.init()
+
+  let loggedInAccount = self.accountsService.fetchLoggedInAccount()
+  self.resumeLogin = loggedInAccount.isValid()
+  if self.resumeLogin:
+    self.controller.setLoggedInAccount(loggedInAccount)
+    self.finishAppLoading2()
+    return
+
+  let accountsLoadFailed = self.buildLoginAccountsModel()
 
   self.delegate.onboardingDidLoad()
   if accountsLoadFailed:
@@ -418,8 +422,15 @@ method onKeycardExportLoginKeysSuccess*[T](self: Module[T], exportedKeys: Keycar
 
 method onKeycardAccountConverted*[T](self: Module[T], success: bool) =
   let state = if success: ProgressState.Success else: ProgressState.Failed
+  let restartRequired = self.accountsService.isAppRestartRequiredAfterProfileConversion()
+  debug "keycard account converted", success, restartRequired
+  self.view.setConvertKeycardAccountRestartRequired(restartRequired)
   self.view.setConvertKeycardAccountState(state)
   self.generalService.logout()
+  if success and not restartRequired:
+    self.postLoginTasks = newSeq[PostOnboardingTask]()
+    self.accountsService.clearOpenedAccountsCache()
+    discard self.buildLoginAccountsModel()
 
 method getPostOnboardingTasks*[T](self: Module[T]): seq[PostOnboardingTask] =
   return self.postOnboardingTasks

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -151,6 +151,9 @@ QtObject:
   proc getPasswordStrengthScore(self: View, password: string, userName: string): int {.slot.} =
     return self.delegate.getPasswordStrengthScore(password, userName)
 
+  proc isProfileMigratedToDEKEncryption(self: View, keyUid: string): bool {.slot.} =
+    return self.delegate.isProfileMigratedToDEKEncryption(keyUid)
+
   proc validMnemonic(self: View, mnemonic: string): bool {.slot.} =
     return self.delegate.validMnemonic(mnemonic)
 

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -15,6 +15,7 @@ QtObject:
       loginAccountsModel: login_acc_model.Model
       loginAccountsModelVariant: QVariant
       convertKeycardAccountState: ProgressState
+      convertKeycardAccountRestartRequired: bool
       keycardModule: QVariant
 
   proc delete*(self: View)
@@ -25,6 +26,7 @@ QtObject:
     result.loginAccountsModel = login_acc_model.newModel()
     result.loginAccountsModelVariant = newQVariant(result.loginAccountsModel)
     result.keycardModule = newQVariant()
+    result.convertKeycardAccountRestartRequired = true
 
   ### QtSignals ###
 
@@ -135,6 +137,18 @@ QtObject:
   QtProperty[int] convertKeycardAccountState:
     read = getConvertKeycardAccountState
     notify = convertKeycardAccountStateChanged
+
+  proc convertKeycardAccountRestartRequiredChanged*(self: View) {.signal.}
+  proc getConvertKeycardAccountRestartRequired(self: View): bool {.slot.} =
+    return self.convertKeycardAccountRestartRequired
+  proc setConvertKeycardAccountRestartRequired*(self: View, value: bool) =
+    if self.convertKeycardAccountRestartRequired == value:
+      return
+    self.convertKeycardAccountRestartRequired = value
+    self.convertKeycardAccountRestartRequiredChanged()
+  QtProperty[bool] convertKeycardAccountRestartRequired:
+    read = getConvertKeycardAccountRestartRequired
+    notify = convertKeycardAccountRestartRequiredChanged
 
   proc keycardModuleChanged*(self: View) {.signal.}
   proc getKeycardModule(self: View): QVariant {.slot.} =

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -467,6 +467,14 @@ QtObject:
       error "login failed", errName = e.name, errDesription = e.msg
       self.events.emit(SIGNAL_LOGIN_ERROR, LoginErrorArgs(error: e.msg))
 
+  proc isProfileMigratedToDEKEncryption*(self: Service, keyUid: string): bool =
+    try:
+      let response = status_privacy.getProfileEncryptionInfo(keyUid)
+      return response.result{"migrated"}.getBool(false)
+    except Exception as e:
+      error "error: ", procName="isProfileMigratedToDEKEncryption", errName = e.name, errDesription = e.msg
+    return false
+
   proc convertRegularProfileKeypairToKeycard*(self: Service, keycardUid, currentPassword: string, newPassword: string) =
     var accountDataJson = %* {
       "key-uid": self.getLoggedInAccount().keyUid,
@@ -488,7 +496,8 @@ QtObject:
       newPassword: newPassword
     )
 
-    DB_BLOCKED_DUE_TO_PROFILE_MIGRATION = true
+    if not self.isProfileMigratedToDEKEncryption(self.getLoggedInAccount().keyUid):
+      DB_BLOCKED_DUE_TO_PROFILE_MIGRATION = true
     self.threadpool.start(arg)
 
   proc onConvertRegularProfileKeypairToKeycard*(self: Service, response: string) {.slot.} =
@@ -516,7 +525,8 @@ QtObject:
       hashedNewPassword: hashedNewPassword
     )
 
-    DB_BLOCKED_DUE_TO_PROFILE_MIGRATION = true
+    if not self.isProfileMigratedToDEKEncryption(self.getLoggedInAccount().keyUid):
+      DB_BLOCKED_DUE_TO_PROFILE_MIGRATION = true
     self.threadpool.start(arg)
 
   proc onConvertKeycardProfileKeypairToRegular*(self: Service, response: string) {.slot.} =

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -125,6 +125,12 @@ QtObject:
       error "error: ", procName="openedAccounts", errName = e.name, errDesription = e.msg
       raise
 
+  proc clearOpenedAccountsCache*(self: Service) =
+    self.accounts = @[]
+
+  proc isAppRestartRequiredAfterProfileConversion*(self: Service): bool =
+    return DB_BLOCKED_DUE_TO_PROFILE_MIGRATION
+
   proc openedAccountsContainsKeyUid*(self: Service, keyUid: string): bool =
     try:
       return (keyUID in self.openedAccounts().mapIt(it.keyUid))

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -71,7 +71,16 @@ QtObject:
     self.events.emit(SIGNAL_MESSENGER_STARTED, MessengerStartedArgs(error: startError))
 
   proc logout*(self: Service) =
-    discard status_general.logout()
+    try:
+      let response = status_general.logout()
+      let errMsg = response.result{"error"}.getStr
+      if errMsg.len > 0:
+        error "logout failed", errDescription=errMsg
+      else:
+        debug "logout succeeded"
+        self.messengerStartScheduled = false
+    except Exception as e:
+      error "logout failed", errName=e.name, errDescription=e.msg
 
   proc getWakuPeerCount*(self: Service): int =
     try:

--- a/src/app_service/service/privacy/async_tasks.nim
+++ b/src/app_service/service/privacy/async_tasks.nim
@@ -5,6 +5,7 @@ type
     accountId: string
     currentPassword: string
     newPassword: string
+    rekey: bool
 
 proc changeDatabasePasswordTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[ChangeDatabasePasswordTaskArg](argEncoded)
@@ -14,7 +15,7 @@ proc changeDatabasePasswordTask*(argEncoded: string) {.gcsafe, nimcall.} =
   }
 
   try:
-    let result = status_privacy.changeDatabasePassword(arg.accountId, arg.currentPassword, arg.newPassword)
+    let result = status_privacy.changeDatabasePassword(arg.accountId, arg.currentPassword, arg.newPassword, arg.rekey)
     output["result"] = %result.result
   except Exception as e:
     output["error"] = %e.msg

--- a/src/app_service/service/privacy/service.nim
+++ b/src/app_service/service/privacy/service.nim
@@ -32,11 +32,13 @@ QtObject:
     threadpool: threadpool.ThreadPool
 
   proc delete*(self: Service)
-  proc newService*(events: EventEmitter, settingsService: settings_service.Service,
+  proc newService*(events: EventEmitter, threadpool: threadpool.ThreadPool,
+    settingsService: settings_service.Service,
     accountsService: accounts_service.Service): Service =
     new(result, delete)
     result.QObject.setup
     result.events = events
+    result.threadpool = threadpool
     result.settingsService = settingsService
     result.accountsService = accountsService
 
@@ -69,11 +71,11 @@ QtObject:
     except Exception as e:
       error "error: ", procName="changePassword", errName = e.name, errDesription = e.msg
       data.errorMsg = e.msg
-    
+
     self.events.emit(SIGNAL_PASSWORD_CHANGED, data)
 
 
-  proc changePassword*(self: Service, password: string, newPassword: string) =
+  proc changePassword*(self: Service, password: string, newPassword: string, rekey: bool = false) =
     try:
       let loggedInAccount = self.accountsService.getLoggedInAccount()
       let arg = ChangeDatabasePasswordTaskArg(
@@ -82,12 +84,22 @@ QtObject:
         slot: "onChangeDatabasePasswordResponse",
         accountId: loggedInAccount.keyUid,
         currentPassword: common_utils.hashPassword(password),
-        newPassword: common_utils.hashPassword(newPassword)
+        newPassword: common_utils.hashPassword(newPassword),
+        rekey: rekey
       )
       self.threadpool.start(arg)
 
     except Exception as e:
       error "error: ", procName="changePassword", errName = e.name, errDesription = e.msg
+
+  proc isProfileMigratedToDEKEncryption*(self: Service): bool =
+    try:
+      let loggedInAccount = self.accountsService.getLoggedInAccount()
+      let response = status_privacy.getProfileEncryptionInfo(loggedInAccount.keyUid)
+      return response.result{"migrated"}.getBool(false)
+    except Exception as e:
+      error "error: ", procName="isProfileMigratedToDEKEncryption", errName = e.name, errDesription = e.msg
+      return false
 
   proc isMnemonicBackedUp*(self: Service): bool =
     return self.settingsService.getMnemonic().len == 0

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -137,6 +137,23 @@ proc startWallet(self: Service) =
     return
   discard backend.startWallet()
 
+proc onProfileKeypairConversionCompleted(self: Service, success: bool) =
+  if not success:
+    return
+  try:
+    let profileKeyUid = singletonInstance.userProfile.getKeyUid()
+    if profileKeyUid.len == 0 or not self.accountsService.isProfileMigratedToDEKEncryption(profileKeyUid):
+      return
+    let dbKp = self.getKeypairByKeyUidFromDb(profileKeyUid)
+    if dbKp.isNil:
+      return
+    self.replaceKeypair(dbKp)
+    singletonInstance.userProfile.setMigratedToColdWallet(dbKp.migratedToColdWallet())
+    self.events.emit(SIGNAL_NEW_KEYCARD_SET, KeycardArgs(success: true,
+      keycard: KeycardDto(keyUid: profileKeyUid)))
+  except Exception as e:
+    error "error refreshing profile keypair after conversion", errDesription=e.msg
+
 proc init*(self: Service) =
   try:
     self.buildTokensDebouncer = debouncer_service.newDebouncer(
@@ -205,6 +222,10 @@ proc init*(self: Service) =
   self.events.on(SIGNAL_PASSWORD_PROVIDED) do(e: Args):
     let args = AuthenticationArgs(e)
     self.onPasswordProvided(args.keyUid, args.password)
+
+  self.events.on(accounts_service.SIGNAL_CONVERTING_PROFILE_KEYPAIR) do(e: Args):
+    let args = accounts_service.ResultArgs(e)
+    self.onProfileKeypairConversionCompleted(args.success)
 
   let addresses = self.getWalletAddresses()
   self.buildAllTokens(addresses, forceRefresh = true)

--- a/src/backend/privacy.nim
+++ b/src/backend/privacy.nim
@@ -8,16 +8,29 @@ export response_type
 logScope:
   topics = "rpc-privacy"
 
-proc changeDatabasePassword*(keyUID: string, oldHashedPassword: string, newHashedPassword: string): RpcResponse[JsonNode]
+proc changeDatabasePassword*(keyUID: string, oldHashedPassword: string, newHashedPassword: string,
+  rekey: bool = false): RpcResponse[JsonNode]
   =
   try:
     let request = %* {
       "keyUID": keyUID,
       "oldPassword": oldHashedPassword,
       "newPassword": newHashedPassword,
+      "rekey": rekey,
     }
     let response = status_go.changeDatabasePasswordV2($request)
     result.result = Json.decode(response, JsonNode)
   except RpcException as e:
     error "error", methodName = "changeDatabasePassword", exception=e.msg
+    raise newException(RpcException, e.msg)
+
+proc getProfileEncryptionInfo*(keyUID: string): RpcResponse[JsonNode] =
+  try:
+    let request = %* {
+      "keyUID": keyUID,
+    }
+    let response = status_go.getProfileEncryptionInfo($request)
+    result.result = Json.decode(response, JsonNode)
+  except RpcException as e:
+    error "error", methodName = "getProfileEncryptionInfo", exception=e.msg
     raise newException(RpcException, e.msg)

--- a/src/status_go.nim
+++ b/src/status_go.nim
@@ -144,6 +144,11 @@ proc changeDatabasePasswordV2*(paramsJSON: string): string =
   defer: go_shim.free(funcOut)
   return $funcOut
 
+proc getProfileEncryptionInfo*(paramsJSON: string): string =
+  var funcOut = go_shim.getProfileEncryptionInfo(paramsJSON.cstring)
+  defer: go_shim.free(funcOut)
+  return $funcOut
+
 proc validateMnemonic*(mnemonic: string): string =
   var funcOut = go_shim.validateMnemonic(mnemonic.cstring)
   defer: go_shim.free(funcOut)

--- a/src/status_go/impl.nim
+++ b/src/status_go/impl.nim
@@ -62,6 +62,8 @@ proc logout*(): cstring {.importc: "Logout".}
 
 proc changeDatabasePasswordV2*(paramsJSON: cstring): cstring {.importc: "ChangeDatabasePasswordV2".}
 
+proc getProfileEncryptionInfo*(paramsJSON: cstring): cstring {.importc: "GetProfileEncryptionInfo".}
+
 proc validateMnemonic*(mnemonic: cstring): cstring {.importc: "ValidateMnemonic".}
 
 proc getRandomMnemonic*(): cstring {.importc: "GetRandomMnemonic".}

--- a/storybook/pages/ChangePasswordViewPage.qml
+++ b/storybook/pages/ChangePasswordViewPage.qml
@@ -36,16 +36,21 @@ SplitView {
                 property QtObject privacyModule: QtObject {
                     signal passwordChanged(success: bool, errorMsg: string)
                     signal saveBiometricsRequested(string keyUid, string credential)
+
+                    function changePassword(password, newPassword, rekey = false) {
+                        passwordChanged(ctrlChangePassSuccess.checked,
+                                        ctrlChangePassSuccess.checked ? "" : "Err changing password")
+                    }
+
+                    function isProfileMigratedToDEKEncryption() {
+                        return ctrlFastPasswordChange.checked
+                    }
                 }
 
                 readonly property string keyUid: keyUidInput.text
 
                 function tryStoreToKeyChain(errorDescription) {
                     privacyModule.saveBiometricsRequested(keyUid, passwordInput.text)
-                }
-
-                function changePassword(from, to) {
-                    privacyModule.passwordChanged(ctrlChangePassSuccess.checked, ctrlChangePassSuccess.checked ? "" : "Err changing password")
                 }
             }
 
@@ -97,6 +102,11 @@ SplitView {
                 Switch {
                     id: ctrlChangePassSuccess
                     text: "Password change will succeed"
+                    checked: true
+                }
+                Switch {
+                    id: ctrlFastPasswordChange
+                    text: "DEK / fast password change"
                     checked: true
                 }
             }

--- a/storybook/pages/ConfirmChangePasswordModalPage.qml
+++ b/storybook/pages/ConfirmChangePasswordModalPage.qml
@@ -24,6 +24,7 @@ SplitView {
 
             visible: true
             modal: false
+            fastPasswordChangePossible: fastPathCheckBox.checked
 
             onChangePasswordRequested: passwordChangedTimer.start()
 
@@ -50,9 +51,19 @@ SplitView {
 
         ColumnLayout {
             CheckBox {
+                id: fastPathCheckBox
+                text: "Fast password change possible (DEK)"
+                checked: true
+            }
+            CheckBox {
                 id: successFlow
                 text: "%1 in 2 seconds".arg(successFlow.checked ? "Success" : "Error")
                 checked: true
+            }
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                text: "Use the modal rekey checkbox (DEK only) to force the deep restart path."
             }
         }
     }

--- a/storybook/pages/ConvertKeycardAccountPagePage.qml
+++ b/storybook/pages/ConvertKeycardAccountPagePage.qml
@@ -28,6 +28,7 @@ Item {
             SplitView.fillHeight: true
 
             convertKeycardAccountState: ctrlState.currentValue
+            restartRequired: ctrlRestartRequired.checked
             onRestartRequested: {
                 logs.logEvent("restartRequested")
             }
@@ -54,6 +55,15 @@ Item {
         textRole: "name"
         valueRole: "value"
         model: Onboarding.getModelFromEnum("ProgressState")
+    }
+
+    Switch {
+        id: ctrlRestartRequired
+        anchors.right: ctrlState.left
+        anchors.rightMargin: 8
+        anchors.verticalCenter: ctrlState.verticalCenter
+        text: "Restart required (legacy profile)"
+        checked: true
     }
 
     Settings {

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -99,6 +99,11 @@ SplitView {
                 return Math.min(password.length-1, 4)
             }
 
+            function isProfileMigratedToDEKEncryption(keyUid: string): bool {
+                logs.logEvent("OnboardingStore.isProfileMigratedToDEKEncryption", ["keyUid"], arguments)
+                return ctrlProfileEncryptionMigrated.checked
+            }
+
             // seedphrase/mnemonic
             function validMnemonic(mnemonic: string): bool {
                 logs.logEvent("OnboardingStore.validMnemonic", ["mnemonic"], arguments)
@@ -410,6 +415,13 @@ SplitView {
                 Switch {
                     id: ctrlLoginScreen
                     text: "Show login screen"
+                    checkable: true
+                    onToggled: root.restart()
+                }
+
+                Switch {
+                    id: ctrlProfileEncryptionMigrated
+                    text: "Profile encryption migrated (DEK)"
                     checkable: true
                     onToggled: root.restart()
                 }

--- a/storybook/qmlTests/tests/tst_ConfirmChangePasswordModal.qml
+++ b/storybook/qmlTests/tests/tst_ConfirmChangePasswordModal.qml
@@ -1,0 +1,156 @@
+import QtQuick
+import QtQuick.Controls
+import QtTest
+
+import AppLayouts.Profile.popups
+
+Item {
+    id: root
+
+    width: 1024
+    height: 768
+
+    Component {
+        id: componentUnderTest
+
+        ConfirmChangePasswordModal {
+            anchors.centerIn: parent
+            destroyOnClose: false
+            modal: false
+            closePolicy: Popup.NoAutoClose
+        }
+    }
+
+    property ConfirmChangePasswordModal controlUnderTest: null
+
+    SignalSpy {
+        id: changePasswordSpy
+        target: controlUnderTest
+        signalName: "changePasswordRequested"
+    }
+
+    TestCase {
+        name: "ConfirmChangePasswordModal"
+        when: windowShown
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            verify(!!controlUnderTest)
+            changePasswordSpy.target = controlUnderTest
+            changePasswordSpy.clear()
+        }
+
+        function cleanup() {
+            if (controlUnderTest) {
+                controlUnderTest.close()
+                controlUnderTest.destroy()
+                controlUnderTest = null
+            }
+            changePasswordSpy.clear()
+        }
+
+        function openDialog(fastPasswordChangePossible) {
+            controlUnderTest.fastPasswordChangePossible = fastPasswordChangePossible
+            controlUnderTest.open()
+            tryCompare(controlUnderTest, "opened", true)
+        }
+
+        function submitButton() {
+            const button = findChild(controlUnderTest, "changePasswordModalSubmitButton")
+            verify(!!button)
+            return button
+        }
+
+        function rekeyCheckbox() {
+            const checkbox = findChild(controlUnderTest, "changePasswordModalRekeyCheckBox")
+            verify(!!checkbox)
+            return checkbox
+        }
+
+        function description() {
+            const textItem = findChild(controlUnderTest, "changePasswordModalDescription")
+            verify(!!textItem)
+            return textItem
+        }
+
+        function rekeySectionVisible(checkbox) {
+            // ColumnLayout toggles visibility; child.visible stays true on its own.
+            return checkbox.parent.visible
+        }
+
+        function test_legacy_path_hides_rekey_and_requests_restart() {
+            openDialog(false)
+
+            const checkbox = rekeyCheckbox()
+            verify(!rekeySectionVisible(checkbox))
+            verify(description().text.indexOf("Future password changes will be instant") !== -1)
+            compare(submitButton().text, "Re-encrypt data using new password")
+
+            mouseClick(submitButton())
+            tryCompare(changePasswordSpy, "count", 1)
+            compare(changePasswordSpy.signalArguments[0][0], false)
+            compare(submitButton().text, "Restart Status")
+            verify(!submitButton().enabled)
+
+            controlUnderTest.passwordSuccessfulyChanged()
+            compare(submitButton().text, "Restart Status")
+            verify(submitButton().enabled)
+            // Do not click Restart Status — SystemUtils.restartApplication exits the process.
+        }
+
+        function test_fast_path_shows_close_and_emits_rekey_false() {
+            openDialog(true)
+
+            const checkbox = rekeyCheckbox()
+            verify(rekeySectionVisible(checkbox))
+            verify(!checkbox.checked)
+            verify(description().text.indexOf("no restart needed") !== -1)
+            compare(submitButton().text, "Change password")
+
+            mouseClick(submitButton())
+            tryCompare(changePasswordSpy, "count", 1)
+            compare(changePasswordSpy.signalArguments[0][0], false)
+
+            controlUnderTest.passwordSuccessfulyChanged()
+            compare(submitButton().text, "Close")
+            verify(submitButton().enabled)
+
+            mouseClick(submitButton())
+            tryCompare(controlUnderTest, "opened", false)
+        }
+
+        function test_fast_path_with_rekey_requests_deep_change() {
+            openDialog(true)
+
+            const checkbox = rekeyCheckbox()
+            verify(rekeySectionVisible(checkbox))
+            mouseClick(checkbox)
+            tryCompare(checkbox, "checked", true)
+
+            verify(description().text.indexOf("fully re-encrypted with a new encryption key") !== -1)
+            compare(submitButton().text, "Re-encrypt data using new password")
+
+            mouseClick(submitButton())
+            tryCompare(changePasswordSpy, "count", 1)
+            compare(changePasswordSpy.signalArguments[0][0], true)
+
+            controlUnderTest.passwordSuccessfulyChanged()
+            compare(submitButton().text, "Restart Status")
+            // Do not click Restart Status — SystemUtils.restartApplication exits the process.
+        }
+
+        function test_rekey_checkbox_hidden_while_in_progress_and_after_success() {
+            openDialog(true)
+
+            const checkbox = rekeyCheckbox()
+            verify(rekeySectionVisible(checkbox))
+
+            mouseClick(submitButton())
+            tryCompare(changePasswordSpy, "count", 1)
+            verify(!rekeySectionVisible(checkbox))
+
+            controlUnderTest.passwordSuccessfulyChanged()
+            verify(!rekeySectionVisible(checkbox))
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -28,6 +28,7 @@ Item {
         property int keycardState // enum Onboarding.KeycardState
         property bool biometricsAvailable
         property string existingPin
+        property bool profileEncryptionMigrated: false
 
         readonly property string mnemonic: "apple banana cat country catalog catch category cattle dog elephant fish grape"
         readonly property string dummyNewPassword: "0123456789"
@@ -72,6 +73,10 @@ Item {
                 // password
                 function getPasswordStrengthScore(password: string) {
                     return Math.min(password.length-1, 4)
+                }
+
+                function isProfileMigratedToDEKEncryption(keyUid: string) { // -> bool
+                    return mockDriver.profileEncryptionMigrated
                 }
 
                 function finishOnboardingFlow(flow: int, data: Object) { // -> bool

--- a/test/e2e/configs/timeouts.py
+++ b/test/e2e/configs/timeouts.py
@@ -6,6 +6,7 @@ LOADING_LIST_TIMEOUT_MSEC = 20000
 PROCESS_TIMEOUT_SEC = 10
 PROCESS_TIMEOUT_SEC_WINDOWS = 20  # Longer timeout for slow first startup on Windows VMs
 APP_LOAD_TIMEOUT_MSEC = 60000
+FAST_PASSWORD_TIMEOUT_MSEC = 5000
 WALLET_SYNC_TIMEOUT_MSEC = APP_LOAD_TIMEOUT_MSEC
 # Wallet balance sync after import/testnet toggle can exceed the default wallet sync timeout.
 WALLET_TRANSACTION_SYNC_TIMEOUT_MSEC = 120_000

--- a/test/e2e/constants/settings.py
+++ b/test/e2e/constants/settings.py
@@ -3,3 +3,4 @@ from enum import Enum
 
 class PasswordView(Enum):
     RESTART_STATUS = 'Restart Status'
+    CLOSE = 'Close'

--- a/test/e2e/gui/components/change_password_popup.py
+++ b/test/e2e/gui/components/change_password_popup.py
@@ -1,6 +1,7 @@
 import configs.timeouts
 from constants.settings import PasswordView
 from gui.elements.button import Button
+from gui.elements.check_box import CheckBox
 from gui.elements.object import QObject
 from gui.objects_map import names
 
@@ -10,16 +11,39 @@ class ChangePasswordPopup(QObject):
     def __init__(self):
         super().__init__(names.changePasswordPopup)
         self.re_encrypt_data_restart_button = Button(names.reEncryptRestartButton)
+        self.rekey_checkbox = CheckBox(names.reEncryptRekeyCheckbox)
 
-    def click_re_encrypt_data_restart_button(self):
+    def set_rekey_option(self, value: bool):
         """
-        The Restart button is visible but disabled while re-encryption runs — wait for enabled,
+        Only available on profiles using the DEK encryption scheme (all profiles created
+        by current builds). Checking it forces the slow full-re-encryption path.
+        """
+        self.rekey_checkbox.set(value)
+
+    def confirm_password_change(self) -> bool:
+        """
+        Starts the password change and completes the popup flow.
+
+        Returns True when the app is restarting (slow path: one-time migration of a legacy
+        profile, or the rekey option), False when the fast path finished — the popup was
+        closed and the app keeps running.
+
+        The button is visible but disabled while the operation runs — wait for enabled,
         not merely for the object to exist (see ConfirmChangePasswordModal.qml).
         """
         timeout_msec = configs.timeouts.APP_LOAD_TIMEOUT_MSEC
 
         self.re_encrypt_data_restart_button.click()
         self.re_encrypt_data_restart_button.wait_until_enabled(timeout_msec=timeout_msec)
-        assert getattr(self.re_encrypt_data_restart_button.object, 'text') == PasswordView.RESTART_STATUS.value, \
-            f'Expected Restart button label, got {self.re_encrypt_data_restart_button.object.text!r}'
+
+        label = getattr(self.re_encrypt_data_restart_button.object, 'text')
+        assert label in (PasswordView.RESTART_STATUS.value, PasswordView.CLOSE.value), \
+            f'Expected Restart/Close button label, got {label!r}'
+
         self.re_encrypt_data_restart_button.click()
+        return label == PasswordView.RESTART_STATUS.value
+
+    def click_re_encrypt_data_restart_button(self):
+        # kept for backwards compatibility with older suites
+        restarting = self.confirm_password_change()
+        assert restarting, 'Expected the slow (restart) password-change path'

--- a/test/e2e/gui/components/change_password_popup.py
+++ b/test/e2e/gui/components/change_password_popup.py
@@ -1,7 +1,6 @@
 import configs.timeouts
 from constants.settings import PasswordView
 from gui.elements.button import Button
-from gui.elements.check_box import CheckBox
 from gui.elements.object import QObject
 from gui.objects_map import names
 
@@ -11,14 +10,6 @@ class ChangePasswordPopup(QObject):
     def __init__(self):
         super().__init__(names.changePasswordPopup)
         self.re_encrypt_data_restart_button = Button(names.reEncryptRestartButton)
-        self.rekey_checkbox = CheckBox(names.reEncryptRekeyCheckbox)
-
-    def set_rekey_option(self, value: bool):
-        """
-        Only available on profiles using the DEK encryption scheme (all profiles created
-        by current builds). Checking it forces the slow full-re-encryption path.
-        """
-        self.rekey_checkbox.set(value)
 
     def confirm_password_change(self) -> bool:
         """
@@ -31,7 +22,7 @@ class ChangePasswordPopup(QObject):
         The button is visible but disabled while the operation runs — wait for enabled,
         not merely for the object to exist (see ConfirmChangePasswordModal.qml).
         """
-        timeout_msec = configs.timeouts.APP_LOAD_TIMEOUT_MSEC
+        timeout_msec = configs.timeouts.FAST_PASSWORD_TIMEOUT_MSEC
 
         self.re_encrypt_data_restart_button.click()
         self.re_encrypt_data_restart_button.wait_until_enabled(timeout_msec=timeout_msec)
@@ -42,8 +33,3 @@ class ChangePasswordPopup(QObject):
 
         self.re_encrypt_data_restart_button.click()
         return label == PasswordView.RESTART_STATUS.value
-
-    def click_re_encrypt_data_restart_button(self):
-        # kept for backwards compatibility with older suites
-        restarting = self.confirm_password_change()
-        assert restarting, 'Expected the slow (restart) password-change path'

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -878,8 +878,6 @@ change_password_menu_change_password_button = {"container": settingsContentBase_
 changePasswordPopup = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmChangePasswordModal", "type": "PopupItem", "visible": True}
 reEncryptRestartButton = {"container": statusDesktop_mainWindow_overlay,
                           "objectName": "changePasswordModalSubmitButton", "type": "StatusButton", "visible": True}
-reEncryptRekeyCheckbox = {"container": statusDesktop_mainWindow_overlay,
-                          "objectName": "changePasswordModalRekeyCheckBox", "type": "StatusCheckBox", "visible": True}
 reEncryptionComplete = {"container": statusDesktop_mainWindow_overlay, "objectName": "statusListItemSubTitle",
                         "type": "StatusTextWithLoadingState", "visible": True}
 

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -878,6 +878,8 @@ change_password_menu_change_password_button = {"container": settingsContentBase_
 changePasswordPopup = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmChangePasswordModal", "type": "PopupItem", "visible": True}
 reEncryptRestartButton = {"container": statusDesktop_mainWindow_overlay,
                           "objectName": "changePasswordModalSubmitButton", "type": "StatusButton", "visible": True}
+reEncryptRekeyCheckbox = {"container": statusDesktop_mainWindow_overlay,
+                          "objectName": "changePasswordModalRekeyCheckBox", "type": "StatusCheckBox", "visible": True}
 reEncryptionComplete = {"container": statusDesktop_mainWindow_overlay, "objectName": "statusListItemSubTitle",
                         "type": "StatusTextWithLoadingState", "visible": True}
 

--- a/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
@@ -1,6 +1,4 @@
 import allure
-import configs
-import constants
 import pytest
 from allure_commons._allure import step
 
@@ -25,68 +23,6 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
         restarting = change_password_popup.confirm_password_change()
         assert not restarting, \
             'Profiles created by this build use the fast password change; no restart expected'
-
-    with step('Restart application'):
-        aut.restart()
-        main_screen.prepare()
-
-    with step('Login with new password'):
-        main_screen.authorize_user(UserAccount(name=user_account.name,
-                                               password=new_password))
-
-    with step('Verify that the user logged in correctly'):
-        online_identifier = main_screen.left_panel.open_online_identifier()
-        profile_popup = online_identifier.open_profile_popup_from_online_identifier()
-        assert profile_popup.user_name == user_account.name
-
-
-@pytest.mark.critical
-@pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'member'])
-@pytest.mark.parametrize('user_account', [constants.user.community_member])
-def test_change_password_legacy_profile_migration(aut: AUT, main_screen: MainWindow, user_data, user_account):
-    """
-    The checked-in 'member' profile predates the DEK encryption scheme (no
-    <keyUID>-profile.kek file): its first password change performs the one-time lazy
-    migration — the slow, full re-encryption path with a mandatory restart.
-    """
-    with step('Open change password view'):
-        password_view = main_screen.left_panel.open_settings().left_panel.open_password_settings()
-
-    with step('Fill in the change password form and submit'):
-        new_password = random_password_string()
-        change_password_popup = password_view.change_password(user_account.password, new_password)
-
-    with step('Confirm the change: legacy profile takes the one-time migration path with a restart'):
-        restarting = change_password_popup.confirm_password_change()
-        assert restarting, 'Legacy profiles must take the one-time migration (restart) path'
-
-    with step('Restart application'):
-        aut.restart()
-        main_screen.prepare()
-
-    with step('Login with new password'):
-        main_screen.authorize_user(UserAccount(name=user_account.name,
-                                               password=new_password))
-
-    with step('Verify that the user logged in correctly'):
-        online_identifier = main_screen.left_panel.open_online_identifier()
-        profile_popup = online_identifier.open_profile_popup_from_online_identifier()
-        assert profile_popup.user_name == user_account.name
-
-
-@pytest.mark.critical
-def test_change_password_with_rekey_and_login(aut: AUT, main_screen: MainWindow, user_account):
-    with step('Open change password view'):
-        password_view = main_screen.left_panel.open_settings().left_panel.open_password_settings()
-
-    with step('Fill in the change password form and submit'):
-        new_password = random_password_string()
-        change_password_popup = password_view.change_password(user_account.password, new_password)
-
-    with step('Enable the re-encryption (rekey) option and confirm (slow path, restart required)'):
-        change_password_popup.set_rekey_option(True)
-        restarting = change_password_popup.confirm_password_change()
-        assert restarting, 'The rekey option must take the full re-encryption path with a restart'
 
     with step('Restart application'):
         aut.restart()

--- a/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
@@ -1,4 +1,6 @@
 import allure
+import configs
+import constants
 import pytest
 from allure_commons._allure import step
 
@@ -19,8 +21,72 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
         new_password = random_password_string()
         change_password_popup = password_view.change_password(user_account.password, new_password)
 
-    with step('Click re-encrypt data button and then restart'):
-        change_password_popup.click_re_encrypt_data_restart_button()
+    with step('Confirm the password change (fast path, no restart required)'):
+        restarting = change_password_popup.confirm_password_change()
+        assert not restarting, \
+            'Profiles created by this build use the fast password change; no restart expected'
+
+    with step('Restart application'):
+        aut.restart()
+        main_screen.prepare()
+
+    with step('Login with new password'):
+        main_screen.authorize_user(UserAccount(name=user_account.name,
+                                               password=new_password))
+
+    with step('Verify that the user logged in correctly'):
+        online_identifier = main_screen.left_panel.open_online_identifier()
+        profile_popup = online_identifier.open_profile_popup_from_online_identifier()
+        assert profile_popup.user_name == user_account.name
+
+
+@pytest.mark.critical
+@pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'member'])
+@pytest.mark.parametrize('user_account', [constants.user.community_member])
+def test_change_password_legacy_profile_migration(aut: AUT, main_screen: MainWindow, user_data, user_account):
+    """
+    The checked-in 'member' profile predates the DEK encryption scheme (no
+    <keyUID>-profile.kek file): its first password change performs the one-time lazy
+    migration — the slow, full re-encryption path with a mandatory restart.
+    """
+    with step('Open change password view'):
+        password_view = main_screen.left_panel.open_settings().left_panel.open_password_settings()
+
+    with step('Fill in the change password form and submit'):
+        new_password = random_password_string()
+        change_password_popup = password_view.change_password(user_account.password, new_password)
+
+    with step('Confirm the change: legacy profile takes the one-time migration path with a restart'):
+        restarting = change_password_popup.confirm_password_change()
+        assert restarting, 'Legacy profiles must take the one-time migration (restart) path'
+
+    with step('Restart application'):
+        aut.restart()
+        main_screen.prepare()
+
+    with step('Login with new password'):
+        main_screen.authorize_user(UserAccount(name=user_account.name,
+                                               password=new_password))
+
+    with step('Verify that the user logged in correctly'):
+        online_identifier = main_screen.left_panel.open_online_identifier()
+        profile_popup = online_identifier.open_profile_popup_from_online_identifier()
+        assert profile_popup.user_name == user_account.name
+
+
+@pytest.mark.critical
+def test_change_password_with_rekey_and_login(aut: AUT, main_screen: MainWindow, user_account):
+    with step('Open change password view'):
+        password_view = main_screen.left_panel.open_settings().left_panel.open_password_settings()
+
+    with step('Fill in the change password form and submit'):
+        new_password = random_password_string()
+        change_password_popup = password_view.change_password(user_account.password, new_password)
+
+    with step('Enable the re-encryption (rekey) option and confirm (slow path, restart required)'):
+        change_password_popup.set_rekey_option(True)
+        restarting = change_password_popup.confirm_password_change()
+        assert restarting, 'The rekey option must take the full re-encryption path with a restart'
 
     with step('Restart application'):
         aut.restart()

--- a/test/e2e_appium/pages/settings/change_password_modal.py
+++ b/test/e2e_appium/pages/settings/change_password_modal.py
@@ -38,6 +38,21 @@ class ChangePasswordModal(BasePage):
         except Exception:
             pass
 
+        if self._wait_for_primary_button_enabled(timeout=timeout):
+            label = ""
+            button = self.find_element_safe(self.locators.PRIMARY_BUTTON, timeout=2)
+            if button:
+                try:
+                    label = (button.text or "").strip()
+                except Exception:
+                    label = ""
+            if label.lower() == "close":
+                self.logger.info("Fast password change detected; closing modal, no restart")
+                self.safe_click(self.locators.PRIMARY_BUTTON, timeout=5)
+                if user and new_password:
+                    user.password = new_password
+                return True
+
         deadline = time.time() + timeout
         attempt = 1
         restart_confirmed = False

--- a/test/ui-test/testSuites/global_shared/scripts/settings_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/settings_names.py
@@ -174,4 +174,5 @@ change_password_menu_current_password = {"container": statusDesktop_mainWindow_o
 change_password_menu_new_password = {"container": statusDesktop_mainWindow_overlay, "objectName": "passwordViewNewPassword", "type": "StatusPasswordInput", "visible": True}
 change_password_menu_new_password_confirm = {"container": statusDesktop_mainWindow_overlay, "objectName": "passwordViewNewPasswordConfirm", "type": "StatusPasswordInput", "visible": True}
 change_password_menu_submit_button = {"container": statusDesktop_mainWindow_overlay, "objectName": "changePasswordModalSubmitButton", "type": "StatusButton", "visible": True}
+change_password_menu_rekey_checkbox = {"container": statusDesktop_mainWindow_overlay, "objectName": "changePasswordModalRekeyCheckBox", "type": "StatusCheckBox", "visible": True}
 change_password_success_menu_sign_out_quit_button = {"container": statusDesktop_mainWindow_overlay, "objectName": "changePasswordSuccessModalSignOutAndQuitButton", "type": "StatusButton", "visible": True}

--- a/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
@@ -57,6 +57,7 @@ OnboardingStackView {
     // functions
     required property var isBiometricsLogin // (string account) => bool
     required property var passwordStrengthScoreFunction
+    property var isProfileMigratedToDEKEncryption: (keyUid) => false // (string keyUid) => bool
     required property var isSeedPhraseValid
     required property var isSeedPhraseDuplicate
     required property var validateConnectionString
@@ -334,6 +335,10 @@ OnboardingStackView {
             isSeedPhraseValid: root.isSeedPhraseValid
             isSeedPhraseDuplicate: root.isSeedPhraseDuplicate
             passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
+            isProfileMigratedToDEKEncryption: {
+                const keyUid = root.loginScreen ? root.loginScreen.selectedProfileKeyId : ""
+                return keyUid ? root.isProfileMigratedToDEKEncryption(keyUid) : false
+            }
 
             onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
             onSetPasswordRequested: (password) => root.setPasswordRequested(password)
@@ -439,7 +444,7 @@ OnboardingStackView {
                 d.flow = onboardingFlow
                 root.skippedBiometricFlow()
                 root.onboardingKeycardFlowCompletedWithData(flow, dataJson)
-                root.finished(onboardingFlow)                
+                root.finished(onboardingFlow)
             }
 
             onKeycardFlowCompleted: function(flow, kUid, kcUid, success) {

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -161,6 +161,7 @@ Page {
 
         isBiometricsLogin: (account) => root.keychain.hasCredential(account) === Keychain.StatusSuccess
         passwordStrengthScoreFunction: root.onboardingStore.getPasswordStrengthScore
+        isProfileMigratedToDEKEncryption: root.onboardingStore.isProfileMigratedToDEKEncryption
         isSeedPhraseValid: root.onboardingStore.validMnemonic
         isSeedPhraseDuplicate: root.onboardingStore.isMnemonicDuplicate
         validateConnectionString: root.onboardingStore.validateLocalPairingConnectionString

--- a/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
+++ b/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
@@ -156,10 +156,12 @@ Item {
 
             ConvertKeycardAccountPage {
                 convertKeycardAccountState: onboardingStore.convertKeycardAccountState
+                restartRequired: onboardingStore.convertKeycardAccountRestartRequired
                 onRestartRequested: {
                     SystemUtils.restartApplication(true)
                 }
                 onBackToLoginRequested: {
+                    onboardingStore.loginRequestSent = false
                     onboardingLayout.unwindToLoginScreen()
                 }
             }

--- a/ui/app/AppLayouts/Onboarding/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/UseRecoveryPhraseFlow.qml
@@ -16,6 +16,8 @@ OnboardingStackView {
 
     required property int type
 
+    property bool isProfileMigratedToDEKEncryption: false
+
     // functions
     required property var passwordStrengthScoreFunction // (string) => int
     required property var isSeedPhraseValid // (string) => bool
@@ -31,6 +33,7 @@ OnboardingStackView {
     Component {
         id: conversionAckPage
         ConvertKeycardAccountAcksPage {
+            isProfileMigratedToDEKEncryption: root.isProfileMigratedToDEKEncryption
             onContinueRequested: root.push(seedPhrasePage)
         }
     }

--- a/ui/app/AppLayouts/Onboarding/pages/ConvertKeycardAccountAcksPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/ConvertKeycardAccountAcksPage.qml
@@ -11,6 +11,8 @@ OnboardingPage {
 
     title: qsTr("Are you sure you want to migrate this profile keypair to Status?")
 
+    property bool isProfileMigratedToDEKEncryption: false
+
     signal continueRequested()
 
     contentItem: Item {
@@ -52,7 +54,9 @@ OnboardingPage {
                 Layout.alignment: Qt.AlignCenter
                 wrapMode: Text.WordWrap
                 horizontalAlignment: Text.AlignHCenter
-                text: qsTr("Your data will also be re-encrypted, restricting access to Status for up to 30 mins. Do you wish to continue?")
+                text: root.isProfileMigratedToDEKEncryption
+                      ? qsTr("Your profile encryption key will also be updated. Do you wish to continue?")
+                      : qsTr("Your data will also be re-encrypted, restricting access to Status for up to 30 mins. Do you wish to continue?")
             }
 
             StatusButton {

--- a/ui/app/AppLayouts/Onboarding/pages/ConvertKeycardAccountPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/ConvertKeycardAccountPage.qml
@@ -14,6 +14,8 @@ OnboardingPage {
     readonly property bool backAvailableHint: false
     required property int convertKeycardAccountState
 
+    property bool restartRequired: true
+
     signal restartRequested()
     signal backToLoginRequested()
 
@@ -45,13 +47,18 @@ OnboardingPage {
                 when: root.convertKeycardAccountState === Onboarding.ProgressState.Success
 
                 PropertyChanges {
-                    root.title: qsTr("Re-encryption complete")
+                    target: root
+                    root.title: root.restartRequired ? qsTr("Re-encryption complete")
+                                                     : qsTr("Profile migration complete")
                 }
                 PropertyChanges {
                     iconLoader.sourceComponent: successIcon
                 }
                 PropertyChanges {
-                    subtitle.text: qsTr("Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.")
+                    target: subtitle
+                    subtitle.text: root.restartRequired
+                                   ? qsTr("Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.")
+                                   : qsTr("Your profile no longer uses Keycard. You can now log in using the password you just created.")
                 }
                 PropertyChanges {
                     warningText.visible: false
@@ -147,9 +154,16 @@ OnboardingPage {
 
                 visible: false
                 isOutline: false
-                text: qsTr("Restart Status and log in with new password")
+                text: root.restartRequired
+                      ? qsTr("Restart Status and log in with new password")
+                      : qsTr("Back to login")
                 Layout.alignment: Qt.AlignHCenter
-                onClicked: root.restartRequested()
+                onClicked: {
+                    if (root.restartRequired)
+                        root.restartRequested()
+                    else
+                        root.backToLoginRequested()
+                }
             }
 
             StatusButton {

--- a/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
@@ -62,6 +62,10 @@ QtObject {
         return d.onboardingModuleInst.getPasswordStrengthScore(password, "") // The second argument is username
     }
 
+    function isProfileMigratedToDEKEncryption(keyUid: string) : bool {
+        return d.onboardingModuleInst.isProfileMigratedToDEKEncryption(keyUid)
+    }
+
     // seedphrase/mnemonic
     function validMnemonic(mnemonic: string) : bool {
         return d.onboardingModuleInst.validMnemonic(mnemonic)

--- a/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
@@ -32,6 +32,7 @@ QtObject {
     readonly property string keycardUID: d.onboardingModuleInst.keycardUID
     readonly property string keycardKeyUID: d.onboardingModuleInst.keycardKeyUID
     readonly property int convertKeycardAccountState: d.onboardingModuleInst.convertKeycardAccountState // cf. enum Onboarding.ProgressState
+    readonly property bool convertKeycardAccountRestartRequired: d.onboardingModuleInst.convertKeycardAccountRestartRequired
     readonly property int keycardRemainingPinAttempts: d.onboardingModuleInst.keycardRemainingPinAttempts
     readonly property int keycardRemainingPukAttempts: d.onboardingModuleInst.keycardRemainingPukAttempts
     readonly property bool keycardStatusAvailable: d.onboardingModuleInst.keycardStatusAvailable

--- a/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
@@ -23,7 +23,9 @@ import "../views"
 StatusDialog {
     id: root
 
-    signal changePasswordRequested()
+    property bool fastPasswordChangePossible: false
+
+    signal changePasswordRequested(bool rekey)
     // Currently this modal handles only the happy path
     // The error is handled in the caller
     function passwordSuccessfulyChanged() {
@@ -37,10 +39,14 @@ StatusDialog {
         function reset() {
             d.dbEncryptionInProgress = false;
             d.passwordChanged = false;
+            rekeyCheckBox.checked = false;
         }
 
         property bool passwordChanged: false
         property bool dbEncryptionInProgress: false
+
+        // Deep password change implies a full db/keystore files re-encryption in case of not DEK migrated or if re-key is checked (for DEK migrated) profiles
+        readonly property bool doDeepPasswordChange: !root.fastPasswordChangePossible || rekeyCheckBox.checked
     }
 
     onClosed: {
@@ -48,9 +54,8 @@ StatusDialog {
     }
 
     width: 480
-    closePolicy: d.passwordChanged || d.dbEncryptionInProgress
-                     ? Popup.NoAutoClose
-                     : Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    closePolicy: d.dbEncryptionInProgress || (d.passwordChanged && d.doDeepPasswordChange)? Popup.NoAutoClose
+                                                                                          : Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
     // Overwrite the default modal background with a conditioned blurred one
     Overlay.modal: Item {
@@ -64,7 +69,7 @@ StatusDialog {
             id: blurredBackground
 
             anchors.fill: parent
-            visible: d.dbEncryptionInProgress
+            visible: d.dbEncryptionInProgress && d.doDeepPasswordChange
 
             // Update the blur source only once, when the modal is shown for performance reasons
             onVisibleChanged: {
@@ -110,7 +115,37 @@ StatusDialog {
         StatusBaseText {
             width: parent.width
             wrapMode: Text.WordWrap
-            text: qsTr("Your data must now be re-encrypted with your new password. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.")
+            text: {
+                if (!d.doDeepPasswordChange) {
+                    return qsTr("Your password will be changed. This only re-encrypts your profile key file and takes a moment — no restart needed.")
+                }
+                if (root.fastPasswordChangePossible) {
+                    return qsTr("Your data will be fully re-encrypted with a new encryption key. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.")
+                }
+                return qsTr("Your data must now be re-encrypted with your new password. This one-time process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status. Future password changes will be instant.")
+            }
+        }
+
+        ColumnLayout {
+            width: parent.width
+            spacing: 4
+            visible: root.fastPasswordChangePossible && !d.dbEncryptionInProgress && !d.passwordChanged
+
+            StatusCheckBox {
+                id: rekeyCheckBox
+                objectName: "changePasswordModalRekeyCheckBox"
+                Layout.fillWidth: true
+                text: qsTr("Also re-encrypt my data with a new encryption key")
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                Layout.leftMargin: rekeyCheckBox.indicator.width + rekeyCheckBox.spacing
+                wrapMode: Text.WordWrap
+                font.pixelSize: Theme.tertiaryTextFontSize
+                color: Theme.palette.baseColor1
+                text: qsTr("Only needed if you suspect your device was compromised. Takes considerably longer and requires a restart.")
+            }
         }
 
         Item {
@@ -131,11 +166,27 @@ StatusDialog {
                 anchors.fill: parent
                 sensor.enabled: false
                 visible: (d.dbEncryptionInProgress || d.passwordChanged)
-                title: !d.dbEncryptionInProgress ? qsTr("Re-encryption complete") :
-                                                   qsTr("Re-encrypting your data with your new password...")
-                subTitle: !d.dbEncryptionInProgress ? qsTr("Restart Status and log in using your new password") :
-                                                      qsTr("Do not quit the app or turn off your device")
-                statusListItemSubTitle.customColor: !d.passwordChanged ? Theme.palette.dangerColor1 : Theme.palette.successColor1
+                title: {
+                    if (!d.dbEncryptionInProgress) {
+                        return d.doDeepPasswordChange ? qsTr("Re-encryption complete") : qsTr("Password changed")
+                    }
+                    return d.doDeepPasswordChange ? qsTr("Re-encrypting your data...")
+                                                  : qsTr("Changing your password...")
+                }
+                subTitle: {
+                    if (!d.dbEncryptionInProgress) {
+                        return d.doDeepPasswordChange ? qsTr("Restart Status and log in using your new password")
+                                                      : qsTr("You can continue using Status")
+                    }
+                    return d.doDeepPasswordChange ? qsTr("Do not quit the app or turn off your device")
+                                                  : qsTr("This should only take a moment")
+                }
+                statusListItemSubTitle.customColor: {
+                    if (d.passwordChanged) {
+                        return Theme.palette.successColor1
+                    }
+                    return d.doDeepPasswordChange ? Theme.palette.dangerColor1 : Theme.palette.baseColor1
+                }
                 statusListItemIcon.active: d.passwordChanged
                 asset.name: "checkmark-circle"
                 asset.width: 24
@@ -171,14 +222,23 @@ StatusDialog {
             StatusButton {
                 id: submitBtn
                 objectName: "changePasswordModalSubmitButton"
-                text: !d.dbEncryptionInProgress && !d.passwordChanged ? qsTr("Re-encrypt data using new password") : qsTr("Restart Status")
+                text: {
+                    if (!d.dbEncryptionInProgress && !d.passwordChanged) {
+                        return d.doDeepPasswordChange ? qsTr("Re-encrypt data using new password") : qsTr("Change password")
+                    }
+                    return d.doDeepPasswordChange ? qsTr("Restart Status") : qsTr("Close")
+                }
                 enabled: !d.dbEncryptionInProgress
                 onClicked: {
                     if (d.passwordChanged) {
-                        SystemUtils.restartApplication(true);
+                        if (d.doDeepPasswordChange) {
+                            SystemUtils.restartApplication(true);
+                        } else {
+                            root.close();
+                        }
                     } else {
                         d.dbEncryptionInProgress = true
-                        root.changePasswordRequested()
+                        root.changePasswordRequested(rekeyCheckBox.checked)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
@@ -113,6 +113,7 @@ StatusDialog {
         spacing: 20
 
         StatusBaseText {
+            objectName: "changePasswordModalDescription"
             width: parent.width
             wrapMode: Text.WordWrap
             text: {

--- a/ui/app/AppLayouts/Profile/stores/PrivacyStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/PrivacyStore.qml
@@ -19,8 +19,12 @@ QtObject {
         appSettingsInst.newsRSSEnabled = isStatusNewsViaRSSEnabled
     }
 
-    function changePassword(password, newPassword) {
-        root.privacyModule.changePassword(password, newPassword)
+    function changePassword(password, newPassword, rekey = false) {
+        root.privacyModule.changePassword(password, newPassword, rekey)
+    }
+
+    function isProfileMigratedToDEKEncryption() {
+        return root.privacyModule.isProfileMigratedToDEKEncryption()
     }
 
     function getMnemonic() {

--- a/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
+++ b/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
@@ -58,6 +58,11 @@ SettingsContentBase {
                         qsTr("Biometric login and transaction authentication enabled for this device"),
                         "", "checkmark-circle", false, Constants.ephemeralNotificationType.success, "")
         }
+
+        function openConfirmChangePasswordPopup() {
+            confirmPasswordChangePopup.fastPasswordChangePossible = root.privacyStore.isProfileMigratedToDEKEncryption()
+            confirmPasswordChangePopup.open()
+        }
     }
 
     readonly property Item biometricsPopup: titleRowComponentLoader.item
@@ -160,7 +165,7 @@ SettingsContentBase {
 
             onReturnPressed: {
                 if (ready) {
-                    confirmPasswordChangePopup.open();
+                    d.openConfirmChangePasswordPopup();
                 }
             }
         }
@@ -199,8 +204,8 @@ SettingsContentBase {
 
         ConfirmChangePasswordModal {
             id: confirmPasswordChangePopup
-            onChangePasswordRequested: {
-                root.privacyStore.changePassword(choosePasswordForm.currentPswText, choosePasswordForm.newPswText);
+            onChangePasswordRequested: function(rekey) {
+                root.privacyStore.changePassword(choosePasswordForm.currentPswText, choosePasswordForm.newPswText, rekey);
             }
 
             Connections {
@@ -210,6 +215,8 @@ SettingsContentBase {
                         confirmPasswordChangePopup.passwordSuccessfulyChanged()
                         keychain.updateCredential(privacyStore.keyUid,
                                                   choosePasswordForm.newPswText)
+                        // Reset, cause no restart in this case.
+                        choosePasswordForm.reset()
                         return
                     }
 
@@ -227,6 +234,6 @@ SettingsContentBase {
         objectName: "changePasswordModalSubmitButton"
         text: qsTr("Change")
         enabled: choosePasswordForm.ready
-        onClicked: { confirmPasswordChangePopup.open(); }
+        onClicked: { d.openConfirmChangePasswordPopup(); }
     }
 }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -4011,15 +4011,39 @@ file format</source>
 <context>
     <name>ConfirmChangePasswordModal</name>
     <message>
-        <source>Your data must now be re-encrypted with your new password. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Re-encryption complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Re-encrypting your data with your new password...</source>
+        <source>Your password will be changed. This only re-encrypts your profile key file and takes a moment — no restart needed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data will be fully re-encrypted with a new encryption key. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data must now be re-encrypted with your new password. This one-time process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status. Future password changes will be instant.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Also re-encrypt my data with a new encryption key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only needed if you suspect your device was compromised. Takes considerably longer and requires a restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re-encrypting your data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Changing your password...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4027,7 +4051,15 @@ file format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>You can continue using Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Do not quit the app or turn off your device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This should only take a moment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4044,6 +4076,10 @@ file format</source>
     </message>
     <message>
         <source>Restart Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4536,6 +4572,10 @@ You will remain logged in, and your recovery phrase will be entirely in your han
     </message>
     <message>
         <source>This profile and its accounts will be less secure, as Keycard will no longer be required to transact or login.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your profile encryption key will also be updated. Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -4602,7 +4602,15 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Profile migration complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -4626,8 +4626,16 @@ Zůstanete přihlášeni a vaše obnovovací fráze bude zcela ve vašich rukou.
         <translation>Přešifrování dokončeno</translation>
     </message>
     <message>
+        <source>Profile migration complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
         <translation>Vaše data byla úspěšně přešifrována vaším novým heslem. Nyní můžete restartovat Status a přihlásit se ke svému profilu pomocí hesla, které jste právě vytvořili.</translation>
+    </message>
+    <message>
+        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Re-encryption failed</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -4032,24 +4032,56 @@ formát souboru</translation>
 <context>
     <name>ConfirmChangePasswordModal</name>
     <message>
-        <source>Your data must now be re-encrypted with your new password. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
-        <translation>Vaše data musí být nyní přešifrována vaším novým heslem. Tento proces může chvíli trvat, během které nebudete moci s aplikací interagovat. Neukončujte aplikaci ani nevypínejte zařízení. Mohlo by to vést k poškození dat, ztrátě vašeho profilu Status a nemožnosti restartovat Status.</translation>
-    </message>
-    <message>
         <source>Re-encryption complete</source>
         <translation>Přešifrování dokončeno</translation>
     </message>
     <message>
-        <source>Re-encrypting your data with your new password...</source>
-        <translation>Přešifrování vašich dat novým heslem...</translation>
+        <source>Your password will be changed. This only re-encrypts your profile key file and takes a moment — no restart needed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data will be fully re-encrypted with a new encryption key. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data must now be re-encrypted with your new password. This one-time process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status. Future password changes will be instant.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Also re-encrypt my data with a new encryption key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only needed if you suspect your device was compromised. Takes considerably longer and requires a restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re-encrypting your data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Changing your password...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restart Status and log in using your new password</source>
         <translation>Restartujte Status a přihlaste se pomocí nového hesla</translation>
     </message>
     <message>
+        <source>You can continue using Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Do not quit the app or turn off your device</source>
         <translation>Neukončujte aplikaci ani nevypínejte zařízení</translation>
+    </message>
+    <message>
+        <source>This should only take a moment</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change password</source>
@@ -4066,6 +4098,10 @@ formát souboru</translation>
     <message>
         <source>Restart Status</source>
         <translation>Restartovat Status</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Zavřít</translation>
     </message>
 </context>
 <context>
@@ -4563,8 +4599,12 @@ Zůstanete přihlášeni a vaše obnovovací fráze bude zcela ve vašich rukou.
         <translation>Tento profil a jeho účty budou méně zabezpečené, protože Keycard již nebude vyžadována pro transakce nebo přihlášení.</translation>
     </message>
     <message>
+        <source>Your profile encryption key will also be updated. Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data will also be re-encrypted, restricting access to Status for up to 30 mins. Do you wish to continue?</source>
-        <translation>Vaše data budou také přešifrována, což omezí přístup ke Statusu až na 30 minut. Přejete si pokračovat?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Continue</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -4014,24 +4014,56 @@ no compatible</translation>
 <context>
     <name>ConfirmChangePasswordModal</name>
     <message>
-        <source>Your data must now be re-encrypted with your new password. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
-        <translation>Tus datos ahora deben volver a cifrarse con tu nueva contraseña. Este proceso puede tomar algún tiempo, durante el cual no podrás interactuar con la aplicación. No cierres la aplicación ni apagues tu dispositivo. Hacerlo provocará corrupción de datos, pérdida de tu perfil de Status y la incapacidad de reiniciar Status.</translation>
-    </message>
-    <message>
         <source>Re-encryption complete</source>
         <translation>Re-cifrado completado</translation>
     </message>
     <message>
-        <source>Re-encrypting your data with your new password...</source>
-        <translation>Re-cifrando tus datos con tu nueva contraseña...</translation>
+        <source>Your password will be changed. This only re-encrypts your profile key file and takes a moment — no restart needed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data will be fully re-encrypted with a new encryption key. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data must now be re-encrypted with your new password. This one-time process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status. Future password changes will be instant.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Also re-encrypt my data with a new encryption key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only needed if you suspect your device was compromised. Takes considerably longer and requires a restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re-encrypting your data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Changing your password...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restart Status and log in using your new password</source>
         <translation>Reinicia Status e inicia sesión con tu nueva contraseña</translation>
     </message>
     <message>
+        <source>You can continue using Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Do not quit the app or turn off your device</source>
         <translation>No cierres la aplicación ni apagues tu dispositivo</translation>
+    </message>
+    <message>
+        <source>This should only take a moment</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change password</source>
@@ -4048,6 +4080,10 @@ no compatible</translation>
     <message>
         <source>Restart Status</source>
         <translation>Reiniciar Status</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Cerrar</translation>
     </message>
 </context>
 <context>
@@ -4544,8 +4580,12 @@ Permanecerás conectado y tu frase de recuperación estará completamente en tus
         <translation>Este perfil y sus cuentas serán menos seguros, ya que Keycard ya no será necesario para transacciones o inicio de sesión.</translation>
     </message>
     <message>
+        <source>Your profile encryption key will also be updated. Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data will also be re-encrypted, restricting access to Status for up to 30 mins. Do you wish to continue?</source>
-        <translation>Tus datos también se volverán a cifrar, restringiendo el acceso a Status hasta por 30 minutos. ¿Deseas continuar?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Continue</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -4607,8 +4607,16 @@ Permanecerás conectado y tu frase de recuperación estará completamente en tus
         <translation>Re-cifrado completado</translation>
     </message>
     <message>
+        <source>Profile migration complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
         <translation>Tus datos se volvieron a cifrar exitosamente con tu nueva contraseña. Ahora puedes reiniciar Status e iniciar sesión en tu perfil usando la contraseña que acabas de crear.</translation>
+    </message>
+    <message>
+        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Re-encryption failed</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -4012,24 +4012,56 @@ file format</source>
 <context>
     <name>ConfirmChangePasswordModal</name>
     <message>
-        <source>Your data must now be re-encrypted with your new password. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
-        <translation>Vos données doivent maintenant être réchiffrées avec votre nouveau mot de passe. Ce processus peut prendre un certain temps, pendant lequel vous ne pourrez pas interagir avec l’application. Ne quittez pas l’application et n’éteignez pas votre appareil. Cela entraînerait une corruption des données, la perte de votre profil Status et l’impossibilité de redémarrer Status.</translation>
-    </message>
-    <message>
         <source>Re-encryption complete</source>
         <translation>Réchiffrement terminé</translation>
     </message>
     <message>
-        <source>Re-encrypting your data with your new password...</source>
-        <translation>Vos données sont en cours de réchiffrement avec votre nouveau mot de passe... </translation>
+        <source>Your password will be changed. This only re-encrypts your profile key file and takes a moment — no restart needed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data will be fully re-encrypted with a new encryption key. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data must now be re-encrypted with your new password. This one-time process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status. Future password changes will be instant.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Also re-encrypt my data with a new encryption key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only needed if you suspect your device was compromised. Takes considerably longer and requires a restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re-encrypting your data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Changing your password...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restart Status and log in using your new password</source>
         <translation>Redémarrez Status et connectez-vous à l’aide de votre nouveau mot de passe</translation>
     </message>
     <message>
+        <source>You can continue using Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Do not quit the app or turn off your device</source>
         <translation>Ne quittez pas l’application et n’éteignez pas votre appareil</translation>
+    </message>
+    <message>
+        <source>This should only take a moment</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change password</source>
@@ -4046,6 +4078,10 @@ file format</source>
     <message>
         <source>Restart Status</source>
         <translation>Redémarrer Status</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Fermer</translation>
     </message>
 </context>
 <context>
@@ -4542,6 +4578,10 @@ Vous resterez connecté et votre phrase de récupération sera entièrement entr
         <translation>Ce profil et ses comptes seront moins sécurisés, car la Keycard ne sera plus nécessaire pour effectuer des transactions ou se connecter.</translation>
     </message>
     <message>
+        <source>Your profile encryption key will also be updated. Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data will also be re-encrypted, restricting access to Status for up to 30 mins. Do you wish to continue?</source>
         <translation>Vos données seront également re-chiffrées, ce qui limitera l’accès à Status pendant un maximum de 30&#xa0;minutes. Souhaitez-vous continuer&#xa0;?</translation>
     </message>
@@ -4565,8 +4605,16 @@ Vous resterez connecté et votre phrase de récupération sera entièrement entr
         <translation>Réencryption terminée</translation>
     </message>
     <message>
+        <source>Profile migration complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
         <translation>Vos données ont été re-chiffrées avec succès à l’aide de votre nouveau mot de passe. Vous pouvez maintenant redémarrer Status et vous connecter à votre profil en utilisant le mot de passe que vous venez de créer.</translation>
+    </message>
+    <message>
+        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Re-encryption failed</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -4587,8 +4587,16 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation>재암호화 완료</translation>
     </message>
     <message>
+        <source>Profile migration complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
         <translation>데이터가 새 비밀번호로 성공적으로 재암호화되었습니다. 이제 Status를 다시 시작하고, 방금 만든 비밀번호로 프로필에 로그인할 수 있어요.</translation>
+    </message>
+    <message>
+        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Re-encryption failed</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -3995,24 +3995,56 @@ file format</source>
 <context>
     <name>ConfirmChangePasswordModal</name>
     <message>
-        <source>Your data must now be re-encrypted with your new password. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
-        <translation>지금 새 비밀번호로 데이터를 다시 암호화해야 합니다. 이 과정은 시간이 걸릴 수 있으며, 진행되는 동안 앱을 사용할 수 없습니다. 앱을 종료하거나 기기를 끄지 마세요. 그렇게 하면 데이터가 손상되고 Status 프로필이 사라지며, Status를 다시 시작할 수 없게 됩니다.</translation>
-    </message>
-    <message>
         <source>Re-encryption complete</source>
         <translation>재암호화 완료</translation>
     </message>
     <message>
-        <source>Re-encrypting your data with your new password...</source>
-        <translation>새 비밀번호로 데이터 재암호화 중...</translation>
+        <source>Your password will be changed. This only re-encrypts your profile key file and takes a moment — no restart needed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data will be fully re-encrypted with a new encryption key. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your data must now be re-encrypted with your new password. This one-time process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status. Future password changes will be instant.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Also re-encrypt my data with a new encryption key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only needed if you suspect your device was compromised. Takes considerably longer and requires a restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re-encrypting your data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Changing your password...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restart Status and log in using your new password</source>
         <translation>Status를 다시 시작하고 새 비밀번호로 로그인하세요</translation>
     </message>
     <message>
+        <source>You can continue using Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Do not quit the app or turn off your device</source>
         <translation>앱을 종료하거나 기기를 끄지 마세요</translation>
+    </message>
+    <message>
+        <source>This should only take a moment</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change password</source>
@@ -4029,6 +4061,10 @@ file format</source>
     <message>
         <source>Restart Status</source>
         <translation>Status 다시 시작</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">닫기</translation>
     </message>
 </context>
 <context>
@@ -4524,8 +4560,12 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation>이 프로필과 해당 계정은 보안이 약화됩니다. 이제 거래하거나 로그인할 때 Keycard가 더 이상 필요하지 않습니다.</translation>
     </message>
     <message>
+        <source>Your profile encryption key will also be updated. Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Your data will also be re-encrypted, restricting access to Status for up to 30 mins. Do you wish to continue?</source>
-        <translation>데이터도 다시 암호화되어 최대 30분 동안 Status 접근이 제한됩니다. 계속하시겠습니까?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Continue</source>

--- a/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
+++ b/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
@@ -45,7 +45,15 @@ StatusDialog {
 
     width: Constants.keycard.general.popupWidth
     padding: Theme.halfPadding
-    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    closePolicy: d.closingPopupDisabled ? Popup.NoAutoClose
+                                        : Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    closeHandler: () => {
+                      if (d.closingPopupDisabled)
+                      return
+                      root.close()
+                  }
 
     title: {
         switch(root.flow) {
@@ -130,6 +138,13 @@ StatusDialog {
         property bool success: false
         property bool mixedFlowSuccess: false
         property string error: ""
+
+        readonly property bool profileConversionRequiresRestart:
+            (root.flow === Constants.keycard.flow.moveProfileKeyPair
+             || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)
+            && !userProfile.migratedToDEKEncryption
+        readonly property bool closingPopupDisabled: d.processing
+                                                     || profileConversionRequiresRestart && d.success
 
         property bool factoryResetConfirmationChecked: false
 
@@ -1141,8 +1156,7 @@ StatusDialog {
                     if (!!d.error) {
                         return qsTr("Done")
                     } else if (d.success) {
-                        if (root.flow === Constants.keycard.flow.moveProfileKeyPair
-                                || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile) {
+                        if (d.profileConversionRequiresRestart) {
                             return qsTr("Quit and restart Status")
                         }
                         return qsTr("Done")
@@ -1151,8 +1165,7 @@ StatusDialog {
                 }
 
                 onClicked: {
-                    if (d.success && (root.flow === Constants.keycard.flow.moveProfileKeyPair
-                                      || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)) {
+                    if (d.success && d.profileConversionRequiresRestart) {
                         console.info("the app is closing due to successfully converted profile key pair - flow: ", root.flow)
                         root.store.signOutAndQuit()
                     }
@@ -1529,10 +1542,12 @@ StatusDialog {
             }
             processingSpecialWarning1: (root.flow === Constants.keycard.flow.moveProfileKeyPair
                                         || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)
+                                       && !userProfile.migratedToDEKEncryption
                                        ? qsTr("Re-encrypting data may take some time")
                                        : ""
             processingSpecialWarning2: (root.flow === Constants.keycard.flow.moveProfileKeyPair
                                         || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)
+                                       && !userProfile.migratedToDEKEncryption
                                        ? qsTr("Do not quit the application or turn off your device. Doing so will lead to data\ncorruption, loss of your Status profile and the inability to restart Status.")
                                        : ""
 


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/7691

A random **DEK** (data encryption key) encrypts the data, and the login secret (**KEK**) only wraps the DEK in a small per-profile file. Changing the password re-wraps one file, meaning no database re-encryption, no restart.

The change-password modal has options:
- do fast password change re-wrap the DEK
- do deep password change in case of legacy profiles (one-time migration), or the new profiles for which "also re-encrypt my data" (rekey) checkbox is checked

Closes #21877

## How it was

```mermaid
flowchart LR
    subgraph before ["login secret encrypts everything"]
        direction LR
        KEK1["Login secret<br/>(hashed password or<br/>keycard encryption key)"]
        KEK1 -- "sqlcipher passphrase<br/>kdf_iter = 256 000" --> ADB1[("app DB<br/>(messages, settings)")]
        KEK1 -- "sqlcipher passphrase<br/>kdf_iter = 256 000" --> WDB1[("wallet DB")]
        KEK1 -- "keystore passphrase" --> KS1["keystore files"]
    end
```

## How it's now

```mermaid
flowchart LR
    subgraph after ["DEK encrypts everything, login secret only wraps the DEK"]
        direction LR
        KEK2["Login secret<br/>(hashed password or<br/>keycard encryption key)"]
        ENV["&lt;keyUID&gt;-profile.kek<br/>wrapped DEK file<br/>(scrypt + AES, MAC-verified)"]
        DEK["DEK<br/>random 32 bytes"]
        KEK2 -- "unwraps (once per login)" --> ENV
        ENV --> DEK
        DEK -- "sqlcipher passphrase<br/>kdf_iter = 3 200 (high-entropy key)" --> ADB2[("app DB")]
        DEK -- "sqlcipher passphrase<br/>kdf_iter = 3 200" --> WDB2[("wallet DB")]
        DEK -- "keystore passphrase" --> KS2["keystore files"]
    end
```

- wrong password now fails at the envelope MAC check, before anything else is touched
- logins also get faster (3 200 instead of 256 000 PBKDF2 iterations per DB open)

## Password change

```mermaid
flowchart TD
    REQ["ChangeDatabasePasswordV2<br/>{ keyUID, oldPassword, newPassword, rekey }"]
    E{"profile has a<br/>wrapped-DEK file?"}
    RK{"rekey<br/>requested?"}
    FAST["FAST PATH<br/>re-wrap the DEK file with the new password<br/>~instant, no logout, no restart"]
    MIG["ONE-TIME MIGRATION (lazy)<br/>fresh DEK, re-encrypt keystore + both DBs<br/>restart needed"]
    REKEY["DEEP REKEY (opt-in checkbox)<br/>fresh DEK, re-encrypt keystore + both DBs<br/>restart needed"]

    REQ --> E
    E -- "no (legacy profile)" --> MIG
    E -- yes --> RK
    RK -- no --> FAST
    RK -- yes --> REKEY

    MIG -.-> DONE["profile on DEK scheme<br/>all later changes take the fast path"]
    REKEY -.-> DONE
    FAST -.-> DONE
```

- new profiles are created on the DEK scheme
- keycard conversions (to/from) go through the same logic as password change

## Local pairing

```mermaid
sequenceDiagram
    participant S as Sender (any version)
    participant W as Wire (QR + encrypted channel)
    participant R as Receiver (any version)

    Note over S: migrated sender re-encrypts keystore files<br/>in memory: DEK -> transfer password
    S->>W: keystore files (password-encrypted, as always)
    W->>R: keystore files
    Note over R: new receiver adopts a fresh device-local DEK:<br/>writes envelope, re-encrypts stored files<br/>first login creates DBs under the DEK
    Note over S,R: DEKs never leave a device - each device has its own DEK
```