### PR TITLE
feat(storybook): chat and community section pages with configurable mocks

### DIFF
--- a/storybook/pages/ChatLoaderPage.qml
+++ b/storybook/pages/ChatLoaderPage.qml
@@ -136,13 +136,15 @@ SplitView {
 
         function fillMessages(model, count, peerIdx) {
             const now = Date.now()
+            // like message_model.nim: index 0 is the newest message and
+            // history grows towards higher indexes
             for (let i = 0; i < count; ++i) {
                 const own = i % 3 === 1
-                const ts = now - (count - i) * 60000
+                const ts = now - i * 60000
                 model.append({
                     id: "msg-" + peerIdx + "-" + i,
-                    prevMsgIndex: i - 1,
-                    nextMsgIndex: i + 1,
+                    prevMsgIndex: i + 1,
+                    nextMsgIndex: i - 1,
                     prevMsgTimestamp: ts - 60000,
                     nextMsgTimestamp: ts + 60000,
                     prevMsgSenderId: "",
@@ -158,9 +160,9 @@ SplitView {
                     senderEnsVerified: false,
                     senderTrustStatus: 0,
                     amISender: own,
-                    messageText: "Message " + i + " — the quick brown fox jumps over the lazy dog. "
+                    messageText: "Message " + (count - i) + " — the quick brown fox jumps over the lazy dog. "
                                  + (i % 5 === 0 ? "A somewhat longer paragraph to vary the bubble heights and make the layout work harder while measuring text. " : ""),
-                    unparsedText: "Message " + i,
+                    unparsedText: "Message " + (count - i),
                     messageImage: "",
                     messageAttachments: "",
                     contentType: Constants.messageContentType.messageType,
@@ -230,7 +232,7 @@ SplitView {
                     chatsModel.setProperty(i, "loaderActive", true)
             }
             d.activeChatId = id
-            sectionModuleMock.activeItem = ({ id: id })
+            sectionModuleMock.activeItem = ({ id: id, type: Constants.chatType.oneToOne })
             const module = contentModuleFor(id)
             if (module && !module.messagesModel) {
                 module.messagesModel = messagesModelComp.createObject(module)
@@ -245,7 +247,7 @@ SplitView {
 
         property bool chatsLoaded: true
         property var model: chatsModel
-        property var activeItem: ({ id: "" })
+        property var activeItem: ({ id: "", type: -1 })
         property bool amIMember: true
         property bool requiresTokenPermissionToJoin: false
         property bool isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin: false

--- a/storybook/pages/ChatLoaderPage.qml
+++ b/storybook/pages/ChatLoaderPage.qml
@@ -243,6 +243,7 @@ SplitView {
     QtObject {
         id: sectionModuleMock
 
+        property bool chatsLoaded: true
         property var model: chatsModel
         property var activeItem: ({ id: "" })
         property bool amIMember: true

--- a/storybook/pages/ChatLoaderPage.qml
+++ b/storybook/pages/ChatLoaderPage.qml
@@ -1,0 +1,486 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core.Theme
+
+import utils
+
+import shared.stores as SharedStores
+import shared.stores.send as SendStores
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStores
+
+import mainui.adaptors
+import mainui.sectionLoaders
+
+import Models
+import Storybook
+
+// Exercises the real ChatLoader: loader-owned section chrome with skeleton
+// panels, async incubation of the real ChatLayout/ChatView, and the
+// skeleton → real panel swap. Refresh recreates the whole loader.
+// Note: portrait/landscape follows the storybook WINDOW width (the chrome
+// keys off Window.width), so resize the window to see the portrait flow.
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    // With the extra "profile-exit" positional argument the app quits shortly
+    // after the section loads, so an attached qmlprofiler saves its trace on
+    // clean exit (storybook's CLI parser rejects unknown --options)
+    readonly property bool profileExitMode: Qt.application.arguments.indexOf("profile-exit") >= 0
+
+    Timer {
+        id: profilerExitTimer
+        interval: 4000
+        onTriggered: Qt.exit(0)
+    }
+
+    ListModel { id: chatsModel }
+    ListModel { id: contactsModel }
+
+    // Each chat gets its own message history model, built lazily when the
+    // chat's content module is first requested
+    Component {
+        id: messagesModelComp
+        ListModel {}
+    }
+
+    QtObject {
+        id: d
+
+        property double loadStartTime: 0
+        property var contentModules: ({})
+        readonly property var mockState: ({ preparedChatId: "" })
+        property string activeChatId: ""
+
+        // Embedded data-URI images from ModelsData, cycled as contact avatars;
+        // every third contact keeps the letter identicon for a realistic mix
+        readonly property var avatars: [
+            ModelsData.icons.status, ModelsData.icons.superRare,
+            ModelsData.icons.coinbase, ModelsData.icons.dragonereum,
+            ModelsData.icons.cryptPunks, ModelsData.icons.socks,
+            ModelsData.icons.rarible, ModelsData.icons.spotify,
+            ModelsData.icons.dribble
+        ]
+
+        function avatarFor(i) {
+            return i % 3 === 2 ? "" : avatars[i % avatars.length]
+        }
+
+        function buildChats(count) {
+            chatsModel.clear()
+            contactsModel.clear()
+            for (let i = 0; i < count; ++i) {
+                contactsModel.append({
+                    pubKey: "0xpeer-" + i,
+                    displayName: "Contact " + i,
+                    preferredDisplayName: "Contact " + i,
+                    ensName: "",
+                    isEnsVerified: false,
+                    localNickname: "",
+                    alias: "contact alias " + i,
+                    icon: avatarFor(i),
+                    colorId: i % 10,
+                    onlineStatus: i % 2,
+                    isContact: true,
+                    isVerified: false,
+                    isUntrustworthy: false,
+                    isBlocked: false,
+                    contactRequest: 2,
+                    isCurrentUser: false,
+                    lastUpdated: 1,
+                    lastUpdatedLocally: 1,
+                    bio: "",
+                    thumbnailImage: avatarFor(i),
+                    largeImage: avatarFor(i),
+                    isContactRequestReceived: false,
+                    isContactRequestSent: false,
+                    isRemoved: false,
+                    trustStatus: 0
+                })
+                chatsModel.append({
+                    itemId: "chat-" + i,
+                    categoryId: "",
+                    name: "Contact " + i,
+                    type: Constants.chatType.oneToOne,
+                    muted: false,
+                    active: false,
+                    loaderActive: false,
+                    blocked: false,
+                    hasUnreadMessages: i % 7 === 0,
+                    notificationsCount: i % 7 === 0 ? (i % 3) + 1 : 0,
+                    highlight: false,
+                    icon: avatarFor(i),
+                    emoji: "",
+                    color: "",
+                    colorId: i % 10,
+                    categoryOpened: true,
+                    usesDefaultName: false,
+                    onlineStatus: i % 2,
+                    requiresPermissions: false,
+                    locked: false,
+                    isCategory: false,
+                    position: i,
+                    categoryPosition: -1
+                })
+            }
+        }
+
+        function fillMessages(model, count, peerIdx) {
+            const now = Date.now()
+            for (let i = 0; i < count; ++i) {
+                const own = i % 3 === 1
+                const ts = now - (count - i) * 60000
+                model.append({
+                    id: "msg-" + peerIdx + "-" + i,
+                    prevMsgIndex: i - 1,
+                    nextMsgIndex: i + 1,
+                    prevMsgTimestamp: ts - 60000,
+                    nextMsgTimestamp: ts + 60000,
+                    prevMsgSenderId: "",
+                    prevMsgContentType: Constants.messageContentType.messageType,
+                    prevMsgDeleted: false,
+                    timestamp: ts,
+                    responseToMessageWithId: "",
+                    senderId: own ? "0xdeadbeef" : "0xpeer-" + peerIdx,
+                    senderDisplayName: own ? "Me" : "Contact " + peerIdx,
+                    senderOptionalName: "",
+                    senderIcon: own ? "" : avatarFor(peerIdx),
+                    senderIsAdded: true,
+                    senderEnsVerified: false,
+                    senderTrustStatus: 0,
+                    amISender: own,
+                    messageText: "Message " + i + " — the quick brown fox jumps over the lazy dog. "
+                                 + (i % 5 === 0 ? "A somewhat longer paragraph to vary the bubble heights and make the layout work harder while measuring text. " : ""),
+                    unparsedText: "Message " + i,
+                    messageImage: "",
+                    messageAttachments: "",
+                    contentType: Constants.messageContentType.messageType,
+                    sticker: "",
+                    stickerPack: -1,
+                    outgoingStatus: own ? "sent" : "",
+                    resendError: "",
+                    mentioned: false,
+                    quotedMessageText: "",
+                    quotedMessageParsedText: "",
+                    quotedMessageFrom: "",
+                    quotedMessageAuthorDisplayName: "",
+                    quotedMessageAuthorName: "",
+                    quotedMessageAuthorThumbnailImage: "",
+                    quotedMessageAuthorEnsVerified: false,
+                    quotedMessageAuthorIsContact: false,
+                    quotedMessageContentType: Constants.messageContentType.messageType,
+                    quotedMessageDeleted: false,
+                    quotedMessageAlbumImagesCount: 0,
+                    quotedMessageAlbumMessageImages: "",
+                    linkPreviewModel: [],
+                    links: "",
+                    paymentRequestModel: [],
+                    transactionParameters: [],
+                    pinned: false,
+                    pinnedBy: "",
+                    reactions: [],
+                    editMode: false,
+                    isEdited: false,
+                    deleted: false,
+                    deletedBy: "",
+                    deletedByContactDisplayName: "",
+                    deletedByContactIcon: "",
+                    gapFrom: 0,
+                    gapTo: 0,
+                    communityId: "",
+                    compressedKey: "",
+                    bridgeName: "",
+                    albumMessageImages: "",
+                    albumImagesCount: 0,
+                    usesDefaultName: false
+                })
+            }
+        }
+
+        // The message history is filled only when a chat becomes active —
+        // mirroring the backend, and keeping the mock-data build cost of
+        // inactive chats out of the measured section-load window
+        function contentModuleFor(chatId) {
+            if (chatId === "")
+                return null
+            if (!contentModules[chatId]) {
+                const idx = chatId.split("-")[1]
+                contentModules[chatId] = contentModuleComp.createObject(root, {
+                    chatId: chatId,
+                    chatName: "Contact " + idx
+                })
+            }
+            return contentModules[chatId]
+        }
+
+        function setActiveChat(id) {
+            for (let i = 0; i < chatsModel.count; ++i) {
+                const isActive = chatsModel.get(i).itemId === id
+                chatsModel.setProperty(i, "active", isActive)
+                if (isActive)
+                    chatsModel.setProperty(i, "loaderActive", true)
+            }
+            d.activeChatId = id
+            sectionModuleMock.activeItem = ({ id: id })
+            const module = contentModuleFor(id)
+            if (module && !module.messagesModel) {
+                module.messagesModel = messagesModelComp.createObject(module)
+                fillMessages(module.messagesModel, ctrlMessages.value, id.split("-")[1])
+            }
+            ChatStores.ChatStoresConfig.currentChatContentModule = module
+        }
+    }
+
+    QtObject {
+        id: sectionModuleMock
+
+        property var model: chatsModel
+        property var activeItem: ({ id: "" })
+        property bool amIMember: true
+        property bool requiresTokenPermissionToJoin: false
+        property bool isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin: false
+        property int requestToJoinState: 0
+        property bool loadingHistoryMessagesInProgress: false
+
+        function isCommunity() { return false }
+        function setActiveItem(id) {
+            logs.logEvent("setActiveItem: " + id)
+            d.setActiveChat(id)
+        }
+        function prepareChatContentModuleForChatId(chatId) { d.mockState.preparedChatId = chatId }
+        function getChatContentModule() { return d.contentModuleFor(d.mockState.preparedChatId) }
+        function getItemAsJson(id) { return "{}" }
+        function muteChat(chatId, interval) {}
+        function unmuteChat(chatId) {}
+        function markAllMessagesRead(chatId) {}
+        function clearChatHistory(chatId) {}
+        function leaveChat(chatId) {}
+        function updateGroupChatDetails() {}
+        function createOneToOneChat(ensName, pubKey, nickname) {}
+    }
+
+    Component {
+        id: contentModuleComp
+
+        QtObject {
+            id: contentModule
+
+            property string chatId
+            property string chatName
+            property var messagesModel: null
+
+            readonly property var chatDetails: QtObject {
+                readonly property string id: contentModule.chatId
+                readonly property string name: contentModule.chatName
+                readonly property int type: Constants.chatType.oneToOne
+                readonly property bool active: contentModule.chatId === d.activeChatId
+                readonly property bool muted: false
+                readonly property bool hasUnreadMessages: false
+                readonly property bool highlight: false
+                readonly property string emoji: ""
+                readonly property bool canView: true
+                readonly property bool canPost: true
+                readonly property bool canPostReactions: true
+                readonly property bool missingEncryptionKey: false
+                readonly property bool isUsersListAvailable: true
+                readonly property string color: "#4360DF"
+                readonly property string description: ""
+            }
+
+            readonly property var messagesModule: QtObject {
+                readonly property var model: contentModule.messagesModel
+                readonly property bool loading: false
+
+                signal messageSuccessfullySent()
+                signal sendingMessageFailed(string error)
+                signal reactionActionFailed()
+                signal scrollToMessage(string messageId)
+
+                function getChatId() { return contentModule.chatId }
+                function loadMoreMessages() {}
+                function updateKeepUnread(flag) {}
+            }
+
+            readonly property var inputAreaModule: QtObject {
+                readonly property var preservedProperties: ({ text: "" })
+            }
+
+            function markAllMessagesRead() {}
+            function markMessageRead(id) {}
+            function getMyChatId() { return contentModule.chatId }
+            function amIChatAdmin() { return false }
+        }
+    }
+
+    // Non-visual store mocks (typed via the storybook stubs)
+    AppStores.RootStore { id: appRootStoreMock }
+    AppStores.ContactsStore { id: contactsStoreMock }
+    AppStores.AccountSettingsStore {
+        id: accountSettingsStoreMock
+        showUsersList: ctrlMembers.checked
+    }
+    AppStores.FeatureFlagsStore { id: featureFlagsStoreMock }
+    SharedStores.RootStore { id: sharedRootStoreMock }
+    SharedStores.CurrenciesStore { id: currenciesStoreMock }
+    SharedStores.CommunityTokensStore { id: communityTokensStoreMock }
+    SharedStores.NetworkConnectionStore { id: networkConnectionStoreMock }
+    SharedStores.NetworksStore { id: networksStoreMock }
+    SendStores.TransactionStore { id: transactionStoreMock }
+    WalletStores.TokensStore { id: tokensStoreMock }
+    WalletStores.WalletAssetsStore { id: walletAssetsStoreMock }
+    ProfileStores.AdvancedStore { id: advancedStoreMock }
+    ChatStores.CreateChatPropertiesStore { id: createChatPropertiesStoreMock }
+    ContactsModelAdaptor {
+        id: contactsAdaptorMock
+        allContacts: contactsModel
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        // Hidden shared popup loaders the ChatLoader API requires
+        Item {
+            visible: false
+            Loader { id: emojiPopupLoaderMock; active: false }
+            Loader { id: stickersPopupLoaderMock; active: false }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: Theme.padding
+            color: Theme.palette.statusAppLayout.backgroundColor
+            border.color: Theme.palette.baseColor2
+
+            Loader {
+                id: harness
+                anchors.fill: parent
+                anchors.margins: 1
+                active: false
+
+                sourceComponent: ChatLoader {
+                    active: true
+
+                    rootStore: appRootStoreMock
+                    contactsStore: contactsStoreMock
+                    accountSettingsStore: accountSettingsStoreMock
+                    featureFlagsStore: featureFlagsStoreMock
+                    sharedRootStore: sharedRootStoreMock
+                    currencyStore: currenciesStoreMock
+                    communityTokensStore: communityTokensStoreMock
+                    networkConnectionStore: networkConnectionStoreMock
+                    networksStore: networksStoreMock
+                    transactionStore: transactionStoreMock
+                    tokensStore: tokensStoreMock
+                    walletAssetsStore: walletAssetsStoreMock
+                    advancedStore: advancedStoreMock
+                    createChatPropertiesStore: createChatPropertiesStoreMock
+                    contactsAdaptor: contactsAdaptorMock
+                    popupHandler: null
+                    emojiPopupLoader: emojiPopupLoaderMock
+                    stickersPopupLoader: stickersPopupLoaderMock
+                    createChatViewOpened: false
+                    isPortraitMode: (Window.width ?? 0) < ThemeUtils.portraitBreakpoint.width
+
+                    onStatusChanged: {
+                        if (status === Loader.Ready) {
+                            const ms = Date.now() - d.loadStartTime
+                            logs.logEvent("ChatLoader READY in " + ms + " ms")
+                            console.info("ChatLoader READY in", ms, "ms")
+                            if (root.profileExitMode)
+                                profilerExitTimer.start()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 120
+        SplitView.preferredHeight: 120
+        SplitView.fillWidth: true
+
+        logsView.logText: logs.logText
+
+        RowLayout {
+            anchors.fill: parent
+            spacing: Theme.bigPadding
+
+            Button {
+                objectName: "chatLoaderRefreshButton"
+                text: "Refresh"
+                onClicked: root.refresh()
+            }
+
+            RowLayout {
+                Label { text: "Contacts:" }
+                SpinBox {
+                    id: ctrlChats
+                    objectName: "chatLoaderContactsSpinBox"
+                    from: 0
+                    to: 5000
+                    stepSize: 50
+                    value: 1000
+                    editable: true
+                }
+            }
+
+            RowLayout {
+                Label { text: "Msgs/chat:" }
+                SpinBox {
+                    id: ctrlMessages
+                    objectName: "chatLoaderMessagesSpinBox"
+                    from: 0
+                    to: 10000
+                    stepSize: 100
+                    value: 2000
+                    editable: true
+                }
+            }
+
+            Switch {
+                id: ctrlMembers
+                text: "Members panel"
+            }
+
+            Item { Layout.fillWidth: true }
+        }
+    }
+
+    function refresh() {
+        harness.active = false
+        ChatStores.ChatStoresConfig.currentChatContentModule = null
+        // CommunitySectionMock.install() (community page) writes these too —
+        // opening this page after it must not run on the community's mocks
+        ChatStores.ChatStoresConfig.sectionDetails = null
+        ChatStores.ChatStoresConfig.usersModel = null
+        ChatStores.ChatStoresConfig.assetsModel = null
+        ChatStores.ChatStoresConfig.collectiblesModel = null
+        for (const key in d.contentModules)
+            d.contentModules[key].destroy()
+        d.contentModules = {}
+        d.mockState.preparedChatId = ""
+        d.buildChats(ctrlChats.value)
+        d.setActiveChat(chatsModel.count > 0 ? "chat-0" : "")
+        d.loadStartTime = Date.now()
+        harness.active = true
+        logs.logEvent("refresh: %1 contacts, %2 messages each".arg(chatsModel.count).arg(ctrlMessages.value))
+    }
+
+    Component.onCompleted: {
+        ChatStores.ChatStoresConfig.chatSectionModule = sectionModuleMock
+        refresh()
+    }
+}
+
+// category: Panels

--- a/storybook/pages/CommunityChatLoaderPage.qml
+++ b/storybook/pages/CommunityChatLoaderPage.qml
@@ -1,0 +1,342 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core.Theme
+
+import utils
+
+import shared.stores as SharedStores
+import shared.stores.send as SendStores
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Communities.stores as CommunitiesStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStores
+import AppLayouts.stores.Messaging as MessagingStores
+
+import mainui.adaptors
+import mainui.sectionLoaders
+
+import Models
+import Storybook
+
+// Exercises the real CommunityChatLoader against a fully configurable mock
+// community (CommunitySectionMock): membership/join state, member role,
+// categories, private channels and their members, token permissions and
+// scale knobs for load benchmarks. Refresh recreates the whole loader.
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    // With the extra "profile-exit" positional argument the app quits shortly
+    // after the section loads, so an attached qmlprofiler saves its trace on
+    // clean exit (storybook's CLI parser rejects unknown --options)
+    readonly property bool profileExitMode: Qt.application.arguments.indexOf("profile-exit") >= 0
+
+    // Benchmark configs are scriptable the same way: extra "key=value"
+    // positionals override the knob defaults, e.g.
+    //   Storybook CommunityChatLoader profile-exit members=5000 channels=20
+    function argValue(name, fallback) {
+        for (const arg of Qt.application.arguments) {
+            if (arg.indexOf(name + "=") === 0)
+                return parseInt(arg.substring(name.length + 1))
+        }
+        return fallback
+    }
+
+    Timer {
+        id: profilerExitTimer
+        interval: 4000
+        onTriggered: Qt.exit(0)
+    }
+
+    QtObject {
+        id: d
+
+        property double loadStartTime: 0
+
+        readonly property var joinStates: [
+            { name: "Joined member", joined: true, banned: false, gated: true, requestState: Constants.RequestToJoinState.None, ownerOffline: false },
+            { name: "Not joined — token gated", joined: false, banned: false, gated: true, requestState: Constants.RequestToJoinState.None, ownerOffline: false },
+            { name: "Request pending", joined: false, banned: false, gated: true, requestState: Constants.RequestToJoinState.Requested, ownerOffline: false },
+            { name: "Banned", joined: false, banned: true, gated: true, requestState: Constants.RequestToJoinState.None, ownerOffline: false },
+            { name: "Owner offline (rejoin)", joined: false, banned: false, gated: true, requestState: Constants.RequestToJoinState.None, ownerOffline: true }
+        ]
+
+        readonly property var memberRoles: [
+            { name: "Regular member", role: Constants.memberRole.none },
+            { name: "Admin", role: Constants.memberRole.admin },
+            { name: "Owner", role: Constants.memberRole.owner },
+            { name: "Token master", role: Constants.memberRole.tokenMaster }
+        ]
+
+        function applyConfig() {
+            const joinState = joinStates[ctrlJoinState.currentIndex]
+            mock.joined = joinState.joined
+            mock.amIBanned = joinState.banned
+            mock.requiresTokenPermissionToJoin = joinState.gated
+            mock.requestToJoinState = joinState.requestState
+            mock.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin = joinState.ownerOffline
+            mock.memberRole = memberRoles[ctrlRole.currentIndex].role
+
+            mock.name = "Mock Community"
+            mock.image = ModelsData.icons.status
+            mock.membersCount = ctrlMembers.value
+            mock.categoriesCount = ctrlCategories.value
+            mock.channelsPerCategory = ctrlChannels.value
+            mock.uncategorizedChannelsCount = 2
+            mock.privateChannelsPerCategory = Math.min(ctrlPrivate.value, ctrlChannels.value)
+            mock.privateChannelMembersCount = ctrlPrivateMembers.value
+            mock.messagesPerChannel = ctrlMessages.value
+            mock.canViewPrivateChannels = ctrlCanViewPrivate.checked
+            mock.canPostInPrivateChannels = ctrlCanViewPrivate.checked
+            mock.tokenCriteriaMet = ctrlCriteriaMet.checked
+            mock.allTokenRequirementsMet = ctrlCriteriaMet.checked
+        }
+    }
+
+    CommunitySectionMock { id: mock }
+
+    // Non-visual store mocks (typed via the storybook stubs)
+    AppStores.RootStore { id: appRootStoreMock }
+    AppStores.ContactsStore { id: contactsStoreMock }
+    AppStores.AccountSettingsStore {
+        id: accountSettingsStoreMock
+        showUsersList: ctrlMembersPanel.checked
+    }
+    AppStores.FeatureFlagsStore { id: featureFlagsStoreMock }
+    SharedStores.RootStore { id: sharedRootStoreMock }
+    SharedStores.CurrenciesStore { id: currenciesStoreMock }
+    SharedStores.CommunityTokensStore { id: communityTokensStoreMock }
+    SharedStores.NetworkConnectionStore { id: networkConnectionStoreMock }
+    SharedStores.NetworksStore { id: networksStoreMock }
+    SendStores.TransactionStore { id: transactionStoreMock }
+    WalletStores.TokensStore { id: tokensStoreMock }
+    WalletStores.WalletAssetsStore { id: walletAssetsStoreMock }
+    ProfileStores.AdvancedStore { id: advancedStoreMock }
+    CommunitiesStores.CommunitiesStore { id: communitiesStoreMock }
+    MessagingStores.MessagingRootStore { id: messagingRootStoreMock }
+    ChatStores.CreateChatPropertiesStore { id: createChatPropertiesStoreMock }
+    ContactsModelAdaptor {
+        id: contactsAdaptorMock
+        allContacts: ListModel {}
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        // Hidden shared popup loaders the loader API requires
+        Item {
+            visible: false
+            Loader { id: emojiPopupLoaderMock; active: false }
+            Loader { id: stickersPopupLoaderMock; active: false }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: Theme.padding
+            color: Theme.palette.statusAppLayout.backgroundColor
+            border.color: Theme.palette.baseColor2
+
+            Loader {
+                id: harness
+                anchors.fill: parent
+                anchors.margins: 1
+                active: false
+
+                sourceComponent: CommunityChatLoader {
+                    active: true
+
+                    rootStore: appRootStoreMock
+                    contactsStore: contactsStoreMock
+                    accountSettingsStore: accountSettingsStoreMock
+                    featureFlagsStore: featureFlagsStoreMock
+                    sharedRootStore: sharedRootStoreMock
+                    currencyStore: currenciesStoreMock
+                    communityTokensStore: communityTokensStoreMock
+                    networkConnectionStore: networkConnectionStoreMock
+                    networksStore: networksStoreMock
+                    transactionStore: transactionStoreMock
+                    tokensStore: tokensStoreMock
+                    walletAssetsStore: walletAssetsStoreMock
+                    advancedStore: advancedStoreMock
+                    communitiesStore: communitiesStoreMock
+                    messagingRootStore: messagingRootStoreMock
+                    createChatPropertiesStore: createChatPropertiesStoreMock
+                    contactsAdaptor: contactsAdaptorMock
+                    popupHandler: null
+                    emojiPopupLoader: emojiPopupLoaderMock
+                    stickersPopupLoader: stickersPopupLoaderMock
+                    sectionId: mock.communityId
+                    sectionItemModel: mock.sectionItemModel
+                    createChatViewOpened: false
+                    isPortraitMode: (Window.width ?? 0) < ThemeUtils.portraitBreakpoint.width
+
+                    onStatusChanged: {
+                        if (status === Loader.Ready) {
+                            const ms = Date.now() - d.loadStartTime
+                            logs.logEvent("CommunityChatLoader READY in " + ms + " ms")
+                            console.info("CommunityChatLoader READY in", ms, "ms")
+                            if (root.profileExitMode)
+                                profilerExitTimer.start()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 180
+        SplitView.preferredHeight: 180
+        SplitView.fillWidth: true
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            RowLayout {
+                spacing: Theme.bigPadding
+
+                Button {
+                    objectName: "communityLoaderRefreshButton"
+                    text: "Refresh"
+                    onClicked: root.refresh()
+                }
+
+                RowLayout {
+                    Label { text: "State:" }
+                    ComboBox {
+                        id: ctrlJoinState
+                        objectName: "communityLoaderJoinStateCombo"
+                        Layout.preferredWidth: 220
+                        model: d.joinStates.map(s => s.name)
+                    }
+                }
+
+                RowLayout {
+                    Label { text: "Role:" }
+                    ComboBox {
+                        id: ctrlRole
+                        objectName: "communityLoaderRoleCombo"
+                        Layout.preferredWidth: 160
+                        model: d.memberRoles.map(r => r.name)
+                        currentIndex: root.argValue("role", 0)
+                    }
+                }
+
+                Switch {
+                    id: ctrlMembersPanel
+                    objectName: "communityLoaderMembersPanelSwitch"
+                    text: "Members panel"
+                    checked: root.argValue("membersPanel", 0) === 1
+                }
+
+                Switch {
+                    id: ctrlCriteriaMet
+                    objectName: "communityLoaderCriteriaMetSwitch"
+                    text: "Token criteria met"
+                    checked: true
+                }
+
+                Switch {
+                    id: ctrlCanViewPrivate
+                    objectName: "communityLoaderPrivateUnlockedSwitch"
+                    text: "Private channels unlocked"
+                    checked: true
+                }
+
+                Item { Layout.fillWidth: true }
+            }
+
+            RowLayout {
+                spacing: Theme.bigPadding
+
+                RowLayout {
+                    Label { text: "Members:" }
+                    SpinBox {
+                        id: ctrlMembers
+                        objectName: "communityLoaderMembersSpinBox"
+                        from: 0; to: 10000; stepSize: 50; editable: true
+                        value: root.argValue("members", 500)
+                    }
+                }
+
+                RowLayout {
+                    Label { text: "Categories:" }
+                    SpinBox {
+                        id: ctrlCategories
+                        from: 0; to: 50; stepSize: 1; editable: true
+                        value: root.argValue("categories", 3)
+                    }
+                }
+
+                RowLayout {
+                    Label { text: "Channels/cat:" }
+                    SpinBox {
+                        id: ctrlChannels
+                        from: 0; to: 100; stepSize: 1; editable: true
+                        value: root.argValue("channels", 6)
+                    }
+                }
+
+                RowLayout {
+                    Label { text: "Private/cat:" }
+                    SpinBox {
+                        id: ctrlPrivate
+                        from: 0; to: 100; stepSize: 1; value: 2; editable: true
+                    }
+                }
+
+                RowLayout {
+                    Label { text: "Private members:" }
+                    SpinBox {
+                        id: ctrlPrivateMembers
+                        from: 0; to: 10000; stepSize: 10; value: 20; editable: true
+                    }
+                }
+
+                RowLayout {
+                    Label { text: "Msgs/chat:" }
+                    SpinBox {
+                        id: ctrlMessages
+                        objectName: "communityLoaderMessagesSpinBox"
+                        from: 0; to: 10000; stepSize: 100; editable: true
+                        value: root.argValue("messages", 500)
+                    }
+                }
+
+                Item { Layout.fillWidth: true }
+            }
+        }
+    }
+
+    function refresh() {
+        harness.active = false
+        mock.uninstall()
+        const t0 = Date.now()
+        d.applyConfig()
+        const t1 = Date.now()
+        mock.install()
+        console.info("mock: applyConfig", t1 - t0, "ms, install", Date.now() - t1, "ms")
+        d.loadStartTime = Date.now()
+        harness.active = true
+        logs.logEvent("refresh: %1 (%2) — %3 members, %4 channels, %5 msgs each"
+                      .arg(d.joinStates[ctrlJoinState.currentIndex].name)
+                      .arg(d.memberRoles[ctrlRole.currentIndex].name)
+                      .arg(mock.membersCount)
+                      .arg(mock.uncategorizedChannelsCount + mock.categoriesCount * mock.channelsPerCategory)
+                      .arg(mock.messagesPerChannel))
+    }
+
+    Component.onCompleted: refresh()
+}
+
+// category: Panels

--- a/storybook/src/Models/CommunitySectionMock.qml
+++ b/storybook/src/Models/CommunitySectionMock.qml
@@ -1,0 +1,696 @@
+import QtQuick
+
+import utils
+
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.stores.Messaging as MessagingStores
+import AppLayouts.stores.Messaging.Community as CommunityStores
+
+/*!
+    Fully configurable mock community backing the CommunityChatLoader, shared
+    by the storybook page (benchmarks) and the qml tests (regression).
+
+    Configure the properties, then call install(); it wires the stub store
+    hooks (ChatStoresConfig + MessagingStoresConfig) and builds:
+      - the chats model (categories, public and private channels)
+      - the community and private-channel members models
+      - the token-permissions model (with belongsToChat, like the nim model)
+      - the section item model and the community section module mock
+    Call uninstall() in cleanup — the hooks are global singletons.
+*/
+QtObject {
+    id: root
+
+    // Community identity
+    property string communityId: "communityMock"
+    property string name: "Mock Community"
+    property string description: "A community for storybook and tests"
+    property string introMessage: "Welcome to the mock community"
+    property string color: "#4360DF"
+    property string image: ""
+
+    // My membership / join state
+    property bool joined: true
+    property int memberRole: Constants.memberRole.none
+    property bool amIBanned: false
+    property int requestToJoinState: Constants.RequestToJoinState.None
+    property bool requiresTokenPermissionToJoin: false
+    property bool isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin: false
+    property bool spectated: false
+    property int access: Constants.communityChatOnRequestAccess
+
+    // Scale
+    property int membersCount: 50
+    property int categoriesCount: 2
+    property int channelsPerCategory: 5
+    property int uncategorizedChannelsCount: 2
+    // the last N channels of every category are token-gated
+    property int privateChannelsPerCategory: 1
+    property int privateChannelMembersCount: 10
+    property int messagesPerChannel: 150
+
+    // What my (mocked) permissions grant on the private channels
+    property bool canViewPrivateChannels: true
+    property bool canPostInPrivateChannels: true
+
+    // Token permissions
+    property int becomeMemberPermissionsCount: 1
+    property int viewOnlyPermissionsCount: 1     // scoped to the private channels
+    property int viewAndPostPermissionsCount: 1  // scoped to the private channels
+    property bool permissionsArePrivate: false
+    property bool tokenCriteriaMet: true
+    property bool allTokenRequirementsMet: true
+
+    // Permission-check machinery state
+    property bool permissionsCheckOngoing: false
+    property int communityMemberReevaluationStatus: 0
+    property bool allChannelsAreHiddenBecauseNotPermitted: false
+
+    property string activeChatId: ""
+
+    // Built models
+    // Wallet models resolving permission holdings to symbols/icons; the
+    // generated holdings cycle over the assets below
+    readonly property AssetsModel assetsModel: AssetsModel {}
+    readonly property CollectiblesModel collectiblesModel: CollectiblesModel {}
+    readonly property ListModel chatsModel: ListModel {}
+    readonly property ListModel membersModel: ListModel {}
+    readonly property ListModel privateChannelMembersModel: ListModel {}
+    readonly property ListModel permissionsModel: ListModel {
+        // permissionId -> [chatIds]; absent/empty = community-wide
+        property var channelMap: ({})
+
+        function belongsToChat(permissionId, chatId) {
+            const channels = channelMap[permissionId]
+            if (!channels || channels.length === 0)
+                return true
+            return channels.indexOf(chatId) !== -1
+        }
+    }
+
+    // Row of mainModule.sectionsModel for this community (all roles of
+    // src/app/modules/shared_models/section_model.nim)
+    readonly property QtObject sectionItemModel: QtObject {
+        readonly property string id: root.communityId
+        readonly property int sectionType: Constants.appSection.community
+        readonly property string name: root.name
+        readonly property int memberRole: root.memberRole
+        readonly property bool isControlNode: false
+        readonly property string description: root.description
+        readonly property string introMessage: root.introMessage
+        readonly property string outroMessage: ""
+        readonly property string image: root.image
+        readonly property string bannerImageData: ""
+        readonly property string icon: ""
+        readonly property string color: root.color
+        readonly property var tags: []
+        readonly property bool hasNotification: false
+        readonly property int notificationsCount: 0
+        readonly property bool active: true
+        readonly property bool enabled: true
+        readonly property bool joined: root.joined
+        readonly property bool spectated: root.spectated
+        readonly property bool isMember: root.joined
+        // the production role is named isMember; ChatLayout reads amIMember —
+        // expose both so either spelling behaves
+        readonly property bool amIMember: root.joined
+        readonly property bool canJoin: !root.joined
+        readonly property bool canManageUsers: root.memberRole === Constants.memberRole.owner
+                                               || root.memberRole === Constants.memberRole.admin
+        readonly property bool canRequestAccess: !root.joined
+        readonly property int access: root.access
+        readonly property bool ensOnly: false
+        readonly property bool muted: false
+        readonly property int allMembers: root.membersCount
+        readonly property int joinedMembersCount: root.membersCount
+        readonly property bool historyArchiveSupportEnabled: false
+        readonly property bool pinMessageAllMembersEnabled: false
+        readonly property bool encrypted: root.requiresTokenPermissionToJoin
+        readonly property var communityTokens: []
+        readonly property bool amIBanned: root.amIBanned
+        readonly property bool isPendingOwnershipRequest: false
+        readonly property int activeMembersCount: root.membersCount
+        readonly property bool membersLoaded: true
+        readonly property bool tokensLoading: false
+    }
+
+    // Mock of the nim chatCommunitySectionModule
+    readonly property QtObject sectionModule: QtObject {
+        readonly property var model: root.chatsModel
+        property var activeItem: ({ id: "", type: -1 })
+        readonly property bool amIMember: root.joined
+        readonly property bool requiresTokenPermissionToJoin: root.requiresTokenPermissionToJoin
+        readonly property bool isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin: root.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin
+        readonly property int requestToJoinState: root.requestToJoinState
+        readonly property bool loadingHistoryMessagesInProgress: false
+        readonly property bool chatsLoaded: true
+        readonly property var membersModel: root.membersModel
+        readonly property var contactRequestsModel: null
+        readonly property string emoji: ""
+
+        signal openNoPermissionsToJoinPopup(string communityName, string chatName, string communityId, string chatId)
+        signal permissionSavedSuccessfully()
+
+        function isCommunity() { return true }
+        function setActiveItem(id) { root.setActiveChat(id) }
+        function prepareChatContentModuleForChatId(chatId) { d.preparedChatId = chatId }
+        function getChatContentModule() { return d.contentModuleFor(d.preparedChatId) }
+        function getItemAsJson(id) { return JSON.stringify(d.chatInfo[id] ?? {}) }
+        function getMySectionId() { return root.communityId }
+
+        function muteChat(chatId, interval) {}
+        function unmuteChat(chatId) {}
+        function muteCategory(categoryId, interval) {}
+        function unmuteCategory(categoryId) {}
+        function markAllMessagesRead(chatId) {}
+        function clearChatHistory(chatId) {}
+        function leaveChat(chatId) {}
+        function leaveCommunity() {}
+        function updateGroupChatDetails() {}
+        function createOneToOneChat(ensName, pubKey, nickname) {}
+        function removeMemberFromGroupChat(chatId, pubKey) {}
+        function createCommunityChannel(name, description, emoji, color, categoryId, viewersCanPostReactions) {}
+        function editCommunityChannel(chatId, name, description, emoji, color, categoryId, viewersCanPostReactions) {}
+        function removeCommunityChat(chatId) {}
+        function createCommunityCategory(name, channels) {}
+        function editCommunityCategory(categoryId, name, channels) {}
+        function deleteCommunityCategory(categoryId) {}
+        function prepareEditCategoryModel(categoryId) {}
+        function reorderCommunityCategories(categoryId, position) {}
+        // captured for tests
+        property var lastReorder: null
+        function reorderCommunityChat(categoryId, chatId, position) {
+            lastReorder = ({ categoryId: categoryId, chatId: chatId, to: position })
+            d.applyChatReorder(categoryId, chatId, position)
+        }
+        function toggleCollapsedCommunityCategory(categoryId, collapsed) { root.setCategoryOpened(categoryId, !collapsed) }
+        function removeUserFromCommunity(pubKey) {}
+        function banUserFromCommunity(pubKey, deleteAllMessages) {}
+        function unbanUserFromCommunity(pubKey) {}
+        function loadCommunityMemberMessages(pubKey) {}
+        function collectCommunityMetricsMessagesCount(intervals) {}
+        function collectCommunityMetricsMessagesTimestamps(intervals) {}
+    }
+
+    // Stub store instances handed to the loader-created CommunityRootStore
+    readonly property CommunityStores.CommunityAccessStore accessStore: CommunityStores.CommunityAccessStore {
+        communityId: root.communityId
+        joined: root.joined
+        allChannelsAreHiddenBecauseNotPermitted: root.allChannelsAreHiddenBecauseNotPermitted
+        communityMemberReevaluationStatus: root.communityMemberReevaluationStatus
+        spectatedPermissionsModel: root.permissionsModel
+        communityPermissionsCheckOngoing: root.permissionsCheckOngoing
+        chatPermissionsCheckOngoing: root.permissionsCheckOngoing
+        isMyCommunityRequestPending: root.requestToJoinState !== Constants.RequestToJoinState.None
+    }
+
+    readonly property CommunityStores.PermissionsStore permissionsStore: CommunityStores.PermissionsStore {
+        activeSectionId: root.communityId
+        activeChannelId: root.activeChatId
+        allTokenRequirementsMet: root.allTokenRequirementsMet
+        permissionsModel: root.permissionsModel
+    }
+
+    readonly property Component communityRootStoreComponent: Component {
+        CommunityStores.CommunityRootStore {
+            communityId: root.communityId
+            communityAccessStore: root.accessStore
+            communityPermissionsStore: root.permissionsStore
+        }
+    }
+
+    readonly property Component messagesModelComponent: Component {
+        ListModel {}
+    }
+
+    readonly property Component contentModuleComponent: Component {
+        QtObject {
+            id: contentModule
+
+            property string chatId
+            property var info
+            property var messagesModel: null
+
+            readonly property var chatDetails: QtObject {
+                readonly property string id: contentModule.chatId
+                readonly property string name: contentModule.info.name
+                readonly property int type: Constants.chatType.communityChat
+                readonly property bool belongsToCommunity: true
+                readonly property bool requiresPermissions: contentModule.info.requiresPermissions
+                readonly property bool active: contentModule.chatId === root.activeChatId
+                readonly property bool muted: false
+                readonly property bool hasUnreadMessages: false
+                readonly property bool highlight: false
+                readonly property string emoji: ""
+                readonly property bool canView: contentModule.info.canView
+                readonly property bool canPost: contentModule.info.canPost
+                readonly property bool canPostReactions: true
+                readonly property bool missingEncryptionKey: false
+                readonly property bool isUsersListAvailable: true
+                readonly property bool blocked: false
+                readonly property string icon: ""
+                readonly property int notificationCount: 0
+                readonly property string color: root.color
+                readonly property string description: contentModule.info.description
+            }
+
+            readonly property ListModel pinnedMessagesModel: ListModel {}
+
+            readonly property var messagesModule: QtObject {
+                readonly property var model: contentModule.messagesModel
+                readonly property bool loading: false
+
+                signal messageSuccessfullySent()
+                signal sendingMessageFailed(string error)
+                signal reactionActionFailed()
+                signal scrollToMessage(string messageId)
+
+                function getChatId() { return contentModule.chatId }
+                function loadMoreMessages() {}
+                function updateKeepUnread(flag) {}
+            }
+
+            readonly property var usersModule: QtObject {
+                readonly property var model: contentModule.info.requiresPermissions
+                                             ? root.privateChannelMembersModel
+                                             : root.membersModel
+            }
+
+            readonly property var inputAreaModule: QtObject {
+                readonly property var preservedProperties: ({ text: "" })
+                readonly property bool sendingInProgress: false
+                readonly property var linkPreviewModel: null
+                readonly property var paymentRequestModel: null
+                readonly property bool askToEnableLinkPreview: false
+
+                function clearLinkPreviewCache() {}
+            }
+
+            function markAllMessagesRead() {}
+            function markMessageRead(id) {}
+            function getMyChatId() { return contentModule.chatId }
+            function amIChatAdmin() {
+                return root.memberRole === Constants.memberRole.owner
+                        || root.memberRole === Constants.memberRole.admin
+            }
+        }
+    }
+
+    readonly property QtObject d: QtObject {
+        id: d
+
+        property string preparedChatId: ""
+        property var contentModules: ({})
+        // chatId -> { name, description, requiresPermissions, canView, canPost }
+        property var chatInfo: ({})
+
+        function appendChatRow(itemId, chatName, isCategory, categoryId, position,
+                               categoryPosition, isPrivate) {
+            root.chatsModel.append({
+                itemId: itemId,
+                name: chatName,
+                usesDefaultName: false,
+                memberRole: root.memberRole,
+                icon: "",
+                color: root.color,
+                colorId: position >= 0 ? position % 10 : 0,
+                emoji: "",
+                description: isCategory ? "" : "Description of " + chatName,
+                type: isCategory ? Constants.chatType.category : Constants.chatType.communityChat,
+                lastMessageTimestamp: 0,
+                lastMessageText: "",
+                hasUnreadMessages: false,
+                notificationsCount: 0,
+                muted: false,
+                blocked: false,
+                active: false,
+                selected: false,
+                position: position,
+                categoryId: categoryId,
+                hideIfPermissionsNotMet: false,
+                categoryPosition: categoryPosition,
+                highlight: false,
+                categoryOpened: true,
+                trustStatus: 0,
+                onlineStatus: 1,
+                isCategory: isCategory,
+                loaderActive: false,
+                locked: isPrivate && !root.canViewPrivateChannels,
+                requiresPermissions: isPrivate,
+                canPost: !isPrivate || root.canPostInPrivateChannels,
+                canView: !isPrivate || root.canViewPrivateChannels,
+                canPostReactions: true,
+                viewersCanPostReactions: true,
+                shouldBeHiddenBecausePermissionsAreNotMet: false,
+                missingEncryptionKey: false,
+                permissionsCheckOngoing: false
+            })
+            if (!isCategory) {
+                d.chatInfo[itemId] = {
+                    name: chatName,
+                    description: "Description of " + chatName,
+                    requiresPermissions: isPrivate,
+                    canView: !isPrivate || root.canViewPrivateChannels,
+                    canPost: !isPrivate || root.canPostInPrivateChannels
+                }
+            }
+        }
+
+        // Mirrors the backend: move the chat row into `categoryId` at
+        // `position`, then renumber positions per category from row order.
+        function applyChatReorder(categoryId, chatId, position) {
+            let from = -1
+            for (let i = 0; i < root.chatsModel.count; ++i) {
+                if (root.chatsModel.get(i).itemId === chatId) {
+                    from = i
+                    break
+                }
+            }
+            if (from === -1)
+                return
+
+            // target model index: position-th channel row of the category
+            let to = -1
+            let channelIndex = 0
+            for (let i = 0; i < root.chatsModel.count; ++i) {
+                const row = root.chatsModel.get(i)
+                if (row.isCategory || row.categoryId !== categoryId)
+                    continue
+                if (channelIndex === position) {
+                    to = i
+                    break
+                }
+                ++channelIndex
+            }
+            if (to === -1 || to === from)
+                return
+
+            root.chatsModel.move(from, to, 1)
+            root.chatsModel.setProperty(to, "categoryId", categoryId)
+
+            const positions = ({})
+            for (let i = 0; i < root.chatsModel.count; ++i) {
+                const row = root.chatsModel.get(i)
+                if (row.isCategory)
+                    continue
+                const next = (positions[row.categoryId] || 0)
+                positions[row.categoryId] = next + 1
+                if (row.position !== next)
+                    root.chatsModel.setProperty(i, "position", next)
+            }
+        }
+
+        function buildChats() {
+            root.chatsModel.clear()
+            d.chatInfo = ({})
+            for (let u = 0; u < root.uncategorizedChannelsCount; ++u)
+                appendChatRow("channel-u-" + u, "channel-" + u, false, "", u, -1, false)
+            for (let c = 0; c < root.categoriesCount; ++c) {
+                const categoryId = "category-" + c
+                appendChatRow(categoryId, "Category " + c, true, categoryId, -1, c, false)
+                for (let i = 0; i < root.channelsPerCategory; ++i) {
+                    const isPrivate = i >= root.channelsPerCategory - root.privateChannelsPerCategory
+                    appendChatRow("channel-" + c + "-" + i,
+                                  (isPrivate ? "private-" : "") + "channel-" + c + "-" + i,
+                                  false, categoryId, i, c, isPrivate)
+                }
+            }
+        }
+
+        function appendMember(model, pubKey, memberName, index, role) {
+            model.append({
+                pubKey: pubKey,
+                compressedPubKey: "zQ3" + pubKey,
+                displayName: memberName,
+                preferredDisplayName: memberName,
+                ensName: "",
+                isEnsVerified: false,
+                localNickname: "",
+                alias: "three word alias",
+                icon: "",
+                colorId: index % 10,
+                onlineStatus: index % 2,
+                isContact: false,
+                isVerified: false,
+                isUntrustworthy: false,
+                isBlocked: false,
+                isAdmin: role === Constants.memberRole.admin,
+                memberRole: role,
+                isCurrentUser: pubKey === "0xdeadbeef",
+                contactRequest: 0,
+                emojiHash: JSON.stringify(["👨🏻‍🍼", "🏃🏿‍♂️", "🌇", "🤶🏿", "🏮", "🤷🏻‍♂️", "🤦🏻",
+                                           "📣", "🤎", "👷🏽", "😺", "🥞", "🔃", "🧝🏽‍♂️"]),
+                trustStatus: 0,
+                usesDefaultName: false,
+                joined: true
+            })
+        }
+
+        function buildMembers() {
+            root.membersModel.clear()
+            root.privateChannelMembersModel.clear()
+            appendMember(root.membersModel, "0xdeadbeef", "Me", 0, root.memberRole)
+            for (let i = 0; i < root.membersCount; ++i) {
+                const role = i === 0 ? Constants.memberRole.owner : Constants.memberRole.none
+                appendMember(root.membersModel, "0xmember-" + i, "Member " + i, i + 1, role)
+            }
+            appendMember(root.privateChannelMembersModel, "0xdeadbeef", "Me", 0, root.memberRole)
+            for (let i = 0; i < root.privateChannelMembersCount; ++i)
+                appendMember(root.privateChannelMembersModel, "0xmember-" + i, "Member " + i, i + 1,
+                             i === 0 ? Constants.memberRole.owner : Constants.memberRole.none)
+        }
+
+        function privateChannelIds() {
+            const ids = []
+            for (const chatId in d.chatInfo) {
+                if (d.chatInfo[chatId].requiresPermissions)
+                    ids.push(chatId)
+            }
+            return ids
+        }
+
+        // Mirrors entries of the AssetsModel mock (which fills itself only on
+        // Component.onCompleted, possibly after the first rebuild() call)
+        readonly property var holdingTokens: [
+            { key: "socks", symbol: "SOCKS", shortName: "SOCKS", name: "Unisocks" },
+            { key: "zrx", symbol: "ZRX", shortName: "ZRX", name: "Ox" },
+            { key: "1inch", symbol: "1INCH", shortName: "1INCH", name: "1inch" },
+            { key: "eth", symbol: "ETH", shortName: "eth", name: "eth" }
+        ]
+
+        function appendPermission(index, permissionType, channelIds) {
+            const id = "permission-" + index
+            const asset = holdingTokens[index % holdingTokens.length]
+            root.permissionsModel.append({
+                id: id,
+                key: id,
+                permissionType: permissionType,
+                holdingsListModel: [{
+                    key: asset.key,
+                    type: Constants.TokenType.ERC20,
+                    symbol: asset.symbol,
+                    shortName: asset.shortName,
+                    name: asset.name,
+                    amount: "" + (10 * (index + 1)),
+                    available: true
+                }],
+                channelsListModel: channelIds.map(chatId => ({
+                    key: chatId,
+                    channelName: d.chatInfo[chatId].name
+                })),
+                isPrivate: root.permissionsArePrivate,
+                tokenCriteriaMet: root.tokenCriteriaMet,
+                permissionState: 0
+            })
+            root.permissionsModel.channelMap[id] = channelIds
+        }
+
+        function buildPermissions() {
+            root.permissionsModel.clear()
+            root.permissionsModel.channelMap = ({})
+            let index = 0
+            for (let i = 0; i < root.becomeMemberPermissionsCount; ++i)
+                appendPermission(index++, Constants.permissionType.member, [])
+            const gated = privateChannelIds()
+            for (let i = 0; i < root.viewOnlyPermissionsCount; ++i)
+                appendPermission(index++, Constants.permissionType.read, gated)
+            for (let i = 0; i < root.viewAndPostPermissionsCount; ++i)
+                appendPermission(index++, Constants.permissionType.viewAndPost, gated)
+        }
+
+        function fillMessages(model, chatId) {
+            const now = Date.now()
+            const count = root.messagesPerChannel
+            const senderCount = Math.max(1, Math.min(root.membersCount, 20))
+            // like the production model: index 0 is the newest message and
+            // history grows towards higher indexes
+            for (let i = 0; i < count; ++i) {
+                const own = i % 7 === 1
+                const senderIdx = i % senderCount
+                const ts = now - i * 60000
+                model.append({
+                    id: "msg-" + chatId + "-" + i,
+                    prevMsgIndex: i + 1,
+                    nextMsgIndex: i - 1,
+                    prevMsgTimestamp: ts - 60000,
+                    nextMsgTimestamp: ts + 60000,
+                    prevMsgSenderId: "",
+                    prevMsgContentType: Constants.messageContentType.messageType,
+                    prevMsgDeleted: false,
+                    timestamp: ts,
+                    responseToMessageWithId: "",
+                    senderId: own ? "0xdeadbeef" : "0xmember-" + senderIdx,
+                    senderDisplayName: own ? "Me" : "Member " + senderIdx,
+                    senderOptionalName: "",
+                    senderIcon: "",
+                    senderIsAdded: true,
+                    senderEnsVerified: false,
+                    senderTrustStatus: 0,
+                    amISender: own,
+                    messageText: "Message " + (count - i) + " — the quick brown fox jumps over the lazy dog. "
+                                 + (i % 5 === 0 ? "A somewhat longer paragraph to vary the bubble heights while measuring text. " : ""),
+                    unparsedText: "Message " + (count - i),
+                    messageImage: "",
+                    messageAttachments: "",
+                    contentType: Constants.messageContentType.messageType,
+                    sticker: "",
+                    stickerPack: -1,
+                    outgoingStatus: own ? "sent" : "",
+                    resendError: "",
+                    mentioned: false,
+                    quotedMessageText: "",
+                    quotedMessageParsedText: "",
+                    quotedMessageFrom: "",
+                    quotedMessageAuthorDisplayName: "",
+                    quotedMessageAuthorName: "",
+                    quotedMessageAuthorThumbnailImage: "",
+                    quotedMessageAuthorEnsVerified: false,
+                    quotedMessageAuthorIsContact: false,
+                    quotedMessageContentType: Constants.messageContentType.messageType,
+                    quotedMessageDeleted: false,
+                    quotedMessageAlbumImagesCount: 0,
+                    quotedMessageAlbumMessageImages: "",
+                    linkPreviewModel: [],
+                    links: "",
+                    paymentRequestModel: [],
+                    transactionParameters: [],
+                    pinned: false,
+                    pinnedBy: "",
+                    reactions: [],
+                    editMode: false,
+                    isEdited: false,
+                    deleted: false,
+                    deletedBy: "",
+                    deletedByContactDisplayName: "",
+                    deletedByContactIcon: "",
+                    gapFrom: 0,
+                    gapTo: 0,
+                    communityId: root.communityId,
+                    compressedKey: "",
+                    bridgeName: "",
+                    albumMessageImages: "",
+                    albumImagesCount: 0,
+                    usesDefaultName: false
+                })
+            }
+        }
+
+        // Message history is filled lazily on first activation, mirroring the
+        // backend and keeping inactive channels out of measured load windows
+        function contentModuleFor(chatId) {
+            if (chatId === "" || !d.chatInfo[chatId])
+                return null
+            if (!d.contentModules[chatId]) {
+                d.contentModules[chatId] = root.contentModuleComponent.createObject(root, {
+                    chatId: chatId,
+                    info: d.chatInfo[chatId]
+                })
+            }
+            return d.contentModules[chatId]
+        }
+
+        function destroyContentModules() {
+            for (const chatId in d.contentModules)
+                d.contentModules[chatId].destroy()
+            d.contentModules = ({})
+            d.preparedChatId = ""
+        }
+    }
+
+    function firstChannelId() {
+        return uncategorizedChannelsCount > 0 ? "channel-u-0"
+             : (categoriesCount > 0 && channelsPerCategory > 0 ? "channel-0-0" : "")
+    }
+
+    function firstPrivateChannelId() {
+        const ids = d.privateChannelIds()
+        return ids.length > 0 ? ids[0] : ""
+    }
+
+    function setCategoryOpened(categoryId, opened) {
+        for (let i = 0; i < chatsModel.count; ++i) {
+            if (chatsModel.get(i).categoryId === categoryId)
+                chatsModel.setProperty(i, "categoryOpened", opened)
+        }
+    }
+
+    // Only touches the rows that change, like the nim model does — a
+    // full-model write storm would bill SFPM/ListView invalidation work to
+    // whatever loads next
+    function setActiveChat(id) {
+        for (let i = 0; i < chatsModel.count; ++i) {
+            const row = chatsModel.get(i)
+            const isActive = row.itemId === id
+            if (row.active !== isActive) {
+                chatsModel.setProperty(i, "active", isActive)
+                chatsModel.setProperty(i, "selected", isActive)
+            }
+            if (isActive && !row.loaderActive)
+                chatsModel.setProperty(i, "loaderActive", true)
+        }
+        activeChatId = id
+        sectionModule.activeItem = ({ id: id, type: Constants.chatType.communityChat })
+        const module = d.contentModuleFor(id)
+        if (module && !module.messagesModel) {
+            module.messagesModel = messagesModelComponent.createObject(module)
+            d.fillMessages(module.messagesModel, id)
+        }
+        ChatStores.ChatStoresConfig.currentChatContentModule = module
+        ChatStores.ChatStoresConfig.usersModel = module && module.info.requiresPermissions
+                ? privateChannelMembersModel
+                : membersModel
+    }
+
+    function rebuild() {
+        d.destroyContentModules()
+        activeChatId = ""
+        sectionModule.activeItem = ({ id: "", type: -1 })
+        d.buildChats()
+        d.buildMembers()
+        d.buildPermissions()
+    }
+
+    function install() {
+        rebuild()
+        ChatStores.ChatStoresConfig.chatSectionModule = sectionModule
+        ChatStores.ChatStoresConfig.sectionDetails = sectionItemModel
+        ChatStores.ChatStoresConfig.assetsModel = assetsModel
+        ChatStores.ChatStoresConfig.collectiblesModel = collectiblesModel
+        MessagingStores.MessagingStoresConfig.communityRootStoreFactory =
+                (parent, communityId) => communityRootStoreComponent.createObject(parent)
+        const first = firstChannelId()
+        if (first !== "")
+            setActiveChat(first)
+    }
+
+    function uninstall() {
+        ChatStores.ChatStoresConfig.chatSectionModule = null
+        ChatStores.ChatStoresConfig.currentChatContentModule = null
+        ChatStores.ChatStoresConfig.usersModel = null
+        ChatStores.ChatStoresConfig.sectionDetails = null
+        ChatStores.ChatStoresConfig.assetsModel = null
+        ChatStores.ChatStoresConfig.collectiblesModel = null
+        MessagingStores.MessagingStoresConfig.communityRootStoreFactory = null
+        d.destroyContentModules()
+    }
+}

--- a/storybook/src/Models/CommunitySectionMock.qml
+++ b/storybook/src/Models/CommunitySectionMock.qml
@@ -7,8 +7,9 @@ import AppLayouts.stores.Messaging as MessagingStores
 import AppLayouts.stores.Messaging.Community as CommunityStores
 
 /*!
-    Fully configurable mock community backing the CommunityChatLoader, shared
-    by the storybook page (benchmarks) and the qml tests (regression).
+    Fully configurable mock community backing the CommunityChatLoader, used
+    by the storybook page (benchmarks) and built for reuse by qml tests
+    (regression) added later in this PR stack.
 
     Configure the properties, then call install(); it wires the stub store
     hooks (ChatStoresConfig + MessagingStoresConfig) and builds:
@@ -121,15 +122,17 @@ QtObject {
         readonly property int access: root.access
         readonly property bool ensOnly: false
         readonly property bool muted: false
-        readonly property int allMembers: root.membersCount
-        readonly property int joinedMembersCount: root.membersCount
+        // counters follow the built model (membersCount + the current user)
+        // so UI counts never disagree with the members list
+        readonly property int allMembers: root.membersModel.count
+        readonly property int joinedMembersCount: root.membersModel.count
         readonly property bool historyArchiveSupportEnabled: false
         readonly property bool pinMessageAllMembersEnabled: false
         readonly property bool encrypted: root.requiresTokenPermissionToJoin
         readonly property var communityTokens: []
         readonly property bool amIBanned: root.amIBanned
         readonly property bool isPendingOwnershipRequest: false
-        readonly property int activeMembersCount: root.membersCount
+        readonly property int activeMembersCount: root.membersModel.count
         readonly property bool membersLoaded: true
         readonly property bool tokensLoading: false
     }
@@ -677,7 +680,14 @@ QtObject {
         ChatStores.ChatStoresConfig.assetsModel = assetsModel
         ChatStores.ChatStoresConfig.collectiblesModel = collectiblesModel
         MessagingStores.MessagingStoresConfig.communityRootStoreFactory =
-                (parent, communityId) => communityRootStoreComponent.createObject(parent)
+                (parent, communityId) => {
+                    // this mock backs exactly one community; a store built here
+                    // for any other id would be silently wrong
+                    if (communityId !== root.communityId)
+                        console.warn("CommunitySectionMock: communityRootStoreFactory asked for",
+                                     communityId, "but the mock is wired for", root.communityId)
+                    return communityRootStoreComponent.createObject(parent)
+                }
         const first = firstChannelId()
         if (first !== "")
             setActiveChat(first)

--- a/storybook/src/Models/qmldir
+++ b/storybook/src/Models/qmldir
@@ -6,6 +6,7 @@ ChannelsModel 1.0 ChannelsModel.qml
 ChatsModel 1.0 ChatsModel.qml
 ChatsSearchModel 1.0 ChatsSearchModel.qml
 CollectiblesModel 1.0 CollectiblesModel.qml
+CommunitySectionMock 1.0 CommunitySectionMock.qml
 DappsModel 1.0 DappsModel.qml
 FeesModel 1.0 FeesModel.qml
 FlatTokensModel 1.0 FlatTokensModel.qml

--- a/storybook/stubs/AppLayouts/Chat/stores/ChatStoresConfig.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/ChatStoresConfig.qml
@@ -1,0 +1,20 @@
+pragma Singleton
+import QtQuick
+
+// Storybook-only configuration hook: pages populate these before creating
+// components that internally instantiate the stub ChatStores.RootStore
+// (e.g. the section loaders), so the stub can hand out page-controlled mocks.
+QtObject {
+    // Mock of the nim chatCommunitySectionModule (chat list model, activeItem…)
+    property var chatSectionModule: null
+    // Mock of the currently active chat content module (chatDetails, messagesModule…)
+    property var currentChatContentModule: null
+    // Members model for the active chat (production UsersStore selects between
+    // the section members and the channel members — mocks do it here)
+    property var usersModel: null
+    // Section details for the active section (id, name, image, joined, amIBanned…)
+    property var sectionDetails: null
+    // Wallet models used to resolve token-permission holdings to symbols/icons
+    property var assetsModel: null
+    property var collectiblesModel: null
+}

--- a/storybook/stubs/AppLayouts/Chat/stores/CreateChatPropertiesStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/CreateChatPropertiesStore.qml
@@ -1,0 +1,8 @@
+import QtQuick
+
+QtObject {
+    property string createChatInitMessage: ""
+    property var createChatFileUrls: []
+
+    function resetProperties() {}
+}

--- a/storybook/stubs/AppLayouts/Chat/stores/MessageStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/MessageStore.qml
@@ -1,5 +1,57 @@
 import QtQuick
 
+// Functional stub mirroring the real MessageStore wrapper, minus the nim
+// context-property dependencies. Works against a page-provided mock
+// messageModule exposing at least { model, loading, getChatId() }.
 QtObject {
-    
+    id: root
+
+    property var messageModule
+    property var messagesModel
+    property var chatSectionModule
+
+    readonly property bool loadingHistoryMessagesInProgress: chatSectionModule ?
+                                                                 !!chatSectionModule.loadingHistoryMessagesInProgress : false
+    readonly property int newMessagesCount: messagesModel && messagesModel.newMessagesCount !== undefined ?
+                                                messagesModel.newMessagesCount : 0
+    readonly property bool messageSearchOngoing: false
+    readonly property bool loading: messageModule ? !!messageModule.loading : false
+    readonly property bool amIChatAdmin: false
+    readonly property bool isPinMessageAllowedForMembers: false
+    readonly property string chatId: messageModule ? messageModule.getChatId() : ""
+    readonly property int chatType: 0
+    readonly property string chatColor: "#4360DF"
+    readonly property string chatIcon: ""
+    readonly property bool keepUnread: false
+    readonly property bool isChatActive: true
+
+    onMessageModuleChanged: {
+        if (messageModule)
+            messagesModel = messageModule.model
+    }
+
+    function loadMoreMessages() {}
+    function setKeepUnread(flag) {}
+    function getMessageByIdAsJson(id) { return undefined }
+    function getMessageByIndexAsJson(index) { return false }
+    function getSectionId() { return "" }
+    function getChatId() { return chatId }
+    function getNumberOfPinnedMessages() { return 0 }
+    function pinMessage(messageId) {}
+    function unpinMessage(messageId) {}
+    function toggleReaction(messageId, hexcode) {}
+    function deleteMessage(messageId) {}
+    function markMessageAsUnread(messageId) {}
+    function warnAndDeleteMessage(messageId) {}
+    function setEditModeOn(messageId) {}
+    function setEditModeOnLastMessage(pubkey) {}
+    function setEditModeOff(messageId) {}
+    function editMessage(messageId, updatedMsg) {}
+    function fillGaps(messageId) {}
+    function leaveChat() {}
+    function addNewMessagesMarker() {}
+    function firstUnseenMentionMessageId() { return "" }
+    function jumpToMessage(id) {}
+    function createMessageLink(chatId, messageId) { return "" }
+    function resendMessage(messageId) {}
 }

--- a/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
@@ -1,8 +1,74 @@
 import QtQuick
 
 QtObject {
-    property var chatCommunitySectionModule
+    id: root
+
+    // Wired from ChatStoresConfig so pages can inject mocks even when this
+    // store is created internally by a component under test (section loaders)
+    property var chatCommunitySectionModule: ChatStoresConfig.chatSectionModule
     property var contactsStore
     property bool isChatSectionModule
     property var communityId
+
+    // Properties assigned by the section loaders
+    property var currencyStore
+    property var communityTokensStore
+    property var networkConnectionStore
+    property bool openCreateChat: false
+    property bool loadingHistoryMessagesInProgress: false
+
+    // Surface read by the chat views
+    property bool isDebugEnabled: false
+    property bool joined: true
+    property bool isUserAllowedToSendMessage: true
+    property string chatInputPlaceHolderText: "Message"
+    property int activeChatType: 1
+    property var assetsModel: ChatStoresConfig.assetsModel
+    property var collectiblesModel: ChatStoresConfig.collectiblesModel
+    property var communityItemsModel: chatCommunitySectionModule ? chatCommunitySectionModule.model : null
+    property var communitiesModuleInst: null
+
+    readonly property var sectionDetails: ChatStoresConfig.sectionDetails ?? defaultSectionDetails
+
+    readonly property var defaultSectionDetails: QtObject {
+        property bool joined: true
+        property bool amIBanned: false
+    }
+
+    property UsersStore usersStore: UsersStore {}
+    property StickersStore stickersStore: StickersStore {}
+
+    function currentChatContentModule() {
+        return ChatStoresConfig.currentChatContentModule
+    }
+
+    function amIChatAdmin() {
+        return false
+    }
+
+    function cleanMessageText(text) {
+        return text
+    }
+
+    function sendMessage() {
+        return false
+    }
+
+    function sendSticker() {}
+    function removeMemberFromGroupChat() {}
+
+    // Community mutators proxied to the section module, like the real store
+    function toggleCollapsedCommunityCategory(categoryId, collapsed) {
+        chatCommunitySectionModule?.toggleCollapsedCommunityCategory(categoryId, collapsed)
+    }
+    function reorderCommunityChat(categoryId, chatId, to) {
+        chatCommunitySectionModule?.reorderCommunityChat(categoryId, chatId, to)
+    }
+    function reorderCommunityCategories(categoryId, to) {
+        chatCommunitySectionModule?.reorderCommunityCategories(categoryId, to)
+    }
+    function removeCommunityChat(chatId) {}
+    function deleteCommunityCategory(categoryId) {}
+    function prepareEditCategoryModel(categoryId) {}
+    function leaveCommunity() {}
 }

--- a/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
@@ -1,5 +1,7 @@
 import QtQuick
 
+import utils
+
 QtObject {
     id: root
 
@@ -17,12 +19,18 @@ QtObject {
     property bool openCreateChat: false
     property bool loadingHistoryMessagesInProgress: false
 
-    // Surface read by the chat views
+    // Surface read by the chat views. Derived like the real store so the
+    // injected content module's permissions (canPost, admin role) gate the
+    // input area instead of being hardcoded no-ops.
     property bool isDebugEnabled: false
     property bool joined: true
-    property bool isUserAllowedToSendMessage: true
-    property string chatInputPlaceHolderText: "Message"
-    property int activeChatType: 1
+    readonly property bool isUserAllowedToSendMessage: {
+        if (activeChatType === Constants.chatType.communityChat)
+            return !!(currentChatContentModule()?.chatDetails?.canPost ?? false)
+        return true
+    }
+    readonly property string chatInputPlaceHolderText: qsTr("Type something")
+    readonly property int activeChatType: chatCommunitySectionModule?.activeItem?.type ?? -1
     property var assetsModel: ChatStoresConfig.assetsModel
     property var collectiblesModel: ChatStoresConfig.collectiblesModel
     property var communityItemsModel: chatCommunitySectionModule ? chatCommunitySectionModule.model : null
@@ -43,7 +51,7 @@ QtObject {
     }
 
     function amIChatAdmin() {
-        return false
+        return currentChatContentModule()?.amIChatAdmin() ?? false
     }
 
     function cleanMessageText(text) {

--- a/storybook/stubs/AppLayouts/Chat/stores/StickersStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/StickersStore.qml
@@ -1,3 +1,5 @@
 import QtQuick
 
-QtObject {}
+QtObject {
+    property var stickersModule: null
+}

--- a/storybook/stubs/AppLayouts/Chat/stores/UsersStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/UsersStore.qml
@@ -1,5 +1,7 @@
 import QtQuick
 
 QtObject {
-    
+    property var usersModel: ChatStoresConfig.usersModel
+
+    function groupMembersUpdateRequested(membersPubKeysList) {}
 }

--- a/storybook/stubs/AppLayouts/Chat/stores/qmldir
+++ b/storybook/stubs/AppLayouts/Chat/stores/qmldir
@@ -1,4 +1,6 @@
+singleton ChatStoresConfig 1.0 ChatStoresConfig.qml
+CreateChatPropertiesStore 1.0 CreateChatPropertiesStore.qml
+MessageStore 1.0 MessageStore.qml
 RootStore 1.0 RootStore.qml
 StickersStore 1.0 StickersStore.qml
-MessageStore 1.0 MessageStore.qml
 UsersStore 1.0 UsersStore.qml

--- a/storybook/stubs/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/storybook/stubs/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -1,3 +1,6 @@
 import QtQuick
 
-QtObject {}
+QtObject {
+    property real discordImportProgress: 0
+    property bool discordImportInProgress: false
+}

--- a/storybook/stubs/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/storybook/stubs/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -1,4 +1,7 @@
 import QtQuick
 
 QtObject {
+    property bool copyMessageLinksEnabled: false
+    property bool ensCommunityPermissionsEnabled: false
+    property bool isManageCommunityOnTestModeEnabled: false
 }

--- a/storybook/stubs/AppLayouts/stores/AccountSettingsStore.qml
+++ b/storybook/stubs/AppLayouts/stores/AccountSettingsStore.qml
@@ -1,0 +1,9 @@
+import QtQuick
+
+QtObject {
+    property bool showUsersList: false
+
+    function setShowUsersList(show) {
+        showUsersList = show
+    }
+}

--- a/storybook/stubs/AppLayouts/stores/ContactsStore.qml
+++ b/storybook/stubs/AppLayouts/stores/ContactsStore.qml
@@ -1,7 +1,14 @@
 import QtQuick
 
 QtObject {
+    property string myPublicKey: "0xdeadbeef"
+
     function getContactPublicKeyByAddress(address) {
         return ""
     }
+
+    function changeContactNickname(pubKey, nickname, displayName, isEdit) {}
+    function removeTrustStatus(pubKey) {}
+    function dismissContactRequest(chatId, contactRequestId) {}
+    function acceptContactRequest(chatId, contactRequestId) {}
 }

--- a/storybook/stubs/AppLayouts/stores/FeatureFlagsStore.qml
+++ b/storybook/stubs/AppLayouts/stores/FeatureFlagsStore.qml
@@ -1,0 +1,10 @@
+import QtQuick
+
+QtObject {
+    property bool sendViaPersonalChatEnabled: false
+    property bool messageLinkSharingEnabled: false
+    property bool paymentRequestEnabled: false
+    property bool swapEnabled: false
+    property bool buyEnabled: false
+    property bool keycardEnabled: false
+}

--- a/storybook/stubs/AppLayouts/stores/Messaging/Community/CommunityAccessStore.qml
+++ b/storybook/stubs/AppLayouts/stores/Messaging/Community/CommunityAccessStore.qml
@@ -1,0 +1,32 @@
+import QtQuick
+
+// Same public surface as the real CommunityAccessStore, but every input is a
+// plain settable property (no nim context modules behind it)
+QtObject {
+    property var communityId
+    property bool isModuleReady: true
+    property bool joined: false
+    property bool allChannelsAreHiddenBecauseNotPermitted: false
+    property int communityMemberReevaluationStatus: 0
+    property bool spectatedPermissionsCheckOngoing: false
+    property var spectatedPermissionsModel: null
+    property bool communityPermissionsCheckOngoing: false
+    property bool chatPermissionsCheckOngoing: false
+    property bool isMyCommunityRequestPending: false
+
+    signal communityAccessFailed(string communityId)
+    signal allSharedAddressesSigned()
+    signal communityMembershipNotificationReceived()
+    signal acceptRequestToJoinCommunityRequested(string requestId, string communityId)
+    signal declineRequestToJoinCommunityRequested(string requestId, string communityId)
+
+    function spectateCommunity(communityId) {}
+    function updatePermissionsModel(communityId, sharedAddresses) {}
+    function signSharedAddressesForKeypair(keyUid) {}
+    function joinCommunityOrEditSharedAddresses() {}
+    function cleanJoinEditCommunityData() {}
+    function cancelPendingRequest(id) {}
+    function prepareTokenModelForCommunity(publicKey) {}
+    function prepareTokenModelForCommunityChat(publicKey, chatId) {}
+    function prepareKeypairsForSigning(communityId, ensName, addressesToShare, airdropAddress, editMode) {}
+}

--- a/storybook/stubs/AppLayouts/stores/Messaging/Community/CommunityRootStore.qml
+++ b/storybook/stubs/AppLayouts/stores/Messaging/Community/CommunityRootStore.qml
@@ -1,0 +1,11 @@
+import QtQuick
+
+// Thin shell matching the real CommunityRootStore's public API. The section
+// loaders create one per community and destroy it on unload, so the actual
+// access/permissions stores are handed in by the page/test fixture and
+// outlive this object.
+QtObject {
+    property var communityId
+    property CommunityAccessStore communityAccessStore
+    property PermissionsStore communityPermissionsStore
+}

--- a/storybook/stubs/AppLayouts/stores/Messaging/Community/PermissionsStore.qml
+++ b/storybook/stubs/AppLayouts/stores/Messaging/Community/PermissionsStore.qml
@@ -1,0 +1,121 @@
+import QtQml
+
+import SortFilterProxyModel
+
+import StatusQ
+
+import utils
+
+// Mirrors the real PermissionsStore including its derived filtered models
+// (the real one has no nim dependencies), but the inputs are plain settable
+// properties. The injected permissionsModel must implement
+// belongsToChat(permissionId, chatId), like the nim model does.
+QtObject {
+    id: root
+
+    property string activeSectionId
+    property string activeChannelId
+    property bool allTokenRequirementsMet: false
+    property var permissionsModel: null
+
+    readonly property bool isOwner: false
+
+    readonly property var selectedChannelPermissionsModel: SortFilterProxyModel {
+        id: selectedChannelPermissionsModel
+        sourceModel: root.permissionsModel
+
+        function filterPredicate(modelData) {
+            return root.permissionsModel.belongsToChat(modelData.id, root.activeChannelId) &&
+                    (modelData.tokenCriteriaMet || !modelData.isPrivate)
+        }
+        filters: [
+            FastExpressionFilter {
+                expression: {
+                    root.activeChannelId
+                    selectedChannelPermissionsModel.filterPredicate(model)
+                }
+                expectedRoles: ["id", "tokenCriteriaMet", "isPrivate"]
+            }
+        ]
+    }
+
+    readonly property var viewOnlyPermissionsModel: SortFilterProxyModel {
+        id: viewOnlyPermissionsModel
+        sourceModel: root.permissionsModel
+
+        function filterPredicate(modelData) {
+            return (modelData.permissionType == Constants.permissionType.read) &&
+                    root.permissionsModel.belongsToChat(modelData.id, root.activeChannelId) &&
+                    (modelData.tokenCriteriaMet || !modelData.isPrivate)
+        }
+        filters: [
+            FastExpressionFilter {
+                expression: {
+                    root.activeChannelId
+                    viewOnlyPermissionsModel.filterPredicate(model)
+                }
+                expectedRoles: ["id", "tokenCriteriaMet", "isPrivate", "permissionType"]
+            }
+        ]
+    }
+
+    readonly property var viewAndPostPermissionsModel: SortFilterProxyModel {
+        id: viewAndPostPermissionsModel
+        sourceModel: root.permissionsModel
+        function filterPredicate(modelData) {
+            return (modelData.permissionType == Constants.permissionType.viewAndPost) &&
+                    root.permissionsModel.belongsToChat(modelData.id, root.activeChannelId) &&
+                    (modelData.tokenCriteriaMet || !modelData.isPrivate)
+        }
+        filters: [
+            FastExpressionFilter {
+                expression: {
+                    root.activeChannelId
+                    viewAndPostPermissionsModel.filterPredicate(model)
+                }
+                expectedRoles: ["id", "tokenCriteriaMet", "isPrivate", "permissionType"]
+            }
+        ]
+    }
+
+    readonly property var becomeMemberPermissionsModel: SortFilterProxyModel {
+        id: becomeMemberPermissionsModel
+        sourceModel: root.permissionsModel
+        function filterPredicate(permissionType) {
+            return (permissionType === Constants.permissionType.member ||
+                    permissionType === Constants.permissionType.admin ||
+                    permissionType === Constants.permissionType.becomeTokenMaster)
+        }
+        filters: [
+            FastExpressionFilter {
+                expression: { return becomeMemberPermissionsModel.filterPredicate(model.permissionType) }
+                expectedRoles: ["permissionType"]
+            }
+        ]
+    }
+
+    signal createOrEditCommunityTokenPermission(string key, int permissionType, var holdings, var channels, bool isPrivate)
+    signal deleteCommunityTokenPermission(string key)
+
+    function createPermission(holdings, permissionType, isPrivate, channels) {
+        root.createOrEditCommunityTokenPermission(
+                    "",
+                    permissionType,
+                    JSON.stringify(holdings),
+                    channels.map(c => c.key).join(","),
+                    isPrivate)
+    }
+
+    function editPermission(key, holdings, permissionType, channels, isPrivate) {
+        root.createOrEditCommunityTokenPermission(
+                    key,
+                    permissionType,
+                    JSON.stringify(holdings),
+                    channels.map(c => c.key).join(","),
+                    isPrivate)
+    }
+
+    function removePermission(key) {
+        root.deleteCommunityTokenPermission(key)
+    }
+}

--- a/storybook/stubs/AppLayouts/stores/Messaging/Community/qmldir
+++ b/storybook/stubs/AppLayouts/stores/Messaging/Community/qmldir
@@ -1,0 +1,3 @@
+CommunityAccessStore 1.0 CommunityAccessStore.qml
+CommunityRootStore 1.0 CommunityRootStore.qml
+PermissionsStore 1.0 PermissionsStore.qml

--- a/storybook/stubs/AppLayouts/stores/Messaging/MessagingRootStore.qml
+++ b/storybook/stubs/AppLayouts/stores/Messaging/MessagingRootStore.qml
@@ -1,0 +1,12 @@
+import QtQuick
+
+QtObject {
+    readonly property MessagingSettingsStore messagingSettingsStore: MessagingSettingsStore {}
+
+    function createCommunityRootStore(parent, communityId) {
+        if (MessagingStoresConfig.communityRootStoreFactory)
+            return MessagingStoresConfig.communityRootStoreFactory(parent, communityId)
+        console.warn("Stub MessagingRootStore: no communityRootStoreFactory installed")
+        return null
+    }
+}

--- a/storybook/stubs/AppLayouts/stores/Messaging/MessagingSettingsStore.qml
+++ b/storybook/stubs/AppLayouts/stores/Messaging/MessagingSettingsStore.qml
@@ -1,0 +1,14 @@
+import QtQuick
+
+QtObject {
+    property var mailservers: null
+    property bool useMailservers: false
+    property bool messagesFromContactsOnly: false
+    property bool syncingOnMobileNetwork: false
+    property int urlUnfurlingMode: 0
+
+    function toggleUseMailservers(value) {}
+    function setMessagesFromContactsOnly(value) {}
+    function setSyncingOnMobileNetwork(value) {}
+    function setUrlUnfurlingMode(value) {}
+}

--- a/storybook/stubs/AppLayouts/stores/Messaging/MessagingStoresConfig.qml
+++ b/storybook/stubs/AppLayouts/stores/Messaging/MessagingStoresConfig.qml
@@ -1,0 +1,12 @@
+pragma Singleton
+import QtQuick
+
+// Storybook-only configuration hook: pages/tests install a factory before
+// creating components that internally request a CommunityRootStore from the
+// stub MessagingRootStore (the community section loader creates one per
+// section and destroys it on unload, so a long-lived instance can't be
+// handed out directly).
+QtObject {
+    // function(parent, communityId) -> stub CommunityRootStore instance
+    property var communityRootStoreFactory: null
+}

--- a/storybook/stubs/AppLayouts/stores/Messaging/qmldir
+++ b/storybook/stubs/AppLayouts/stores/Messaging/qmldir
@@ -1,0 +1,3 @@
+MessagingRootStore 1.0 MessagingRootStore.qml
+MessagingSettingsStore 1.0 MessagingSettingsStore.qml
+singleton MessagingStoresConfig 1.0 MessagingStoresConfig.qml

--- a/storybook/stubs/AppLayouts/stores/RootStore.qml
+++ b/storybook/stubs/AppLayouts/stores/RootStore.qml
@@ -1,4 +1,15 @@
 import QtQuick
 
 QtObject {
+    property bool isProduction: false
+    property bool navToMsgDetails: false
+    property bool navToMsgList: false
+
+    function setNavToMsgDetailsFlag(navigate) {
+        navToMsgDetails = navigate
+    }
+
+    function setNavToMsgListFlag(navigate) {
+        navToMsgList = navigate
+    }
 }

--- a/storybook/stubs/AppLayouts/stores/qmldir
+++ b/storybook/stubs/AppLayouts/stores/qmldir
@@ -1,3 +1,5 @@
+AccountSettingsStore 1.0 AccountSettingsStore.qml
 ActivityCenterStore 1.0 ActivityCenterStore.qml
-RootStore 1.0 RootStore.qml
 ContactsStore 1.0 ContactsStore.qml
+FeatureFlagsStore 1.0 FeatureFlagsStore.qml
+RootStore 1.0 RootStore.qml

--- a/storybook/stubs/nim/sectionmocks/GlobalUtils.qml
+++ b/storybook/stubs/nim/sectionmocks/GlobalUtils.qml
@@ -1,0 +1,21 @@
+import QtQuick
+
+QtObject {
+    readonly property string contextPropertyName: "globalUtils"
+
+    function isCompressedPubKey(value) {
+        return false
+    }
+
+    function isAlias(name) {
+        return false
+    }
+
+    function getColorId(publicKey) {
+        return 0
+    }
+
+    function getCompressedPk(publicKey) {
+        return publicKey
+    }
+}

--- a/storybook/stubs/nim/sectionmocks/LocalAppSettings.qml
+++ b/storybook/stubs/nim/sectionmocks/LocalAppSettings.qml
@@ -1,0 +1,13 @@
+import QtQuick
+
+QtObject {
+    readonly property string contextPropertyName: "localAppSettings"
+
+    property bool isCustomMouseScrollingEnabled: false
+    property real scrollDeceleration: 0
+    property real scrollVelocity: 0
+    // registered globally for every storybook page — must not alter their
+    // default behavior (testEnvironment pre-validates community forms)
+    property bool testEnvironment: false
+    property bool refreshTokenEnabled: false
+}

--- a/storybook/stubs/shared/stores/NetworkConnectionStore.qml
+++ b/storybook/stubs/shared/stores/NetworkConnectionStore.qml
@@ -4,4 +4,5 @@ QtObject {
     property bool isOnline: true
     property var blockchainNetworksDown: []
     property bool walletReadyForTransactionsEnabled: true
+    property string walletReadyForTransactionsToolTipText: ""
 }

--- a/storybook/stubs/shared/stores/RootStore.qml
+++ b/storybook/stubs/shared/stores/RootStore.qml
@@ -1,3 +1,10 @@
 import QtQuick
 
-QtObject {}
+QtObject {
+    property bool gifUnfurlingEnabled: false
+    property bool neverAskAboutUnfurlingAgain: false
+
+    function setNeverAskAboutUnfurlingAgain(neverAskAgain) {
+        neverAskAboutUnfurlingAgain = neverAskAgain
+    }
+}

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -19,12 +19,13 @@ import shared.views.chat
 import AppLayouts.Profile.stores
 import AppLayouts.stores as AppLayoutStores
 
+import AppLayouts.Chat.stores as ChatStores
+
 import "../helpers"
 import "../controls"
 import "../popups"
 import "../panels"
 import "../../Wallet"
-import "../stores"
 
 ColumnLayout {
     id: root
@@ -33,7 +34,7 @@ ColumnLayout {
     property var chatContentModule
     property var chatSectionModule
 
-    property RootStore rootStore
+    property ChatStores.RootStore rootStore
     property string chatId
     property int chatType: Constants.chatType.unknown
     property var formatBalance
@@ -55,7 +56,7 @@ ColumnLayout {
     property bool stickersLoaded: false
     property bool joined
 
-    readonly property MessageStore messageStore: MessageStore {
+    readonly property ChatStores.MessageStore messageStore: ChatStores.MessageStore {
         messageModule: chatContentModule ? chatContentModule.messagesModule : null
         chatSectionModule: root.rootStore.chatCommunitySectionModule
     }

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -11,8 +11,9 @@ import utils
 
 import shared.views.chat
 
+import AppLayouts.Chat.stores as ChatStores
+
 import "../panels"
-import "../stores"
 
 RowLayout {
     id: root
@@ -21,7 +22,7 @@ RowLayout {
     property alias membersButton: membersButton
     property alias searchButton: searchButton
 
-    property RootStore rootStore
+    property ChatStores.RootStore rootStore
 
     property var mutualContactsModel
 
@@ -67,7 +68,7 @@ RowLayout {
         readonly property bool selectingMembers: root.state == stateMembersSelectorContent
     }
 
-    MessageStore {
+    ChatStores.MessageStore {
         id: messageStore
         messageModule: chatContentModule ? chatContentModule.messagesModule : null
         chatSectionModule: root.rootStore.chatCommunitySectionModule


### PR DESCRIPTION
### What does the PR do

ChatLoaderPage and CommunityChatLoaderPage load the real section loaders against stubbed stores. CommunitySectionMock builds a full community behind the section-module interface — configurable join state, member role, categories, channels, private channels with their own members, token permissions and scale knobs (members/categories/channels/messages, positional args for benchmarking) — and applies mutations (reorder, category collapse, active chat) to its models so interactions give real feedback. Store stubs extended accordingly (Messaging tree, chat/ community/shared stores, section context-property mocks).

### Affected areas

Storybook

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/57da84a7-d74d-4715-846e-99c9236a5ac4

### Impact on end user

chat and community is availabe in storybook

### How to test

load the page in storybook

### Risk 

low