### PR TITLE
feat: add asynchronous old log cleanup

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -22,6 +22,7 @@ import app_service/service/profile/service as profile_service
 import app_service/service/settings/service as settings_service
 import app_service/service/stickers/service as stickers_service
 import app_service/service/about/service as about_service
+import app_service/service/advanced/service as advanced_service
 import app_service/service/node_configuration/service as node_configuration_service
 import app_service/service/network/service as network_service
 import app_service/service/activity_center/service as activity_center_service
@@ -84,6 +85,7 @@ type
     settingsService: settings_service.Service
     stickersService: stickers_service.Service
     aboutService: about_service.Service
+    advancedService: advanced_service.Service
     networkService: network_service.Service
     activityCenterService: activity_center_service.Service
     privacyService: privacy_service.Service
@@ -207,6 +209,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
     result.tokenService
   )
   result.aboutService = about_service.newService(statusFoundation.events, statusFoundation.threadpool)
+  result.advancedService = advanced_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.dappPermissionsService = dapp_permissions_service.newService()
   result.privacyService = privacy_service.newService(statusFoundation.events, result.settingsService,
   result.accountsService)
@@ -261,6 +264,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
     result.settingsService,
     result.contactsService,
     result.aboutService,
+    result.advancedService,
     result.dappPermissionsService,
     result.privacyService,
     result.stickersService,
@@ -330,6 +334,7 @@ proc delete*(self: AppController) =
   self.transactionService.delete
   self.walletAccountService.delete
   self.aboutService.delete
+  self.advancedService.delete
   self.networkService.delete
   self.activityCenterService.delete
   self.dappPermissionsService.delete

--- a/src/app/global/log_cleanup.nim
+++ b/src/app/global/log_cleanup.nim
@@ -1,0 +1,89 @@
+import std/[locks, os, strutils, times]
+
+const LogRetentionDays* = 14
+
+type
+  LogCleanupMode* = enum
+    ClearClosedLogs,
+    RemoveExpiredLogs
+
+  LogCleanupResult* = object
+    deletedCount*: int
+    failedCount*: int
+    skippedCount*: int
+
+var cleanupLock: Lock
+var logCleanupStartedAt = getTime()
+
+initLock(cleanupLock)
+
+proc initializeLogCleanup*(processStartedAt: Time) =
+  logCleanupStartedAt = processStartedAt
+
+proc logCleanupProcessStartedAt*(): Time =
+  logCleanupStartedAt
+
+proc isDataLogFile(path: string): bool =
+  path.toLowerAscii().endsWith(".log")
+
+proc shouldRemove(fileTime, processStartedAt, currentTime: Time,
+    mode: LogCleanupMode): bool =
+  if fileTime >= processStartedAt:
+    return false
+
+  return mode == ClearClosedLogs or
+    fileTime < currentTime - initDuration(days = LogRetentionDays)
+
+proc cleanupFile(path: string, processStartedAt, currentTime: Time,
+    mode: LogCleanupMode, result: var LogCleanupResult) =
+  try:
+    let fileInfo = getFileInfo(path, followSymlink = false)
+    if fileInfo.kind != pcFile:
+      inc result.skippedCount
+      return
+
+    if not shouldRemove(fileInfo.lastWriteTime, processStartedAt, currentTime, mode):
+      inc result.skippedCount
+      return
+
+    if tryRemoveFile(path):
+      inc result.deletedCount
+    elif fileExists(path):
+      inc result.failedCount
+  except OSError:
+    if fileExists(path):
+      inc result.failedCount
+
+proc cleanupDataDirectory(directory: string, processStartedAt, currentTime: Time,
+    mode: LogCleanupMode, result: var LogCleanupResult) =
+  if not dirExists(directory):
+    return
+
+  try:
+    for kind, path in walkDir(directory):
+      case kind
+      of pcFile:
+        if isDataLogFile(path):
+          cleanupFile(path, processStartedAt, currentTime, mode, result)
+      of pcDir:
+        cleanupDataDirectory(path, processStartedAt, currentTime, mode, result)
+      else:
+        discard
+  except OSError:
+    inc result.failedCount
+
+proc cleanupLogFiles*(logsDir, dataDir: string, processStartedAt, currentTime: Time,
+    mode: LogCleanupMode): LogCleanupResult =
+  acquire(cleanupLock)
+  defer:
+    release(cleanupLock)
+
+  if dirExists(logsDir):
+    try:
+      for kind, path in walkDir(logsDir):
+        if kind == pcFile:
+          cleanupFile(path, processStartedAt, currentTime, mode, result)
+    except OSError:
+      inc result.failedCount
+
+  cleanupDataDirectory(dataDir, processStartedAt, currentTime, mode, result)

--- a/src/app/global/log_cleanup_tasks.nim
+++ b/src/app/global/log_cleanup_tasks.nim
@@ -1,0 +1,38 @@
+import std/times
+
+import chronicles
+
+import app/core/tasks/threadpool
+import ./log_cleanup
+
+logScope:
+  topics = "log-cleanup"
+
+type StartupLogCleanupTaskArg = ref object of TaskArg
+  logsDir: string
+  dataDir: string
+  processStartedAtUnix: int64
+
+proc startupLogCleanupTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[StartupLogCleanupTaskArg](argEncoded)
+  let result = cleanupLogFiles(
+    arg.logsDir,
+    arg.dataDir,
+    fromUnix(arg.processStartedAtUnix),
+    getTime(),
+    RemoveExpiredLogs)
+
+  if result.failedCount > 0:
+    warn "failed to remove some expired log files", deletedCount = result.deletedCount,
+      failedCount = result.failedCount
+  else:
+    debug "removed expired log files", deletedCount = result.deletedCount
+
+proc scheduleStartupLogCleanup*(threadpool: ThreadPool, logsDir, dataDir: string,
+    processStartedAt: Time) =
+  let arg = StartupLogCleanupTaskArg(
+    tptr: startupLogCleanupTask,
+    logsDir: logsDir,
+    dataDir: dataDir,
+    processStartedAtUnix: processStartedAt.toUnix)
+  threadpool.start(arg)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -52,6 +52,7 @@ import app_service/service/accounts/service as accounts_service
 import app_service/service/settings/service as settings_service
 import app_service/service/contacts/service as contacts_service
 import app_service/service/about/service as about_service
+import app_service/service/advanced/service as advanced_service
 import app_service/service/privacy/service as privacy_service
 import app_service/service/stickers/service as stickers_service
 import app_service/service/activity_center/service as activity_center_service
@@ -181,6 +182,7 @@ proc newModule*[T](
   settingsService: settings_service.Service,
   contactsService: contacts_service.Service,
   aboutService: about_service.Service,
+  advancedService: advanced_service.Service,
   dappPermissionsService: dapp_permissions_service.Service,
   privacyService: privacy_service.Service,
   stickersService: stickers_service.Service,
@@ -266,7 +268,7 @@ proc newModule*[T](
     result, events, accountsService, settingsService, stickersService,
     profileService, contactsService, aboutService, privacyService, nodeConfigurationService,
     devicesService, mailserversService, chatService, ensService, walletAccountService, generalService, communityService,
-    networkService, tokenService, nodeService
+    networkService, tokenService, nodeService, advancedService
   )
   result.stickersModule = stickers_module.newModule(result, events, stickersService, settingsService, walletAccountService,
     networkService, tokenService)

--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -6,6 +6,7 @@ import ../../../../core/eventemitter
 import ../../../../../app_service/service/settings/service as settings_service
 import ../../../../../app_service/service/stickers/service as stickers_service
 import ../../../../../app_service/service/node_configuration/service as node_configuration_service
+import ../../../../../app_service/service/advanced/service as advanced_service
 
 logScope:
   topics = "profile-section-advanced-module-controller"
@@ -17,22 +18,30 @@ type
     settingsService: settings_service.Service
     stickersService: stickers_service.Service
     nodeConfigurationService: node_configuration_service.Service
+    advancedService: advanced_service.Service
+
+proc onOldLogsCleanupFinished*(self: Controller, deletedCount, failedCount: int,
+  error: string)
 
 proc newController*(delegate: io_interface.AccessInterface, events: EventEmitter,
   settingsService: settings_service.Service,
   stickersService: stickers_service.Service,
-  nodeConfigurationService: node_configuration_service.Service): Controller =
+  nodeConfigurationService: node_configuration_service.Service,
+  advancedService: advanced_service.Service): Controller =
   result = Controller()
   result.delegate = delegate
   result.events = events
   result.settingsService = settingsService
   result.nodeConfigurationService = nodeConfigurationService
+  result.advancedService = advancedService
 
 proc delete*(self: Controller) =
   discard
 
 proc init*(self: Controller) =
-  discard
+  self.events.on(advanced_service.SIGNAL_ADVANCED_LOGS_CLEANUP_FINISHED) do(e: Args):
+    let args = advanced_service.AdvancedLogsCleanupFinishedArgs(e)
+    self.onOldLogsCleanupFinished(args.deletedCount, args.failedCount, args.error)
 
 proc getFleet*(self: Controller): string =
   return self.settingsService.getFleetAsString()
@@ -55,6 +64,17 @@ proc setMaxLogBackups*(self: Controller, value: int) =
     return
 
   self.delegate.onLogMaxBackupsChanged()
+
+proc getIsClearingOldLogs*(self: Controller): bool =
+  return self.advancedService.isClearingOldLogs()
+
+proc clearOldLogs*(self: Controller) =
+  if self.advancedService.clearOldLogs():
+    self.delegate.onOldLogsCleanupStarted()
+
+proc onOldLogsCleanupFinished*(self: Controller, deletedCount, failedCount: int,
+    error: string) =
+  self.delegate.onOldLogsCleanupFinished(deletedCount, failedCount, error)
 
 proc getWakuV2LightClientEnabled*(self: Controller): bool =
   return self.nodeConfigurationService.isLightClient()

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -86,3 +86,16 @@ method setMaxLogBackups*(self: AccessInterface, value: int) {.base.} =
 
 method onLogMaxBackupsChanged*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getIsClearingOldLogs*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method clearOldLogs*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onOldLogsCleanupFinished*(self: AccessInterface, deletedCount, failedCount: int,
+    error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onOldLogsCleanupStarted*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -9,6 +9,7 @@ import ../../../../global/global_singleton
 import ../../../../../app_service/service/settings/service as settings_service
 import ../../../../../app_service/service/stickers/service as stickers_service
 import ../../../../../app_service/service/node_configuration/service as node_configuration_service
+import ../../../../../app_service/service/advanced/service as advanced_service
 
 export io_interface
 
@@ -26,12 +27,14 @@ type
 proc newModule*(delegate: delegate_interface.AccessInterface, events: EventEmitter,
   settingsService: settings_service.Service,
   stickersService: stickers_service.Service,
-  nodeConfigurationService: node_configuration_service.Service): Module =
+  nodeConfigurationService: node_configuration_service.Service,
+  advancedService: advanced_service.Service): Module =
   result = Module()
   result.delegate = delegate
   result.view = view.newView(result)
   result.viewVariant = newQVariant(result.view)
-  result.controller = controller.newController(result, events, settingsService, stickersService, nodeConfigurationService)
+  result.controller = controller.newController(result, events, settingsService, stickersService,
+    nodeConfigurationService, advancedService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
@@ -126,3 +129,17 @@ method setMaxLogBackups*(self: Module, value: int) =
 
 method onLogMaxBackupsChanged*(self: Module) =
   self.view.logMaxBackupsChanged()
+
+method getIsClearingOldLogs*(self: Module): bool =
+  return self.controller.getIsClearingOldLogs()
+
+method clearOldLogs*(self: Module) =
+  self.controller.clearOldLogs()
+
+method onOldLogsCleanupStarted*(self: Module) =
+  self.view.isClearingOldLogsChanged()
+
+method onOldLogsCleanupFinished*(self: Module, deletedCount, failedCount: int,
+    error: string) =
+  self.view.isClearingOldLogsChanged()
+  self.view.oldLogsCleanupFinished(deletedCount, failedCount, error)

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -99,6 +99,17 @@ QtObject:
   proc setMaxLogBackups*(self: View, value: int) {.slot.} =
     self.delegate.setMaxLogBackups(value)
 
+  proc isClearingOldLogsChanged*(self: View) {.signal.}
+  proc getIsClearingOldLogs*(self: View): bool {.slot.} =
+    return self.delegate.getIsClearingOldLogs()
+  QtProperty[bool] isClearingOldLogs:
+    read = getIsClearingOldLogs
+    notify = isClearingOldLogsChanged
+
+  proc oldLogsCleanupFinished*(self: View, deletedCount: int, failedCount: int, error: string) {.signal.}
+  proc clearOldLogs*(self: View) {.slot.} =
+    self.delegate.clearOldLogs()
+
   proc delete*(self: View) =
     self.QObject.delete
 

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -21,6 +21,7 @@ import ../../../../app_service/service/general/service as general_service
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/token/service as token_service
 import ../../../../app_service/service/node/service as node_service
+import ../../../../app_service/service/advanced/service as advanced_service
 
 import ./profile/module as profile_module
 import ./contacts/module as contacts_module
@@ -79,7 +80,8 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   communityService: community_service.Service,
   networkService: network_service.Service,
   tokenService: token_service.Service,
-  nodeService: node_service.Service
+  nodeService: node_service.Service,
+  advancedService: advanced_service.Service
 ): Module =
   result = Module()
   result.delegate = delegate
@@ -95,7 +97,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
     generalService)
   result.aboutModule = about_module.newModule(result, events, aboutService)
   result.advancedModule = advanced_module.newModule(result, events, settingsService, stickersService,
-    nodeConfigurationService)
+    nodeConfigurationService, advancedService)
   result.devicesModule = devices_module.newModule(result, events, settingsService, devicesService)
   result.syncModule = sync_module.newModule(result, events, settingsService, nodeConfigurationService,
     generalService, devicesService)

--- a/src/app_service/service/advanced/async_tasks.nim
+++ b/src/app_service/service/advanced/async_tasks.nim
@@ -1,0 +1,36 @@
+import std/[json, times]
+
+import chronicles
+
+import app/core/tasks/[qt, threadpool]
+import app/global/log_cleanup
+
+logScope:
+  topics = "advanced-app-service"
+
+type ClearOldLogsTaskArg* = ref object of QObjectTaskArg
+  logsDir*: string
+  dataDir*: string
+  processStartedAtUnix*: int64
+
+proc clearOldLogsTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[ClearOldLogsTaskArg](argEncoded)
+  try:
+    let result = cleanupLogFiles(
+      arg.logsDir,
+      arg.dataDir,
+      fromUnix(arg.processStartedAtUnix),
+      getTime(),
+      ClearClosedLogs)
+    arg.finish(%* {
+      "deletedCount": result.deletedCount,
+      "failedCount": result.failedCount,
+      "error": "",
+    })
+  except Exception as e:
+    error "failed to clear old log files", error = e.msg
+    arg.finish(%* {
+      "deletedCount": 0,
+      "failedCount": 0,
+      "error": e.msg,
+    })

--- a/src/app_service/service/advanced/service.nim
+++ b/src/app_service/service/advanced/service.nim
@@ -1,0 +1,67 @@
+import std/times
+
+import nimqml, json, chronicles
+
+import app/core/eventemitter
+import app/core/tasks/threadpool
+import app/global/log_cleanup
+import constants
+import ./async_tasks
+
+logScope:
+  topics = "advanced-app-service"
+
+const SIGNAL_ADVANCED_LOGS_CLEANUP_FINISHED* = "advancedLogsCleanupFinished"
+
+type AdvancedLogsCleanupFinishedArgs* = ref object of Args
+  deletedCount*: int
+  failedCount*: int
+  error*: string
+
+QtObject:
+  type Service* = ref object of QObject
+    events: EventEmitter
+    threadpool: ThreadPool
+    clearingOldLogs: bool
+
+  proc delete*(self: Service)
+  proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
+    new(result, delete)
+    result.QObject.setup
+    result.events = events
+    result.threadpool = threadpool
+    result.clearingOldLogs = false
+
+  proc isClearingOldLogs*(self: Service): bool =
+    return self.clearingOldLogs
+
+  proc clearOldLogs*(self: Service): bool =
+    if self.clearingOldLogs:
+      return false
+
+    self.clearingOldLogs = true
+    let arg = ClearOldLogsTaskArg(
+      tptr: clearOldLogsTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onOldLogsCleanupFinished",
+      logsDir: LOGDIR,
+      dataDir: STATUSGODIR,
+      processStartedAtUnix: logCleanupProcessStartedAt().toUnix)
+    self.threadpool.start(arg)
+    return true
+
+  proc onOldLogsCleanupFinished*(self: Service, response: string) {.slot.} =
+    var result = AdvancedLogsCleanupFinishedArgs()
+    try:
+      let responseObj = response.parseJson
+      result.deletedCount = responseObj{"deletedCount"}.getInt()
+      result.failedCount = responseObj{"failedCount"}.getInt()
+      result.error = responseObj{"error"}.getStr()
+    except Exception as e:
+      result.error = e.msg
+
+    self.clearingOldLogs = false
+    self.events.emit(SIGNAL_ADVANCED_LOGS_CLEANUP_FINISHED, result)
+
+  proc delete*(self: Service) =
+    self.QObject.delete

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -27,6 +27,8 @@ when defined(qmldebug):
 
 import app/global/global_singleton
 import app/global/app_lifecycle
+import app/global/log_cleanup
+import app/global/log_cleanup_tasks
 import app/boot/app_controller
 
 featureGuard KEYCARD_ENABLED:
@@ -236,6 +238,9 @@ proc mainProc() =
 
   ensureDirectories(DATADIR, TMPDIR, LOGDIR)
 
+  let logCleanupProcessStartedAt = getTime()
+  initializeLogCleanup(logCleanupProcessStartedAt)
+
   # Open the log file and set the log level before any subsystem starts logging.
   # On iOS the stdout sink is disabled (no valid stdout FILE*), so logs go to the
   # file sink only; opening it here guarantees every startup log has a valid sink
@@ -248,6 +253,8 @@ proc mainProc() =
   let statusAppIconPath = determineStatusAppIconPath()
 
   let statusFoundation = newStatusFoundation()
+  scheduleStartupLogCleanup(statusFoundation.threadpool, LOGDIR, STATUSGODIR,
+    logCleanupProcessStartedAt)
 
   # Required by the WalletConnectSDK view right after creating the QGuiApplication instance
   statusq_initializeWebEngine()

--- a/test/nim/log_cleanup_test.nim
+++ b/test/nim/log_cleanup_test.nim
@@ -1,0 +1,118 @@
+import std/[os, times, unittest]
+
+import app/core/tasks/threadpool
+import app/global/log_cleanup
+import app/global/log_cleanup_tasks
+
+proc removeTree(path: string) =
+  if not dirExists(path):
+    return
+
+  for kind, child in walkDir(path):
+    case kind
+    of pcDir:
+      removeTree(child)
+    else:
+      removeFile(child)
+  removeDir(path)
+
+proc writeLog(path: string, modifiedAt: Time) =
+  createDir(parentDir(path))
+  writeFile(path, "log")
+  setLastModificationTime(path, modifiedAt)
+
+suite "log cleanup":
+  var tempDir: string
+  var logsDir: string
+  var dataDir: string
+
+  setup:
+    tempDir = getTempDir() / ("status-log-cleanup-" & $getCurrentProcessId() & "-" & $epochTime())
+    logsDir = tempDir / "logs"
+    dataDir = tempDir / "data"
+    createDir(logsDir)
+    createDir(dataDir)
+
+  teardown:
+    removeTree(tempDir)
+
+  test "clear closed logs removes logs and preserves active files":
+    let processStartedAt = getTime()
+    let closedTime = processStartedAt - initDuration(hours = 1)
+    let activeTime = processStartedAt + initDuration(seconds = 1)
+    let closedAppLog = logsDir / "app-old.log"
+    let closedArchive = logsDir / "app-old.log.gz"
+    let activeAppLog = logsDir / "app-current.log"
+    let closedDataLog = dataDir / "geth.log"
+    let nestedClosedDataLog = dataDir / "keycard" / "keycard.log"
+    let activeDataLog = dataDir / "pre_login.log"
+    let dataFile = dataDir / "node-config.json"
+
+    writeLog(closedAppLog, closedTime)
+    writeLog(closedArchive, closedTime)
+    writeLog(activeAppLog, activeTime)
+    writeLog(closedDataLog, closedTime)
+    writeLog(nestedClosedDataLog, closedTime)
+    writeLog(activeDataLog, activeTime)
+    writeFile(dataFile, "config")
+
+    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt, processStartedAt,
+      ClearClosedLogs)
+
+    check result.deletedCount == 4
+    check result.failedCount == 0
+    check not fileExists(closedAppLog)
+    check not fileExists(closedArchive)
+    check not fileExists(closedDataLog)
+    check not fileExists(nestedClosedDataLog)
+    check fileExists(activeAppLog)
+    check fileExists(activeDataLog)
+    check fileExists(dataFile)
+
+  test "retention removes only closed logs older than two weeks":
+    let processStartedAt = getTime()
+    let expiredTime = processStartedAt - initDuration(days = LogRetentionDays + 1)
+    let recentTime = processStartedAt - initDuration(days = LogRetentionDays - 1)
+    let activeTime = processStartedAt + initDuration(seconds = 1)
+    let expiredAppLog = logsDir / "app-expired.log"
+    let recentAppLog = logsDir / "app-recent.log"
+    let expiredDataLog = dataDir / "geth.log"
+    let recentDataLog = dataDir / "nested" / "keycard.log"
+    let activeDataLog = dataDir / "pre_login.log"
+
+    writeLog(expiredAppLog, expiredTime)
+    writeLog(recentAppLog, recentTime)
+    writeLog(expiredDataLog, expiredTime)
+    writeLog(recentDataLog, recentTime)
+    writeLog(activeDataLog, activeTime)
+
+    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt, processStartedAt,
+      RemoveExpiredLogs)
+
+    check result.deletedCount == 2
+    check result.failedCount == 0
+    check not fileExists(expiredAppLog)
+    check not fileExists(expiredDataLog)
+    check fileExists(recentAppLog)
+    check fileExists(recentDataLog)
+    check fileExists(activeDataLog)
+
+  test "missing log directories are ignored":
+    let currentTime = getTime()
+    let missingLogsDir = tempDir / "missing-logs"
+    let missingDataDir = tempDir / "missing-data"
+    let result = cleanupLogFiles(missingLogsDir, missingDataDir, currentTime, currentTime, ClearClosedLogs)
+
+    check result.deletedCount == 0
+    check result.failedCount == 0
+
+  test "startup retention runs on the shared thread pool":
+    let processStartedAt = getTime()
+    let expiredLog = logsDir / "app-expired.log"
+    writeLog(expiredLog, processStartedAt - initDuration(days = LogRetentionDays + 1))
+    let threadpool = newThreadPool()
+
+    scheduleStartupLogCleanup(threadpool, logsDir, dataDir, processStartedAt)
+    threadpool.teardown()
+
+    check not fileExists(expiredLog)

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -21,6 +21,7 @@ QtObject {
     property bool isDebugEnabled: advancedModule? advancedModule.isDebugEnabled : false
     property int logMaxBackups: advancedModule ? advancedModule.logMaxBackups : 1
     property bool isRuntimeLogLevelSet: advancedModule ? advancedModule.isRuntimeLogLevelSet: false
+    property bool isClearingOldLogs: advancedModule ? advancedModule.isClearingOldLogs : false
     readonly property int archiveProtocolMode: advancedModule ? advancedModule.archiveProtocolMode : AdvancedStore.ArchiveProtocolMode.Disabled
     readonly property string archiveProtocolModeLabel: {
         switch (root.archiveProtocolMode) {
@@ -38,6 +39,16 @@ QtObject {
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []
 
     property bool isManageCommunityOnTestModeEnabled: false
+
+    signal oldLogsCleanupFinished(int deletedCount, int failedCount, string error)
+
+    readonly property Connections oldLogsCleanupConnection: Connections {
+        target: root.advancedModule
+
+        function onOldLogsCleanupFinished(deletedCount, failedCount, error) {
+            root.oldLogsCleanupFinished(deletedCount, failedCount, error)
+        }
+    }
 
     readonly property QtObject experimentalFeatures: QtObject {
         readonly property string browser: "browser"
@@ -102,6 +113,13 @@ QtObject {
             return
 
         root.advancedModule.setMaxLogBackups(value)
+    }
+
+    function clearOldLogs() {
+        if(!root.advancedModule)
+            return
+
+        root.advancedModule.clearOldLogs()
     }
 
     function toggleExperimentalFeature(feature) {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -57,6 +57,27 @@ SettingsContentBase {
         QtObject {
             id: d
             readonly property string experimentalFeatureMessage: qsTr("This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.")
+
+            function showOldLogsCleanupResult(deletedCount, failedCount, error) {
+                if (error !== "" || failedCount > 0) {
+                    Global.displayToastMessage(
+                                qsTr("Some old log files could not be cleared"),
+                                "", "warning", false, Constants.ephemeralNotificationType.danger, "")
+                    return
+                }
+
+                Global.displayToastMessage(
+                            deletedCount > 0 ? qsTr("%n old log file(s) cleared", "", deletedCount) : qsTr("No old log files to clear"),
+                            "", "checkmark-circle", false, Constants.ephemeralNotificationType.success, "")
+            }
+        }
+
+        Connections {
+            target: root.advancedStore
+
+            function onOldLogsCleanupFinished(deletedCount, failedCount, error) {
+                d.showOldLogsCleanupResult(deletedCount, failedCount, error)
+            }
         }
 
         Column {
@@ -140,6 +161,27 @@ SettingsContentBase {
                         }
                         Qt.openUrlExternally(UrlUtils.urlFromUserInput(root.advancedStore.logDir()))
                     }
+                }
+            }
+
+            RowLayout {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: Theme.padding
+                anchors.rightMargin: Theme.padding
+                height: 64
+                spacing: Theme.padding
+
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    text: qsTr("Old logs")
+                    elide: Text.ElideRight
+                }
+
+                StatusButton {
+                    text: root.advancedStore.isClearingOldLogs ? qsTr("Clearing...") : qsTr("Clear old logs")
+                    enabled: !root.advancedStore.isClearingOldLogs
+                    onClicked: clearOldLogsConfirmation.open()
                 }
             }
 
@@ -487,6 +529,18 @@ SettingsContentBase {
             onCancelButtonClicked: {
                 close()
             }
+        }
+
+        ConfirmationDialog {
+            id: clearOldLogsConfirmation
+            showCancelButton: true
+            confirmationText: qsTr("Are you sure you want to clear old log files?")
+            confirmButtonLabel: qsTr("Clear old logs")
+            onConfirmButtonClicked: {
+                root.advancedStore.clearOldLogs()
+                close()
+            }
+            onCancelButtonClicked: close()
         }
 
         ScrollingModal {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1126,6 +1126,33 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Some old log files could not be cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No old log files to clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n old log file(s) cleared</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Old logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clearing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear old logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Archive Protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1195,6 +1222,10 @@
     </message>
     <message>
         <source>Change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear old log files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1129,6 +1129,34 @@
         <translation>Ladění</translation>
     </message>
     <message>
+        <source>Some old log files could not be cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No old log files to clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n old log file(s) cleared</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Old logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clearing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear old logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Archive Protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1199,6 +1227,10 @@
     <message>
         <source>Change</source>
         <translation>Změnit</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear old log files?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disabled</source>

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -27,6 +27,16 @@
     </message>
 </context>
 <context>
+    <name>AdvancedView</name>
+    <message numerus="yes">
+        <source>%n old log file(s) cleared</source>
+        <translation>
+            <numerusform>%n old log file cleared</numerusform>
+            <numerusform>%n old log files cleared</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
     <name>AirdropRecipientsSelector</name>
     <message numerus="yes">
         <source>%n recipient(s)</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1126,6 +1126,33 @@
         <translation>Depuración</translation>
     </message>
     <message>
+        <source>Some old log files could not be cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No old log files to clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n old log file(s) cleared</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Old logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clearing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear old logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Archive Protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1196,6 +1223,10 @@
     <message>
         <source>Change</source>
         <translation>Cambiar</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear old log files?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disabled</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1123,6 +1123,32 @@
         <translation>디버그</translation>
     </message>
     <message>
+        <source>Some old log files could not be cleared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No old log files to clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n old log file(s) cleared</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Old logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clearing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear old logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Archive Protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1193,6 +1219,10 @@
     <message>
         <source>Change</source>
         <translation>변경</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear old log files?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disabled</source>


### PR DESCRIPTION
### What does the PR do

Fixes #21151

Add a Clear old logs action to Advanced settings that deletes closed log files while preserving logs from the active session.

Run asynchronous startup retention to remove closed log files older than 14 days from the application log and data directories.

### Affected areas

- AdvancedView
- Advanced module
- New Advanced service
- New clear logs tasks

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring

### Screencapture of the functionality

[clear-logs.webm](https://github.com/user-attachments/assets/dc98a639-8dd9-40d2-a50c-76c644f45c44)

### Impact on end user

Cleans the logs automatically to keep the storage low + less things to share when sharing logs.

### How to test

Go to Advanced Settings and click the button

### Risk 

Low
