### PR TITLE
Chat view: tap on mobile / right click on desktop to open message menu

### DIFF
--- a/storybook/qmlTests/tests/tst_ChatTextView.qml
+++ b/storybook/qmlTests/tests/tst_ChatTextView.qml
@@ -266,6 +266,70 @@ Item {
             tryCompare(first, "selectedText", "")
         }
 
+        // Selects across both blocks in `ctrl` (which must be selectable with content laid out)
+        // and asserts a non-empty selection results.
+        function selectAll(ctrl) {
+            mousePress(ctrl, 0, 3)
+            mouseMove(ctrl, ctrl.width - 4, ctrl.implicitHeight - 4)
+            mouseRelease(ctrl, ctrl.width - 4, ctrl.implicitHeight - 4)
+            verify(ctrl.selectedText.length > 0, "nothing selected")
+        }
+
+        readonly property var twoBlocks: [
+            { type: "text", html: "first line" },
+            { type: "text", html: "second line" }
+        ]
+
+        // clearSelectionOnLostFocus (default true): losing active focus drops the selection.
+        function test_clearSelectionOnLostFocus_defaultClearsOnFocusLoss() {
+            control.selectable = true
+            control.blocks = twoBlocks
+            tryVerify(() => control.implicitHeight > 0)
+
+            selectAll(control)
+            verify(control.activeFocus, "selecting should have moved focus to the view")
+
+            // Focus goes elsewhere → selection cleared.
+            otherEditor.forceActiveFocus()
+            tryVerify(() => !control.activeFocus)
+            tryCompare(control, "selectedText", "")
+        }
+
+        // With clearSelectionOnLostFocus false, the selection survives focus loss (used while a
+        // context menu popup holds focus).
+        function test_clearSelectionOnLostFocus_falseKeepsSelectionOnFocusLoss() {
+            control.selectable = true
+            control.clearSelectionOnLostFocus = false
+            control.blocks = twoBlocks
+            tryVerify(() => control.implicitHeight > 0)
+
+            selectAll(control)
+            verify(control.activeFocus, "selecting should have moved focus to the view")
+
+            otherEditor.forceActiveFocus()
+            tryVerify(() => !control.activeFocus)
+            // Selection preserved despite having lost focus.
+            verify(control.selectedText.length > 0, "selection cleared despite the flag being false")
+        }
+
+        // Restoring the flag to true while the view already has a selection but no focus (e.g. the
+        // context menu just closed) doesn't clear the now-stale selection.
+        function test_clearSelectionOnLostFocus_setTrueWhileUnfocusedClears() {
+            control.selectable = true
+            control.clearSelectionOnLostFocus = false
+            control.blocks = twoBlocks
+            tryVerify(() => control.implicitHeight > 0)
+
+            selectAll(control)
+            otherEditor.forceActiveFocus()
+            tryVerify(() => !control.activeFocus)
+            verify(control.selectedText.length > 0, "precondition: selection kept while flag is false")
+
+            // Re-enabling the flag while unfocused doesn't clear the selection.
+            control.clearSelectionOnLostFocus = true
+            verify(control.selectedText.length > 0, "selection cleared by changing clearSelectionOnLostFocus")
+        }
+
         // Toggling `selectable` after blocks are set rebuilds each block's renderer (Loader
         // swap) and the coordinator re-collects the newly-created editors.
         function test_selectableToggledAfterBlocks() {

--- a/ui/StatusQ/src/StatusQ/Components/ChatTextView.qml
+++ b/ui/StatusQ/src/StatusQ/Components/ChatTextView.qml
@@ -27,6 +27,10 @@ Control {
     // that spans blocks; when false, they are plain (non-selectable) Labels.
     property bool selectable: false
 
+    // When true (default), the current selection is dropped when the view loses active focus.
+    // Set to false to keep the selection while focus temporarily moves elsewhere (e.g. a popup).
+    property bool clearSelectionOnLostFocus: true
+
     // When true, a small, dimmed "(edited)" marker is appended after the last block.
     property bool edited: false
     property int editedMarkerFontSize: Theme.tertiaryTextFontSize
@@ -75,7 +79,7 @@ Control {
 
     // Dropping the selection on focus loss keeps a single active selection,
     // so the copy shortcut stays unambiguous.
-    onActiveFocusChanged: if (!activeFocus) d.clearSelection()
+    onActiveFocusChanged: if (!activeFocus && root.clearSelectionOnLostFocus) d.clearSelection()
 
     // Renders one text or code region, instantiating exactly one child (via Loader): a Label
     // (not selectable) or a read-only TextEdit (selectable), plain or framed for code. Widths

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -90,7 +90,6 @@ Control {
     signal senderNameClicked(var sender)
     signal replyProfileClicked(var sender, var mouse)
     signal replyMessageClicked(var mouse)
-    signal contextMenuRequested(point pos)
 
     signal addReactionClicked(var sender, var mouse)
     signal toggleReactionClicked(string hexcode)
@@ -411,7 +410,6 @@ Control {
         isMobile: root.isMobile
         onLinkActivated: link => root.linkActivated(link)
         onHoveredLinkChanged: root.hoveredLink = hoveredLink
-        onContextMenuRequested: pos => root.contextMenuRequested(pos)
         onSelectedTextChanged: d.selectedText = selectedText
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -81,6 +81,10 @@ Control {
     property string disabledTooltipText
     readonly property string selectedText: d.selectedText
 
+    // When true (default), the text selection is dropped when the message text loses active focus.
+    // Set to false to keep the selection while focus temporarily moves elsewhere (e.g. a context menu).
+    property bool clearSelectionOnLostFocus: true
+
     property bool isMobile: Utils.isMobile
 
     property StatusMessageDetails messageDetails: StatusMessageDetails {}
@@ -408,6 +412,7 @@ Control {
         linkAddressAndEnsName: root.linkAddressAndEnsName
         disabledTooltipText: root.disabledTooltipText
         isMobile: root.isMobile
+        clearSelectionOnLostFocus: root.clearSelectionOnLostFocus
         onLinkActivated: link => root.linkActivated(link)
         onHoveredLinkChanged: root.hoveredLink = hoveredLink
         onSelectedTextChanged: d.selectedText = selectedText

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -26,7 +26,6 @@ Item {
     property alias textField: chatTextView
 
     signal linkActivated(string link)
-    signal contextMenuRequested(point pos)
 
     implicitHeight: chatTextView.height + d.showMoreHeight / 2
 
@@ -91,15 +90,21 @@ Item {
         onMentionClicked: (pubKey) => root.linkActivated("//" + pubKey)
         onLinkClicked: (url) => root.linkActivated(url)
 
-        HoverHandler {
-            id: hoverHandler
+        // HoverHandler bloks external mouse events (e.g. for opening the context menu),
+        // so we use a MouseArea there
+        MouseArea {
+            id: hoverArea
+
+            acceptedButtons: Qt.NoButton
+            anchors.fill: parent
+            hoverEnabled: true
         }
+
         StatusToolTip {
-            id: disabledLinkTooltip
             text: root.disabledTooltipText
             delay: 100
-            x: hoverHandler.point.position.x - 60
-            y: -disabledLinkTooltip.height + hoverHandler.point.position.y - 10
+            x: hoverArea.mouseX - 60
+            y: -height + hoverArea.mouseY - 10
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -14,6 +14,7 @@ Item {
     readonly property string selectedText: chatTextView.selectedText
 
     property alias highlightedLink: chatTextView.highlightedLink
+    property alias clearSelectionOnLostFocus: chatTextView.clearSelectionOnLostFocus
     property bool linkAddressAndEnsName
     property string disabledTooltipText
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -926,7 +926,6 @@ Loader {
                     root.messageStore.resendMessage(root.messageId)
                 }
 
-                onContextMenuRequested: pos => root.openMessageContextMenu(pos, delegate.selectedText) // for StatusTextMessage which would eat the press events internally
                 TapHandler {
                     gesturePolicy: TapHandler.ReleaseWithinBounds // exclusive grab on press
                     acceptedDevices: PointerDevice.TouchScreen

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -254,7 +254,7 @@ Loader {
         profileContextMenuComponent.createObject(root, params).popup(x, y)
     }
 
-    function openMessageContextMenu(point, selectedText = "") {
+    function openMessageContextMenu(delegate, point, selectedText = "") {
         if (isViewMemberMessagesePopup || placeholderMessage || !root.joined)
             return
 
@@ -283,8 +283,15 @@ Loader {
         }
 
         d.preventVirtualKeyboardOpening()
+        // Keep the text selection visible/available while the menu is open; the popup takes focus
+        // and would otherwise clear it. Restored in the menu's onAboutToHide handler.
+        delegate.clearSelectionOnLostFocus = false
         d.contextMenu = messageContextMenuComponent.createObject(root, params)
         d.contextMenu.popup(point)
+        d.contextMenu.aboutToHide.connect(() => {
+            if (delegate)
+                delegate.clearSelectionOnLostFocus = true
+        })
     }
 
     function getMessageLinkUrl() {
@@ -929,13 +936,13 @@ Loader {
                 TapHandler {
                     gesturePolicy: TapHandler.ReleaseWithinBounds // exclusive grab on press
                     acceptedDevices: PointerDevice.TouchScreen
-                    onLongPressed: root.openMessageContextMenu(point.position, delegate.selectedText)
+                    onLongPressed: root.openMessageContextMenu(delegate, point.position, delegate.selectedText)
                 }
 
                 TapHandler {
                     acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
                     acceptedButtons: Qt.RightButton
-                    onTapped: (point, button) => root.openMessageContextMenu(point.position, delegate.selectedText)
+                    onTapped: (point, button) => root.openMessageContextMenu(delegate, point.position, delegate.selectedText)
                 }
 
                 messageDetails: StatusMessageDetails {


### PR DESCRIPTION
### What does the PR do

Message menu was not opening correctly within the are of the message text (only header).
This PR solves that by:

- converting problematic `HoverHandler` to `MouseArea`
- introducing `clearSelectionOnLostFocus` property for `ChatTextView` to keep selection when menu is opened

Closes: #21846

### Affected areas

`ChatTextView`, `MessageView`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/b63ffe8a-75ee-4e17-99dc-6e2ca56a4712


### Impact on end user

Allows interaction with the message

### How to test

Go to chat, long-press the message on mobile, right click on desktop

### Risk 

Low
