### PR TITLE
perf(wallet): load panel content asynchronously with skeletons

### DIFF
--- a/storybook/qmlTests/tests/tst_AccountOrderSync.qml
+++ b/storybook/qmlTests/tests/tst_AccountOrderSync.qml
@@ -112,8 +112,9 @@ Item {
         }
 
         function verifyWalletOrder(expectedTitles) {
+            // the accounts list builds behind an asynchronous Loader
+            tryVerify(() => !!findChild(walletView(), "walletAccountsListView"))
             const listView = findChild(walletView(), "walletAccountsListView")
-            verify(!!listView)
             waitForRendering(listView)
             tryVerify(() => {
                 if (listView.count !== expectedTitles.length)

--- a/storybook/qmlTests/tests/tst_LeftTabView.qml
+++ b/storybook/qmlTests/tests/tst_LeftTabView.qml
@@ -79,8 +79,9 @@ Item {
         }
 
         function verifyWalletOrder(expectedTitles) {
+            // the accounts list builds behind an asynchronous Loader
+            tryVerify(() => !!findChild(controlUnderTest, "walletAccountsListView"))
             const listView = findChild(controlUnderTest, "walletAccountsListView")
-            verify(!!listView)
             waitForRendering(listView)
             tryVerify(() => {
                 if (listView.count !== expectedTitles.length)

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import QtCore
 
 import StatusQ
 import StatusQ.Layout
@@ -34,13 +33,34 @@ import "popups/buy"
 Item {
     id: root
 
-    // --- Back-navigation contract, forwarded to the inner StatusSectionLayout
-    // (walletSectionLayout). This Item wrapper would otherwise be a dead-end
-    // for AppMain's Link 2 on desktop. See AppMain.tryGoBack().
+    // The section chrome (StatusSectionLayout) is owned by WalletLoader; it is
+    // injected here so the existing panel hook-ups keep their call sites.
+    property StatusSectionLayout sectionLayout
+
+    // --- Back-navigation contract, forwarded to the loader-owned chrome.
+    // This Item wrapper would otherwise be a dead-end for AppMain's Link 2 on
+    // desktop. See AppMain.tryGoBack().
     function tryGoBack() {
-        return walletSectionLayout.tryGoBack()
+        return root.sectionLayout?.tryGoBack() ?? false
     }
-    readonly property bool canGoBack: walletSectionLayout.canGoBack
+    readonly property bool canGoBack: root.sectionLayout?.canGoBack ?? false
+
+    // Consumed by the chrome in WalletLoader
+    readonly property string backButtonName: RootStore.backButtonName
+
+    function handleBackButtonClicked() {
+        if (rightPanelStackView.currentItem && !!rightPanelStackView.currentItem.resetStack) {
+            rightPanelStackView.currentItem.resetStack()
+        }
+    }
+
+    // Subsection back history keyed by the selected account. Navigates via
+    // d.displayAddress (not changeSelectedAccount, which advances the panel).
+    readonly property var subsectionHistory: StatusQUtils.SubsectionNavigationHistory {
+        currentKey: RootStore.selectedAddress
+        validateFn: (address) => StatusQUtils.ModelUtils.indexOf(RootStore.accounts, "address", address) >= 0
+        onNavigateRequested: (address) => d.displayAddress(address)
+    }
 
     property WalletStores.RootStore walletRootStore
     property SharedStores.RootStore sharedRootStore
@@ -73,17 +93,6 @@ Item {
     signal sendTokenRequested(string senderAddress, string groupKey, int tokenType)
 
     signal openSwapModalRequested(var swapFormData)
-
-    // Layout interaction:
-    /*!
-        \qmlproperty int StatusSectionLayoutLandscape::leftPanelWidthOverride
-        This property provides an external override for the left panel width.
-
-        When greater than 0, the layout uses this value to temporarily expand the
-        left panel area. When set to 0, the override is cleared and the layout
-        collapses the left panel back to its default width.
-    */
-    property int leftPanelWidthOverride: 0
 
     onAppMainVisibleChanged: {
         resetView()
@@ -183,7 +192,7 @@ Item {
         }
 
         // In portrait mode, it automatically swipes to the detailed content
-        walletSectionLayout.goToNextPanel()
+        root.sectionLayout?.goToNextPanel()
     }
 
     QtObject {
@@ -351,26 +360,9 @@ Item {
         accountBalanceNotAvailableText: root.networkConnectionStore.accountBalanceNotAvailableText
     }
 
-    StatusSectionLayout {
-        id: walletSectionLayout
-        currentIndex: 1
-        anchors.fill: parent
-        backButtonName: RootStore.backButtonName
-        onBackButtonClicked: {
-            if (rightPanelStackView.currentItem && !!rightPanelStackView.currentItem.resetStack) {
-                rightPanelStackView.currentItem.resetStack()
-            }
-        }
-
-        // Subsection back history keyed by the selected account. Navigates via
-        // d.displayAddress (not changeSelectedAccount, which advances the panel).
-        subsectionHistory: StatusQUtils.SubsectionNavigationHistory {
-            currentKey: RootStore.selectedAddress
-            validateFn: (address) => StatusQUtils.ModelUtils.indexOf(RootStore.accounts, "address", address) >= 0
-            onNavigateRequested: (address) => d.displayAddress(address)
-        }
-
-        leftPanel: LeftTabView {
+    // Panels are constructed and wired here, but presented by the loader-owned
+    // chrome (LayoutItemProxy targets); they have no visual parent until then.
+    readonly property Item leftPanel: LeftTabView {
             id: leftTab
             anchors.fill: parent
             viewState: leftPanelState
@@ -386,24 +378,24 @@ Item {
                 root.walletRootStore.authenticateLoggedInUser(requestedBy)
 
             onAccountSelected: address => {
-                walletSectionLayout.goToNextPanel()
+                root.sectionLayout?.goToNextPanel()
                 d.displayAddress(address)
             }
             onAllAccountsSelected: {
-                walletSectionLayout.goToNextPanel()
+                root.sectionLayout?.goToNextPanel()
                 d.displayAllAddresses()
             }
             onSavedAddressesSelected: {
-                walletSectionLayout.goToNextPanel()
+                root.sectionLayout?.goToNextPanel()
                 d.displaySavedAddresses()
             }
             onFollowingAddressesSelected: {
-                walletSectionLayout.goToNextPanel()
+                root.sectionLayout?.goToNextPanel()
                 d.displayFollowingAddresses()
             }
         }
 
-        centerPanel: StackView {
+    readonly property Item centerPanel: StackView {
             id: rightPanelStackView
             anchors.fill: parent
             anchors.leftMargin: Theme.xlPadding * 2
@@ -416,12 +408,12 @@ Item {
                 NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 400; easing.type: Easing.OutCubic }
             }
         }
-        headerBackground: AccountHeaderGradient {
+    readonly property Item headerBackground: AccountHeaderGradient {
             width: parent ? parent.width : 0
             overview: RootStore.overview
         }
 
-        footer: WalletFooter {
+    readonly property Item footer: WalletFooter {
             id: footer
 
             visible: anyActionAvailable
@@ -457,10 +449,6 @@ Item {
             onLaunchBuyCryptoModal: d.launchBuyCryptoModal()
         }
 
-        // Layout
-        leftPanelWidthOverride: root.leftPanelWidthOverride
-    }
-
     Loader {
         id: addAccount
         active: false
@@ -487,11 +475,5 @@ Item {
         onLoaded: {
             keypairImport.item.open()
         }
-    }
-
-    Settings {
-        id: walletLocalSettings
-        category: "WalletLocalSettings_%1".arg(userProfile.pubKey)
-        property alias selectedPanelIndex: walletSectionLayout.currentIndex
     }
 }

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -250,15 +250,19 @@ Rectangle {
             Layout.fillHeight: true
             Layout.fillWidth: true
 
-            // Skeleton mimicking the accounts list, shown while the ListView incubates
-            WalletAccountsSkeleton {
+            // Skeleton mimicking the accounts list, shown while the ListView
+            // incubates and released afterwards: an alive invisible skeleton
+            // re-evaluates its tile geometry on every resize
+            Loader {
                 anchors {
                     top: parent.top
                     left: parent.left
                     right: parent.right
                     margins: Theme.padding
                 }
-                visible: walletAccountsListViewLoader.status !== Loader.Ready
+                active: walletAccountsListViewLoader.status !== Loader.Ready
+                visible: active
+                sourceComponent: WalletAccountsSkeleton {}
             }
 
             Loader {

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -18,6 +18,7 @@ import shared.controls
 import shared.popups
 
 import "../controls"
+import "../panels"
 import "../popups"
 import "../stores"
 
@@ -55,6 +56,9 @@ Rectangle {
         readonly property string removeAccountIdentifier: "wallet-section-remove-account"
         readonly property real bottomSafeMargin: root.SafeArea.margins.bottom
         readonly property real footerHeight: footer.height + followingAddressesFooter.height
+
+        // null until the async loader finishes; consumers must fall back gracefully
+        readonly property var accountsListView: walletAccountsListViewLoader.item
     }
 
     Loader {
@@ -231,7 +235,7 @@ Rectangle {
             color: root.color
             z: 2
 
-            layer.enabled: !walletAccountsListView.atYBeginning
+            layer.enabled: !(d.accountsListView?.atYBeginning ?? true)
             layer.effect: DropShadow {
                 verticalOffset: 10
                 radius: 20
@@ -246,9 +250,21 @@ Rectangle {
             Layout.fillHeight: true
             Layout.fillWidth: true
 
-            StatusListView {
-                id: walletAccountsListView
-                objectName: "walletAccountsListView"
+            // Skeleton mimicking the accounts list, shown while the ListView incubates
+            WalletAccountsSkeleton {
+                anchors {
+                    top: parent.top
+                    left: parent.left
+                    right: parent.right
+                    margins: Theme.padding
+                }
+                visible: walletAccountsListViewLoader.status !== Loader.Ready
+            }
+
+            Loader {
+                id: walletAccountsListViewLoader
+                asynchronous: true
+                visible: status === Loader.Ready
                 anchors {
                     top: parent.top
                     left: parent.left
@@ -256,144 +272,149 @@ Rectangle {
                 }
                 height: Math.max(0, parent.height - d.footerHeight)
 
-                spacing: Theme.smallPadding
-                currentIndex: -1
-                highlightRangeMode: ListView.ApplyRange
-                preferredHighlightBegin: 0
-                preferredHighlightEnd: height
-                bottomMargin: Theme.padding
-                verticalScrollBar.implicitWidth: Math.max(Theme.halfPadding, 8)
+                sourceComponent: StatusListView {
+                    id: walletAccountsListView
+                    objectName: "walletAccountsListView"
 
-                readonly property Item firstItem: count > 0 ? itemAtIndex(0) : null
-                readonly property bool footerOverlayed: d.loaded && contentHeight > availableHeight
+                    spacing: Theme.smallPadding
+                    currentIndex: -1
+                    highlightRangeMode: ListView.ApplyRange
+                    preferredHighlightBegin: 0
+                    preferredHighlightEnd: height
+                    bottomMargin: Theme.padding
+                    verticalScrollBar.implicitWidth: Math.max(Theme.halfPadding, 8)
 
-                delegate: StatusListItem {
-                    objectName: "walletAccountListItem"
-                    readonly property bool itemLoaded: !model.assetsLoading // needed for e2e tests
-                    width: ListView.view.width - Theme.padding * 2
-                    highlighted: viewState.selectedAddress.toLowerCase() === model.address.toLowerCase()
-                    onHighlightedChanged: {
-                        if (highlighted)
-                            ListView.view.currentIndex = index
-                    }
-                    anchors.horizontalCenter: !!parent ? parent.horizontalCenter : undefined
-                    title: model.name
-                    subTitle: !model.hideFromTotalBalance ? LocaleUtils.currencyAmountToLocaleString(model.currencyBalance): ""
-                    asset.emoji: !!model.emoji ? model.emoji: ""
-                    asset.color: Utils.getColorForId(Theme.palette, model.colorId)
-                    asset.name: !model.emoji ? "filled-account": ""
-                    asset.width: 40
-                    asset.height: 40
-                    asset.letterSize: 14
-                    asset.isLetterIdenticon: !!model.emoji ? true : false
-                    asset.bgColor: Theme.palette.primaryColor3
-                    statusListItemTitle.font.weight: Font.Medium
-                    color: sensor.containsMouse || highlighted ? Theme.palette.baseColor3 : "transparent"
-                    statusListItemSubTitle.loading: !!model.assetsLoading
-                    errorMode: viewState.accountBalanceNotAvailable
-                    errorIcon.tooltip.maxWidth: 300
-                    errorIcon.tooltip.text: viewState.accountBalanceNotAvailableText
-                    onClicked: function(itemId, mouse) {
-                        if (mouse.button === Qt.RightButton) {
-                            walletAccountContextMenu.active = true
-                            walletAccountContextMenu.item.account = model
-                            walletAccountContextMenu.item.popup(this, mouse.x, mouse.y)
-                            return
+                    readonly property Item firstItem: count > 0 ? itemAtIndex(0) : null
+                    readonly property bool footerOverlayed: d.loaded && contentHeight > availableHeight
+
+                    delegate: StatusListItem {
+                        objectName: "walletAccountListItem"
+                        readonly property bool itemLoaded: !model.assetsLoading // needed for e2e tests
+                        width: ListView.view.width - Theme.padding * 2
+                        highlighted: viewState.selectedAddress.toLowerCase() === model.address.toLowerCase()
+                        onHighlightedChanged: {
+                            if (highlighted)
+                                ListView.view.currentIndex = index
                         }
-                        root.accountSelected(model.address)
-                    }
-                    components: [
-                        StatusIcon {
-                            width: !!icon ? 15: 0
-                            height: !!icon ? 15: 0
-                            color: Theme.palette.directColor1
-                            icon: model.walletType === Constants.watchWalletType ? "show" : ""
-                        },
-                        StatusIcon {
-                            width: !!icon ? 15: 0
-                            height: !!icon ? 15: 0
-                            color: Theme.palette.directColor1
-                            icon: model.migratedToColdWallet ? "keycard" : ""
-                        }
-                    ]
-                }
-
-                header: StatusFlatButton {
-                    id: header
-                    verticalPadding: Theme.padding
-                    horizontalPadding: Theme.padding
-                    highlighted: viewState.showAllAccounts
-                    objectName: "allAccountsBtn"
-
-                    leftInset: Theme.padding
-                    bottomInset: Theme.padding
-                    leftPadding: Theme.xlPadding
-                    bottomPadding: Theme.bigPadding
-
-                    background: Rectangle {
-                        radius: Theme.radius
-                        color: header.highlighted || header.hovered ? Theme.palette.backgroundHover : root.color
-                        implicitWidth: parent.ListView.view.width - Theme.padding * 2
-                    }
-
-                    onClicked: root.allAccountsSelected()
-
-                    contentItem: ColumnLayout {
-                        spacing: 0
-                        StatusBaseText {
-                            id: allAccounts
-                            color: Theme.palette.baseColor1
-                            text: qsTr("All accounts")
-                            font.weight: Font.Medium
-                            font.pixelSize: Theme.primaryTextFontSize
-                            lineHeightMode: Text.FixedHeight
-                            lineHeight: 22
-                        }
-                        RowLayout {
-                            spacing: 4
-                            StatusTextWithLoadingState {
-                                id: walletAmountValue
-                                objectName: "walletLeftListAmountValue"
-                                customColor: Theme.palette.textColor
-                                text: viewState.totalCurrencyBalance
-                                      ? LocaleUtils.currencyAmountToLocaleString(viewState.totalCurrencyBalance, {noSymbol: true})
-                                      : ""
-                                font.pixelSize: Theme.fontSize(22)
-                                loading: viewState.balanceLoading
-                                lineHeightMode: Text.FixedHeight
-                                lineHeight: 36
-                                verticalAlignment: Text.AlignVCenter
+                        anchors.horizontalCenter: !!parent ? parent.horizontalCenter : undefined
+                        title: model.name
+                        subTitle: !model.hideFromTotalBalance ? LocaleUtils.currencyAmountToLocaleString(model.currencyBalance): ""
+                        asset.emoji: !!model.emoji ? model.emoji: ""
+                        asset.color: Utils.getColorForId(Theme.palette, model.colorId)
+                        asset.name: !model.emoji ? "filled-account": ""
+                        asset.width: 40
+                        asset.height: 40
+                        asset.letterSize: 14
+                        asset.isLetterIdenticon: !!model.emoji ? true : false
+                        asset.bgColor: Theme.palette.primaryColor3
+                        statusListItemTitle.font.weight: Font.Medium
+                        color: sensor.containsMouse || highlighted ? Theme.palette.baseColor3 : "transparent"
+                        statusListItemSubTitle.loading: !!model.assetsLoading
+                        errorMode: viewState.accountBalanceNotAvailable
+                        errorIcon.tooltip.maxWidth: 300
+                        errorIcon.tooltip.text: viewState.accountBalanceNotAvailableText
+                        onClicked: function(itemId, mouse) {
+                            if (mouse.button === Qt.RightButton) {
+                                walletAccountContextMenu.active = true
+                                walletAccountContextMenu.item.account = model
+                                walletAccountContextMenu.item.popup(this, mouse.x, mouse.y)
+                                return
                             }
-                            StatusTextWithLoadingState {
-                                customColor: Theme.palette.textColor
-                                text: viewState.totalCurrencyBalance ? viewState.totalCurrencyBalance.symbol : ""
-                                font.pixelSize: Theme.additionalTextSize
-                                loading: viewState.balanceLoading
+                            root.accountSelected(model.address)
+                        }
+                        components: [
+                            StatusIcon {
+                                width: !!icon ? 15: 0
+                                height: !!icon ? 15: 0
+                                color: Theme.palette.directColor1
+                                icon: model.walletType === Constants.watchWalletType ? "show" : ""
+                            },
+                            StatusIcon {
+                                width: !!icon ? 15: 0
+                                height: !!icon ? 15: 0
+                                color: Theme.palette.directColor1
+                                icon: model.migratedToColdWallet ? "keycard" : ""
+                            }
+                        ]
+                    }
+
+                    header: StatusFlatButton {
+                        id: header
+                        verticalPadding: Theme.padding
+                        horizontalPadding: Theme.padding
+                        highlighted: viewState.showAllAccounts
+                        objectName: "allAccountsBtn"
+
+                        leftInset: Theme.padding
+                        bottomInset: Theme.padding
+                        leftPadding: Theme.xlPadding
+                        bottomPadding: Theme.bigPadding
+
+                        background: Rectangle {
+                            radius: Theme.radius
+                            color: header.highlighted || header.hovered ? Theme.palette.backgroundHover : root.color
+                            implicitWidth: parent.ListView.view.width - Theme.padding * 2
+                        }
+
+                        onClicked: root.allAccountsSelected()
+
+                        contentItem: ColumnLayout {
+                            spacing: 0
+                            StatusBaseText {
+                                id: allAccounts
+                                color: Theme.palette.baseColor1
+                                text: qsTr("All accounts")
                                 font.weight: Font.Medium
+                                font.pixelSize: Theme.primaryTextFontSize
                                 lineHeightMode: Text.FixedHeight
                                 lineHeight: 22
-                                verticalAlignment: Text.AlignBottom
                             }
-                            visible: !viewState.accountBalanceNotAvailable
-                        }
-                        StatusFlatRoundButton {
-                            id: errorIcon
-                            Layout.preferredWidth: 14
-                            Layout.preferredHeight: 14
-                            icon.width: 14
-                            icon.height: 14
-                            icon.name: "tiny/warning"
-                            icon.color: Theme.palette.dangerColor1
-                            tooltip.text: viewState.accountBalanceNotAvailableText
-                            tooltip.maxWidth: 200
-                            visible: viewState.accountBalanceNotAvailable
+                            RowLayout {
+                                spacing: 4
+                                StatusTextWithLoadingState {
+                                    id: walletAmountValue
+                                    objectName: "walletLeftListAmountValue"
+                                    customColor: Theme.palette.textColor
+                                    text: viewState.totalCurrencyBalance
+                                        ? LocaleUtils.currencyAmountToLocaleString(viewState.totalCurrencyBalance, {noSymbol: true})
+                                        : ""
+                                    font.pixelSize: Theme.fontSize(22)
+                                    loading: viewState.balanceLoading
+                                    lineHeightMode: Text.FixedHeight
+                                    lineHeight: 36
+                                    verticalAlignment: Text.AlignVCenter
+                                }
+                                StatusTextWithLoadingState {
+                                    customColor: Theme.palette.textColor
+                                    text: viewState.totalCurrencyBalance ? viewState.totalCurrencyBalance.symbol : ""
+                                    font.pixelSize: Theme.additionalTextSize
+                                    loading: viewState.balanceLoading
+                                    font.weight: Font.Medium
+                                    lineHeightMode: Text.FixedHeight
+                                    lineHeight: 22
+                                    verticalAlignment: Text.AlignBottom
+                                }
+                                visible: !viewState.accountBalanceNotAvailable
+                            }
+                            StatusFlatRoundButton {
+                                id: errorIcon
+                                Layout.preferredWidth: 14
+                                Layout.preferredHeight: 14
+                                icon.width: 14
+                                icon.height: 14
+                                icon.name: "tiny/warning"
+                                icon.color: Theme.palette.dangerColor1
+                                tooltip.text: viewState.accountBalanceNotAvailableText
+                                tooltip.maxWidth: 200
+                                visible: viewState.accountBalanceNotAvailable
+                            }
                         }
                     }
-                }
 
-                model: SortFilterProxyModel {
-                    sourceModel: viewState.accountsModel
-                    sorters: RoleSorter { roleName: "position"; sortOrder: Qt.AscendingOrder }
+                    model: SortFilterProxyModel {
+                        sourceModel: viewState.accountsModel
+                        sorters: RoleSorter { roleName: "position"; sortOrder: Qt.AscendingOrder }
+                    }
                 }
             }
 
@@ -402,8 +423,14 @@ Rectangle {
 
                 anchors {
                     top: parent.top
-                    // Bottom Margin is not applied to ListView if it's fully visible
-                    topMargin: Math.min(walletAccountsListView.contentHeight, parent.height - d.footerHeight) + (walletAccountsListView.footerOverlayed ? 0 : walletAccountsListView.bottomMargin)
+                    // Bottom Margin is not applied to ListView if it's fully visible;
+                    // while the list is still loading, keep the footer at the bottom
+                    topMargin: {
+                        const listView = d.accountsListView
+                        if (!listView)
+                            return parent.height - d.footerHeight
+                        return Math.min(listView.contentHeight, parent.height - d.footerHeight) + (listView.footerOverlayed ? 0 : listView.bottomMargin)
+                    }
                     left: parent.left
                     right: parent.right
                 }
@@ -415,9 +442,9 @@ Rectangle {
                     id: footerBackground
                     color: root.color
                     implicitWidth: root.width
-                    implicitHeight: (walletAccountsListView.firstItem?.height ?? Theme.xlPadding*2) + Theme.xlPadding
+                    implicitHeight: (d.accountsListView?.firstItem?.height ?? Theme.xlPadding*2) + Theme.xlPadding
 
-                    layer.enabled: walletAccountsListView.footerOverlayed && !walletAccountsListView.atYEnd
+                    layer.enabled: (d.accountsListView?.footerOverlayed ?? false) && !(d.accountsListView?.atYEnd ?? true)
                     layer.effect: DropShadow {
                         verticalOffset: -10
                         radius: 20
@@ -447,7 +474,7 @@ Rectangle {
                     isRoundIcon: true
                     textColor: Theme.palette.directColor1
                     textFillWidth: true
-                    spacing: walletAccountsListView.firstItem?.statusListItemTitleArea.anchors.leftMargin ?? Theme.padding
+                    spacing: d.accountsListView?.firstItem?.statusListItemTitleArea.anchors.leftMargin ?? Theme.padding
                     onClicked: root.savedAddressesSelected()
                 }
             }
@@ -478,7 +505,7 @@ Rectangle {
                     isRoundIcon: true
                     textColor: Theme.palette.directColor1
                     textFillWidth: true
-                    spacing: walletAccountsListView.firstItem?.statusListItemTitleArea.anchors.leftMargin ?? Theme.padding
+                    spacing: d.accountsListView?.firstItem?.statusListItemTitleArea.anchors.leftMargin ?? Theme.padding
                     onClicked: root.followingAddressesSelected()
                 }
             }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -319,11 +319,132 @@ RightTabBaseView {
                 }
             }
 
+            // Per-tab skeleton shown while the tab view incubates; takes the
+            // loader's layout slot while the loader is hidden. Built from plain
+            // LoadingComponent shapes — the real loading delegates
+            // (LoadingTokenDelegate & co) are too expensive to create here.
+            Loader {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.topMargin: Theme.padding
+                active: mainViewLoader.status !== Loader.Ready
+                visible: active
+                sourceComponent: {
+                    switch (walletTabBar.currentIndex) {
+                    case RightTabView.TabIndex.Collectibles:
+                        return collectiblesSkeleton
+                    case RightTabView.TabIndex.Activity:
+                        return activitySkeleton
+                    default:
+                        return assetsSkeleton
+                    }
+                }
+            }
+
+            Component {
+                id: assetsSkeleton
+
+                WalletAssetListSkeleton {}
+            }
+
+            // cell metrics mirror CollectiblesView
+            Component {
+                id: collectiblesSkeleton
+
+                LoadingSkeletonGroup {
+                    id: collectiblesSkeletonRoot
+
+                    readonly property bool compact: width < 600
+                    readonly property int itemSpacing: compact ? Theme.halfPadding : 0
+                    readonly property int cellWidth: compact ? Math.floor(width / 3) : 176
+                    readonly property int cellHeight: compact ? cellWidth + 49 : 225
+
+                    Flow {
+                        anchors.fill: parent
+                        spacing: collectiblesSkeletonRoot.itemSpacing
+
+                        Repeater {
+                            model: 6
+                            ColumnLayout {
+                                width: collectiblesSkeletonRoot.cellWidth - collectiblesSkeletonRoot.itemSpacing
+                                height: collectiblesSkeletonRoot.cellHeight - collectiblesSkeletonRoot.itemSpacing
+                                spacing: Theme.halfPadding
+
+                                LoadingSkeletonTile {
+                                    Layout.fillWidth: true
+                                    Layout.fillHeight: true
+                                    radius: Theme.radius
+                                }
+                                LoadingSkeletonTile {
+                                    implicitWidth: 90
+                                    implicitHeight: 14
+                                }
+                                LoadingSkeletonTile {
+                                    Layout.bottomMargin: Theme.halfPadding
+                                    implicitWidth: 60
+                                    implicitHeight: 12
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: activitySkeleton
+
+                LoadingSkeletonGroup {
+                    ColumnLayout {
+                        anchors {
+                            top: parent.top
+                            left: parent.left
+                            right: parent.right
+                        }
+                        spacing: Theme.padding
+
+                        Repeater {
+                            model: 6
+                            RowLayout {
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: 56
+                                spacing: Theme.padding
+
+                                LoadingSkeletonTile {
+                                    implicitWidth: 32
+                                    implicitHeight: 32
+                                    radius: width / 2
+                                }
+                                ColumnLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.halfPadding
+
+                                    LoadingSkeletonTile {
+                                        implicitWidth: 140
+                                        implicitHeight: 14
+                                    }
+                                    LoadingSkeletonTile {
+                                        implicitWidth: 100
+                                        implicitHeight: 12
+                                    }
+                                }
+                                LoadingSkeletonTile {
+                                    Layout.alignment: Qt.AlignRight
+                                    implicitWidth: 70
+                                    implicitHeight: 14
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             Loader {
                 id: mainViewLoader
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 Layout.topMargin: Theme.padding
+                asynchronous: true
+                visible: status === Loader.Ready
                 sourceComponent: d.walletViewsMap[walletTabBar.currentIndex]
 
                 Component {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1300,7 +1300,7 @@ Item {
                 profileLoader.settingsSubsection = subsection || Constants.settingsSubsection.profile
                 profileLoader.forceSubsectionNavigation()
             } else if (sectionType === Constants.appSection.wallet) {
-                appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(subsection, subSubsection, data)
+                appView.children[Constants.appViewStackIndex.wallet].openDesiredView(subsection, subSubsection, data)
             } else if (sectionType === Constants.appSection.swap) {
                 popupRequestsHandler.launchSwap()
             } else if (sectionType === Constants.appSection.chat) {

--- a/ui/app/mainui/sectionLoaders/WalletLoader.qml
+++ b/ui/app/mainui/sectionLoaders/WalletLoader.qml
@@ -66,22 +66,27 @@ Loader {
     }
 
     // Skeleton slot items carry the same page paddings as the real panels
-    // (LeftTabView's internal padding, resp. the center StackView's margins)
-    Item {
+    // (LeftTabView's internal padding, resp. the center StackView's margins).
+    // Each lives behind a Loader gated on its slot: an alive invisible skeleton
+    // re-evaluates its tile geometry bindings on every resize for the lifetime
+    // of the section.
+    Loader {
         id: accountsSkeleton
-        visible: root.status !== Loader.Ready
+        active: root.status !== Loader.Ready
+        visible: active
 
-        WalletAccountsSkeleton {
+        sourceComponent: WalletAccountsSkeleton {
             anchors.fill: parent
             anchors.margins: Theme.padding
         }
     }
 
-    Item {
+    Loader {
         id: centerSkeleton
-        visible: root.status !== Loader.Ready
+        active: root.status !== Loader.Ready
+        visible: active
 
-        WalletCenterPanelSkeleton {
+        sourceComponent: WalletCenterPanelSkeleton {
             anchors.fill: parent
             anchors.topMargin: Theme.padding
             anchors.leftMargin: Theme.xlPadding * 2

--- a/ui/app/mainui/sectionLoaders/WalletLoader.qml
+++ b/ui/app/mainui/sectionLoaders/WalletLoader.qml
@@ -39,6 +39,29 @@ Loader {
     property bool appMainVisible: false
     property real leftPanelWidthOverride: 0
 
+    // Back-navigation contract for AppMain's back chain. The chrome is
+    // interactive while the section item still incubates, so the loader must
+    // answer for it during that phase; once loaded, the item leads.
+    readonly property bool canGoBack: root.item?.canGoBack ?? sectionLayout.canGoBack
+    function tryGoBack() {
+        if (root.item && typeof root.item.tryGoBack === "function")
+            return root.item.tryGoBack()
+        return sectionLayout.tryGoBack()
+    }
+
+    // Navigation into a specific wallet view may arrive (synchronously, from
+    // activity-center/toast redirects) while the section still incubates —
+    // queue it and replay once the real layout is up.
+    function openDesiredView(leftPanelSelection, rightPanelSelection, data) {
+        if (root.item && root.item.openDesiredView) {
+            root.item.openDesiredView(leftPanelSelection, rightPanelSelection, data)
+            return
+        }
+        d.pendingViewRequest = ({ left: leftPanelSelection,
+                                  right: rightPanelSelection,
+                                  data: data })
+    }
+
     asynchronous: true
 
     // The section chrome is owned by the loader: it shows instantly with
@@ -97,12 +120,14 @@ Loader {
     // Panel index persistence, kept under the same category/key WalletLayout
     // used when it owned the chrome
     Settings {
-        category: "WalletLocalSettings_%1".arg(root.contactsStore.myPublicKey)
+        category: "WalletLocalSettings_%1".arg(userProfile.pubKey)
         property alias selectedPanelIndex: sectionLayout.currentIndex
     }
 
     QtObject {
         id: d
+
+        property var pendingViewRequest: null
 
         readonly property url realUrl: QmlCompiler.walletUrl
         readonly property url privacyWallUrl: QmlCompiler.walletPrivacyWallUrl
@@ -166,6 +191,12 @@ Loader {
         if (root.item.resetView)
             root.item.resetView()
         root.item.visible = true
+        if (d.pendingViewRequest) {
+            const request = d.pendingViewRequest
+            d.pendingViewRequest = null
+            if (root.item.openDesiredView)
+                root.item.openDesiredView(request.left, request.right, request.data)
+        }
     }
 
     Connections {

--- a/ui/app/mainui/sectionLoaders/WalletLoader.qml
+++ b/ui/app/mainui/sectionLoaders/WalletLoader.qml
@@ -1,5 +1,11 @@
+import QtCore
 import QtQml
 import QtQuick
+
+import StatusQ.Core.Theme
+import StatusQ.Layout
+
+import AppLayouts.Wallet.panels
 
 import utils
 
@@ -33,7 +39,62 @@ Loader {
     property bool appMainVisible: false
     property real leftPanelWidthOverride: 0
 
-    asynchronous: false
+    asynchronous: true
+
+    // The section chrome is owned by the loader: it shows instantly with
+    // skeleton panels and swaps in the real panels produced by WalletLayout
+    // (LayoutItemProxy retarget) once the section finishes incubating.
+    StatusSectionLayout {
+        id: sectionLayout
+
+        anchors.fill: parent
+        currentIndex: 1
+
+        // The privacy wall is a full-page item rendered by the Loader itself
+        visible: d.targetUrl !== d.privacyWallUrl
+
+        backButtonName: root.item?.backButtonName ?? ""
+        onBackButtonClicked: root.item?.handleBackButtonClicked()
+        subsectionHistory: root.item?.subsectionHistory ?? null
+
+        leftPanel: root.item?.leftPanel ?? accountsSkeleton
+        centerPanel: root.item?.centerPanel ?? centerSkeleton
+        headerBackground: root.item?.headerBackground ?? null
+        footer: root.item?.footer ?? null
+
+        leftPanelWidthOverride: root.leftPanelWidthOverride
+    }
+
+    // Skeleton slot items carry the same page paddings as the real panels
+    // (LeftTabView's internal padding, resp. the center StackView's margins)
+    Item {
+        id: accountsSkeleton
+        visible: root.status !== Loader.Ready
+
+        WalletAccountsSkeleton {
+            anchors.fill: parent
+            anchors.margins: Theme.padding
+        }
+    }
+
+    Item {
+        id: centerSkeleton
+        visible: root.status !== Loader.Ready
+
+        WalletCenterPanelSkeleton {
+            anchors.fill: parent
+            anchors.topMargin: Theme.padding
+            anchors.leftMargin: Theme.xlPadding * 2
+            anchors.rightMargin: Theme.xlPadding * 2
+        }
+    }
+
+    // Panel index persistence, kept under the same category/key WalletLayout
+    // used when it owned the chrome
+    Settings {
+        category: "WalletLocalSettings_%1".arg(root.contactsStore.myPublicKey)
+        property alias selectedPanelIndex: sectionLayout.currentIndex
+    }
 
     QtObject {
         id: d
@@ -62,6 +123,7 @@ Loader {
         setSource(d.realUrl, {
             visible:                false,
             objectName:             "walletLayoutReal",
+            sectionLayout:          sectionLayout,
             walletRootStore:        WalletStores.RootStore,
             sharedRootStore:        Qt.binding(() => root.sharedRootStore),
             store:                  Qt.binding(() => root.rootStore),
@@ -84,7 +146,6 @@ Loader {
                                             ? root.dappsServiceLoader.item.dappsModel
                                             : null),
             isKeycardEnabled:       Qt.binding(() => root.featureFlagsStore.keycardEnabled),
-            leftPanelWidthOverride: Qt.binding(() => root.leftPanelWidthOverride),
         })
     }
 


### PR DESCRIPTION
### What does the PR do

WalletLoader owns the section chrome and shows the accounts/asset-list/ center-panel skeletons while LeftTabView's account list and RightTabView's tab content incubate behind asynchronous Loaders.

### Affected areas

wallet

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/9d5537ed-c075-475b-8346-673e939f0561

### Impact on end user

Don't freeze while loading wallet

### How to test

Navigate to wallet from another section

### Risk 

low