### PR TITLE
Perf/loading skeletons

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -405,8 +405,6 @@ method onChatsLoaded*(
       if chatId == activeChatId:
         cModule.onMadeActive()
 
-  self.view.chatsLoaded()
-
 proc checkIfModuleDidLoad(self: Module) =
   if self.moduleLoaded:
     return
@@ -574,7 +572,7 @@ method onActiveSectionChange*(self: Module, sectionId: string) =
     self.controller.setIsCurrentSectionActive(false)
     return
   var firstLoad = false
-  if not self.view.getChatsLoaded:
+  if not self.chatsLoaded:
     firstLoad = true
     self.controller.getChatsAndBuildUI()
 

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -26,7 +26,6 @@ QtObject:
       allTokenRequirementsMet: bool
       requiresTokenPermissionToJoin: bool
       amIMember: bool
-      chatsLoaded: bool
       communityMetrics: string # NOTE: later this should be replaced with QAbstractListModel-based model
       permissionsCheckOngoing: bool
       isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin: bool
@@ -59,7 +58,6 @@ QtObject:
     result.tokenPermissionsVariant = newQVariant(result.tokenPermissionsModel)
     result.amIMember = false
     result.requiresTokenPermissionToJoin = false
-    result.chatsLoaded = false
     result.communityMetrics = "[]"
     result.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin = false
     result.memberMessagesModel = member_msg_model.newModel()
@@ -86,18 +84,6 @@ QtObject:
 
   QtProperty[QVariant] model:
     read = getModel
-
-  proc chatsLoadedChanged(self: View) {.signal.}
-
-  proc chatsLoaded*(self: View) =
-    self.chatsLoaded = true
-    self.chatsLoadedChanged()
-
-  proc getChatsLoaded*(self: View): bool {.slot.} =
-    return self.chatsLoaded
-  QtProperty[bool] chatsLoaded:
-    read = getChatsLoaded
-    notify = chatsLoadedChanged
 
   proc editCategoryChannelsModel*(self: View): chats_model.Model =
     return self.editCategoryChannelsModel

--- a/storybook/pages/ChatHeaderSkeletonPage.qml
+++ b/storybook/pages/ChatHeaderSkeletonPage.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Chat.panels
+
+import StatusQ.Core.Theme
+
+import Storybook
+
+SplitView {
+    id: root
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            // toolbar-like strip, as hosted by the section chrome
+            Rectangle {
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: parent.top
+                anchors.topMargin: 40
+                width: widthSlider.value
+                height: 56
+                color: Theme.palette.baseColor4
+                border.color: Theme.palette.baseColor2
+
+                ChatHeaderSkeleton {
+                    anchors.fill: parent
+                    anchors.leftMargin: Theme.padding
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label { text: "Toolbar width: %1".arg(widthSlider.value) }
+            Slider {
+                id: widthSlider
+                Layout.fillWidth: true
+                from: 200
+                to: 900
+                value: 600
+                stepSize: 1
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/ChatInputSkeletonPage.qml
+++ b/storybook/pages/ChatInputSkeletonPage.qml
@@ -1,0 +1,59 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Chat.panels
+
+import StatusQ.Core.Theme
+
+import Storybook
+
+SplitView {
+    id: root
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: widthSlider.value
+                height: inputSkeleton.implicitHeight + 2 * Theme.padding
+                color: Theme.palette.baseColor4
+                border.color: Theme.palette.baseColor2
+
+                ChatInputSkeleton {
+                    id: inputSkeleton
+                    anchors.fill: parent
+                    anchors.margins: Theme.padding
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label { text: "Panel width: %1".arg(widthSlider.value) }
+            Slider {
+                id: widthSlider
+                Layout.fillWidth: true
+                from: 300
+                to: 1000
+                value: 700
+                stepSize: 1
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/CommunityChannelsSkeletonPage.qml
+++ b/storybook/pages/CommunityChannelsSkeletonPage.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Communities.panels
+
+import StatusQ.Core.Theme
+
+import Models
+import Storybook
+
+SplitView {
+    id: root
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: widthSlider.value
+                height: parent.height - 40
+                color: Theme.palette.baseColor4
+                border.color: Theme.palette.baseColor2
+
+                CommunityChannelsSkeleton {
+                    anchors.fill: parent
+
+                    name: nameField.text
+                    membersCount: 245
+                    image: ModelsData.icons.status
+                    color: "#4360DF"
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label { text: "Panel width: %1".arg(widthSlider.value) }
+            Slider {
+                id: widthSlider
+                Layout.fillWidth: true
+                from: 80
+                to: 400
+                value: 270
+                stepSize: 1
+            }
+            Label { text: "Community name" }
+            TextField {
+                id: nameField
+                Layout.fillWidth: true
+                text: "Status Community"
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/LoadingSkeletonGroupPage.qml
+++ b/storybook/pages/LoadingSkeletonGroupPage.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+SplitView {
+    id: root
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            // primitives: arbitrary tile arrangements sharing one shimmer sweep
+            LoadingSkeletonGroup {
+                anchors.centerIn: parent
+                width: 320
+                height: 260
+                visible: visibleSwitch.checked
+
+                Column {
+                    spacing: Theme.padding
+
+                    Repeater {
+                        model: 4
+
+                        Row {
+                            spacing: Theme.halfPadding
+
+                            LoadingSkeletonTile {
+                                anchors.verticalCenter: parent.verticalCenter
+                                width: 40
+                                height: 40
+                                radius: 20
+                            }
+                            Column {
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: 6
+
+                                LoadingSkeletonTile { width: 180; height: 14 }
+                                LoadingSkeletonTile { width: 120; height: 10 }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Switch {
+                id: visibleSwitch
+                text: "Visible (shimmer only runs while visible)"
+                checked: true
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/MembersListSkeletonPage.qml
+++ b/storybook/pages/MembersListSkeletonPage.qml
@@ -1,0 +1,57 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Chat.panels
+
+import StatusQ.Core.Theme
+
+import Storybook
+
+SplitView {
+    id: root
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: widthSlider.value
+                height: parent.height - 40
+                color: Theme.palette.baseColor4
+                border.color: Theme.palette.baseColor2
+
+                MembersListSkeleton {
+                    anchors.fill: parent
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label { text: "Panel width: %1".arg(widthSlider.value) }
+            Slider {
+                id: widthSlider
+                Layout.fillWidth: true
+                from: 80
+                to: 400
+                value: 270
+                stepSize: 1
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/MessageRowsSkeletonPage.qml
+++ b/storybook/pages/MessageRowsSkeletonPage.qml
@@ -1,0 +1,58 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Chat.panels
+
+import StatusQ.Core.Theme
+
+import Storybook
+
+SplitView {
+    id: root
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: widthSlider.value
+                height: parent.height - 40
+                color: Theme.palette.baseColor4
+                border.color: Theme.palette.baseColor2
+
+                MessageRowsSkeleton {
+                    anchors.fill: parent
+                    anchors.margins: Theme.padding
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label { text: "Panel width: %1".arg(widthSlider.value) }
+            Slider {
+                id: widthSlider
+                Layout.fillWidth: true
+                from: 300
+                to: 1000
+                value: 700
+                stepSize: 1
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/MessagesChatSkeletonPage.qml
+++ b/storybook/pages/MessagesChatSkeletonPage.qml
@@ -1,0 +1,58 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Chat.panels
+
+import StatusQ.Core.Theme
+
+import Storybook
+
+SplitView {
+    id: root
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: widthSlider.value
+                height: parent.height - 40
+                color: Theme.palette.baseColor4
+                border.color: Theme.palette.baseColor2
+
+                MessagesChatSkeleton {
+                    anchors.fill: parent
+                    anchors.margins: Theme.padding
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label { text: "Panel width: %1".arg(widthSlider.value) }
+            Slider {
+                id: widthSlider
+                Layout.fillWidth: true
+                from: 300
+                to: 1000
+                value: 700
+                stepSize: 1
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/MessagesListSkeletonPage.qml
+++ b/storybook/pages/MessagesListSkeletonPage.qml
@@ -1,0 +1,74 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Chat.panels
+
+import StatusQ.Core.Theme
+
+import Storybook
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: widthSlider.value
+                height: parent.height - 40
+                color: Theme.palette.baseColor4
+                border.color: Theme.palette.baseColor2
+
+                MessagesListSkeleton {
+                    anchors.fill: parent
+
+                    createChatOpened: createChatSwitch.checked
+
+                    onShareOwnProfileRequested: logs.logEvent("MessagesListSkeleton::shareOwnProfileRequested")
+                    onStartChatClicked: logs.logEvent("MessagesListSkeleton::startChatClicked")
+                }
+            }
+        }
+
+        LogsAndControlsPanel {
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 160
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label { text: "Panel width: %1".arg(widthSlider.value) }
+            Slider {
+                id: widthSlider
+                Layout.fillWidth: true
+                from: 80
+                to: 500
+                value: 300
+                stepSize: 1
+            }
+            Switch {
+                id: createChatSwitch
+                text: "Create chat opened"
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/MessagesSkeletonsPage.qml
+++ b/storybook/pages/MessagesSkeletonsPage.qml
@@ -1,0 +1,125 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core.Theme
+
+import AppLayouts.Chat.panels
+import AppLayouts.Communities.panels
+
+import Storybook
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Rectangle {
+            anchors.centerIn: parent
+            width: ctrlWidth.value
+            height: parent.height - 2 * Theme.padding
+            color: Theme.palette.statusAppLayout.backgroundColor
+            border.color: Theme.palette.baseColor2
+
+            RowLayout {
+                id: panelsRow
+
+                readonly property bool landscape: ctrlLandscape.checked
+
+                anchors.fill: parent
+                anchors.margins: Theme.padding
+                spacing: Theme.padding
+
+                MessagesListSkeleton {
+                    visible: !ctrlCommunity.checked
+                    Layout.preferredWidth: panelsRow.landscape ? 306 : -1
+                    Layout.fillWidth: !panelsRow.landscape
+                    Layout.fillHeight: true
+
+                    onShareOwnProfileRequested: logs.logEvent("shareOwnProfileRequested")
+                    onStartChatClicked: logs.logEvent("startChatClicked")
+                }
+
+                CommunityChannelsSkeleton {
+                    visible: ctrlCommunity.checked
+                    Layout.preferredWidth: panelsRow.landscape ? 306 : -1
+                    Layout.fillWidth: !panelsRow.landscape
+                    Layout.fillHeight: true
+                }
+
+                ColumnLayout {
+                    visible: panelsRow.landscape
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Layout.leftMargin: Theme.xlPadding
+                    Layout.rightMargin: Theme.xlPadding
+                    spacing: Theme.padding
+
+                    ChatHeaderSkeleton {
+                        Layout.preferredHeight: 40
+                    }
+
+                    MessagesChatSkeleton {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                    }
+                }
+
+                MembersListSkeleton {
+                    visible: panelsRow.landscape && ctrlMembers.checked
+                    Layout.preferredWidth: 250
+                    Layout.fillHeight: true
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 100
+        SplitView.fillWidth: true
+
+        logsView.logText: logs.logText
+
+        RowLayout {
+            anchors.fill: parent
+            spacing: Theme.bigPadding
+
+            Switch {
+                id: ctrlLandscape
+                text: "Landscape (list + chat)"
+            }
+
+            Switch {
+                id: ctrlCommunity
+                text: "Community list"
+            }
+
+            Switch {
+                id: ctrlMembers
+                text: "Members panel"
+            }
+
+            RowLayout {
+                Label { text: "Width:" }
+                Slider {
+                    id: ctrlWidth
+                    from: 320
+                    to: 1200
+                    value: 455
+                }
+                Label { text: Math.round(ctrlWidth.value) }
+            }
+
+            Item { Layout.fillWidth: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/storybook/pages/WalletSkeletonsPage.qml
+++ b/storybook/pages/WalletSkeletonsPage.qml
@@ -1,0 +1,75 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core.Theme
+
+import AppLayouts.Wallet.panels
+
+import Storybook
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Rectangle {
+            anchors.centerIn: parent
+            width: ctrlWidth.value
+            height: parent.height - 2 * Theme.padding
+            color: Theme.palette.statusAppLayout.backgroundColor
+            border.color: Theme.palette.baseColor2
+
+            StackLayout {
+                anchors.fill: parent
+                anchors.margins: Theme.padding
+                currentIndex: ctrlCenter.checked ? 0 : 1
+
+                WalletCenterPanelSkeleton {}
+
+                WalletAccountsSkeleton {}
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 120
+        SplitView.preferredHeight: 120
+        SplitView.fillWidth: true
+
+        RowLayout {
+            anchors.fill: parent
+            spacing: Theme.bigPadding
+
+            ColumnLayout {
+                RadioButton {
+                    id: ctrlCenter
+                    text: "Center panel"
+                    checked: true
+                }
+                RadioButton {
+                    text: "Accounts (left) panel"
+                }
+            }
+
+            RowLayout {
+                Label { text: "Width:" }
+                Slider {
+                    id: ctrlWidth
+                    from: 320
+                    to: 900
+                    value: 455
+                }
+                Label { text: Math.round(ctrlWidth.value) }
+            }
+
+            Item { Layout.fillWidth: true }
+        }
+    }
+}
+
+// category: Skeletons

--- a/ui/StatusQ/src/StatusQ/Components/LoadingSkeletonGroup.qml
+++ b/ui/StatusQ/src/StatusQ/Components/LoadingSkeletonGroup.qml
@@ -1,0 +1,97 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+
+import StatusQ.Core.Theme
+
+/*!
+   \qmltype LoadingSkeletonGroup
+   \inherits Item
+   \inqmlmodule StatusQ.Components
+   \since StatusQ.Components 0.1
+   \brief Renders an arbitrary arrangement of LoadingSkeletonTile shapes with a
+   single shared shimmer sweep.
+
+   Use this for creation-time skeleton screens instead of many LoadingComponent
+   instances: tiles are plain rectangles and the whole group costs one effect
+   pass, where every LoadingComponent carries its own OpacityMask and animator.
+
+   Example:
+
+   \qml
+    LoadingSkeletonGroup {
+        width: 200
+        height: 60
+
+        Row {
+            spacing: 8
+            LoadingSkeletonTile { width: 40; height: 40; radius: 20 }
+            Column {
+                spacing: 6
+                LoadingSkeletonTile { width: 120; height: 14 }
+                LoadingSkeletonTile { width: 80; height: 12 }
+            }
+        }
+    }
+   \endqml
+*/
+Item {
+    id: root
+
+    default property alias contentData: shapesContainer.data
+
+    Item {
+        id: shapesContainer
+        anchors.fill: parent
+    }
+
+    // The animated sweep band, materialized only while the group is visible.
+    // It is masked by the shapes so the shimmer only shows on the tiles.
+    Item {
+        id: sweepContainer
+        anchors.fill: parent
+        visible: false
+
+        Loader {
+            anchors.fill: parent
+            active: root.visible
+            sourceComponent: Rectangle {
+                id: sweep
+
+                width: 100
+                height: 2 * parent.height
+                x: -width
+                y: -height / 4
+                rotation: 20
+
+                gradient: Gradient {
+                    orientation: Gradient.Horizontal
+                    GradientStop { position: 0.2; color: StatusColors.transparent }
+                    GradientStop { position: 0.5; color: Theme.palette.statusLoadingHighlight2 }
+                    GradientStop { position: 0.8; color: StatusColors.transparent }
+                }
+
+                XAnimator on x {
+                    id: sweepAnimator
+                    easing.type: Easing.Linear
+                    loops: Animation.Infinite
+                    running: true
+                    from: -sweep.width
+                    to: sweep.parent.width + sweep.width
+                    duration: 1000
+                }
+
+                Connections {
+                    target: sweep.parent
+                    function onWidthChanged() { sweepAnimator.restart() }
+                }
+            }
+        }
+    }
+
+    OpacityMask {
+        anchors.fill: parent
+        source: sweepContainer
+        maskSource: shapesContainer
+        visible: root.visible
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/LoadingSkeletonTile.qml
+++ b/ui/StatusQ/src/StatusQ/Components/LoadingSkeletonTile.qml
@@ -1,0 +1,16 @@
+import QtQuick
+
+import StatusQ.Core.Theme
+
+/*!
+   \qmltype LoadingSkeletonTile
+   \inherits Rectangle
+   \inqmlmodule StatusQ.Components
+   \since StatusQ.Components 0.1
+   \brief A plain skeleton shape, meant to be arranged inside a
+   LoadingSkeletonGroup which provides the shared shimmer.
+*/
+Rectangle {
+    color: Theme.palette.statusLoadingHighlight
+    radius: 4
+}

--- a/ui/StatusQ/src/StatusQ/Components/qmldir
+++ b/ui/StatusQ/src/StatusQ/Components/qmldir
@@ -5,6 +5,8 @@ ChatTextView 0.1 ChatTextView.qml
 LoadingComponent 0.1 LoadingComponent.qml
 LoadingErrorComponent 0.1 LoadingErrorComponent.qml
 CountdownProgressIndicator 0.1 CountdownProgressIndicator.qml
+LoadingSkeletonGroup 0.1 LoadingSkeletonGroup.qml
+LoadingSkeletonTile 0.1 LoadingSkeletonTile.qml
 StatusAnimatedImage 0.1 StatusAnimatedImage.qml
 StatusBadge 0.1 StatusBadge.qml
 StatusBetaTag 0.1 StatusBetaTag.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -5,6 +5,8 @@
         <file>StatusQ/Components/LoadingComponent.qml</file>
         <file>StatusQ/Components/LoadingErrorComponent.qml</file>
         <file>StatusQ/Components/CountdownProgressIndicator.qml</file>
+        <file>StatusQ/Components/LoadingSkeletonGroup.qml</file>
+        <file>StatusQ/Components/LoadingSkeletonTile.qml</file>
         <file>StatusQ/Components/StatusAnimatedImage.qml</file>
         <file>StatusQ/Components/StatusBadge.qml</file>
         <file>StatusQ/Components/StatusBetaTag.qml</file>

--- a/ui/app/AppLayouts/Chat/panels/ChatHeaderSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/ChatHeaderSkeleton.qml
@@ -1,0 +1,44 @@
+import QtQuick
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder for the chat header: avatar + name/subtitle lines
+LoadingSkeletonGroup {
+    id: root
+
+    implicitWidth: 220
+    implicitHeight: 40
+
+    // Mirrors StatusChatInfoButton metrics (36px avatar, horizontalPadding 4,
+    // avatar-to-text spacing 4, title/subtitle spacing 2) so the swap to the
+    // real header doesn't shift anything.
+    Row {
+        anchors.verticalCenter: parent.verticalCenter
+        // the real StatusChatInfoButton content sits 2px lower (verticalPadding)
+        anchors.verticalCenterOffset: 2
+        anchors.left: parent.left
+        anchors.leftMargin: 4
+        spacing: 4
+
+        LoadingSkeletonTile {
+            width: 36
+            height: 36
+            radius: width / 2
+            anchors.verticalCenter: parent.verticalCenter
+        }
+        Column {
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 2
+
+            LoadingSkeletonTile {
+                width: 120
+                height: 15
+            }
+            LoadingSkeletonTile {
+                width: 80
+                height: 10
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/ChatInputSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/ChatInputSkeleton.qml
@@ -1,0 +1,54 @@
+import QtQuick
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder for the chat input area: rounded text field with its
+// action buttons row below. Use only where the real StatusChatInput is not
+// on screen. Plain positioners on purpose — skeletons must stay near-free,
+// QtQuick.Layouts polish is too expensive here.
+LoadingSkeletonGroup {
+    id: root
+
+    implicitHeight: inputColumn.implicitHeight
+
+    Column {
+        id: inputColumn
+
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+        }
+        spacing: Theme.halfPadding
+
+        LoadingSkeletonTile {
+            width: parent.width
+            height: 48
+            radius: Theme.radius
+        }
+        Item {
+            width: parent.width
+            height: 32
+
+            Row {
+                spacing: Theme.halfPadding
+
+                Repeater {
+                    model: 6
+                    LoadingSkeletonTile {
+                        implicitWidth: 32
+                        implicitHeight: 32
+                        radius: Theme.radius
+                    }
+                }
+            }
+            LoadingSkeletonTile {
+                anchors.right: parent.right
+                implicitWidth: 32
+                implicitHeight: 32
+                radius: width / 2
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/MembersListSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/MembersListSkeleton.qml
@@ -1,0 +1,95 @@
+import QtQuick
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder mimicking the chat members panel: the real header
+// (label + disabled search button) above skeleton member rows (avatar + name).
+// Plain positioners on purpose — skeletons must stay near-free,
+// QtQuick.Layouts polish is too expensive here.
+Column {
+    id: root
+
+    topPadding: Theme.padding
+    // the header's own bottom margin plus the panel spacing
+    spacing: Theme.padding + Theme.halfPadding
+
+    MembersPanelHeader {
+        x: Theme.padding
+        width: parent.width - 2 * Theme.padding
+        label: qsTr("Members")
+        searchEnabled: false
+    }
+
+    LoadingSkeletonGroup {
+        // list margin + StatusMemberListItem's own horizontal padding
+        x: Theme.padding + Theme.halfPadding
+        width: parent.width - x
+        height: root.height - y
+        // rows that don't fit must not bleed past the panel
+        clip: true
+
+        Column {
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+            }
+            spacing: Theme.padding
+
+            // two member categories (online / inactive), each a small label
+            // followed by member rows: avatar + name and key lines
+            Repeater {
+                model: 2
+
+                Column {
+                    id: categorySection
+
+                    required property int index
+
+                    width: parent.width
+                    topPadding: index > 0 ? Theme.halfPadding : 0
+                    spacing: Theme.padding
+
+                    LoadingSkeletonTile {
+                        implicitWidth: 44 + categorySection.index * 16
+                        implicitHeight: 12
+                    }
+
+                    Repeater {
+                        model: categorySection.index === 0 ? 6 : 3
+                        Row {
+                            id: memberRow
+
+                            required property int index
+
+                            width: parent.width
+                            spacing: Theme.halfPadding
+
+                            LoadingSkeletonTile {
+                                implicitWidth: 34
+                                implicitHeight: 34
+                                radius: width / 2
+                            }
+                            Column {
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: 4
+
+                                LoadingSkeletonTile {
+                                    // member names vary in length
+                                    implicitWidth: 72 + (memberRow.index * 41
+                                                   + categorySection.index * 23) % 88
+                                    implicitHeight: 12
+                                }
+                                LoadingSkeletonTile {
+                                    implicitWidth: 64
+                                    implicitHeight: 8
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/MembersPanelHeader.qml
+++ b/ui/app/AppLayouts/Chat/panels/MembersPanelHeader.qml
@@ -1,0 +1,46 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Components
+import StatusQ.Controls
+import StatusQ.Core
+import StatusQ.Core.Theme
+
+// The members panel title row — shared between UserListPanel and
+// MembersListSkeleton so the loading state renders identically.
+Control {
+    id: root
+
+    objectName: "membersPanelHeader"
+
+    property alias label: titleText.text
+    property alias searchEnabled: searchBtn.enabled
+    property alias searchChecked: searchBtn.checked
+
+    padding: 0
+
+    contentItem: RowLayout {
+        StatusBaseText {
+            id: titleText
+            objectName: "membersPanelTitle"
+            Layout.fillWidth: true
+
+            opacity: (root.width > 58) ? 1.0 : 0.0
+            visible: (opacity > 0.1)
+            font.weight: Font.Medium
+            wrapMode: Text.Wrap
+        }
+
+        StatusFlatButton {
+            id: searchBtn
+            objectName: "membersSearchButton"
+            icon.name: "search"
+            isRoundIcon: true
+            checkable: true
+            textColor: checked || hovered ? Theme.palette.primaryColor1 : Theme.palette.directColor1
+            tooltip.text: qsTr("Search")
+            tooltip.orientation: StatusToolTip.Orientation.Bottom
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/MessageRowsSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/MessageRowsSkeleton.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import Qt.labs.qmlmodels
 
 import StatusQ.Components
 import StatusQ.Core.Theme
@@ -35,59 +36,62 @@ LoadingSkeletonGroup {
                 { name: 0.2, lines: [0.88, 0.44] },
             ]
 
-            Item {
-                id: entry
+            delegate: DelegateChooser {
+                role: "separator"
 
-                required property var modelData
-
-                // available width for the text bars; derived from the stable
-                // root width, not the row itself, to avoid a sizing cycle
-                readonly property real textWidth:
-                    Math.max(0, root.width - 40 - Theme.halfPadding)
-
-                width: parent.width
-                height: childrenRect.height
-
-                LoadingSkeletonTile {
-                    visible: !!entry.modelData.separator
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    implicitWidth: 96
-                    implicitHeight: 12
-                }
-
-                Row {
-                    visible: !entry.modelData.separator
-                    width: parent.width
-                    spacing: Theme.halfPadding
+                DelegateChoice {
+                    roleValue: true
 
                     LoadingSkeletonTile {
-                        implicitWidth: 40
-                        implicitHeight: 40
-                        radius: width / 2
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        implicitWidth: 96
+                        implicitHeight: 12
                     }
-                    Column {
-                        spacing: 6
+                }
+                DelegateChoice {
+                    Row {
+                        id: entry
+
+                        required property var modelData
+
+                        // available width for the text bars; derived from the
+                        // stable root width, not the row itself, to avoid a
+                        // sizing cycle
+                        readonly property real textWidth:
+                            Math.max(0, root.width - 40 - Theme.halfPadding)
+
+                        width: parent.width
+                        spacing: Theme.halfPadding
 
                         LoadingSkeletonTile {
-                            implicitWidth: entry.textWidth * (entry.modelData.name ?? 0.2)
-                            implicitHeight: 12
+                            implicitWidth: 40
+                            implicitHeight: 40
+                            radius: width / 2
                         }
-                        Repeater {
-                            model: entry.modelData.lines ?? []
+                        Column {
+                            spacing: 6
 
                             LoadingSkeletonTile {
-                                required property real modelData
-
-                                implicitWidth: entry.textWidth * modelData
-                                implicitHeight: 14
+                                implicitWidth: entry.textWidth * (entry.modelData.name ?? 0.2)
+                                implicitHeight: 12
                             }
-                        }
-                        // attachment / link-preview card
-                        LoadingSkeletonTile {
-                            visible: !!entry.modelData.card
-                            implicitWidth: Math.min(320, entry.textWidth * 0.6)
-                            implicitHeight: 150
-                            radius: Theme.radius
+                            Repeater {
+                                model: entry.modelData.lines ?? []
+
+                                LoadingSkeletonTile {
+                                    required property real modelData
+
+                                    implicitWidth: entry.textWidth * modelData
+                                    implicitHeight: 14
+                                }
+                            }
+                            // attachment / link-preview card
+                            LoadingSkeletonTile {
+                                visible: !!entry.modelData.card
+                                implicitWidth: Math.min(320, entry.textWidth * 0.6)
+                                implicitHeight: 150
+                                radius: Theme.radius
+                            }
                         }
                     }
                 }

--- a/ui/app/AppLayouts/Chat/panels/MessageRowsSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/MessageRowsSkeleton.qml
@@ -1,0 +1,97 @@
+import QtQuick
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder for the message list alone: left-aligned message rows
+// of varying sizes with date separators and an attachment card. Pair with
+// ChatInputSkeleton when the real input is not on screen. Plain positioners
+// on purpose — skeletons must stay near-free, QtQuick.Layouts polish is too
+// expensive here.
+LoadingSkeletonGroup {
+    id: root
+
+    // rows stack upward from the bottom edge (where the input sits); rows
+    // that don't fit are clipped at the top instead of bleeding below
+    clip: true
+
+    Column {
+        anchors {
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+        spacing: Theme.padding
+
+        // name/line widths are fractions of the available text width so the
+        // shape survives narrow and wide panels alike
+        Repeater {
+            model: [
+                { name: 0.22, lines: [0.95, 0.9, 0.86, 0.5] },
+                { separator: true },
+                { name: 0.18, lines: [0.6], card: true },
+                { name: 0.26, lines: [0.92, 0.35] },
+                { separator: true },
+                { name: 0.2, lines: [0.88, 0.44] },
+            ]
+
+            Item {
+                id: entry
+
+                required property var modelData
+
+                // available width for the text bars; derived from the stable
+                // root width, not the row itself, to avoid a sizing cycle
+                readonly property real textWidth:
+                    Math.max(0, root.width - 40 - Theme.halfPadding)
+
+                width: parent.width
+                height: childrenRect.height
+
+                LoadingSkeletonTile {
+                    visible: !!entry.modelData.separator
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    implicitWidth: 96
+                    implicitHeight: 12
+                }
+
+                Row {
+                    visible: !entry.modelData.separator
+                    width: parent.width
+                    spacing: Theme.halfPadding
+
+                    LoadingSkeletonTile {
+                        implicitWidth: 40
+                        implicitHeight: 40
+                        radius: width / 2
+                    }
+                    Column {
+                        spacing: 6
+
+                        LoadingSkeletonTile {
+                            implicitWidth: entry.textWidth * (entry.modelData.name ?? 0.2)
+                            implicitHeight: 12
+                        }
+                        Repeater {
+                            model: entry.modelData.lines ?? []
+
+                            LoadingSkeletonTile {
+                                required property real modelData
+
+                                implicitWidth: entry.textWidth * modelData
+                                implicitHeight: 14
+                            }
+                        }
+                        // attachment / link-preview card
+                        LoadingSkeletonTile {
+                            visible: !!entry.modelData.card
+                            implicitWidth: Math.min(320, entry.textWidth * 0.6)
+                            implicitHeight: 150
+                            radius: Theme.radius
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/MessagesChatSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/MessagesChatSkeleton.qml
@@ -1,0 +1,29 @@
+import QtQuick
+
+import StatusQ.Core.Theme
+
+// Loading placeholder for a whole chat center panel: message rows plus the
+// input area. For contexts where the real header/input are already on
+// screen use MessageRowsSkeleton alone.
+Item {
+    id: root
+
+    ChatInputSkeleton {
+        id: inputSkeleton
+        anchors {
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+    }
+
+    MessageRowsSkeleton {
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+            bottom: inputSkeleton.top
+            bottomMargin: Theme.padding
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/MessagesListHeader.qml
+++ b/ui/app/AppLayouts/Chat/panels/MessagesListHeader.qml
@@ -1,0 +1,63 @@
+import QtQuick
+import QtQuick.Layouts
+
+import StatusQ.Components
+import StatusQ.Controls
+import StatusQ.Core.Theme
+
+// The Messages list headline row: title + invite / start-chat / search buttons.
+// Used by ContactsColumnView and, in disabled form, by the section loading
+// skeleton so the real header shows while the section incubates.
+RowLayout {
+    id: root
+
+    property bool createChatOpened: false
+    property alias searchChecked: searchBtn.checked
+    // Search only acts on the loaded chat list; disabled while the section loads
+    property alias searchEnabled: searchBtn.enabled
+    property bool searchVisible: true
+
+    signal shareOwnProfileRequested()
+    signal startChatClicked()
+
+    component HeaderButton: StatusFlatButton {
+        icon.color: hovered || checked ? Theme.palette.primaryColor1 : Theme.palette.directColor1
+        isRoundIcon: true
+        tooltip.orientation: StatusToolTip.Orientation.Bottom
+        tooltip.y: parent.height + Theme.padding
+    }
+
+    StatusNavigationPanelHeadline {
+        objectName: "ContactsColumnView_MessagesHeadline"
+        text: qsTr("Messages")
+    }
+
+    Item {
+        Layout.fillWidth: true
+    }
+
+    HeaderButton {
+        objectName: "shareProfileButton"
+        icon.name: "add-contact"
+        tooltip.text: qsTr("Invite contacts")
+        onClicked: root.shareOwnProfileRequested()
+    }
+
+    HeaderButton {
+        objectName: "startChatButton"
+        icon.name: "chat-commands"
+        checkable: true
+        checked: root.createChatOpened
+        tooltip.text: qsTr("Start chat")
+        onClicked: root.startChatClicked()
+    }
+
+    HeaderButton {
+        id: searchBtn
+        objectName: "searchButton"
+        icon.name: "search"
+        tooltip.text: qsTr("Search")
+        checkable: true
+        visible: root.searchVisible
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/MessagesListSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/MessagesListSkeleton.qml
@@ -1,0 +1,74 @@
+import QtQuick
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder mimicking the messages chat list: the real header row
+// followed by skeleton chat rows (avatar + name). Plain positioners on
+// purpose — skeletons must stay near-free, QtQuick.Layouts polish is too
+// expensive here.
+Column {
+    id: root
+
+    property alias createChatOpened: header.createChatOpened
+
+    signal shareOwnProfileRequested()
+    signal startChatClicked()
+
+    // margins/spacing mirror ContactsColumnView so the swap doesn't shift
+    topPadding: Theme.smallPadding
+    spacing: Theme.halfPadding
+
+    // The real header: invite and start-chat act app-globally, so they work
+    // before the section exists; search needs the loaded list, so it is disabled
+    MessagesListHeader {
+        id: header
+        x: Theme.padding
+        width: parent.width - 2 * Theme.padding
+        searchEnabled: false
+
+        onShareOwnProfileRequested: root.shareOwnProfileRequested()
+        onStartChatClicked: root.startChatClicked()
+    }
+
+    LoadingSkeletonGroup {
+        x: Theme.padding
+        width: parent.width - 2 * Theme.padding
+        height: root.height - y
+        // rows that don't fit must not bleed past the panel
+        clip: true
+
+        Column {
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+            }
+            spacing: Theme.padding
+
+            Repeater {
+                model: 12
+                Row {
+                    id: chatRow
+
+                    required property int index
+
+                    width: parent.width
+                    spacing: Theme.halfPadding
+
+                    LoadingSkeletonTile {
+                        implicitWidth: 30
+                        implicitHeight: 30
+                        radius: width / 2
+                    }
+                    LoadingSkeletonTile {
+                        anchors.verticalCenter: parent.verticalCenter
+                        // chat names vary in length
+                        implicitWidth: 88 + (chatRow.index * 59) % 132
+                        implicitHeight: 14
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/qmldir
+++ b/ui/app/AppLayouts/Chat/panels/qmldir
@@ -1,5 +1,13 @@
 ChatAnchorButtonsPanel 1.0 ChatAnchorButtonsPanel.qml
+ChatHeaderSkeleton 1.0 ChatHeaderSkeleton.qml
+ChatInputSkeleton 1.0 ChatInputSkeleton.qml
 EmptyChatPanel 1.0 EmptyChatPanel.qml
 InlineSelectorPanel 1.0 InlineSelectorPanel.qml
+MembersListSkeleton 1.0 MembersListSkeleton.qml
+MembersPanelHeader 1.0 MembersPanelHeader.qml
+MessageRowsSkeleton 1.0 MessageRowsSkeleton.qml
+MessagesChatSkeleton 1.0 MessagesChatSkeleton.qml
+MessagesListHeader 1.0 MessagesListHeader.qml
+MessagesListSkeleton 1.0 MessagesListSkeleton.qml
 SuggestionBoxPanel 1.0 SuggestionBoxPanel.qml
 UserListPanel 1.0 UserListPanel.qml

--- a/ui/app/AppLayouts/Communities/panels/CommunityChannelsSkeleton.qml
+++ b/ui/app/AppLayouts/Communities/panels/CommunityChannelsSkeleton.qml
@@ -1,0 +1,108 @@
+import QtQuick
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder mimicking the community left column: the real
+// community header (its data is known before the section loads) followed
+// by skeleton channel rows. Plain positioners on purpose — skeletons must
+// stay near-free, QtQuick.Layouts polish is too expensive here.
+Column {
+    id: root
+
+    property alias name: header.name
+    property alias membersCount: header.membersCount
+    property alias image: header.image
+    property alias color: header.color
+
+    signal shareOwnProfileRequested()
+
+    // mirrors CommunityColumnView's own top margin; the chrome slot adds none
+    topPadding: Theme.smallPadding
+    spacing: Theme.halfPadding
+
+    ColumnHeaderPanel {
+        id: header
+        width: parent.width
+        amISectionAdmin: false
+        onShareOwnProfileRequested: root.shareOwnProfileRequested()
+    }
+
+    LoadingSkeletonGroup {
+        x: Theme.padding
+        width: parent.width - 2 * Theme.padding
+        height: root.height - y
+        // rows that don't fit must not bleed past the panel
+        clip: true
+
+        Column {
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+            }
+            spacing: Theme.padding
+
+            // two channel categories: category header row (label left,
+            // collapse button right) followed by its channel rows
+            Repeater {
+                model: 2
+
+                Column {
+                    id: categorySection
+
+                    required property int index
+
+                    width: parent.width
+                    topPadding: index > 0 ? Theme.halfPadding : 0
+                    spacing: Theme.padding
+
+                    Item {
+                        width: parent.width
+                        height: 16
+
+                        LoadingSkeletonTile {
+                            anchors.verticalCenter: parent.verticalCenter
+                            implicitWidth: 72 + categorySection.index * 32
+                            implicitHeight: 14
+                        }
+                        LoadingSkeletonTile {
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            implicitWidth: 16
+                            implicitHeight: 16
+                            radius: 4
+                        }
+                    }
+
+                    Repeater {
+                        // first category at the top of the list, the second
+                        // at its bottom third
+                        model: categorySection.index === 0 ? 7 : 4
+                        Row {
+                            id: channelRow
+
+                            required property int index
+
+                            width: parent.width
+                            spacing: Theme.halfPadding
+
+                            LoadingSkeletonTile {
+                                implicitWidth: 28
+                                implicitHeight: 28
+                                radius: width / 2
+                            }
+                            LoadingSkeletonTile {
+                                anchors.verticalCenter: parent.verticalCenter
+                                // channel names vary in length
+                                implicitWidth: 64 + (channelRow.index * 53
+                                               + categorySection.index * 29) % 96
+                                implicitHeight: 16
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/panels/qmldir
+++ b/ui/app/AppLayouts/Communities/panels/qmldir
@@ -6,6 +6,7 @@ ChatPermissionQualificationPanel 1.0 ChatPermissionQualificationPanel.qml
 ColorPanel 1.0 ColorPanel.qml
 ColumnHeaderPanel 1.0 ColumnHeaderPanel.qml
 CommunityBannedMemberCenterPanel 1.0 CommunityBannedMemberCenterPanel.qml
+CommunityChannelsSkeleton 1.0 CommunityChannelsSkeleton.qml
 ControlNodeOfflineCenterPanel 1.0 ControlNodeOfflineCenterPanel.qml
 EditSettingsPanel 1.0 EditSettingsPanel.qml
 FeesBox 1.0 FeesBox.qml

--- a/ui/app/AppLayouts/Wallet/panels/WalletAccountsSkeleton.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletAccountsSkeleton.qml
@@ -1,0 +1,71 @@
+import QtQuick
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder mimicking the wallet left panel: the "All accounts"
+// summary card followed by account list items
+LoadingSkeletonGroup {
+    id: root
+
+    implicitWidth: layout.implicitWidth
+    implicitHeight: layout.implicitHeight
+
+    ColumnLayout {
+        id: layout
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+        }
+        spacing: Theme.smallPadding
+
+        StatusBaseText {
+            id: walletTitleText
+            text: qsTr("Wallet")
+            font.weight: Font.Bold
+            font.pixelSize: Theme.secondaryAdditionalTextSize
+            color: Theme.palette.directColor1
+        }
+
+        // "All accounts" summary card
+        LoadingSkeletonTile {
+            Layout.fillWidth: true
+            Layout.bottomMargin: Theme.halfPadding
+            implicitHeight: 86
+            radius: Theme.radius
+        }
+
+        // account list items
+        Repeater {
+            model: 8
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.padding
+                Layout.preferredHeight: 64
+                spacing: Theme.padding
+
+                LoadingSkeletonTile {
+                    implicitWidth: 40
+                    implicitHeight: 40
+                    radius: width / 2
+                }
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.halfPadding
+
+                    LoadingSkeletonTile {
+                        implicitWidth: 120
+                        implicitHeight: 14
+                    }
+                    LoadingSkeletonTile {
+                        implicitWidth: 80
+                        implicitHeight: 12
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/panels/WalletAssetListSkeleton.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletAssetListSkeleton.qml
@@ -1,0 +1,70 @@
+import QtQuick
+import QtQuick.Layouts
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder mimicking the wallet token list (TokenDelegate rows):
+// icon and token name with balance below on the left, currency value with
+// change indicators right-aligned on the right
+LoadingSkeletonGroup {
+    id: root
+
+    implicitWidth: layout.implicitWidth
+    implicitHeight: layout.implicitHeight
+
+    ColumnLayout {
+        id: layout
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+        }
+        spacing: Theme.padding
+
+        Repeater {
+            model: 8
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 48
+                spacing: Theme.padding
+
+                LoadingSkeletonTile {
+                    implicitWidth: 32
+                    implicitHeight: 32
+                    radius: width / 2
+                }
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    LoadingSkeletonTile {
+                        implicitWidth: 90
+                        implicitHeight: 15
+                    }
+                    LoadingSkeletonTile {
+                        implicitWidth: 130
+                        implicitHeight: 12
+                    }
+                }
+                Item {
+                    Layout.fillWidth: true
+                }
+                ColumnLayout {
+                    spacing: 6
+
+                    LoadingSkeletonTile {
+                        Layout.alignment: Qt.AlignRight
+                        implicitWidth: 100
+                        implicitHeight: 15
+                    }
+                    LoadingSkeletonTile {
+                        Layout.alignment: Qt.AlignRight
+                        implicitWidth: 130
+                        implicitHeight: 12
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/panels/WalletCenterPanelSkeleton.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletCenterPanelSkeleton.qml
@@ -1,0 +1,163 @@
+import QtQuick
+import QtQuick.Layouts
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+// Loading placeholder mimicking the wallet center panel, proportions extracted
+// from WalletAccountHeader (compact mode), the wallet tab bar and TokenDelegate:
+// - header: title + balance (19px text, 26px line height) with a 38x38 reload
+//   button, then dApps button and the 38px-tall network filter pill
+// - tab bar row with the filter button
+// - token list
+ColumnLayout {
+    id: root
+
+    spacing: Theme.padding
+
+    LoadingSkeletonGroup {
+        Layout.fillWidth: true
+        implicitHeight: headerLayout.implicitHeight
+
+        ColumnLayout {
+            id: headerLayout
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+            }
+            spacing: Theme.padding
+
+            // account name + balance, reload button to the right
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.padding
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    LoadingSkeletonTile {
+                        implicitWidth: 110
+                        implicitHeight: 18
+                    }
+                    LoadingSkeletonTile {
+                        implicitWidth: 170
+                        implicitHeight: 22
+                    }
+                }
+                Item {
+                    Layout.fillWidth: true
+                }
+                LoadingSkeletonTile {
+                    Layout.alignment: Qt.AlignTop
+                    implicitWidth: 38
+                    implicitHeight: 38
+                    radius: Theme.radius
+                }
+            }
+
+            // dApps button + network filter pill
+            RowLayout {
+                Layout.fillWidth: true
+
+                LoadingSkeletonTile {
+                    implicitWidth: 36
+                    implicitHeight: 36
+                    radius: width / 2
+                }
+                Item { Layout.fillWidth: true }
+                LoadingSkeletonTile {
+                    implicitWidth: 130
+                    implicitHeight: 38
+                    radius: Theme.radius
+                }
+            }
+        }
+    }
+
+    // tab bar: Assets / Collectibles / History + filter button
+    LoadingSkeletonGroup {
+        Layout.fillWidth: true
+        Layout.topMargin: Theme.padding
+        implicitHeight: tabsLayout.implicitHeight
+
+        RowLayout {
+            id: tabsLayout
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+            }
+            spacing: Theme.padding
+
+            LoadingSkeletonTile {
+                implicitWidth: 48
+                implicitHeight: 16
+            }
+            LoadingSkeletonTile {
+                implicitWidth: 84
+                implicitHeight: 16
+            }
+            LoadingSkeletonTile {
+                implicitWidth: 52
+                implicitHeight: 16
+            }
+            Item { Layout.fillWidth: true }
+            LoadingSkeletonTile {
+                implicitWidth: 20
+                implicitHeight: 20
+                radius: width / 2
+            }
+        }
+    }
+
+    LoadingSkeletonGroup {
+        Layout.fillWidth: true
+        Layout.topMargin: Theme.padding
+        implicitHeight: cardsLayout.implicitHeight
+
+        RowLayout {
+            id: cardsLayout
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+            }
+            spacing: Theme.padding
+
+            LoadingSkeletonTile {
+                Layout.fillWidth: true
+                implicitWidth: 400
+                implicitHeight: 70
+                radius: Theme.radius
+            }
+            LoadingSkeletonTile {
+                Layout.fillWidth: true
+                implicitWidth: 400
+                implicitHeight: 70
+                radius: Theme.radius
+            }
+        }
+    }
+
+    WalletAssetListSkeleton {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.topMargin: Theme.padding
+        clip: true
+    }
+
+    // footer action bar (WalletFooter: 61px, centered icon buttons)
+    LoadingSkeletonGroup {
+        Layout.fillWidth: true
+        implicitHeight: 61
+
+        LoadingSkeletonTile {
+            anchors.centerIn: parent
+            implicitWidth: parent.width * 0.6
+            implicitHeight: 24
+            radius: width / 2
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/panels/qmldir
+++ b/ui/app/AppLayouts/Wallet/panels/qmldir
@@ -19,5 +19,8 @@ StickySendModalHeader 1.0 StickySendModalHeader.qml
 SwapInputPanel 1.0 SwapInputPanel.qml
 TokenSelectorPanel 1.0 TokenSelectorPanel.qml
 WalletAccountHeader 1.0 WalletAccountHeader.qml
+WalletAccountsSkeleton 1.0 WalletAccountsSkeleton.qml
+WalletAssetListSkeleton 1.0 WalletAssetListSkeleton.qml
+WalletCenterPanelSkeleton 1.0 WalletCenterPanelSkeleton.qml
 WalletFollowingAddressesHeader 1.0 WalletFollowingAddressesHeader.qml
 WalletSavedAddressesHeader 1.0 WalletSavedAddressesHeader.qml

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -11190,6 +11190,20 @@ to load</source>
     </message>
 </context>
 <context>
+    <name>MembersListSkeleton</name>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MembersPanelHeader</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MembersSelectorBase</name>
     <message>
         <source>To:</source>
@@ -11441,6 +11455,25 @@ to load</source>
     </message>
     <message>
         <source>Unknown message. Trying to recover it</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MessagesListHeader</name>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite contacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18813,6 +18846,13 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>Last refreshed %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WalletAccountsSkeleton</name>
+    <message>
+        <source>Wallet</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -11259,6 +11259,20 @@ selhalo</translation>
     </message>
 </context>
 <context>
+    <name>MembersListSkeleton</name>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">Členové</translation>
+    </message>
+</context>
+<context>
+    <name>MembersPanelHeader</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">Hledat</translation>
+    </message>
+</context>
+<context>
     <name>MembersSelectorBase</name>
     <message>
         <source>To:</source>
@@ -11512,6 +11526,25 @@ selhalo</translation>
     <message>
         <source>Unknown message. Trying to recover it</source>
         <translation>Neznámá zpráva. Obnovuje se</translation>
+    </message>
+</context>
+<context>
+    <name>MessagesListHeader</name>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">Zprávy</translation>
+    </message>
+    <message>
+        <source>Invite contacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start chat</source>
+        <translation type="unfinished">Zahájit chat</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">Hledat</translation>
     </message>
 </context>
 <context>
@@ -18919,6 +18952,13 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Last refreshed %1</source>
         <translation>Poslední aktualizace %1</translation>
+    </message>
+</context>
+<context>
+    <name>WalletAccountsSkeleton</name>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Peněženka</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -11203,6 +11203,20 @@ al cargar</translation>
     </message>
 </context>
 <context>
+    <name>MembersListSkeleton</name>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">Miembros</translation>
+    </message>
+</context>
+<context>
+    <name>MembersPanelHeader</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">Buscar</translation>
+    </message>
+</context>
+<context>
     <name>MembersSelectorBase</name>
     <message>
         <source>To:</source>
@@ -11455,6 +11469,25 @@ al cargar</translation>
     <message>
         <source>Unknown message. Trying to recover it</source>
         <translation>Mensaje desconocido. Intentando recuperarlo</translation>
+    </message>
+</context>
+<context>
+    <name>MessagesListHeader</name>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">Mensajes</translation>
+    </message>
+    <message>
+        <source>Invite contacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start chat</source>
+        <translation type="unfinished">Iniciar chat</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">Buscar</translation>
     </message>
 </context>
 <context>
@@ -18842,6 +18875,13 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     <message>
         <source>Last refreshed %1</source>
         <translation>Última actualización %1</translation>
+    </message>
+</context>
+<context>
+    <name>WalletAccountsSkeleton</name>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Billetera</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -11200,6 +11200,20 @@ chargement</translation>
     </message>
 </context>
 <context>
+    <name>MembersListSkeleton</name>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">Membres</translation>
+    </message>
+</context>
+<context>
+    <name>MembersPanelHeader</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MembersSelectorBase</name>
     <message>
         <source>To:</source>
@@ -11452,6 +11466,25 @@ chargement</translation>
     <message>
         <source>Unknown message. Trying to recover it</source>
         <translation>Message inconnu. Tentative de récupération.</translation>
+    </message>
+</context>
+<context>
+    <name>MessagesListHeader</name>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">Messages</translation>
+    </message>
+    <message>
+        <source>Invite contacts</source>
+        <translation type="unfinished">Inviter des contacts</translation>
+    </message>
+    <message>
+        <source>Start chat</source>
+        <translation type="unfinished">Démarrer une conversation</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -18841,6 +18874,13 @@ Si une transaction avec un nonce inférieur est en attente, les transactions ave
     <message>
         <source>Last refreshed %1</source>
         <translation>Dernière mise à jour : %1</translation>
+    </message>
+</context>
+<context>
+    <name>WalletAccountsSkeleton</name>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Portefeuille</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -11148,6 +11148,20 @@ to load</source>
     </message>
 </context>
 <context>
+    <name>MembersListSkeleton</name>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">멤버들</translation>
+    </message>
+</context>
+<context>
+    <name>MembersPanelHeader</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">검색</translation>
+    </message>
+</context>
+<context>
     <name>MembersSelectorBase</name>
     <message>
         <source>To:</source>
@@ -11399,6 +11413,25 @@ to load</source>
     <message>
         <source>Unknown message. Trying to recover it</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MessagesListHeader</name>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">메시지</translation>
+    </message>
+    <message>
+        <source>Invite contacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start chat</source>
+        <translation type="unfinished">채팅 시작</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">검색</translation>
     </message>
 </context>
 <context>
@@ -18757,6 +18790,13 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Last refreshed %1</source>
         <translation>마지막 새로고침 %1</translation>
+    </message>
+</context>
+<context>
+    <name>WalletAccountsSkeleton</name>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">지갑</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-app/issues/21825

Loading skeleton components for section loading states

  First PR of a stack that makes app sections load asynchronously behind skeleton placeholders (next up: storybook mocks for the chat/community sections, then the async section
  loading itself). This PR only adds components — nothing is wired into the app yet, so it is riskless to merge.

  What's included

  - StatusQ primitives — LoadingSkeletonGroup (opacity-animated wrapper) and LoadingSkeletonTile (plain rounded placeholder tile). Deliberately shimmer-free and effect-free: these
  render while the GUI thread is at its busiest, so they must cost near nothing.
  - Section skeleton panels matching each section's layout:
    - Chat/Messages: messages list (with a real, functional header and disabled search), chat header, chat input, members list (with panel header)
    - Communities: channel list (with the real community identity header — name/avatar/members are known before the section loads)
    - Wallet: accounts list, asset list, center panel
  - Storybook pages — one page per panel plus grouped MessagesSkeletons/WalletSkeletons preview pages.


### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->
](https://github.com/user-attachments/assets/4095fac3-bcad-43a8-bd8c-623e4df40dee)

### Impact on end user

none
### How to test

  make run-storybook → Skeletons category

### Risk 

low