### PR TITLE
fix(StatusTextMessage): make the expand/collapse button smaller

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -139,6 +139,7 @@ Item {
         sourceComponent: StatusButton {
             type: StatusBaseButton.Type.Primary
             size: StatusBaseButton.Size.Small
+            spacing: 1
             icon.name: d.readMore ? "chevron-up":  "chevron-down"
             onClicked: {
                 d.readMore = !d.readMore


### PR DESCRIPTION
### What does the PR do

- reduces spacing/padding

Fixes #21862

### Affected areas

Status(Text)Message

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Before: 
<img width="1462" height="1800" alt="Snímek obrazovky z 2026-08-10 11-47-05" src="https://github.com/user-attachments/assets/11f7093d-e201-4f68-889f-98b67900d4ba" />

After:
<img width="1462" height="1800" alt="Snímek obrazovky z 2026-08-10 12-21-48" src="https://github.com/user-attachments/assets/6da484ce-4fd9-4710-ae5a-eaf6c296c9d1" />


### Impact on end user

Smoother (mobile) UI

### How to test

- have a long received message
- check the expand/collapse button size

### Risk 

low
