### PR TITLE
fix(badge): update app badge to count all notifications

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -107,6 +107,9 @@ proc hasMoreToShow*(self: Controller): bool =
 proc unreadActivityCenterNotificationsCount*(self: Controller): int =
   return self.activityCenterService.getUnreadActivityCenterNotificationsCount()
 
+proc unreadNonMessagingActivityCenterNotificationsCount*(self: Controller): int =
+  return self.activityCenterService.getUnreadNonMessagingActivityCenterNotificationsCount()
+
 proc hasUnseenActivityCenterNotifications*(self: Controller): bool =
   return self.activityCenterService.getHasUnseenActivityCenterNotifications()
 

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -47,10 +47,6 @@ proc newController*(
 proc delete*(self: Controller) =
   discard
 
-proc updateActivityGroupCounters*(self: Controller) =
-  let counters = self.activityCenterService.getActivityGroupCounters()
-  self.delegate.setActivityGroupCounters(counters)
-
 proc init*(self: Controller) =
   self.events.once(chat_service.SIGNAL_ACTIVE_CHATS_LOADED) do(e:Args):
     # Only fectch activity center notification once channel groups are loaded,
@@ -60,12 +56,11 @@ proc init*(self: Controller) =
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED) do(e: Args):
     let args = ActivityCenterNotificationsArgs(e)
     self.delegate.addActivityCenterNotifications(args.activityCenterNotifications, initialLoad = true)
-    self.updateActivityGroupCounters()
+    self.activityCenterService.asyncActivityCenterCounts()
 
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED) do(e: Args):
     let args = ActivityCenterNotificationsArgs(e)
     self.delegate.addActivityCenterNotifications(args.activityCenterNotifications, initialLoad = false)
-    self.updateActivityGroupCounters()
 
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_MARK_NOTIFICATIONS_AS_READ) do(e: Args):
     var evArgs = ActivityCenterNotificationIdsArgs(e)
@@ -81,8 +76,15 @@ proc init*(self: Controller) =
     self.delegate.markAllActivityCenterNotificationsReadDone()
 
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED) do(e: Args):
-    self.delegate.onNotificationsCountMayHaveChanged()
-    self.updateActivityGroupCounters()
+    self.activityCenterService.asyncActivityCenterCounts()
+
+  self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATION_COUNTS_RESOLVED) do(e: Args):
+    let args = ActivityCenterNotificationCountsArgs(e)
+    self.delegate.onActivityCenterNotificationCountsResolved(
+      args.groupCounters,
+      args.unreadCount,
+      args.unreadNonMessagingCount,
+    )
 
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_UNSEEN_UPDATED) do(e: Args):
     var evArgs = ActivityCenterNotificationHasUnseen(e)
@@ -104,12 +106,6 @@ proc init*(self: Controller) =
 proc hasMoreToShow*(self: Controller): bool =
   return self.activityCenterService.hasMoreToShow()
 
-proc unreadActivityCenterNotificationsCount*(self: Controller): int =
-  return self.activityCenterService.getUnreadActivityCenterNotificationsCount()
-
-proc unreadNonMessagingActivityCenterNotificationsCount*(self: Controller): int =
-  return self.activityCenterService.getUnreadNonMessagingActivityCenterNotificationsCount()
-
 proc hasUnseenActivityCenterNotifications*(self: Controller): bool =
   return self.activityCenterService.getHasUnseenActivityCenterNotifications()
 
@@ -124,6 +120,9 @@ proc getActivityCenterNotifications*(self: Controller): seq[ActivityCenterNotifi
 
 proc asyncActivityNotificationLoad*(self: Controller) =
   self.activityCenterService.asyncActivityNotificationLoad()
+
+proc asyncActivityCenterCounts*(self: Controller) =
+  self.activityCenterService.asyncActivityCenterCounts()
 
 proc markAllActivityCenterNotificationsRead*(self: Controller) =
   self.activityCenterService.markAllActivityCenterNotificationsRead()
@@ -174,7 +173,7 @@ proc setActivityCenterReadType*(self: Controller, readType: ActivityCenterReadTy
   self.activityCenterService.resetCursor()
   let activityCenterNotifications = self.activityCenterService.getActivityCenterNotifications()
   self.delegate.resetActivityCenterNotifications(activityCenterNotifications)
-  self.updateActivityGroupCounters()
+  self.activityCenterService.asyncActivityCenterCounts()
 
 proc getActivityCenterReadType*(self: Controller): ActivityCenterReadType =
   return self.activityCenterService.getActivityCenterReadType()

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -22,9 +22,6 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method hasMoreToShow*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method unreadActivityCenterNotificationsCount*(self: AccessInterface): int {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method unreadNonMessagingActivityCenterNotificationsCount*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -34,7 +31,12 @@ method unreadActivityCenterNotificationsCountFromView*(self: AccessInterface): i
 method hasUnseenActivityCenterNotifications*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onNotificationsCountMayHaveChanged*(self: AccessInterface) {.base.} =
+method onActivityCenterNotificationCountsResolved*(
+    self: AccessInterface,
+    groupCounters: Table[ActivityCenterGroup, int],
+    unreadCount: int,
+    unreadNonMessagingCount: int,
+    ) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onUnseenChanged*(self: AccessInterface, hasUnseen: bool) {.base.} =

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -25,6 +25,9 @@ method hasMoreToShow*(self: AccessInterface): bool {.base.} =
 method unreadActivityCenterNotificationsCount*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method unreadNonMessagingActivityCenterNotificationsCount*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method unreadActivityCenterNotificationsCountFromView*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -70,6 +70,9 @@ method isLoaded*(self: Module): bool =
 method unreadActivityCenterNotificationsCount*(self: Module): int =
   self.controller.unreadActivityCenterNotificationsCount()
 
+method unreadNonMessagingActivityCenterNotificationsCount*(self: Module): int =
+  self.controller.unreadNonMessagingActivityCenterNotificationsCount()
+
 method unreadActivityCenterNotificationsCountFromView*(self: Module): int =
   self.view.unreadCount()
 

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -26,7 +26,7 @@ type
     view: View
     viewVariant: QVariant
     moduleLoaded: bool
-    unreadCount: int
+    unreadNonMessagingCount: int
 
 proc newModule*(
     delegate: delegate_interface.AccessInterface,
@@ -67,11 +67,8 @@ method load*(self: Module) =
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded
 
-method unreadActivityCenterNotificationsCount*(self: Module): int =
-  self.controller.unreadActivityCenterNotificationsCount()
-
 method unreadNonMessagingActivityCenterNotificationsCount*(self: Module): int =
-  self.controller.unreadNonMessagingActivityCenterNotificationsCount()
+  self.unreadNonMessagingCount
 
 method unreadActivityCenterNotificationsCountFromView*(self: Module): int =
   self.view.unreadCount()
@@ -82,14 +79,21 @@ method hasUnseenActivityCenterNotifications*(self: Module): bool =
 method viewDidLoad*(self: Module) =
   self.moduleLoaded = true
   self.delegate.activityCenterDidLoad()
-  self.view.setUnreadCount(self.unreadActivityCenterNotificationsCount())
+  self.controller.asyncActivityCenterCounts()
   self.view.setHasUnseen(self.hasUnseenActivityCenterNotifications())
 
 method hasMoreToShow*(self: Module): bool =
   self.controller.hasMoreToShow()
 
-method onNotificationsCountMayHaveChanged*(self: Module) =
-  self.view.setUnreadCount(self.unreadActivityCenterNotificationsCount())
+method onActivityCenterNotificationCountsResolved*(
+    self: Module,
+    groupCounters: Table[ActivityCenterGroup, int],
+    unreadCount: int,
+    unreadNonMessagingCount: int,
+    ) =
+  self.view.setActivityGroupCounters(groupCounters)
+  self.view.setUnreadCount(unreadCount)
+  self.unreadNonMessagingCount = unreadNonMessagingCount
   self.delegate.onActivityNotificationsUpdated()
 
 method onUnseenChanged*(self: Module, hasUnseen: bool) =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -154,6 +154,7 @@ type
 proc switchToContactOrDisplayUserProfile[T](self: Module[T], publicKey: string)
 method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string)
 proc checkIfWeHaveNotifications[T](self: Module[T])
+proc updateIconBadgeNumber[T](self: Module[T])
 proc createMemberItem[T](self: Module[T], memberId: string, requestId: string, state: MembershipRequestState, role: MemberRole, airdropAddress: string = ""): MemberItem
 proc getAllCommunityMemberItems[T](self: Module[T], community: CommunityDto): seq[MemberItem]
 
@@ -1021,6 +1022,7 @@ method onChatsLoaded*[T](
   self.view.model().addItems(items)
 
   self.checkIfWeHaveNotifications()
+  self.updateIconBadgeNumber()
 
   # Set active section if it is one of the channel sections
   if not activeSection.isEmpty():
@@ -1301,13 +1303,20 @@ proc checkIfWeHaveNotifications[T](self: Module[T]) =
   let activtyCenterNotifications = self.activityCenterModule.unreadActivityCenterNotificationsCountFromView() > 0
   self.view.setNotificationAvailable(sectionWithUnread or activtyCenterNotifications)
 
+proc updateIconBadgeNumber[T](self: Module[T]) =
+  let sectionNotifications = self.view.model().allMentionsCount()
+  let activityCenterNotifications = self.activityCenterModule.unreadNonMessagingActivityCenterNotificationsCount()
+  singletonInstance.globalEvents.notificationsCountChanged(sectionNotifications + activityCenterNotifications)
+
 method onActivityNotificationsUpdated[T](self: Module[T]) =
   self.checkIfWeHaveNotifications()
+  self.updateIconBadgeNumber()
 
 method onNotificationsUpdated[T](self: Module[T], sectionId: string, sectionHasUnreadMessages: bool,
     sectionNotificationCount: int) =
   self.view.model().updateNotifications(sectionId, sectionHasUnreadMessages, sectionNotificationCount)
   self.checkIfWeHaveNotifications()
+  self.updateIconBadgeNumber()
 
 method onPlayNotificationSound[T](self: Module[T]) =
   self.view.playNotificationSound()

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -453,8 +453,6 @@ QtObject:
       updateRole(hasNotification)
       updateRole(notificationsCount)
 
-    singletonInstance.globalEvents.notificationsCountChanged(notificationsCount)
-
   proc isThereASectionWithUnreadMessages*(self: SectionModel): bool =
     for item in self.items:
       if item.isAMessengerItem() and item.hasNotification == true:

--- a/src/app_service/service/activity_center/async_tasks.nim
+++ b/src/app_service/service/activity_center/async_tasks.nim
@@ -8,6 +8,10 @@ type
     group: ActivityCenterGroup
     readType: ActivityCenterReadType
 
+  AsyncActivityCenterCountsTaskArg = ref object of QObjectTaskArg
+    generation: int
+    readType: ActivityCenterReadType
+
 proc asyncActivityNotificationLoadTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncActivityNotificationLoadTaskArg](argEncoded)
   try:
@@ -26,5 +30,54 @@ proc asyncActivityNotificationLoadTask(argEncoded: string) {.gcsafe, nimcall.} =
     })
   except Exception as e:
     arg.finish(%* {
+      "error": e.msg,
+    })
+
+proc asyncActivityCenterCountsTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncActivityCenterCountsTaskArg](argEncoded)
+  try:
+    let activityTypes = activityCenterNotificationTypesByGroup(ActivityCenterGroup.All)
+    let currentCountersResponse = backend.activityCenterNotificationsCount(
+      backend.ActivityCenterCountRequest(
+        activityTypes: activityTypes,
+        readType: arg.readType.int,
+      )
+    )
+    if currentCountersResponse.error != nil:
+      arg.finish(%*{
+        "generation": arg.generation,
+        "readType": arg.readType.int,
+        "error": currentCountersResponse.error.message,
+      })
+      return
+
+    var unreadCounters = currentCountersResponse.result
+    if arg.readType != ActivityCenterReadType.Unread:
+      let unreadCountersResponse = backend.activityCenterNotificationsCount(
+        backend.ActivityCenterCountRequest(
+          activityTypes: activityTypes,
+          readType: ActivityCenterReadType.Unread.int,
+        )
+      )
+      if unreadCountersResponse.error != nil:
+        arg.finish(%*{
+          "generation": arg.generation,
+          "readType": arg.readType.int,
+          "error": unreadCountersResponse.error.message,
+        })
+        return
+      unreadCounters = unreadCountersResponse.result
+
+    arg.finish(%*{
+      "generation": arg.generation,
+      "readType": arg.readType.int,
+      "currentCounters": currentCountersResponse.result,
+      "unreadCounters": unreadCounters,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%*{
+      "generation": arg.generation,
+      "readType": arg.readType.int,
       "error": e.msg,
     })

--- a/src/app_service/service/activity_center/count_refresh_generation.nim
+++ b/src/app_service/service/activity_center/count_refresh_generation.nim
@@ -1,0 +1,38 @@
+type CountRefreshCompletionAction* = enum
+  crcaApply
+  crcaDropAndRefire
+
+type CountRefreshGenerationState* = object
+  desiredGeneration: int
+  inFlightState: bool
+  inFlightGeneration: int
+
+proc initCountRefreshGenerationState*(): CountRefreshGenerationState =
+  CountRefreshGenerationState()
+
+proc inFlight*(self: CountRefreshGenerationState): bool =
+  self.inFlightState
+
+proc currentGeneration*(self: CountRefreshGenerationState): int =
+  self.inFlightGeneration
+
+proc requestRefresh*(self: var CountRefreshGenerationState): tuple[shouldStart: bool, generation: int] =
+  inc self.desiredGeneration
+  if self.inFlightState:
+    return (shouldStart: false, generation: self.desiredGeneration)
+
+  self.inFlightState = true
+  self.inFlightGeneration = self.desiredGeneration
+  return (shouldStart: true, generation: self.desiredGeneration)
+
+proc onCompletion*(
+    self: var CountRefreshGenerationState,
+    completedGeneration: int,
+    ): tuple[action: CountRefreshCompletionAction, generation: int] =
+  if completedGeneration < self.desiredGeneration:
+    self.inFlightState = true
+    self.inFlightGeneration = self.desiredGeneration
+    return (action: crcaDropAndRefire, generation: self.desiredGeneration)
+
+  self.inFlightState = false
+  return (action: crcaApply, generation: completedGeneration)

--- a/src/app_service/service/activity_center/count_snapshot.nim
+++ b/src/app_service/service/activity_center/count_snapshot.nim
@@ -1,0 +1,43 @@
+import std/tables
+
+import ./dto/notification
+
+const COUNTED_ACTIVITY_GROUPS* = @[
+  ActivityCenterGroup.Mentions,
+  ActivityCenterGroup.Replies,
+  ActivityCenterGroup.Membership,
+  ActivityCenterGroup.Admin,
+  ActivityCenterGroup.ContactRequests,
+  ActivityCenterGroup.IdentityVerification,
+  ActivityCenterGroup.System,
+  ActivityCenterGroup.News
+]
+
+type ActivityCenterCountSnapshot* = object
+  groupCounters*: Table[ActivityCenterGroup, int]
+  unreadCount*: int
+  unreadNonMessagingCount*: int
+
+proc sumCounts(counters: Table[int, int], activityTypes: openArray[int]): int =
+  for activityType in activityTypes:
+    result += counters.getOrDefault(activityType, 0)
+
+proc buildActivityCenterCountSnapshot*(
+    currentReadTypeCounters: Table[int, int],
+    unreadCounters: Table[int, int],
+    ): ActivityCenterCountSnapshot =
+  result.groupCounters = initTable[ActivityCenterGroup, int]()
+  for group in COUNTED_ACTIVITY_GROUPS:
+    result.groupCounters[group] = sumCounts(
+      currentReadTypeCounters,
+      activityCenterNotificationTypesByGroup(group),
+    )
+
+  result.unreadCount = sumCounts(
+    unreadCounters,
+    activityCenterNotificationTypesByGroup(ActivityCenterGroup.All),
+  )
+  result.unreadNonMessagingCount = sumCounts(
+    unreadCounters,
+    activityCenterNotificationTypesByGroup(ActivityCenterGroup.NonMessaging),
+  )

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -51,6 +51,7 @@ type ActivityCenterGroup* {.pure.}= enum
   Transactions = 7,
   System = 8
   News = 9
+  NonMessaging = 10
 
 type ActivityCenterReadType* {.pure.}= enum
   Read = 1,
@@ -235,5 +236,10 @@ proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[i
         ActivityCenterNotificationType.NewInstallationReceived.int,
         ActivityCenterNotificationType.NewInstallationCreated.int,
       ]
+    of ActivityCenterGroup.NonMessaging:
+      for activityType in activityCenterNotificationTypesByGroup(ActivityCenterGroup.All):
+        if activityType != ActivityCenterNotificationType.Mention.int and
+            activityType != ActivityCenterNotificationType.Reply.int:
+          result.add(activityType)
     else:
       return @[]

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -216,6 +216,14 @@ QtObject:
       total = total + counters.getOrDefault(activityType, 0)
     return total
 
+  proc getUnreadNonMessagingActivityCenterNotificationsCount*(self: Service): int =
+    let activityTypes = activityCenterNotificationTypesByGroup(ActivityCenterGroup.NonMessaging)
+    let counters = self.getActivityCenterNotificationsCounters(activityTypes, ActivityCenterReadType.Unread)
+    var total = 0
+    for activityType in activityTypes:
+      total = total + counters.getOrDefault(activityType, 0)
+    return total
+
   proc getHasUnseenActivityCenterNotifications*(self: Service): bool =
     try:
       let response = backend.hasUnseenActivityCenterNotifications()

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -9,6 +9,8 @@ import web3/eth_api_types, web3/conversions, stew/byteutils, nimcrypto
 import ../../../backend/backend
 import ../../../backend/response_type
 import ./dto/notification
+import ./count_refresh_generation
+import ./count_snapshot
 
 import ../../common/activity_center
 import ../message/service
@@ -35,10 +37,16 @@ type
   ActivityCenterNotificationHasUnseen* = ref object of Args
     hasUnseen*: bool
 
+  ActivityCenterNotificationCountsArgs* = ref object of Args
+    groupCounters*: Table[ActivityCenterGroup, int]
+    unreadCount*: int
+    unreadNonMessagingCount*: int
+
 # Signals which may be emitted by this service:
 const SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED* = "activityCenterNotificationsLoaded"
 const SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED* = "activityCenterNotificationsReceived"
 const SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED* = "activityCenterNotificationsCountMayChanged"
+const SIGNAL_ACTIVITY_CENTER_NOTIFICATION_COUNTS_RESOLVED* = "activityCenterNotificationCountsResolved"
 const SIGNAL_ACTIVITY_CENTER_UNSEEN_UPDATED* = "activityCenterNotificationsHasUnseenUpdated"
 const SIGNAL_ACTIVITY_CENTER_MARK_NOTIFICATIONS_AS_READ* = "activityCenterMarkNotificationsAsRead"
 const SIGNAL_ACTIVITY_CENTER_MARK_NOTIFICATIONS_AS_UNREAD* = "activityCenterMarkNotificationsAsUnread"
@@ -49,18 +57,6 @@ const SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_DISMISSED* = "activityCenterNotificat
 
 const DEFAULT_LIMIT = 20
 
-# NOTE: temporary disable Transactions and System and we don't count All group
-const ACTIVITY_GROUPS = @[
-  ActivityCenterGroup.Mentions,
-  ActivityCenterGroup.Replies,
-  ActivityCenterGroup.Membership,
-  ActivityCenterGroup.Admin,
-  ActivityCenterGroup.ContactRequests,
-  ActivityCenterGroup.IdentityVerification,
-  ActivityCenterGroup.System,
-  ActivityCenterGroup.News
-]
-
 QtObject:
   type Service* = ref object of QObject
     threadpool: ThreadPool
@@ -69,6 +65,7 @@ QtObject:
     activeGroup: ActivityCenterGroup
     readType: ActivityCenterReadType
     chatService: chat_service.Service
+    countRefreshState: CountRefreshGenerationState
 
   # Forward declaration
   proc asyncActivityNotificationLoad*(self: Service)
@@ -87,6 +84,7 @@ QtObject:
     result.activeGroup = ActivityCenterGroup.All
     result.readType = ActivityCenterReadType.All
     result.chatService = chatService
+    result.countRefreshState = initCountRefreshGenerationState()
 
   proc handleNewNotificationsLoaded(self: Service, activityCenterNotifications: seq[ActivityCenterNotificationDto]) =
     # For now status-go notify about every notification update regardless active group so we need filter manually on the desktop side
@@ -160,6 +158,21 @@ QtObject:
     )
     self.threadpool.start(arg)
 
+  proc startActivityCenterCountsTask(self: Service, generation: int) =
+    let arg = AsyncActivityCenterCountsTaskArg(
+      tptr: asyncActivityCenterCountsTask,
+      vptr: cast[uint](self.vptr),
+      slot: "asyncActivityCenterCountsLoaded",
+      generation: generation,
+      readType: self.readType,
+    )
+    self.threadpool.start(arg)
+
+  proc asyncActivityCenterCounts*(self: Service) =
+    let request = self.countRefreshState.requestRefresh()
+    if request.shouldStart:
+      self.startActivityCenterCountsTask(request.generation)
+
   proc getActivityCenterNotifications*(self: Service): seq[ActivityCenterNotificationDto] =
     try:
       let activityTypes = activityCenterNotificationTypesByGroup(self.activeGroup)
@@ -179,50 +192,6 @@ QtObject:
 
     except Exception as e:
       error "Error getting activity center notifications", msg = e.msg
-
-  proc getActivityCenterNotificationsCounters(self: Service, activityTypes: seq[int], readType: ActivityCenterReadType): Table[int, int] =
-    try:
-      let response = backend.activityCenterNotificationsCount(
-        backend.ActivityCenterCountRequest(
-          activityTypes: activityTypes,
-          readType: readType.int,
-        )
-      )
-      var counters = initTable[int, int]()
-      if response.result.kind != JNull:
-        for activityType in activityTypes:
-          if response.result.contains($activityType):
-            counters[activityType] = response.result[$activityType].getInt
-      return counters
-    except Exception as e:
-      error "Error getting unread activity center notifications count", msg = e.msg
-
-  proc getActivityGroupCounters*(self: Service): Table[ActivityCenterGroup, int] =
-    let allActivityTypes = activityCenterNotificationTypesByGroup(ActivityCenterGroup.All)
-    let counters = self.getActivityCenterNotificationsCounters(allActivityTypes, self.readType)
-    var groupCounters = initTable[ActivityCenterGroup, int]()
-    for group in ACTIVITY_GROUPS:
-      var groupTotal = 0
-      for activityType in activityCenterNotificationTypesByGroup(group):
-        groupTotal = groupTotal + counters.getOrDefault(activityType, 0)
-      groupCounters[group] = groupTotal
-    return groupCounters
-
-  proc getUnreadActivityCenterNotificationsCount*(self: Service): int =
-    let activityTypes = activityCenterNotificationTypesByGroup(ActivityCenterGroup.All)
-    let counters = self.getActivityCenterNotificationsCounters(activityTypes, ActivityCenterReadType.Unread)
-    var total = 0
-    for activityType in activityTypes:
-      total = total + counters.getOrDefault(activityType, 0)
-    return total
-
-  proc getUnreadNonMessagingActivityCenterNotificationsCount*(self: Service): int =
-    let activityTypes = activityCenterNotificationTypesByGroup(ActivityCenterGroup.NonMessaging)
-    let counters = self.getActivityCenterNotificationsCounters(activityTypes, ActivityCenterReadType.Unread)
-    var total = 0
-    for activityType in activityTypes:
-      total = total + counters.getOrDefault(activityType, 0)
-    return total
 
   proc getHasUnseenActivityCenterNotifications*(self: Service): bool =
     try:
@@ -313,6 +282,51 @@ QtObject:
           ActivityCenterNotificationsArgs(activityCenterNotifications: activityCenterNotificationsTuple[1]))
     except Exception as e:
       error "Error loading activity notification async", msg = e.msg
+
+  proc asyncActivityCenterCountsLoaded*(self: Service, response: string) {.slot.} =
+    var completedGeneration = self.countRefreshState.currentGeneration()
+    var responseObj: JsonNode
+    var responseError = ""
+    try:
+      responseObj = response.parseJson
+      if responseObj{"generation"}.kind != JNull:
+        completedGeneration = responseObj{"generation"}.getInt
+    except Exception as e:
+      responseError = e.msg
+
+    let completion = self.countRefreshState.onCompletion(completedGeneration)
+    if completion.action == crcaDropAndRefire:
+      self.startActivityCenterCountsTask(completion.generation)
+      return
+
+    if responseError != "":
+      error "Error decoding activity center notification counts", msg = responseError
+      return
+
+    try:
+      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
+        raise newException(CatchableError, responseObj{"error"}.getStr)
+
+      var currentCounters = initTable[int, int]()
+      var unreadCounters = initTable[int, int]()
+      let activityTypes = activityCenterNotificationTypesByGroup(ActivityCenterGroup.All)
+      for activityType in activityTypes:
+        if responseObj["currentCounters"].contains($activityType):
+          currentCounters[activityType] = responseObj["currentCounters"][$activityType].getInt
+        if responseObj["unreadCounters"].contains($activityType):
+          unreadCounters[activityType] = responseObj["unreadCounters"][$activityType].getInt
+
+      let snapshot = buildActivityCenterCountSnapshot(currentCounters, unreadCounters)
+      self.events.emit(
+        SIGNAL_ACTIVITY_CENTER_NOTIFICATION_COUNTS_RESOLVED,
+        ActivityCenterNotificationCountsArgs(
+          groupCounters: snapshot.groupCounters,
+          unreadCount: snapshot.unreadCount,
+          unreadNonMessagingCount: snapshot.unreadNonMessagingCount,
+        ),
+      )
+    except Exception as e:
+      error "Error loading activity center notification counts", msg = e.msg
 
 
   proc deleteActivityCenterNotifications*(self: Service, notificationIds: seq[string]): string =

--- a/test/nim/activity_center_badge_count_test.nim
+++ b/test/nim/activity_center_badge_count_test.nim
@@ -1,0 +1,18 @@
+import unittest
+
+import app_service/service/activity_center/dto/notification
+import app_service/service/activity_center/service
+
+suite "activity center badge count":
+  test "non-messaging types exclude only mentions and replies":
+    let allTypes = activityCenterNotificationTypesByGroup(ActivityCenterGroup.All)
+    let nonMessagingTypes = activityCenterNotificationTypesByGroup(ActivityCenterGroup.NonMessaging)
+
+    check ActivityCenterNotificationType.Mention.int notin nonMessagingTypes
+    check ActivityCenterNotificationType.Reply.int notin nonMessagingTypes
+    check nonMessagingTypes.len == allTypes.len - 2
+
+    for activityType in allTypes:
+      if activityType != ActivityCenterNotificationType.Mention.int and
+          activityType != ActivityCenterNotificationType.Reply.int:
+        check activityType in nonMessagingTypes

--- a/test/nim/activity_center_badge_count_test.nim
+++ b/test/nim/activity_center_badge_count_test.nim
@@ -1,7 +1,8 @@
+import std/tables
 import unittest
 
+import app_service/service/activity_center/count_snapshot
 import app_service/service/activity_center/dto/notification
-import app_service/service/activity_center/service
 
 suite "activity center badge count":
   test "non-messaging types exclude only mentions and replies":
@@ -16,3 +17,23 @@ suite "activity center badge count":
       if activityType != ActivityCenterNotificationType.Mention.int and
           activityType != ActivityCenterNotificationType.Reply.int:
         check activityType in nonMessagingTypes
+
+  test "count snapshot derives group and unread totals":
+    var currentCounters = initTable[int, int]()
+    currentCounters[ActivityCenterNotificationType.Mention.int] = 2
+    currentCounters[ActivityCenterNotificationType.Reply.int] = 3
+    currentCounters[ActivityCenterNotificationType.ContactRequest.int] = 5
+
+    var unreadCounters = initTable[int, int]()
+    unreadCounters[ActivityCenterNotificationType.Mention.int] = 7
+    unreadCounters[ActivityCenterNotificationType.Reply.int] = 11
+    unreadCounters[ActivityCenterNotificationType.ContactRequest.int] = 13
+
+    let snapshot = buildActivityCenterCountSnapshot(currentCounters, unreadCounters)
+
+    check snapshot.groupCounters[ActivityCenterGroup.Mentions] == 2
+    check snapshot.groupCounters[ActivityCenterGroup.Replies] == 3
+    check snapshot.groupCounters[ActivityCenterGroup.ContactRequests] == 5
+    check snapshot.groupCounters[ActivityCenterGroup.News] == 0
+    check snapshot.unreadCount == 31
+    check snapshot.unreadNonMessagingCount == 13

--- a/test/nim/activity_center_count_refresh_generation_test.nim
+++ b/test/nim/activity_center_count_refresh_generation_test.nim
@@ -1,0 +1,49 @@
+import unittest
+
+import app_service/service/activity_center/count_refresh_generation
+
+suite "activity center count refresh generation":
+  test "first request starts and a concurrent request coalesces":
+    var state = initCountRefreshGenerationState()
+
+    let first = state.requestRefresh()
+    let second = state.requestRefresh()
+
+    check first.shouldStart
+    check first.generation == 1
+    check not second.shouldStart
+    check second.generation == 2
+    check state.inFlight
+
+  test "stale completion refires the newest generation once":
+    var state = initCountRefreshGenerationState()
+    let first = state.requestRefresh()
+    discard state.requestRefresh()
+
+    let staleCompletion = state.onCompletion(first.generation)
+    check staleCompletion.action == crcaDropAndRefire
+    check staleCompletion.generation == 2
+    check state.inFlight
+
+    let newestCompletion = state.onCompletion(staleCompletion.generation)
+    check newestCompletion.action == crcaApply
+    check not state.inFlight
+
+  test "a request after completion starts immediately":
+    var state = initCountRefreshGenerationState()
+    let first = state.requestRefresh()
+    discard state.onCompletion(first.generation)
+
+    let second = state.requestRefresh()
+
+    check second.shouldStart
+    check second.generation == 2
+
+  test "current generation safely resolves an undecodable completion":
+    var state = initCountRefreshGenerationState()
+    discard state.requestRefresh()
+
+    let completion = state.onCompletion(state.currentGeneration)
+
+    check completion.action == crcaApply
+    check not state.inFlight


### PR DESCRIPTION
### What does the PR do

Fixes #20872

Updates the app badge to be the sum of section notification counts with non-messaging Activity Center notifications, excluding mentions and replies to avoid double counting.

edit: I also added a new commit that moves the AC counting to an async task. We used to call it syncly for multiple flows which could be costly for performance. I recommend reviewing per commit

### Affected areas

- activity center module
- main module
- ac service

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

Also ask Copilot to align feedback with repository architecture boundaries:

- Nim (`src/`): orchestration, signals, module wiring

### Screencapture of the functionality

4 private chat notifs + 1 community notif + 1 non-messaging AC notif (news) = 6

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/de80101c-64ed-42b4-a1d0-979379372d3c" />


### Impact on end user

Shows an accurate badge number

### How to test

Receive messages and notifications

### Risk 

Low
