### PR TITLE
perf(chat): lazy, async member loading for user list and mention suggstions

### DIFF
--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -39,6 +39,7 @@ NIM_TESTS_MODEL_SPY := \
 	assets_adaptor_model_test \
 	collectibles_selector_model_test \
 	grouped_account_assets_model_test \
+	member_model_test \
 	model_sync_move_test \
 	model_sync_unified_test \
 	token_groups_model_test \

--- a/src/app/modules/shared/qt_model_spy.nim
+++ b/src/app/modules/shared/qt_model_spy.nim
@@ -96,9 +96,21 @@ proc recordEndResetModel*() =
   if globalSpy != nil and globalSpy.enabled:
     globalSpy.calls.add(SignalCall(kind: EndResetModel))
 
-# The BeginMoveRows/EndMoveRows kinds are kept (without recorders): model_sync
-# never emits moves — reorders degrade to remove+insert — and model tests filter
-# on these kinds to assert exactly that.
+# model_sync never emits moves — reorders degrade to remove+insert — and its
+# tests filter on the move kinds to assert exactly that. Source-sorted models
+# (member_model) DO emit real moves and record them here.
+proc recordBeginMoveRows*(sourceFirst, sourceLast, destChild: int) =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(
+      kind: BeginMoveRows,
+      sourceFirst: sourceFirst,
+      sourceLast: sourceLast,
+      destChild: destChild
+    ))
+
+proc recordEndMoveRows*() =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(kind: EndMoveRows))
 
 # Query helpers
 proc countInserts*(self: QtModelSpy): int =
@@ -116,6 +128,14 @@ proc countDataChanged*(self: QtModelSpy): int =
 proc countResets*(self: QtModelSpy): int =
   ## Count number of beginResetModel calls
   self.calls.filterIt(it.kind == BeginResetModel).len
+
+proc countMoves*(self: QtModelSpy): int =
+  ## Count number of beginMoveRows calls
+  self.calls.filterIt(it.kind == BeginMoveRows).len
+
+proc getMoves*(self: QtModelSpy): seq[SignalCall] =
+  ## Get all beginMoveRows calls
+  self.calls.filterIt(it.kind == BeginMoveRows)
 
 proc getInserts*(self: QtModelSpy): seq[SignalCall] =
   ## Get all beginInsertRows calls

--- a/src/app/modules/shared_models/member_item.nim
+++ b/src/app/modules/shared_models/member_item.nim
@@ -19,7 +19,6 @@ type
 proc initMemberItem*(
   pubKey: string,
   displayName: string,
-  usesDefaultName: bool,
   ensName: string,
   isEnsVerified: bool,
   localNickname: string,
@@ -53,7 +52,6 @@ proc initMemberItem*(
   result.UserItem.setup(
     pubKey = pubKey,
     displayName = displayName,
-    usesDefaultName = usesDefaultName,
     ensName = ensName,
     isEnsVerified = isEnsVerified,
     localNickname = localNickname,

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -1,11 +1,13 @@
-import nimqml, tables, std/strformat, sequtils, sugar
+import nimqml, tables, std/strformat, algorithm, sequtils, sets, sugar
 # TODO: use generics to remove duplication between user_model and member_model
 
 import ../../../app_service/common/types
 import ../../../app_service/service/contacts/dto/[contacts, contact_details]
 import member_item
-import contacts_utils
 import model_utils
+
+when defined(QT_MODEL_SPY):
+  import ../shared/qt_model_spy
 
 type
   ModelRole {.pure.} = enum
@@ -62,6 +64,43 @@ QtObject:
     for i, it in self.items:
       self.pubKeyIndex[it.pubKey] = i
 
+  # The model maintains the canonical member order (see cmpCanonicalOrder in
+  # user_item) as an invariant: sorted on population, kept sorted via granular
+  # inserts and moves on every mutation. Consumers bind directly — no proxy
+  # sorting above this model.
+  proc cmpMembers(a, b: MemberItem): int =
+    cmpCanonicalOrder(a, b)
+
+  # Move row `ind` to where the canonical order wants it. The O(n) scan is fine:
+  # every caller already paid an O(n)-class table update, and it runs once per
+  # member event.
+  proc repositionRow(self: Model, ind: int) =
+    if ind < 0 or ind >= self.items.len:
+      return
+    let item = self.items[ind]
+    var dest = 0
+    for i in 0 ..< self.items.len:
+      if i != ind and cmpMembers(self.items[i], item) < 0:
+        inc dest
+    if dest == ind:
+      return
+
+    # Qt wants destinationChild in pre-move coordinates: moving down, the
+    # target slot is past the row's own current position.
+    let destChild = if dest > ind: dest + 1 else: dest
+    let parentIndex = newQModelIndex()
+    defer: parentIndex.delete
+    when defined(QT_MODEL_SPY):
+      recordBeginMoveRows(ind, ind, destChild)
+    self.beginMoveRows(parentIndex, ind, ind, parentIndex, destChild)
+    self.items.delete(ind)
+    self.items.insert(item, dest)
+    for i in min(ind, dest) .. max(ind, dest):
+      self.pubKeyIndex[self.items[i].pubKey] = i
+    self.endMoveRows()
+    when defined(QT_MODEL_SPY):
+      recordEndMoveRows()
+
   proc applyPendingAirdropAddress(self: Model, item: MemberItem) =
     if not self.pendingAirdropAddresses.hasKey(item.pubKey):
       return
@@ -70,12 +109,18 @@ QtObject:
     self.pendingAirdropAddresses.del(item.pubKey)
 
   proc setItems*(self: Model, items: seq[MemberItem]) =
+    when defined(QT_MODEL_SPY):
+      recordBeginResetModel()
     self.beginResetModel()
-    self.items = items
+    var sortedItems = items
+    sortedItems.sort(cmpMembers)
+    self.items = sortedItems
     self.rebuildPubKeyIndex()
     for item in self.items:
       self.applyPendingAirdropAddress(item)
     self.endResetModel()
+    when defined(QT_MODEL_SPY):
+      recordEndResetModel()
     self.countChanged()
 
   proc getItems*(self: Model): seq[MemberItem] =
@@ -147,8 +192,7 @@ QtObject:
     of ModelRole.UsesDefaultName:
       result = newQVariant(item.usesDefaultName)
     of ModelRole.PreferredDisplayName:
-      return newQVariant(resolvePreferredDisplayName(
-        item.localNickname, item.ensName, item.displayName, item.alias))
+      result = newQVariant(item.preferredDisplayName)
     of ModelRole.EnsName:
       result = newQVariant(item.ensName)
     of ModelRole.IsEnsVerified:
@@ -192,15 +236,10 @@ QtObject:
     of ModelRole.EmojiHash:
       result = newQVariant(item.emojiHash)
 
+  proc addItems*(self: Model, items: seq[MemberItem])
+
   proc addItem*(self: Model, item: MemberItem) =
-    let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
-    self.beginInsertRows(modelIndex, self.items.len, self.items.len)
-    self.pubKeyIndex[item.pubKey] = self.items.len
-    self.items.add(item)
-    self.applyPendingAirdropAddress(item)
-    self.endInsertRows()
-    self.countChanged()
+    self.addItems(@[item])
 
   proc findIndexForMember*(self: Model, pubKey: string): int =
     return self.pubKeyIndex.getOrDefault(pubKey, -1)
@@ -223,6 +262,8 @@ QtObject:
     defer: parentModelIndex.delete
 
     let removedPubKey = self.items[index].pubKey
+    when defined(QT_MODEL_SPY):
+      recordBeginRemoveRows(index, index)
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
     self.pubKeyIndex.del(removedPubKey)
@@ -232,16 +273,22 @@ QtObject:
       if v > index:
         dec v
     self.endRemoveRows()
+    when defined(QT_MODEL_SPY):
+      recordEndRemoveRows()
     self.countChanged()
 
   proc removeAllItems(self: Model) =
     if self.items.len <= 0:
       return
 
+    when defined(QT_MODEL_SPY):
+      recordBeginResetModel()
     self.beginResetModel()
     self.items = @[]
     self.pubKeyIndex.clear()
     self.endResetModel()
+    when defined(QT_MODEL_SPY):
+      recordEndResetModel()
     self.countChanged()
 
   # TODO: rename me to removeItemByPubkey
@@ -257,26 +304,42 @@ QtObject:
       return
 
     var newItems: seq[MemberItem] = @[]
-    let first = self.items.len
+    var batchKeys = initHashSet[string]()
     for it in items:
-      if self.pubKeyIndex.hasKey(it.pubKey):
+      if self.pubKeyIndex.hasKey(it.pubKey) or batchKeys.contains(it.pubKey):
         continue
-      self.pubKeyIndex[it.pubKey] = first + newItems.len
+      batchKeys.incl(it.pubKey)
+      self.applyPendingAirdropAddress(it)
       newItems.add(it)
 
     if newItems.len == 0:
       return
 
+    # Merge the sorted batch into the sorted model as contiguous insert runs —
+    # one beginInsertRows per run instead of one per item.
+    newItems.sort(cmpMembers)
+
     let modelIndex = newQModelIndex()
     defer: modelIndex.delete
 
-    let last = first + newItems.len - 1
+    var i = 0
+    while i < newItems.len:
+      let pos = self.items.lowerBound(newItems[i], cmpMembers)
+      var j = i + 1
+      while j < newItems.len and
+          (pos == self.items.len or cmpMembers(newItems[j], self.items[pos]) < 0):
+        inc j
 
-    self.beginInsertRows(modelIndex, first, last)
-    self.items.add(newItems)
-    for index in first ..< self.items.len:
-      self.applyPendingAirdropAddress(self.items[index])
-    self.endInsertRows()
+      when defined(QT_MODEL_SPY):
+        recordBeginInsertRows(pos, pos + (j - i) - 1)
+      self.beginInsertRows(modelIndex, pos, pos + (j - i) - 1)
+      self.items = concat(self.items[0 ..< pos], newItems[i ..< j], self.items[pos .. ^1])
+      self.endInsertRows()
+      when defined(QT_MODEL_SPY):
+        recordEndInsertRows()
+      i = j
+
+    self.rebuildPubKeyIndex()
     self.countChanged()
 
   proc isContactWithIdAdded*(self: Model, id: string): bool =
@@ -284,16 +347,17 @@ QtObject:
 
   proc setName*(self: Model, pubKey: string, displayName: string, ensName: string, localNickname: string) =
     updateItemRolesAndNotify self.findIndexForMember(pubKey):
-      let previousPreferredDisplayName = resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias)
-      let currentPreferredDisplayName = resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
-      let usesDefaultName = resolveUsesDefaultName(localNickname, ensName, displayName)
+      let previousPreferredDisplayName = self.items[ind].preferredDisplayName
+      let previousUsesDefaultName = self.items[ind].usesDefaultName
 
       updateRole(displayName)
       updateRole(ensName)
       updateRole(localNickname)
-      updateRole(usesDefaultName)
 
-      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.PreferredDisplayName.int): discard
+      addChangedRole(roles, previousPreferredDisplayName, self.items[ind].preferredDisplayName, ModelRole.PreferredDisplayName.int): discard
+      addChangedRole(roles, previousUsesDefaultName, self.items[ind].usesDefaultName, ModelRole.UsesDefaultName.int): discard
+    if roles.len > 0:
+      self.repositionRow(ind)
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
     updateItemRolesAndNotify self.findIndexForMember(pubKey):
@@ -317,54 +381,55 @@ QtObject:
       contactRequest: ContactRequest,
       callDataChanged: bool = true,
     ): seq[int] =
-    updateItemRolesAndNotify self.findIndexForMember(pubKey):
-      let previousPreferredDisplayName = resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias)
-      let currentPreferredDisplayName = resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
-      let previousTrustStatus = self.items[ind].trustStatus
-      let usesDefaultName = resolveUsesDefaultName(localNickname, ensName, displayName)
+    let ind = self.findIndexForMember(pubKey)
+    if ind == -1:
+      return
 
-      updateRole(displayName)
-      updateRole(usesDefaultName)
-      updateRole(ensName)
-      updateRole(localNickname)
-      updateRole(isEnsVerified)
-      # `alias` is deterministic from the pubkey — preserve any previously
-      # resolved value when the incoming alias is empty (typical for
-      # `getContactDetails` placeholders that haven't been enriched yet).
-      updateRolePreserveOnEmpty(alias, Alias)
-      updateRole(icon)
-      updateRole(isContact)
-      updateRole(memberRole)
-      updateRole(joined)
-      updateRole(trustStatus)
-      updateRole(isBlocked)
-      updateRole(contactRequest)
+    var roles: seq[int] = @[]
 
-      var updatedMembershipRequestState = membershipRequestState
-      if updatedMembershipRequestState == MembershipRequestState.None:
-        updatedMembershipRequestState = self.items[ind].membershipRequestState
+    let previousPreferredDisplayName = self.items[ind].preferredDisplayName
+    let previousUsesDefaultName = self.items[ind].usesDefaultName
+    let previousTrustStatus = self.items[ind].trustStatus
 
-      updateRoleWithValue(membershipRequestState, updatedMembershipRequestState)
+    updateRole(displayName)
+    updateRole(ensName)
+    updateRole(localNickname)
+    updateRole(isEnsVerified)
+    # `alias` is deterministic from the pubkey — preserve any previously
+    # resolved value when the incoming alias is empty (typical for
+    # `getContactDetails` placeholders that haven't been enriched yet).
+    updateRolePreserveOnEmpty(alias, Alias)
+    updateRole(icon)
+    updateRole(isContact)
+    updateRole(memberRole)
+    updateRole(joined)
+    updateRole(trustStatus)
+    updateRole(isBlocked)
+    updateRole(contactRequest)
 
-      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.PreferredDisplayName.int): discard
-      addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsUntrustworthy.int): discard
-      addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsVerified.int): discard
+    var updatedMembershipRequestState = membershipRequestState
+    if updatedMembershipRequestState == MembershipRequestState.None:
+      updatedMembershipRequestState = self.items[ind].membershipRequestState
 
-      if roles.len > 0:
-        if callDataChanged:
-          result = roles
-        else:
-          return roles
+    updateRoleWithValue(membershipRequestState, updatedMembershipRequestState)
+
+    addChangedRole(roles, previousPreferredDisplayName, self.items[ind].preferredDisplayName, ModelRole.PreferredDisplayName.int): discard
+    addChangedRole(roles, previousUsesDefaultName, self.items[ind].usesDefaultName, ModelRole.UsesDefaultName.int): discard
+    addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsUntrustworthy.int): discard
+    addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsVerified.int): discard
+
+    result = roles
+
+    if roles.len > 0:
+      if callDataChanged:
+        let modelIndex = self.createIndex(ind, 0, nil)
+        defer: modelIndex.delete
+        self.dataChanged(modelIndex, modelIndex, roles)
+      self.repositionRow(ind)
 
   proc updateItems*(self: Model, items: seq[MemberItem]) =
-    var startIndex = -1
-    var endIndex = -1
-    var allRoles: seq[int] = @[]
     for item in items:
-      let itemIndex = self.findIndexForMember(item.pubKey)
-      if itemIndex == -1:
-        continue
-      let roles = self.updateItem(
+      discard self.updateItem(
         item.pubKey,
         item.displayName,
         item.ensName,
@@ -379,19 +444,7 @@ QtObject:
         item.membershipRequestState,
         item.trustStatus,
         item.contactRequest,
-        callDataChanged = false,
       )
-
-      if roles.len > 0:
-        if startIndex == -1:
-          startIndex = itemIndex
-        endIndex = itemIndex
-        allRoles = concat(allRoles, roles)
-
-    if allRoles.len == 0:
-      return
-
-    notifyRangeRolesChanged(startIndex, endIndex, allRoles)
 
 
   proc updateToTheseItems*(self: Model, items: seq[MemberItem]) =
@@ -469,6 +522,8 @@ QtObject:
   proc setOnlineStatus*(self: Model, pubKey: string, onlineStatus: OnlineStatus) =
     updateItemRolesAndNotify self.findIndexForMember(pubKey):
       updateRole(onlineStatus)
+    if roles.len > 0:
+      self.repositionRow(ind)
 
   proc setAirdropAddress*(self: Model, pubKey: string, airdropAddress: string) =
     let ind = self.findIndexForMember(pubKey)
@@ -523,11 +578,6 @@ QtObject:
     return initMemberItem(
       pubKey = contactDetails.dto.id,
       displayName = contactDetails.dto.displayName,
-      usesDefaultName = resolveUsesDefaultName(
-        contactDetails.dto.localNickname,
-        contactDetails.dto.name,
-        contactDetails.dto.displayName,
-      ),
       ensName = contactDetails.dto.name,
       isEnsVerified = contactDetails.dto.ensVerified,
       localNickname = contactDetails.dto.localNickname,

--- a/src/app/modules/shared_models/user_item.nim
+++ b/src/app/modules/shared_models/user_item.nim
@@ -1,6 +1,7 @@
-import std/strformat
+import std/[strformat, unicode]
 import app_service/common/types
 import app_service/service/contacts/dto/contacts
+import contacts_utils
 
 type
   ContactRequest* {.pure.} = enum
@@ -26,6 +27,8 @@ type
     compressedPubKey: string
     emojiHash: string
     displayName: string
+    # Derived from the name sources below — never written by callers
+    preferredDisplayName: string
     usesDefaultName: bool
     ensName: string
     isEnsVerified: bool
@@ -49,10 +52,43 @@ type
     isRemoved: bool
     trustStatus: TrustStatus
 
+# Rune-wise simple-casefold compare — the name leg of the canonical member
+# order. Deliberately code-point based, not locale-collation aware.
+proc cmpFoldedNames(a, b: string): int =
+  var i = 0
+  var j = 0
+  while i < a.len and j < b.len:
+    var ra, rb: Rune
+    fastRuneAt(a, i, ra)
+    fastRuneAt(b, j, rb)
+    let fa = toLower(ra)
+    let fb = toLower(rb)
+    if fa != fb:
+      return cmp(fa.int32, fb.int32)
+  cmp(a.len - i, b.len - j)
+
+# Canonical member order (see CONTEXT.md): online first, then case-folded
+# preferred display name, then pubKey. The pubKey leg makes the order total, so
+# incremental repositioning has exactly one correct position.
+proc cmpCanonicalOrder*(a, b: UserItem): int =
+  result = cmp(b.onlineStatus.int, a.onlineStatus.int)
+  if result == 0:
+    result = cmpFoldedNames(a.preferredDisplayName, b.preferredDisplayName)
+  if result == 0:
+    result = cmp(a.pubKey, b.pubKey)
+
+# preferredDisplayName and usesDefaultName are derived from the name sources;
+# an unverified ENS name counts as no name (matches what data() serves)
+proc recomputeDerivedNames(self: UserItem) =
+  let effectiveEnsName = if self.isEnsVerified: self.ensName else: ""
+  self.preferredDisplayName = resolvePreferredDisplayName(
+    self.localNickname, effectiveEnsName, self.displayName, self.alias)
+  self.usesDefaultName = resolveUsesDefaultName(
+    self.localNickname, effectiveEnsName, self.displayName)
+
 proc setup*(self: UserItem,
   pubKey: string,
   displayName: string,
-  usesDefaultName: bool,
   ensName: string,
   isEnsVerified: bool,
   localNickname: string,
@@ -79,7 +115,6 @@ proc setup*(self: UserItem,
   ) =
   self.pubKey = pubKey
   self.displayName = displayName
-  self.usesDefaultName = usesDefaultName
   self.ensName = ensName
   self.isEnsVerified = isEnsVerified
   self.localNickname = localNickname
@@ -102,13 +137,13 @@ proc setup*(self: UserItem,
   self.trustStatus = trustStatus
   self.compressedPubKey = compressedPubKey
   self.emojiHash = emojiHash
+  self.recomputeDerivedNames()
 
 # FIXME: remove defaults
 # TODO: #14964
 proc initUserItem*(
     pubKey: string,
     displayName: string,
-    usesDefaultName: bool,
     ensName: string,
     isEnsVerified: bool,
     localNickname: string,
@@ -136,7 +171,6 @@ proc initUserItem*(
   result.setup(
     pubKey = pubKey,
     displayName = displayName,
-    usesDefaultName = usesDefaultName,
     ensName = ensName,
     isEnsVerified = isEnsVerified,
     localNickname = localNickname,
@@ -209,36 +243,41 @@ proc displayName*(self: UserItem): string {.inline.} =
 
 proc `displayName=`*(self: UserItem, value: string) {.inline.} =
   self.displayName = value
+  self.recomputeDerivedNames()
+
+proc preferredDisplayName*(self: UserItem): string {.inline.} =
+  self.preferredDisplayName
 
 proc usesDefaultName*(self: UserItem): bool {.inline.} =
   self.usesDefaultName
-
-proc `usesDefaultName=`*(self: UserItem, value: bool) {.inline.} =
-  self.usesDefaultName = value
 
 proc ensName*(self: UserItem): string {.inline.} =
   if self.isEnsVerified: self.ensName else: ""
 
 proc `ensName=`*(self: UserItem, value: string) {.inline.} =
   self.ensName = value
+  self.recomputeDerivedNames()
 
 proc isEnsVerified*(self: UserItem): bool {.inline.} =
   self.isEnsVerified
 
 proc `isEnsVerified=`*(self: UserItem, value: bool) {.inline.} =
   self.isEnsVerified = value
+  self.recomputeDerivedNames()
 
 proc localNickname*(self: UserItem): string {.inline.} =
   self.localNickname
 
 proc `localNickname=`*(self: UserItem, value: string) {.inline.} =
   self.localNickname = value
+  self.recomputeDerivedNames()
 
 proc alias*(self: UserItem): string {.inline.} =
   self.alias
 
 proc `alias=`*(self: UserItem, value: string) {.inline.} =
   self.alias = value
+  self.recomputeDerivedNames()
 
 proc icon*(self: UserItem): string {.inline.} =
   self.icon

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -2,7 +2,6 @@ import nimqml, tables, std/strformat, sequtils, sugar
 
 import app_service/common/types
 import app_service/service/contacts/dto/[contacts, contact_details]
-import contacts_utils
 import model_utils
 import user_item
 
@@ -136,10 +135,9 @@ QtObject:
     of ModelRole.DisplayName:
       result = newQVariant(item.displayName)
     of ModelRole.PreferredDisplayName:
-      return newQVariant(resolvePreferredDisplayName(
-        item.localNickname, item.ensName, item.displayName, item.alias))
+      result = newQVariant(item.preferredDisplayName)
     of ModelRole.UsesDefaultName:
-      result = newQVariant(resolveUsesDefaultName(item.localNickname, item.ensName, item.displayName))
+      result = newQVariant(item.usesDefaultName)
     of ModelRole.EnsName:
       result = newQVariant(item.ensName)
     of ModelRole.IsEnsVerified:
@@ -267,15 +265,15 @@ QtObject:
   proc setName*(self: Model, pubKey: string, displayName: string,
       ensName: string, localNickname: string) =
     updateItemRolesAndNotify self.findIndexByPubKey(pubKey):
-      let previousPreferredDisplayName = resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias)
-      let currentPreferredDisplayName = resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
+      let previousPreferredDisplayName = self.items[ind].preferredDisplayName
+      let previousUsesDefaultName = self.items[ind].usesDefaultName
 
       updateRole(displayName)
       updateRole(ensName)
       updateRole(localNickname)
 
-      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.PreferredDisplayName.int): discard
-      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.UsesDefaultName.int): discard
+      addChangedRole(roles, previousPreferredDisplayName, self.items[ind].preferredDisplayName, ModelRole.PreferredDisplayName.int): discard
+      addChangedRole(roles, previousUsesDefaultName, self.items[ind].usesDefaultName, ModelRole.UsesDefaultName.int): discard
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
     updateItemRolesAndNotify self.findIndexByPubKey(pubKey):
@@ -305,8 +303,8 @@ QtObject:
       isRemoved: bool,
     ) =
     updateItemRolesAndNotify self.findIndexByPubKey(pubKey):
-      let previousPreferredDisplayName = resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias)
-      let currentPreferredDisplayName = resolvePreferredDisplayName(localNickname, ensName, displayName, alias)
+      let previousPreferredDisplayName = self.items[ind].preferredDisplayName
+      let previousUsesDefaultName = self.items[ind].usesDefaultName
       let previousTrustStatus = self.items[ind].trustStatus
 
       updateRole(displayName)
@@ -329,8 +327,8 @@ QtObject:
       updateRole(isContactRequestSent)
       updateRole(isRemoved)
 
-      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.PreferredDisplayName.int): discard
-      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.UsesDefaultName.int): discard
+      addChangedRole(roles, previousPreferredDisplayName, self.items[ind].preferredDisplayName, ModelRole.PreferredDisplayName.int): discard
+      addChangedRole(roles, previousUsesDefaultName, self.items[ind].usesDefaultName, ModelRole.UsesDefaultName.int): discard
       addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsUntrustworthy.int): discard
       addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsVerified.int): discard
 
@@ -403,10 +401,6 @@ QtObject:
     return initUserItem(
       pubKey = contactDetails.dto.id,
       displayName = contactDetails.dto.displayName,
-      usesDefaultName = resolveUsesDefaultName(
-        contactDetails.dto.localNickname,
-        contactDetails.dto.name,
-        contactDetails.dto.displayName),
       ensName = contactDetails.dto.name,
       isEnsVerified = contactDetails.dto.ensVerified,
       localNickname = contactDetails.dto.localNickname,

--- a/storybook/qmlTests/tests/helpers/CommunityChatSectionHarness.qml
+++ b/storybook/qmlTests/tests/helpers/CommunityChatSectionHarness.qml
@@ -1,0 +1,122 @@
+import QtQuick
+
+import utils
+
+import Models
+
+import shared.stores as SharedStores
+import shared.stores.send as SendStores
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Communities.stores as CommunitiesStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStores
+import AppLayouts.stores.Messaging as MessagingStores
+
+import mainui.adaptors
+import mainui.sectionLoaders
+
+/*
+   Shared QmlTests harness: a fully-wired CommunityChatLoader against
+   CommunitySectionMock and stub stores. Configure `mock`, flip
+   `loader.active`, and drive the section through `loader.item`.
+*/
+Item {
+    id: root
+
+    readonly property alias mock: mock
+    readonly property alias loader: harnessLoader
+
+    function findChildByTypePrefix(item, prefix) {
+        if (!item)
+            return null
+        if (item.toString().indexOf(prefix) === 0)
+            return item
+        const list = item.children
+        for (let i = 0; i < list.length; ++i) {
+            const found = findChildByTypePrefix(list[i], prefix)
+            if (found)
+                return found
+        }
+        return null
+    }
+
+    function findAllByTypePrefix(item, prefix, out) {
+        if (!item)
+            return out
+        if (item.toString().indexOf(prefix) === 0)
+            out.push(item)
+        const list = item.children
+        for (let i = 0; i < list.length; ++i)
+            findAllByTypePrefix(list[i], prefix, out)
+        return out
+    }
+
+    CommunitySectionMock { id: mock }
+
+    AppStores.RootStore { id: appRootStoreMock }
+    AppStores.ContactsStore { id: contactsStoreMock }
+    AppStores.AccountSettingsStore {
+        id: accountSettingsStoreMock
+        showUsersList: true
+    }
+    AppStores.FeatureFlagsStore { id: featureFlagsStoreMock }
+    SharedStores.RootStore { id: sharedRootStoreMock }
+    SharedStores.CurrenciesStore { id: currenciesStoreMock }
+    SharedStores.CommunityTokensStore { id: communityTokensStoreMock }
+    SharedStores.NetworkConnectionStore { id: networkConnectionStoreMock }
+    SharedStores.NetworksStore { id: networksStoreMock }
+    SendStores.TransactionStore { id: transactionStoreMock }
+    WalletStores.TokensStore { id: tokensStoreMock }
+    WalletStores.WalletAssetsStore { id: walletAssetsStoreMock }
+    ProfileStores.AdvancedStore { id: advancedStoreMock }
+    CommunitiesStores.CommunitiesStore { id: communitiesStoreMock }
+    MessagingStores.MessagingRootStore { id: messagingRootStoreMock }
+    ChatStores.CreateChatPropertiesStore { id: createChatPropertiesStoreMock }
+    ContactsModelAdaptor {
+        id: contactsAdaptorMock
+        allContacts: ListModel {}
+    }
+
+    Item {
+        visible: false
+        Loader { id: emojiPopupLoaderMock; active: false }
+        Loader { id: stickersPopupLoaderMock; active: false }
+    }
+
+    Loader {
+        id: harnessLoader
+        anchors.fill: parent
+        active: false
+
+        sourceComponent: CommunityChatLoader {
+            active: true
+
+            rootStore: appRootStoreMock
+            contactsStore: contactsStoreMock
+            accountSettingsStore: accountSettingsStoreMock
+            featureFlagsStore: featureFlagsStoreMock
+            sharedRootStore: sharedRootStoreMock
+            currencyStore: currenciesStoreMock
+            communityTokensStore: communityTokensStoreMock
+            networkConnectionStore: networkConnectionStoreMock
+            networksStore: networksStoreMock
+            transactionStore: transactionStoreMock
+            tokensStore: tokensStoreMock
+            walletAssetsStore: walletAssetsStoreMock
+            advancedStore: advancedStoreMock
+            communitiesStore: communitiesStoreMock
+            messagingRootStore: messagingRootStoreMock
+            createChatPropertiesStore: createChatPropertiesStoreMock
+            contactsAdaptor: contactsAdaptorMock
+            popupHandler: null
+            emojiPopupLoader: emojiPopupLoaderMock
+            stickersPopupLoader: stickersPopupLoaderMock
+            sectionId: mock.communityId
+            sectionItemModel: mock.sectionItemModel
+            createChatViewOpened: false
+            isPortraitMode: false
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
+++ b/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
@@ -3,20 +3,7 @@ import QtTest
 
 import utils
 
-import Models
-
-import shared.stores as SharedStores
-import shared.stores.send as SendStores
-
-import AppLayouts.stores as AppStores
-import AppLayouts.Chat.stores as ChatStores
-import AppLayouts.Communities.stores as CommunitiesStores
-import AppLayouts.Profile.stores as ProfileStores
-import AppLayouts.Wallet.stores as WalletStores
-import AppLayouts.stores.Messaging as MessagingStores
-
-import mainui.adaptors
-import mainui.sectionLoaders
+import "helpers"
 
 // The members panel is built once and shared across the section's channels.
 // These tests pin that a switch onto a channel with its own members model
@@ -29,76 +16,16 @@ Item {
     width: 1000
     height: 700
 
-    CommunitySectionMock { id: mock }
-
-    AppStores.RootStore { id: appRootStoreMock }
-    AppStores.ContactsStore { id: contactsStoreMock }
-    AppStores.AccountSettingsStore {
-        id: accountSettingsStoreMock
-        showUsersList: true
-    }
-    AppStores.FeatureFlagsStore { id: featureFlagsStoreMock }
-    SharedStores.RootStore { id: sharedRootStoreMock }
-    SharedStores.CurrenciesStore { id: currenciesStoreMock }
-    SharedStores.CommunityTokensStore { id: communityTokensStoreMock }
-    SharedStores.NetworkConnectionStore { id: networkConnectionStoreMock }
-    SharedStores.NetworksStore { id: networksStoreMock }
-    SendStores.TransactionStore { id: transactionStoreMock }
-    WalletStores.TokensStore { id: tokensStoreMock }
-    WalletStores.WalletAssetsStore { id: walletAssetsStoreMock }
-    ProfileStores.AdvancedStore { id: advancedStoreMock }
-    CommunitiesStores.CommunitiesStore { id: communitiesStoreMock }
-    MessagingStores.MessagingRootStore { id: messagingRootStoreMock }
-    ChatStores.CreateChatPropertiesStore { id: createChatPropertiesStoreMock }
-    ContactsModelAdaptor {
-        id: contactsAdaptorMock
-        allContacts: ListModel {}
-    }
-
-    Item {
-        visible: false
-        Loader { id: emojiPopupLoaderMock; active: false }
-        Loader { id: stickersPopupLoaderMock; active: false }
-    }
-
-    Loader {
+    CommunityChatSectionHarness {
         id: harness
         anchors.fill: parent
-        active: false
-
-        sourceComponent: CommunityChatLoader {
-            active: true
-
-            rootStore: appRootStoreMock
-            contactsStore: contactsStoreMock
-            accountSettingsStore: accountSettingsStoreMock
-            featureFlagsStore: featureFlagsStoreMock
-            sharedRootStore: sharedRootStoreMock
-            currencyStore: currenciesStoreMock
-            communityTokensStore: communityTokensStoreMock
-            networkConnectionStore: networkConnectionStoreMock
-            networksStore: networksStoreMock
-            transactionStore: transactionStoreMock
-            tokensStore: tokensStoreMock
-            walletAssetsStore: walletAssetsStoreMock
-            advancedStore: advancedStoreMock
-            communitiesStore: communitiesStoreMock
-            messagingRootStore: messagingRootStoreMock
-            createChatPropertiesStore: createChatPropertiesStoreMock
-            contactsAdaptor: contactsAdaptorMock
-            popupHandler: null
-            emojiPopupLoader: emojiPopupLoaderMock
-            stickersPopupLoader: stickersPopupLoaderMock
-            sectionId: mock.communityId
-            sectionItemModel: mock.sectionItemModel
-            createChatViewOpened: false
-            isPortraitMode: false
-        }
     }
 
     TestCase {
         name: "ChatViewMembersSkeleton"
         when: windowShown
+
+        readonly property var mock: harness.mock
 
         function init() {
             mock.joined = true
@@ -120,44 +47,19 @@ Item {
         }
 
         function cleanup() {
-            harness.active = false
+            harness.loader.active = false
             mock.uninstall()
-        }
-
-        function findChildByTypePrefix(item, prefix) {
-            if (!item)
-                return null
-            if (item.toString().indexOf(prefix) === 0)
-                return item
-            const list = item.children
-            for (let i = 0; i < list.length; ++i) {
-                const found = findChildByTypePrefix(list[i], prefix)
-                if (found)
-                    return found
-            }
-            return null
-        }
-
-        function findAllByTypePrefix(item, prefix, out) {
-            if (!item)
-                return out
-            if (item.toString().indexOf(prefix) === 0)
-                out.push(item)
-            const list = item.children
-            for (let i = 0; i < list.length; ++i)
-                findAllByTypePrefix(list[i], prefix, out)
-            return out
         }
 
         // Loads the section and waits until the members panel is up: the
         // skeleton has cleared and the real list holds the mock's members.
         function loadSectionWithMembers() {
-            harness.active = true
-            const loader = harness.item
+            harness.loader.active = true
+            const loader = harness.loader.item
             verify(!!loader)
             tryVerify(() => loader.status === Loader.Ready, 120000)
 
-            const view = findChildByTypePrefix(loader, "ChatView")
+            const view = harness.findChildByTypePrefix(loader, "ChatView")
             verify(!!view, "the section must load the paneled chat view")
 
             // Test seam: the re-arm delay lives in the view's private object
@@ -189,8 +91,8 @@ Item {
             const targetId = mock.firstPrivateChannelId()
             verify(!!targetId, "the mock must build a permissioned channel")
 
-            const rows = findAllByTypePrefix(lv.contentItem,
-                                             "StatusChatListItem_QMLTYPE", [])
+            const rows = harness.findAllByTypePrefix(lv.contentItem,
+                                                     "StatusChatListItem_QMLTYPE", [])
             for (let i = 0; i < rows.length; ++i) {
                 const row = rows[i]
                 if (row.chatId === targetId && row.visible && row.height > 0)
@@ -206,8 +108,8 @@ Item {
             waitForRendering(lv)
 
             const gatedId = mock.firstPrivateChannelId()
-            const rows = findAllByTypePrefix(lv.contentItem,
-                                             "StatusChatListItem_QMLTYPE", [])
+            const rows = harness.findAllByTypePrefix(lv.contentItem,
+                                                     "StatusChatListItem_QMLTYPE", [])
             for (let i = 0; i < rows.length; ++i) {
                 const row = rows[i]
                 if (row.chatId !== mock.activeChatId && row.chatId !== gatedId
@@ -249,8 +151,8 @@ Item {
 
             compare(ctx.list.count, 0,
                     "the members list must hold no rows while the switch is in flight")
-            compare(findAllByTypePrefix(ctx.list.contentItem,
-                                        "StatusMemberListItem_QMLTYPE", []).length, 0,
+            compare(harness.findAllByTypePrefix(ctx.list.contentItem,
+                                                "StatusMemberListItem_QMLTYPE", []).length, 0,
                     "no member delegate may be built while the switch is in flight")
         }
 

--- a/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
+++ b/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
@@ -1,0 +1,224 @@
+import QtQuick
+import QtTest
+
+import utils
+
+import Models
+
+import shared.stores as SharedStores
+import shared.stores.send as SendStores
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Communities.stores as CommunitiesStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStores
+import AppLayouts.stores.Messaging as MessagingStores
+
+import mainui.adaptors
+import mainui.sectionLoaders
+
+// The members panel is built once and shared across the section's channels.
+// These tests pin that a channel switch drops back to MembersListSkeleton
+// instead of showing the previous channel's members, and that no member rows
+// are built while the switch is in flight.
+Item {
+    id: root
+
+    width: 1000
+    height: 700
+
+    CommunitySectionMock { id: mock }
+
+    AppStores.RootStore { id: appRootStoreMock }
+    AppStores.ContactsStore { id: contactsStoreMock }
+    AppStores.AccountSettingsStore {
+        id: accountSettingsStoreMock
+        showUsersList: true
+    }
+    AppStores.FeatureFlagsStore { id: featureFlagsStoreMock }
+    SharedStores.RootStore { id: sharedRootStoreMock }
+    SharedStores.CurrenciesStore { id: currenciesStoreMock }
+    SharedStores.CommunityTokensStore { id: communityTokensStoreMock }
+    SharedStores.NetworkConnectionStore { id: networkConnectionStoreMock }
+    SharedStores.NetworksStore { id: networksStoreMock }
+    SendStores.TransactionStore { id: transactionStoreMock }
+    WalletStores.TokensStore { id: tokensStoreMock }
+    WalletStores.WalletAssetsStore { id: walletAssetsStoreMock }
+    ProfileStores.AdvancedStore { id: advancedStoreMock }
+    CommunitiesStores.CommunitiesStore { id: communitiesStoreMock }
+    MessagingStores.MessagingRootStore { id: messagingRootStoreMock }
+    ChatStores.CreateChatPropertiesStore { id: createChatPropertiesStoreMock }
+    ContactsModelAdaptor {
+        id: contactsAdaptorMock
+        allContacts: ListModel {}
+    }
+
+    Item {
+        visible: false
+        Loader { id: emojiPopupLoaderMock; active: false }
+        Loader { id: stickersPopupLoaderMock; active: false }
+    }
+
+    Loader {
+        id: harness
+        anchors.fill: parent
+        active: false
+
+        sourceComponent: CommunityChatLoader {
+            active: true
+
+            rootStore: appRootStoreMock
+            contactsStore: contactsStoreMock
+            accountSettingsStore: accountSettingsStoreMock
+            featureFlagsStore: featureFlagsStoreMock
+            sharedRootStore: sharedRootStoreMock
+            currencyStore: currenciesStoreMock
+            communityTokensStore: communityTokensStoreMock
+            networkConnectionStore: networkConnectionStoreMock
+            networksStore: networksStoreMock
+            transactionStore: transactionStoreMock
+            tokensStore: tokensStoreMock
+            walletAssetsStore: walletAssetsStoreMock
+            advancedStore: advancedStoreMock
+            communitiesStore: communitiesStoreMock
+            messagingRootStore: messagingRootStoreMock
+            createChatPropertiesStore: createChatPropertiesStoreMock
+            contactsAdaptor: contactsAdaptorMock
+            popupHandler: null
+            emojiPopupLoader: emojiPopupLoaderMock
+            stickersPopupLoader: stickersPopupLoaderMock
+            sectionId: mock.communityId
+            sectionItemModel: mock.sectionItemModel
+            createChatViewOpened: false
+            isPortraitMode: false
+        }
+    }
+
+    TestCase {
+        name: "ChatViewMembersSkeleton"
+        when: windowShown
+
+        function init() {
+            mock.joined = true
+            mock.memberRole = Constants.memberRole.none
+            mock.amIBanned = false
+            mock.requestToJoinState = Constants.RequestToJoinState.None
+            mock.requiresTokenPermissionToJoin = false
+            mock.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin = false
+            mock.membersCount = 50
+            mock.categoriesCount = 1
+            mock.channelsPerCategory = 3
+            mock.uncategorizedChannelsCount = 2
+            mock.privateChannelsPerCategory = 0
+            mock.messagesPerChannel = 20
+            mock.install()
+        }
+
+        function cleanup() {
+            harness.active = false
+            mock.uninstall()
+        }
+
+        function findChildByTypePrefix(item, prefix) {
+            if (!item)
+                return null
+            if (item.toString().indexOf(prefix) === 0)
+                return item
+            const list = item.children
+            for (let i = 0; i < list.length; ++i) {
+                const found = findChildByTypePrefix(list[i], prefix)
+                if (found)
+                    return found
+            }
+            return null
+        }
+
+        function findAllByTypePrefix(item, prefix, out) {
+            if (!item)
+                return out
+            if (item.toString().indexOf(prefix) === 0)
+                out.push(item)
+            const list = item.children
+            for (let i = 0; i < list.length; ++i)
+                findAllByTypePrefix(list[i], prefix, out)
+            return out
+        }
+
+        // Loads the section and waits until the members panel is up: the
+        // skeleton has cleared and the real list holds the mock's members.
+        function loadSectionWithMembers() {
+            harness.active = true
+            const loader = harness.item
+            verify(!!loader)
+            tryVerify(() => loader.status === Loader.Ready, 120000)
+
+            const view = findChildByTypePrefix(loader, "ChatView")
+            verify(!!view, "the section must load the paneled chat view")
+
+            const skeleton = findChild(loader, "membersPanelSkeleton")
+            verify(!!skeleton, "the members panel must have its skeleton")
+            tryVerify(() => !skeleton.visible, 20000,
+                      "the members skeleton must clear once the panel is built")
+
+            const list = findChild(loader, "userListPanel")
+            verify(!!list)
+            tryVerify(() => list.count > 0, 20000,
+                      "the members list must be populated before the switch")
+
+            return { loader, view, skeleton, list }
+        }
+
+        function otherChannelRow(loader) {
+            const lv = findChild(loader, "chatListItems")
+            verify(!!lv)
+            tryVerify(() => lv.count > 0, 10000)
+            waitForRendering(lv)
+
+            const rows = findAllByTypePrefix(lv.contentItem,
+                                             "StatusChatListItem_QMLTYPE", [])
+            for (let i = 0; i < rows.length; ++i) {
+                const row = rows[i]
+                if (row.chatId !== mock.activeChatId && row.visible && row.height > 0)
+                    return row
+            }
+            return null
+        }
+
+        function test_membersSkeletonReturnsOnChannelSwitch() {
+            const ctx = loadSectionWithMembers()
+            // widen the re-arm window so the assertions do not race the timer
+            ctx.view.membersWireDelay = 2000
+
+            const row = otherChannelRow(ctx.loader)
+            verify(!!row, "a non-active channel row must exist")
+            mouseClick(row)
+            tryVerify(() => mock.activeChatId === row.chatId, 5000)
+
+            verify(ctx.skeleton.visible,
+                   "switching channel must bring the members skeleton back")
+
+            ctx.view.membersWireDelay = 10
+            tryVerify(() => !ctx.skeleton.visible, 20000,
+                      "the members skeleton must clear again after the switch")
+            tryVerify(() => ctx.list.count > 0, 20000,
+                      "the members list must repopulate after the switch")
+        }
+
+        function test_userListBuildsNoMemberRowsDuringChannelSwitch() {
+            const ctx = loadSectionWithMembers()
+            ctx.view.membersWireDelay = 2000
+
+            const row = otherChannelRow(ctx.loader)
+            verify(!!row, "a non-active channel row must exist")
+            mouseClick(row)
+            tryVerify(() => mock.activeChatId === row.chatId, 5000)
+
+            compare(ctx.list.count, 0,
+                    "the members list must hold no rows while the switch is in flight")
+            compare(findAllByTypePrefix(ctx.list.contentItem,
+                                        "StatusMemberListItem_QMLTYPE", []).length, 0,
+                    "no member delegate may be built while the switch is in flight")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
+++ b/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
@@ -19,9 +19,10 @@ import mainui.adaptors
 import mainui.sectionLoaders
 
 // The members panel is built once and shared across the section's channels.
-// These tests pin that a channel switch drops back to MembersListSkeleton
-// instead of showing the previous channel's members, and that no member rows
-// are built while the switch is in flight.
+// These tests pin that a switch onto a channel with its own members model
+// drops back to MembersListSkeleton instead of showing the previous channel's
+// members, that no member rows are built while that switch is in flight, and
+// that a switch which keeps the same model object costs neither.
 Item {
     id: root
 
@@ -110,7 +111,10 @@ Item {
             mock.categoriesCount = 1
             mock.channelsPerCategory = 3
             mock.uncategorizedChannelsCount = 2
-            mock.privateChannelsPerCategory = 0
+            // One permissioned channel per category: only a switch that lands
+            // on it hands the view a different members model, which is what
+            // arms the latch
+            mock.privateChannelsPerCategory = 1
             mock.messagesPerChannel = 20
             mock.install()
         }
@@ -156,6 +160,10 @@ Item {
             const view = findChildByTypePrefix(loader, "ChatView")
             verify(!!view, "the section must load the paneled chat view")
 
+            // Test seam: the re-arm delay lives in the view's private object
+            const internal = findChild(view, "chatViewInternal")
+            verify(!!internal, "the chat view's private object must be reachable")
+
             const skeleton = findChild(loader, "membersPanelSkeleton")
             verify(!!skeleton, "the members panel must have its skeleton")
             tryVerify(() => !skeleton.visible, 20000,
@@ -166,20 +174,44 @@ Item {
             tryVerify(() => list.count > 0, 20000,
                       "the members list must be populated before the switch")
 
-            return { loader, view, skeleton, list }
+            return { loader, view, internal, skeleton, list }
         }
 
-        function otherChannelRow(loader) {
+        // The permissioned channel carries its own members model, so landing on
+        // it is the switch the latch exists for. A switch between unpermissioned
+        // channels keeps the very same model object and must cost nothing.
+        function permissionedChannelRow(loader) {
             const lv = findChild(loader, "chatListItems")
             verify(!!lv)
             tryVerify(() => lv.count > 0, 10000)
             waitForRendering(lv)
 
+            const targetId = mock.firstPrivateChannelId()
+            verify(!!targetId, "the mock must build a permissioned channel")
+
             const rows = findAllByTypePrefix(lv.contentItem,
                                              "StatusChatListItem_QMLTYPE", [])
             for (let i = 0; i < rows.length; ++i) {
                 const row = rows[i]
-                if (row.chatId !== mock.activeChatId && row.visible && row.height > 0)
+                if (row.chatId === targetId && row.visible && row.height > 0)
+                    return row
+            }
+            return null
+        }
+
+        function unpermissionedChannelRow(loader) {
+            const lv = findChild(loader, "chatListItems")
+            verify(!!lv)
+            tryVerify(() => lv.count > 0, 10000)
+            waitForRendering(lv)
+
+            const gatedId = mock.firstPrivateChannelId()
+            const rows = findAllByTypePrefix(lv.contentItem,
+                                             "StatusChatListItem_QMLTYPE", [])
+            for (let i = 0; i < rows.length; ++i) {
+                const row = rows[i]
+                if (row.chatId !== mock.activeChatId && row.chatId !== gatedId
+                        && row.visible && row.height > 0)
                     return row
             }
             return null
@@ -188,17 +220,18 @@ Item {
         function test_membersSkeletonReturnsOnChannelSwitch() {
             const ctx = loadSectionWithMembers()
             // widen the re-arm window so the assertions do not race the timer
-            ctx.view.membersWireDelay = 2000
+            ctx.internal.membersWireDelay = 2000
 
-            const row = otherChannelRow(ctx.loader)
-            verify(!!row, "a non-active channel row must exist")
+            const row = permissionedChannelRow(ctx.loader)
+            verify(!!row, "the permissioned channel row must exist")
             mouseClick(row)
             tryVerify(() => mock.activeChatId === row.chatId, 5000)
 
             verify(ctx.skeleton.visible,
-                   "switching channel must bring the members skeleton back")
+                   "switching to a channel with its own members model must bring "
+                   + "the members skeleton back")
 
-            ctx.view.membersWireDelay = 10
+            ctx.internal.membersWireDelay = 10
             tryVerify(() => !ctx.skeleton.visible, 20000,
                       "the members skeleton must clear again after the switch")
             tryVerify(() => ctx.list.count > 0, 20000,
@@ -207,10 +240,10 @@ Item {
 
         function test_userListBuildsNoMemberRowsDuringChannelSwitch() {
             const ctx = loadSectionWithMembers()
-            ctx.view.membersWireDelay = 2000
+            ctx.internal.membersWireDelay = 2000
 
-            const row = otherChannelRow(ctx.loader)
-            verify(!!row, "a non-active channel row must exist")
+            const row = permissionedChannelRow(ctx.loader)
+            verify(!!row, "the permissioned channel row must exist")
             mouseClick(row)
             tryVerify(() => mock.activeChatId === row.chatId, 5000)
 
@@ -219,6 +252,26 @@ Item {
             compare(findAllByTypePrefix(ctx.list.contentItem,
                                         "StatusMemberListItem_QMLTYPE", []).length, 0,
                     "no member delegate may be built while the switch is in flight")
+        }
+
+        // The dominant path: community channels without permissions all share
+        // the section's members model, so the panel must not be torn down and
+        // re-sorted on those switches.
+        function test_membersPanelSurvivesSwitchWithUnchangedModel() {
+            const ctx = loadSectionWithMembers()
+            // long enough that an erroneous latch drop would still be down here
+            ctx.internal.membersWireDelay = 2000
+
+            const before = ctx.list.count
+            const row = unpermissionedChannelRow(ctx.loader)
+            verify(!!row, "another unpermissioned channel row must exist")
+            mouseClick(row)
+            tryVerify(() => mock.activeChatId === row.chatId, 5000)
+
+            verify(!ctx.skeleton.visible,
+                   "a switch that keeps the same members model must not show the skeleton")
+            compare(ctx.list.count, before,
+                    "a switch that keeps the same members model must not drop the rows")
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
+++ b/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
@@ -5,11 +5,12 @@ import utils
 
 import "helpers"
 
-// The members panel is built once and shared across the section's channels.
-// These tests pin that a switch onto a channel with its own members model
-// drops back to MembersListSkeleton instead of showing the previous channel's
-// members, that no member rows are built while that switch is in flight, and
-// that a switch which keeps the same model object costs neither.
+// The members panel is built once per section, asynchronously behind
+// MembersListSkeleton, and shared across the section's channels. These tests
+// pin that the skeleton covers only that initial incubation: channel switches
+// — whether they keep the members model or swap it (permissioned channels) —
+// must neither tear the panel down nor bring the skeleton back, because the
+// model arrives pre-sorted from Nim and rebinding it is cheap.
 Item {
     id: root
 
@@ -62,10 +63,6 @@ Item {
             const view = harness.findChildByTypePrefix(loader, "ChatView")
             verify(!!view, "the section must load the paneled chat view")
 
-            // Test seam: the re-arm delay lives in the view's private object
-            const internal = findChild(view, "chatViewInternal")
-            verify(!!internal, "the chat view's private object must be reachable")
-
             const skeleton = findChild(loader, "membersPanelSkeleton")
             verify(!!skeleton, "the members panel must have its skeleton")
             tryVerify(() => !skeleton.visible, 20000,
@@ -76,12 +73,12 @@ Item {
             tryVerify(() => list.count > 0, 20000,
                       "the members list must be populated before the switch")
 
-            return { loader, view, internal, skeleton, list }
+            return { loader, view, skeleton, list }
         }
 
         // The permissioned channel carries its own members model, so landing on
-        // it is the switch the latch exists for. A switch between unpermissioned
-        // channels keeps the very same model object and must cost nothing.
+        // it swaps the model under the panel. A switch between unpermissioned
+        // channels keeps the very same model object.
         function permissionedChannelRow(loader) {
             const lv = findChild(loader, "chatListItems")
             verify(!!lv)
@@ -119,50 +116,27 @@ Item {
             return null
         }
 
-        function test_membersSkeletonReturnsOnChannelSwitch() {
+        // Landing on a channel with its own members model swaps the model
+        // under the live panel: the rows follow, the skeleton stays gone.
+        function test_membersPanelSwapsModelWithoutSkeleton() {
             const ctx = loadSectionWithMembers()
-            // widen the re-arm window so the assertions do not race the timer
-            ctx.internal.membersWireDelay = 2000
 
             const row = permissionedChannelRow(ctx.loader)
             verify(!!row, "the permissioned channel row must exist")
             mouseClick(row)
             tryVerify(() => mock.activeChatId === row.chatId, 5000)
 
-            verify(ctx.skeleton.visible,
-                   "switching to a channel with its own members model must bring "
-                   + "the members skeleton back")
-
-            ctx.internal.membersWireDelay = 10
-            tryVerify(() => !ctx.skeleton.visible, 20000,
-                      "the members skeleton must clear again after the switch")
+            verify(!ctx.skeleton.visible,
+                   "a members-model swap must not bring the skeleton back")
             tryVerify(() => ctx.list.count > 0, 20000,
                       "the members list must repopulate after the switch")
         }
 
-        function test_userListBuildsNoMemberRowsDuringChannelSwitch() {
-            const ctx = loadSectionWithMembers()
-            ctx.internal.membersWireDelay = 2000
-
-            const row = permissionedChannelRow(ctx.loader)
-            verify(!!row, "the permissioned channel row must exist")
-            mouseClick(row)
-            tryVerify(() => mock.activeChatId === row.chatId, 5000)
-
-            compare(ctx.list.count, 0,
-                    "the members list must hold no rows while the switch is in flight")
-            compare(harness.findAllByTypePrefix(ctx.list.contentItem,
-                                                "StatusMemberListItem_QMLTYPE", []).length, 0,
-                    "no member delegate may be built while the switch is in flight")
-        }
-
         // The dominant path: community channels without permissions all share
-        // the section's members model, so the panel must not be torn down and
-        // re-sorted on those switches.
+        // the section's members model, so the panel must not be torn down on
+        // those switches.
         function test_membersPanelSurvivesSwitchWithUnchangedModel() {
             const ctx = loadSectionWithMembers()
-            // long enough that an erroneous latch drop would still be down here
-            ctx.internal.membersWireDelay = 2000
 
             const before = ctx.list.count
             const row = unpermissionedChannelRow(ctx.loader)

--- a/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
+++ b/storybook/qmlTests/tests/tst_ChatViewMembersSkeleton.qml
@@ -5,12 +5,14 @@ import utils
 
 import "helpers"
 
-// The members panel is built once per section, asynchronously behind
-// MembersListSkeleton, and shared across the section's channels. These tests
-// pin that the skeleton covers only that initial incubation: channel switches
-// — whether they keep the members model or swap it (permissioned channels) —
-// must neither tear the panel down nor bring the skeleton back, because the
-// model arrives pre-sorted from Nim and rebinding it is cheap.
+// The members panel loads asynchronously behind the section chrome's members
+// skeleton (the loader-owned "rightPanelSkeleton" slot), which must hold until
+// the first viewport of member rows is actually built — swapping earlier makes
+// ListView build every row in one GUI-thread frame and freezes the shimmer
+// mid-sweep. Channel switches — whether they keep the members model or swap it
+// (permissioned channels) — must neither tear the panel down nor bring the
+// skeleton back, because the model arrives pre-sorted from Nim and rebinding
+// it is cheap.
 Item {
     id: root
 
@@ -63,10 +65,10 @@ Item {
             const view = harness.findChildByTypePrefix(loader, "ChatView")
             verify(!!view, "the section must load the paneled chat view")
 
-            const skeleton = findChild(loader, "membersPanelSkeleton")
-            verify(!!skeleton, "the members panel must have its skeleton")
-            tryVerify(() => !skeleton.visible, 20000,
-                      "the members skeleton must clear once the panel is built")
+            const skeleton = findChild(loader, "rightPanelSkeleton")
+            verify(!!skeleton, "the chrome must have its members skeleton slot")
+            tryVerify(() => !skeleton.active, 20000,
+                      "the members skeleton must clear once the rows are built")
 
             const list = findChild(loader, "userListPanel")
             verify(!!list)
@@ -114,6 +116,116 @@ Item {
                     return row
             }
             return null
+        }
+
+        // Counts the real member rows built at the exact instant `skeleton`
+        // deactivates; -1 if it never deactivated while armed.
+        function armRowsAtClearProbe(loader, skeleton) {
+            const probe = { builtAtClear: -1 }
+            skeleton.activeChanged.connect(() => {
+                if (!skeleton.active && probe.builtAtClear === -1) {
+                    const list = findChild(loader, "userListPanel")
+                    probe.builtAtClear = list
+                            ? harness.findAllByTypePrefix(
+                                  list.contentItem,
+                                  "StatusMemberListItem_QMLTYPE", []).length
+                            : 0
+                }
+            })
+            return probe
+        }
+
+        function expectedViewportRows(list) {
+            const expected = Math.min(list.count, Math.floor(list.height / 64))
+            verify(expected > 0, "the viewport must fit at least one member row")
+            return expected
+        }
+
+        // The swap frame is the freeze: if the skeleton clears before the
+        // initially-visible member rows exist, ListView builds them all in
+        // one GUI-thread frame and the shimmer stalls mid-sweep. The skeleton
+        // must hold until that first viewport of rows is actually built.
+        function test_membersSkeletonHoldsUntilRowsBuilt() {
+            harness.loader.active = true
+            const loader = harness.loader.item
+            verify(!!loader)
+
+            // the chrome skeleton exists (and covers) from the first frame,
+            // before the section view is even loaded — watch it from here
+            const skeleton = findChild(loader, "rightPanelSkeleton")
+            verify(!!skeleton)
+            verify(skeleton.active,
+                   "the members skeleton must cover the section load")
+            const probe = armRowsAtClearProbe(loader, skeleton)
+
+            tryVerify(() => !skeleton.active, 20000,
+                      "the members skeleton must eventually clear")
+
+            const list = findChild(loader, "userListPanel")
+            verify(!!list)
+            const expected = expectedViewportRows(list)
+            verify(probe.builtAtClear >= expected,
+                   "skeleton cleared with only " + probe.builtAtClear + " of "
+                   + expected + " visible member rows built")
+        }
+
+        // In portrait the chrome slides between panels and brackets the slide
+        // with panelSwitchStarted/panelSwitchEnded. A panel that becomes
+        // ready mid-slide must keep its skeleton until the end signal —
+        // swapping mid-slide stutters the animation.
+        function test_membersPanelPromotionWaitsOutPanelSwitch() {
+            harness.loader.active = true
+            const loader = harness.loader.item
+            verify(!!loader)
+
+            const chrome = findChild(loader, "sectionChrome")
+            verify(!!chrome)
+            const skeleton = findChild(loader, "rightPanelSkeleton")
+            verify(!!skeleton)
+
+            // a panel switch starts before the members panel is ready...
+            chrome.panelSwitchStarted()
+
+            tryVerify(() => loader.status === Loader.Ready, 120000)
+            const view = harness.findChildByTypePrefix(loader, "ChatView")
+            verify(!!view)
+            tryVerify(() => view.rightPanelReady, 20000,
+                      "the members panel must become ready underneath")
+            verify(skeleton.active,
+                   "the skeleton must hold while the panel switch is in flight")
+
+            chrome.panelSwitchEnded()
+            tryVerify(() => !skeleton.active, 5000,
+                      "the panel must swap in once the switch ends")
+            const list = findChild(loader, "userListPanel")
+            verify(!!list)
+            tryVerify(() => list.count > 0)
+        }
+
+        // The panel is loaded only while shown: hiding the members list
+        // discards it, and the next show re-incubates it behind the
+        // skeleton, held until the rows are back.
+        function test_membersPanelDiscardedWhenHidden() {
+            const ctx = loadSectionWithMembers()
+
+            ctx.view.showUsersList = false
+            tryVerify(() => findChild(ctx.loader, "userListPanel") === null,
+                      5000, "hiding the members panel must unload it")
+
+            const probe = armRowsAtClearProbe(ctx.loader, ctx.skeleton)
+            ctx.view.showUsersList = true
+            verify(ctx.skeleton.active,
+                   "re-showing the members panel must bring the skeleton up")
+
+            tryVerify(() => !ctx.skeleton.active, 20000,
+                      "the members skeleton must clear again after the re-show")
+
+            const list = findChild(ctx.loader, "userListPanel")
+            verify(!!list)
+            const expected = expectedViewportRows(list)
+            verify(probe.builtAtClear >= expected,
+                   "skeleton cleared with only " + probe.builtAtClear + " of "
+                   + expected + " visible member rows built on re-show")
         }
 
         // Landing on a channel with its own members model swaps the model

--- a/storybook/qmlTests/tests/tst_SectionLoaderChrome.qml
+++ b/storybook/qmlTests/tests/tst_SectionLoaderChrome.qml
@@ -167,6 +167,33 @@ Item {
             }
         }
 
+        function test_panelSwapWaitsOutPanelSwitch_data() { return loaderCases() }
+
+        // A panel that becomes ready while the chrome's panel-switch
+        // animation runs must keep its skeleton until the switch ends —
+        // swapping mid-slide stutters the animation. Applies to every slot.
+        function test_panelSwapWaitsOutPanelSwitch(data) {
+            const loader = createLoaderWithStub(data.comp)
+            const stub = loader.item
+            const chrome = findChild(loader, "sectionChrome")
+            verify(!!chrome)
+
+            chrome.panelSwitchStarted()
+            for (const spec of slotSpecs) {
+                stub[spec.flag] = true
+                verify(chrome[spec.slot] === findChild(loader, spec.skeleton),
+                       spec.slot + " must hold its skeleton while a panel switch runs")
+            }
+
+            chrome.panelSwitchEnded()
+            for (const spec of slotSpecs) {
+                verify(chrome[spec.slot] === stub[spec.slot],
+                       spec.slot + " must swap in once the switch ends")
+                verify(!findChild(loader, spec.skeleton).active,
+                       spec.skeleton + " must be released after the deferred swap")
+            }
+        }
+
         function test_slotsAreIndependent_data() { return loaderCases() }
 
         // Retiring one slot must leave the other three on their skeletons.

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -467,6 +467,22 @@ Item {
             tryVerify(() => memberSuggestionIndex("KateRoe") >= 0)
         }
 
+        // A model swap while the user is mid-mention (late member delivery,
+        // permission re-evaluation) gets no enteringSuggestion edge, so the
+        // wiring must re-arm itself or suggestions stay stuck on the skeleton.
+        function test_mentionSuggestions_modelSwapMidMentionRearms() {
+            appendContact("JohnDoe")
+            waitForRendering(controlUnderTest)
+
+            mouseClick(getToolBar().mentionButton)
+            tryVerify(() => memberSuggestionIndex("JohnDoe") >= 0)
+
+            // still in mention-entry mode; swap the model under it
+            appendContact("KateRoe")
+            tryVerify(() => memberSuggestionIndex("KateRoe") >= 0,
+                      5000, "the swapped-in model must wire without leaving mention mode")
+        }
+
         function test_editCancel_emitsSignal() {
             const cancelButton = findChild(controlUnderTest, "statusChatInputEditCloseButton")
             verify(!!cancelButton)
@@ -525,11 +541,12 @@ Item {
             typeText("Hello @zzz")
             waitForRendering(controlUnderTest)
 
-            // enteringSuggestion is true, but there are no matches, so the box stays hidden.
+            // once the members model wires in, "zzz" matches nothing: the box
+            // (a loading skeleton meanwhile) must hide, never sit visible-but-empty
             verify(controlUnderTest.textInput.enteringSuggestion)
             const box = findChild(controlUnderTest, "suggestionsBox")
             verify(!!box)
-            verify(!box.visible, "no suggestion box for a non-matching name")
+            tryVerify(() => !box.visible, 5000, "no suggestion box for a non-matching name")
 
             signalSpy.setup(controlUnderTest, "sendMessageRequested")
             keyClick(Qt.Key_Return) // send (NoModifier maps to send on desktop/offscreen)
@@ -538,6 +555,31 @@ Item {
             verify(!controlUnderTest.getPlainText().includes("@undefined"))
             compare(controlUnderTest.getPlainText(), "Hello @zzz")
             compare(signalSpy.count, 1)
+        }
+
+        // Enter inside the wiring window must still send: the box shows only a
+        // loading skeleton then — nothing committable — and must not swallow it.
+        function test_typedMention_enterDuringLoadingStillSends() {
+            appendContact("JohnDoe")
+            waitForRendering(controlUnderTest)
+
+            // hold the wiring so the loading window stays open
+            controlUnderTest.suggestionsModelWireDelay = 3600000
+
+            controlUnderTest.textInput.forceActiveFocus()
+            typeText("Hello @Jo")
+            waitForRendering(controlUnderTest)
+
+            const box = findChild(controlUnderTest, "suggestionsBox")
+            verify(!!box)
+            tryVerify(() => box.visible && box.loading)
+
+            signalSpy.setup(controlUnderTest, "sendMessageRequested")
+            keyClick(Qt.Key_Return)
+            waitForRendering(controlUnderTest)
+
+            compare(signalSpy.count, 1)
+            verify(!controlUnderTest.getPlainText().includes("@undefined"))
         }
 
         // ── typed emoji-shortcode flow

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -2,6 +2,8 @@ import QtQuick
 import QtQuick.Controls
 import QtTest
 
+import StatusQ.Core.Utils as SQUtils
+
 import shared.status
 
 Item {
@@ -98,6 +100,11 @@ Item {
         }
     }
 
+    Component {
+        id: contactsModelComponent
+        ListModel {}
+    }
+
     TestCase {
         name: "StatusChatInput"
         when: windowShown
@@ -144,9 +151,15 @@ Item {
             controlUnderTest.textInput.select(start, end)
         }
 
+        // Replaces the input's users model with a freshly populated one:
+        // the suggestions ConcatModel captures roles when a source is set,
+        // so rows appended to the initially empty inline model never map.
         function appendContact(displayName) {
-            controlUnderTest.usersModel.append({
+            const contacts = contactsModelComponent.createObject(wrapperUnderTest)
+            contacts.append({
                 pubKey: "0x0" + displayName,
+                preferredDisplayName: displayName,
+                usesDefaultName: false,
                 onlineStatus: 1,
                 isContact: true,
                 isVerified: true,
@@ -160,6 +173,7 @@ Item {
                 icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0BhCExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC",
                 colorId: 7
             })
+            controlUnderTest.usersModel = contacts
         }
 
         function test_sendButton_icon_data() {
@@ -367,6 +381,92 @@ Item {
             compare(signalSpy.count, 1)
         }
 
+        /*
+         Perf guard: profiling showed the mention SuggestionsFilterAdaptor
+         sorting the full community members model on every chat switch (669ms
+         on a low-end device) although suggestions only matter once the user
+         enters a mention. The members model must stay unwired until the first
+         mention entry; a loading skeleton covers the wiring window.
+        */
+        function suggestionList() {
+            const list = findChild(controlUnderTest, "suggestionBoxList")
+            verify(!!list)
+            return list
+        }
+
+        function memberSuggestionIndex(displayName) {
+            return SQUtils.ModelUtils.indexOf(suggestionList().model,
+                                              "pubKey", "0x0" + displayName)
+        }
+
+        function test_mentionSuggestions_membersNotMaterializedBeforeEntry() {
+            appendContact("JohnDoe")
+            waitForRendering(controlUnderTest)
+
+            compare(memberSuggestionIndex("JohnDoe"), -1,
+                    "members must not be materialized before the first mention entry")
+        }
+
+        function test_mentionSuggestions_skeletonShownUntilModelWired() {
+            appendContact("JohnDoe")
+            waitForRendering(controlUnderTest)
+
+            // hold the wiring so the pre-wire state is observable
+            controlUnderTest.suggestionsModelWireDelay = 3600000
+
+            mouseClick(getToolBar().mentionButton)
+
+            const suggestionsBox = findChild(controlUnderTest, "suggestionsBox")
+            verify(!!suggestionsBox)
+            tryVerify(() => suggestionsBox.visible)
+
+            const skeleton = findChild(suggestionsBox, "suggestionsLoadingSkeleton")
+            verify(!!skeleton)
+            verify(skeleton.visible)
+            verify(skeleton.height > 0)
+            compare(memberSuggestionIndex("JohnDoe"), -1,
+                    "members must not be materialized while the skeleton shows")
+        }
+
+        function test_mentionSuggestions_populateOnFirstEntry() {
+            appendContact("JohnDoe")
+            waitForRendering(controlUnderTest)
+
+            mouseClick(getToolBar().mentionButton)
+
+            // members appear once the model is wired (after the skeleton
+            // window), and the skeleton goes away
+            tryVerify(() => memberSuggestionIndex("JohnDoe") >= 0)
+            const skeleton = findChild(controlUnderTest, "suggestionsLoadingSkeleton")
+            verify(!skeleton || !skeleton.visible)
+        }
+
+        // The input instance is shared across chats: a chat switch swaps
+        // usersModel on it. A mention entered in one chat must not leave the
+        // wiring latched, or every later switch re-sorts the new members
+        // model (the 698ms regression seen in the warmstart6 trace).
+        function test_mentionSuggestions_modelSwapResetsWiring() {
+            appendContact("JohnDoe")
+            waitForRendering(controlUnderTest)
+
+            mouseClick(getToolBar().mentionButton)
+            tryVerify(() => memberSuggestionIndex("JohnDoe") >= 0)
+
+            // leave the mention context (as a chat switch does), then swap
+            // the model — the next chat's members must stay unmaterialized
+            controlUnderTest.textInput.clear()
+            waitForRendering(controlUnderTest)
+            appendContact("KateRoe")
+            waitForRendering(controlUnderTest)
+
+            compare(memberSuggestionIndex("KateRoe"), -1,
+                    "swapping usersModel must unwire mention suggestions")
+
+            // a fresh mention entry wires the new model on demand
+            mouseClick(getToolBar().mentionButton)
+            tryVerify(() => memberSuggestionIndex("KateRoe") >= 0)
+        }
+
         function test_editCancel_emitsSignal() {
             const cancelButton = findChild(controlUnderTest, "statusChatInputEditCloseButton")
             verify(!!cancelButton)
@@ -400,6 +500,11 @@ Item {
             verify(box.visible)
             compare(controlUnderTest.textInput.mentionsFilter, "Jo")
             verify(controlUnderTest.getPlainText().includes("@Jo"))
+
+            // the members model wires into the suggestions shortly after the
+            // first mention entry (loading skeleton meanwhile) — a commit
+            // only applies to a visible suggestion
+            tryVerify(() => memberSuggestionIndex("JohnDoe") >= 0)
 
             keyClick(Qt.Key_Tab) // commit the highlighted suggestion
             waitForRendering(controlUnderTest)

--- a/storybook/qmlTests/tests/tst_StatusSectionLayout.qml
+++ b/storybook/qmlTests/tests/tst_StatusSectionLayout.qml
@@ -1,0 +1,136 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Layout
+
+// StatusSectionLayout brackets every panel switch with
+// panelSwitchStarted/panelSwitchEnded. Landscape shows all panels at once —
+// there is no slide — so a currentIndex change must emit the pair
+// back-to-back, and the invisible portrait view's own slide must not leak
+// extra signals. (The window is 1000px wide: landscape mode.)
+Item {
+    id: root
+
+    width: 1000
+    height: 700
+
+    Component {
+        id: layoutComponent
+
+        StatusSectionLayout {
+            anchors.fill: parent
+            showRightPanel: true
+        }
+    }
+
+    Component {
+        id: panelComponent
+        Rectangle {}
+    }
+
+    SignalSpy {
+        id: startedSpy
+        signalName: "panelSwitchStarted"
+    }
+
+    SignalSpy {
+        id: endedSpy
+        signalName: "panelSwitchEnded"
+    }
+
+    TestCase {
+        name: "StatusSectionLayout"
+        when: windowShown
+
+        property var layout: null
+
+        function init() {
+            layout = createTemporaryObject(layoutComponent, root)
+            verify(!!layout)
+            layout.leftPanel = createTemporaryObject(panelComponent, root)
+            layout.centerPanel = createTemporaryObject(panelComponent, root)
+            layout.rightPanel = createTemporaryObject(panelComponent, root)
+            waitForRendering(layout)
+
+            startedSpy.target = layout
+            endedSpy.target = layout
+            startedSpy.clear()
+            endedSpy.clear()
+        }
+
+        // The internal portrait view; its `visible` is what the orientation
+        // selector flips on rotation, so setting it simulates a rotation.
+        function portraitView() {
+            const list = layout.children
+            for (let i = 0; i < list.length; ++i) {
+                if (list[i].toString().indexOf("StatusSectionLayoutPortrait") === 0)
+                    return list[i]
+            }
+            return null
+        }
+
+        // Rotating to landscape mid-slide must close the bracket right away:
+        // the slide is no longer visible, so there is nothing left to defer
+        // panel swaps for.
+        function test_rotateToLandscapeMidSlideClosesBracket() {
+            const pv = portraitView()
+            verify(!!pv)
+            pv.contentItem.highlightMoveDuration = 60000 // hold the slide
+            pv.visible = true // start in portrait
+
+            layout.currentIndex = StatusSectionLayout.RightPanel
+            compare(startedSpy.count, 1)
+            compare(endedSpy.count, 0)
+
+            pv.visible = false // rotate away mid-slide
+            compare(endedSpy.count, 1,
+                    "rotating away mid-slide must close the bracket at once")
+
+            // the invisible slide settling later must not emit anything more
+            pv.contentItem.highlightMoveDuration = 50
+            tryVerify(() => Math.abs(pv.contentItem.contentX - pv.currentItem.x) < 0.5,
+                      5000)
+            compare(startedSpy.count, 1)
+            compare(endedSpy.count, 1)
+        }
+
+        // Rotating to portrait while the (invisible) slide from a landscape
+        // switch is still running must open a bracket for it — the animation
+        // is suddenly visible and panel swaps must defer to its end.
+        function test_rotateToPortraitMidSlideOpensBracket() {
+            const pv = portraitView()
+            verify(!!pv)
+            verify(!pv.visible, "the 1000px window must start in landscape")
+            pv.contentItem.highlightMoveDuration = 60000 // hold the slide
+
+            layout.currentIndex = StatusSectionLayout.RightPanel
+            compare(startedSpy.count, 1, "landscape pair")
+            compare(endedSpy.count, 1, "landscape pair")
+
+            pv.visible = true // rotate into the running slide
+            compare(startedSpy.count, 2,
+                    "rotating into a running slide must open a bracket")
+            compare(endedSpy.count, 1)
+
+            pv.contentItem.highlightMoveDuration = 50
+            tryCompare(endedSpy, "count", 2, 5000,
+                       "the bracket must close when the slide settles")
+            compare(startedSpy.count, 2)
+        }
+
+        function test_landscapeSwitchEmitsPairBackToBack() {
+            layout.currentIndex = StatusSectionLayout.RightPanel
+
+            compare(startedSpy.count, 1,
+                    "a landscape switch must emit panelSwitchStarted")
+            compare(endedSpy.count, 1,
+                    "a landscape switch must emit panelSwitchEnded right after")
+
+            // the invisible portrait view still slides underneath; its own
+            // start/end must not leak through as extra emissions
+            wait(500)
+            compare(startedSpy.count, 1)
+            compare(endedSpy.count, 1)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusSectionLayoutPortrait.qml
+++ b/storybook/qmlTests/tests/tst_StatusSectionLayoutPortrait.qml
@@ -1,0 +1,81 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Layout
+
+// The portrait chrome slides between panels (SwipeView) and brackets every
+// slide with panelSwitchStarted/panelSwitchEnded. Consumers use the pair to
+// defer expensive panel swaps (skeleton → real panel) off the animation:
+// retargeting a slot mid-slide stutters it.
+Item {
+    id: root
+
+    width: 390
+    height: 700
+
+    Component {
+        id: layoutComponent
+
+        StatusSectionLayoutPortrait {
+            anchors.fill: parent
+            showRightPanel: true
+        }
+    }
+
+    Component {
+        id: panelComponent
+        Rectangle {}
+    }
+
+    SignalSpy {
+        id: startedSpy
+        signalName: "panelSwitchStarted"
+    }
+
+    SignalSpy {
+        id: endedSpy
+        signalName: "panelSwitchEnded"
+    }
+
+    TestCase {
+        name: "StatusSectionLayoutPortrait"
+        when: windowShown
+
+        property var layout: null
+
+        function init() {
+            layout = createTemporaryObject(layoutComponent, root)
+            verify(!!layout)
+            layout.leftPanel = createTemporaryObject(panelComponent, root)
+            layout.centerPanel = createTemporaryObject(panelComponent, root)
+            layout.rightPanel = createTemporaryObject(panelComponent, root)
+            waitForRendering(layout)
+
+            startedSpy.target = layout
+            endedSpy.target = layout
+            startedSpy.clear()
+            endedSpy.clear()
+        }
+
+        function test_panelSwitchSignalsBracketTheSlide() {
+            compare(layout.currentIndex, 0)
+            compare(startedSpy.count, 0)
+
+            layout.currentIndex = 2
+            compare(startedSpy.count, 1,
+                    "the slide to another panel must emit panelSwitchStarted")
+            compare(endedSpy.count, 0,
+                    "panelSwitchEnded must wait for the slide to settle")
+
+            tryCompare(endedSpy, "count", 1, 5000,
+                       "panelSwitchEnded must fire once the slide settles")
+            compare(startedSpy.count, 1, "the slide must emit exactly one pair")
+        }
+
+        function test_noSignalsWhileIdle() {
+            waitForRendering(layout)
+            compare(startedSpy.count, 0)
+            compare(endedSpy.count, 0)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_UserListPanel.qml
+++ b/storybook/qmlTests/tests/tst_UserListPanel.qml
@@ -1,0 +1,182 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Chat.panels
+
+import StatusQ.Core.Utils as SQUtils
+
+import utils
+
+/*
+ Perf regression guard: chat-switch profile showed the members panel fully
+ re-sorting the community members model (SFPM RoleSorter + StringSorter,
+ 881ms on a low-end device) even while the right panel was hidden. A hidden
+ panel must not materialize rows from usersModel; showing it populates the
+ sorted list on demand.
+*/
+Item {
+    id: root
+
+    width: 300
+    height: 600
+
+    ListModel {
+        id: membersModel
+
+        function addMember(name, onlineStatus) {
+            append({
+                       pubKey: "0x0" + name,
+                       compressedPubKey: "zx" + name,
+                       preferredDisplayName: name,
+                       displayName: name,
+                       ensName: "",
+                       alias: name + "-alias",
+                       localNickname: "",
+                       usesDefaultName: true,
+                       isEnsVerified: false,
+                       isContact: true,
+                       isVerified: false,
+                       isUntrustworthy: false,
+                       isBlocked: false,
+                       isCurrentUser: false,
+                       memberRole: 0,
+                       contactRequest: 0,
+                       trustStatus: 0,
+                       emojiHash: "[]",
+                       icon: "",
+                       colorId: 1,
+                       onlineStatus: onlineStatus
+                   })
+        }
+    }
+
+    Component {
+        id: panelComponent
+
+        UserListPanel {
+            anchors.fill: parent
+            label: "Members"
+            usersModel: membersModel
+        }
+    }
+
+    Component {
+        id: skeletonComponent
+
+        MembersListSkeleton {
+            anchors.fill: parent
+        }
+    }
+
+    TestCase {
+        name: "UserListPanel"
+        when: windowShown
+
+        function init() {
+            membersModel.clear()
+            // deliberately unsorted input: online statuses mixed, names mixed case
+            membersModel.addMember("charlie", Constants.onlineStatus.inactive)
+            membersModel.addMember("Alice", Constants.onlineStatus.online)
+            membersModel.addMember("bob", Constants.onlineStatus.online)
+        }
+
+        function memberListView(panel) {
+            const listView = findChild(panel, "userListPanel")
+            verify(!!listView)
+            return listView
+        }
+
+        function test_hiddenPanelMaterializesNoRows() {
+            const panel = createTemporaryObject(panelComponent, root,
+                                                {visible: false})
+            verify(!!panel)
+            wait(50)
+
+            compare(memberListView(panel).count, 0,
+                    "hidden panel must not pull rows from usersModel")
+        }
+
+        function test_showingPanelPopulatesSortedList() {
+            const panel = createTemporaryObject(panelComponent, root,
+                                                {visible: false})
+            verify(!!panel)
+
+            panel.visible = true
+            const listView = memberListView(panel)
+            tryCompare(listView, "count", 3)
+
+            // online first (RoleSorter desc), then name case-insensitive
+            const order = []
+            for (let i = 0; i < listView.count; i++)
+                order.push(SQUtils.ModelUtils.get(listView.model, i, "preferredDisplayName"))
+            compare(order, ["Alice", "bob", "charlie"])
+        }
+
+        function test_visiblePanelShowsRowsImmediately() {
+            const panel = createTemporaryObject(panelComponent, root)
+            verify(!!panel)
+            tryCompare(memberListView(panel), "count", 3)
+        }
+
+        // Chrome inversion creates panels without a visual parent until the
+        // section chrome reparents them; that state must not sort either.
+        function test_unparentedPanelMaterializesNoRows() {
+            const panel = createTemporaryObject(panelComponent, null)
+            verify(!!panel)
+            wait(50)
+
+            compare(memberListView(panel).count, 0,
+                    "unparented panel must not pull rows from usersModel")
+        }
+
+        // The skeleton must look identical to the real panel header, so both
+        // must render the SAME header component (search disabled while
+        // loading).
+        function test_panelAndSkeletonShareTheHeader() {
+            const panel = createTemporaryObject(panelComponent, root)
+            verify(!!panel)
+            waitForRendering(panel)
+            verify(!!findChild(panel, "membersPanelHeader"),
+                   "real panel must use the shared header")
+            const panelTitle = findChild(panel, "membersPanelTitle")
+            tryVerify(() => panelTitle.visible, 5000,
+                      "panel title must be visible at panel width")
+            compare(panelTitle.text, "Members")
+
+            const skeleton = createTemporaryObject(skeletonComponent, root)
+            verify(!!skeleton)
+            waitForRendering(skeleton)
+            const skeletonHeader = findChild(skeleton, "membersPanelHeader")
+            verify(!!skeletonHeader, "skeleton must use the shared header")
+            verify(!findChild(skeletonHeader, "membersSearchButton").enabled,
+                   "skeleton search must be disabled")
+            tryVerify(() => findChild(skeleton, "membersPanelTitle").visible, 5000,
+                      "skeleton title must be visible at panel width")
+        }
+
+        function test_searchButtonTogglesSearchBox() {
+            const panel = createTemporaryObject(panelComponent, root)
+            verify(!!panel)
+            waitForRendering(panel)
+
+            const searchBtn = findChild(panel, "membersSearchButton")
+            verify(!!searchBtn)
+            const searchBox = findChild(panel, "membersSearchBox")
+            verify(!!searchBox)
+            verify(!searchBox.visible)
+
+            mouseClick(searchBtn)
+            tryVerify(() => searchBox.visible)
+        }
+
+        function test_hidingPanelReleasesRows() {
+            const panel = createTemporaryObject(panelComponent, root)
+            verify(!!panel)
+            const listView = memberListView(panel)
+            tryCompare(listView, "count", 3)
+
+            panel.visible = false
+            tryCompare(listView, "count", 0)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_UserListPanel.qml
+++ b/storybook/qmlTests/tests/tst_UserListPanel.qml
@@ -9,10 +9,10 @@ import utils
 
 /*
  Perf regression guard: chat-switch profile showed the members panel fully
- re-sorting the community members model (SFPM RoleSorter + StringSorter,
- 881ms on a low-end device) even while the right panel was hidden. A hidden
- panel must not materialize rows from usersModel; showing it populates the
- sorted list on demand.
+ re-sorting the community members model in QML (SFPM RoleSorter + StringSorter,
+ 881ms on a low-end device). The members model now arrives pre-sorted from Nim
+ (online first, then name), so the panel must render rows in source order and
+ never re-sort them.
 */
 Item {
     id: root
@@ -86,30 +86,19 @@ Item {
             return listView
         }
 
-        function test_hiddenPanelMaterializesNoRows() {
-            const panel = createTemporaryObject(panelComponent, root,
-                                                {visible: false})
+        // The model owns the order (sorted in Nim): rows must come out exactly
+        // as fed in, deliberately non-alphabetical here — a QML sorter sneaking
+        // back in would flip this to ["Alice", "bob", "charlie"].
+        function test_panelShowsRowsInModelOrder() {
+            const panel = createTemporaryObject(panelComponent, root)
             verify(!!panel)
-            wait(50)
-
-            compare(memberListView(panel).count, 0,
-                    "hidden panel must not pull rows from usersModel")
-        }
-
-        function test_showingPanelPopulatesSortedList() {
-            const panel = createTemporaryObject(panelComponent, root,
-                                                {visible: false})
-            verify(!!panel)
-
-            panel.visible = true
             const listView = memberListView(panel)
             tryCompare(listView, "count", 3)
 
-            // online first (RoleSorter desc), then name case-insensitive
             const order = []
             for (let i = 0; i < listView.count; i++)
                 order.push(SQUtils.ModelUtils.get(listView.model, i, "preferredDisplayName"))
-            compare(order, ["Alice", "bob", "charlie"])
+            compare(order, ["charlie", "Alice", "bob"])
         }
 
         function test_visiblePanelShowsRowsImmediately() {
@@ -118,15 +107,23 @@ Item {
             tryCompare(memberListView(panel), "count", 3)
         }
 
-        // Chrome inversion creates panels without a visual parent until the
-        // section chrome reparents them; that state must not sort either.
-        function test_unparentedPanelMaterializesNoRows() {
-            const panel = createTemporaryObject(panelComponent, null)
+        function test_searchFiltersMembers() {
+            const panel = createTemporaryObject(panelComponent, root)
             verify(!!panel)
-            wait(50)
+            const listView = memberListView(panel)
+            tryCompare(listView, "count", 3)
 
-            compare(memberListView(panel).count, 0,
-                    "unparented panel must not pull rows from usersModel")
+            mouseClick(findChild(panel, "membersSearchButton"))
+            const searchBox = findChild(panel, "membersSearchBox")
+            tryVerify(() => searchBox.visible)
+
+            searchBox.text = "ali"
+            tryCompare(listView, "count", 1)
+            compare(SQUtils.ModelUtils.get(listView.model, 0, "preferredDisplayName"),
+                    "Alice")
+
+            searchBox.text = ""
+            tryCompare(listView, "count", 3)
         }
 
         // The skeleton must look identical to the real panel header, so both
@@ -169,14 +166,5 @@ Item {
             tryVerify(() => searchBox.visible)
         }
 
-        function test_hidingPanelReleasesRows() {
-            const panel = createTemporaryObject(panelComponent, root)
-            verify(!!panel)
-            const listView = memberListView(panel)
-            tryCompare(listView, "count", 3)
-
-            panel.visible = false
-            tryCompare(listView, "count", 0)
-        }
     }
 }

--- a/storybook/src/Models/CommunitySectionMock.qml
+++ b/storybook/src/Models/CommunitySectionMock.qml
@@ -455,11 +455,11 @@ QtObject {
             appendMember(root.membersModel, "0xdeadbeef", "Me", 0, root.memberRole)
             for (let i = 0; i < root.membersCount; ++i) {
                 const role = i === 0 ? Constants.memberRole.owner : Constants.memberRole.none
-                appendMember(root.membersModel, "0xmember-" + i, "Member " + i, i + 1, role)
+                appendMember(root.membersModel, memberKey(i), "Member " + i, i + 1, role)
             }
             appendMember(root.privateChannelMembersModel, "0xdeadbeef", "Me", 0, root.memberRole)
             for (let i = 0; i < root.privateChannelMembersCount; ++i)
-                appendMember(root.privateChannelMembersModel, "0xmember-" + i, "Member " + i, i + 1,
+                appendMember(root.privateChannelMembersModel, memberKey(i), "Member " + i, i + 1,
                              i === 0 ? Constants.memberRole.owner : Constants.memberRole.none)
         }
 
@@ -521,16 +521,33 @@ QtObject {
                 appendPermission(index++, Constants.permissionType.viewAndPost, gated)
         }
 
+        // Valid mention-grammar pub key ("0x" + 130 hex) for member i, so mock
+        // mentions parse and resolve exactly like production ones
+        function memberKey(i) {
+            return "0x04" + i.toString(16).padStart(128, "0")
+        }
+
         function fillMessages(model, chatId) {
             const now = Date.now()
             const count = root.messagesPerChannel
             const senderCount = Math.max(1, Math.min(root.membersCount, 20))
+            // Deterministic local photos: image rows must not hit the network
+            const photoA = "file:///private/tmp/claude-501/-Users-alexjbanca-Repos-status-desktop/367af37d-a18f-4e58-9856-5ecd5112f2cc/scratchpad/mock_photo_a.png"
+            const photoB = "file:///private/tmp/claude-501/-Users-alexjbanca-Repos-status-desktop/367af37d-a18f-4e58-9856-5ecd5112f2cc/scratchpad/mock_photo_b.png"
             // like the production model: index 0 is the newest message and
             // history grows towards higher indexes
             for (let i = 0; i < count; ++i) {
                 const own = i % 7 === 1
                 const senderIdx = i % senderCount
                 const ts = now - i * 60000
+                // Realistic content mix: every 4th message mentions a member,
+                // every 10th is a photo
+                const mention = !own && i % 4 === 2
+                const image = i % 10 === 7
+                const bodyText = mention
+                    ? "Hey @" + memberKey((senderIdx + 3) % senderCount) + " message " + (count - i) + " needs your eyes"
+                    : "Message " + (count - i) + " — the quick brown fox jumps over the lazy dog. "
+                      + (i % 5 === 0 ? "A somewhat longer paragraph to vary the bubble heights while measuring text. " : "")
                 model.append({
                     id: "msg-" + chatId + "-" + i,
                     prevMsgIndex: i + 1,
@@ -542,7 +559,7 @@ QtObject {
                     prevMsgDeleted: false,
                     timestamp: ts,
                     responseToMessageWithId: "",
-                    senderId: own ? "0xdeadbeef" : "0xmember-" + senderIdx,
+                    senderId: own ? "0xdeadbeef" : memberKey(senderIdx),
                     senderDisplayName: own ? "Me" : "Member " + senderIdx,
                     senderOptionalName: "",
                     senderIcon: "",
@@ -550,12 +567,12 @@ QtObject {
                     senderEnsVerified: false,
                     senderTrustStatus: 0,
                     amISender: own,
-                    messageText: "Message " + (count - i) + " — the quick brown fox jumps over the lazy dog. "
-                                 + (i % 5 === 0 ? "A somewhat longer paragraph to vary the bubble heights while measuring text. " : ""),
-                    unparsedText: "Message " + (count - i),
-                    messageImage: "",
+                    messageText: bodyText,
+                    unparsedText: bodyText,
+                    messageImage: image ? (i % 20 === 7 ? photoA : photoB) : "",
                     messageAttachments: "",
-                    contentType: Constants.messageContentType.messageType,
+                    contentType: image ? Constants.messageContentType.imageType
+                                       : Constants.messageContentType.messageType,
                     sticker: "",
                     stickerPack: -1,
                     outgoingStatus: own ? "sent" : "",

--- a/test/nim/member_model_test.nim
+++ b/test/nim/member_model_test.nim
@@ -1,13 +1,13 @@
 import unittest
 
 import app/modules/shared_models/[member_model, member_item]
+import app/modules/shared/qt_model_spy
 import app_service/common/types
 
 proc createTestMemberItem(pubKey: string): MemberItem =
   return initMemberItem(
       pubKey = pubKey,
       displayName = "",
-      usesDefaultName = true,
       ensName = "",
       isEnsVerified = false,
       localNickname = "",
@@ -141,12 +141,108 @@ suite "updating member items":
     let itemE = model.getMemberItem("0xe")
     check(itemE.displayName == "gina")
 
+suite "derived name state":
+  setup:
+    let model = newModel()
+    model.setItems(@[createTestMemberItem("0xa")])
+
+  test "derived at construction with fixed precedence":
+    proc named(nickname, ens: string, verified: bool, display, alias: string): MemberItem =
+      initMemberItem(
+        pubKey = "0xkey", displayName = display, ensName = ens, isEnsVerified = verified,
+        localNickname = nickname, alias = alias, icon = "", colorId = 0)
+
+    check(named("nick", "foo.eth", true, "display", "alias").preferredDisplayName == "nick")
+    check(named("", "foo.eth", true, "display", "alias").preferredDisplayName == "foo.eth")
+    check(named("", "foo.eth", false, "display", "alias").preferredDisplayName == "display")
+    check(named("", "", false, "", "alias").preferredDisplayName == "alias")
+    # Nameless-last sentinel
+    check(named("", "", false, "", "").preferredDisplayName == "zzz")
+    # Uses-default-name follows the same effective-ENS rule
+    check(named("", "foo.eth", false, "", "alias").usesDefaultName == true)
+    check(named("", "foo.eth", true, "", "alias").usesDefaultName == false)
+
+  test "alias updated in the same batch changes preferredDisplayName":
+    let updatedRoles = model.updateItem(
+        pubkey = "0xa",
+        displayName = "",
+        ensName = "",
+        isEnsVerified = false,
+        localNickname = "",
+        alias = "generated alias",
+        icon = "",
+        isContact = false,
+        isBlocked = false,
+        memberRole = MemberRole.None,
+        joined = false,
+        trustStatus = TrustStatus.Unknown,
+        contactRequest = ContactRequest.None,
+        callDataChanged = false,
+      )
+    # Alias + PreferredDisplayName ("zzz" sentinel -> alias)
+    check(updatedRoles.len() == 2)
+    let item = model.getMemberItem("0xa")
+    check(item.preferredDisplayName == "generated alias")
+
+  test "unverified ENS name is not a name":
+    let updatedRoles = model.updateItem(
+        pubkey = "0xa",
+        displayName = "",
+        ensName = "foo.eth",
+        isEnsVerified = false,
+        localNickname = "",
+        alias = "",
+        icon = "",
+        isContact = false,
+        isBlocked = false,
+        memberRole = MemberRole.None,
+        joined = false,
+        trustStatus = TrustStatus.Unknown,
+        contactRequest = ContactRequest.None,
+        callDataChanged = false,
+      )
+    # Only EnsName changed; the served name and usesDefaultName must not move
+    check(updatedRoles.len() == 1)
+    let item = model.getMemberItem("0xa")
+    check(item.usesDefaultName == true)
+    check(item.preferredDisplayName == "zzz")
+
+  test "verifying the ENS name promotes it to preferredDisplayName":
+    discard model.updateItem(
+        pubkey = "0xa",
+        displayName = "",
+        ensName = "foo.eth",
+        isEnsVerified = true,
+        localNickname = "",
+        alias = "",
+        icon = "",
+        isContact = false,
+        isBlocked = false,
+        memberRole = MemberRole.None,
+        joined = false,
+        trustStatus = TrustStatus.Unknown,
+        contactRequest = ContactRequest.None,
+        callDataChanged = false,
+      )
+    let item = model.getMemberItem("0xa")
+    check(item.preferredDisplayName == "foo.eth")
+    check(item.usesDefaultName == false)
+
 suite "pubKeyIndex invariants":
+  # Fresh nameless items: the canonical order falls through to the pubKey
+  # tie-break, so rows land in pubKey order. (The global memberA..E refs are
+  # mutated by earlier suites and would reorder here.)
+  setup:
+    let mA = createTestMemberItem("0xa")
+    let mB = createTestMemberItem("0xb")
+    let mC = createTestMemberItem("0xc")
+    let mD = createTestMemberItem("0xd")
+
   test "addItems drops duplicates against existing rows":
     let model = newModel()
-    model.addItems(@[memberA, memberB])
-    # memberA is already in the model; memberC is new
-    model.addItems(@[memberA, memberC])
+    model.addItems(@[mA, mB])
+    # mA is already in the model; mC is new
+    model.addItems(@[mA, mC])
     check(model.rowCount == 3)
     check(model.findIndexForMember("0xa") == 0)
     check(model.findIndexForMember("0xb") == 1)
@@ -154,14 +250,14 @@ suite "pubKeyIndex invariants":
 
   test "addItems drops duplicates within the same batch":
     let model = newModel()
-    model.addItems(@[memberA, memberA, memberB])
+    model.addItems(@[mA, mA, mB])
     check(model.rowCount == 2)
     check(model.findIndexForMember("0xa") == 0)
     check(model.findIndexForMember("0xb") == 1)
 
   test "removeItemById shifts pubKeyIndex of later rows":
     let model = newModel()
-    model.addItems(@[memberA, memberB, memberC, memberD])
+    model.addItems(@[mA, mB, mC, mD])
     model.removeItemById("0xb")
     check(model.rowCount == 3)
     check(model.findIndexForMember("0xa") == 0)
@@ -174,11 +270,128 @@ suite "pubKeyIndex invariants":
 
   test "updateToTheseItems with empty seq clears pubKeyIndex":
     let model = newModel()
-    model.addItems(@[memberA, memberB])
+    model.addItems(@[mA, mB])
     model.updateToTheseItems(@[])
     check(model.rowCount == 0)
     check(model.findIndexForMember("0xa") == -1)
     check(model.findIndexForMember("0xb") == -1)
     # New inserts after a clear must start at row 0
-    model.addItems(@[memberC])
+    model.addItems(@[mC])
     check(model.findIndexForMember("0xc") == 0)
+
+# Canonical member order (see CONTEXT.md): onlineStatus descending, then
+# case-folded preferredDisplayName ascending, then pubKey — an invariant of the
+# model itself, maintained via granular moves (never resets).
+suite "canonical member order":
+  proc namedMember(pubKey, name: string, status: OnlineStatus = OnlineStatus.Inactive): MemberItem =
+    initMemberItem(
+      pubKey = pubKey, displayName = name, ensName = "", isEnsVerified = false,
+      localNickname = "", alias = "", icon = "", colorId = 0, onlineStatus = status)
+
+  proc orderedKeys(model: Model): seq[string] =
+    for i in 0 ..< model.rowCount():
+      result.add(model.getMemberItemByIndex(i).pubKey)
+
+  proc indexConsistent(model: Model): bool =
+    result = true
+    for i in 0 ..< model.rowCount():
+      if model.findIndexForMember(model.getMemberItemByIndex(i).pubKey) != i:
+        return false
+
+  test "setItems sorts online-first, then case-folded name":
+    let model = newModel()
+    model.setItems(@[
+      namedMember("0x1", "charlie"),
+      namedMember("0x2", "alice", OnlineStatus.Online),
+      namedMember("0x3", "Bob"),
+      namedMember("0x4", "Delta", OnlineStatus.Online),
+    ])
+    check(model.orderedKeys == @["0x2", "0x4", "0x3", "0x1"])
+    check(model.indexConsistent)
+
+  test "addItems merges into sorted positions":
+    let model = newModel()
+    model.setItems(@[
+      namedMember("0x1", "bob"),
+      namedMember("0x2", "olga", OnlineStatus.Online),
+    ])
+    model.addItems(@[
+      namedMember("0x3", "alice"),
+      namedMember("0x4", "Zed", OnlineStatus.Online),
+      namedMember("0x5", "carol"),
+    ])
+    check(model.orderedKeys == @["0x2", "0x4", "0x3", "0x1", "0x5"])
+    check(model.indexConsistent)
+
+  test "addItem inserts at sorted position":
+    let model = newModel()
+    model.setItems(@[namedMember("0x1", "alice"), namedMember("0x2", "charlie")])
+    model.addItem(namedMember("0x3", "bob"))
+    check(model.orderedKeys == @["0x1", "0x3", "0x2"])
+    check(model.indexConsistent)
+
+  test "equal names tie-break on pubKey":
+    let model = newModel()
+    model.setItems(@[namedMember("0x9", "alice"), namedMember("0x2", "alice")])
+    check(model.orderedKeys == @["0x2", "0x9"])
+
+  test "rename repositions via a move, not a reset":
+    let model = newModel()
+    model.setItems(@[
+      namedMember("0x1", "alice"),
+      namedMember("0x2", "bob"),
+      namedMember("0x3", "carol"),
+    ])
+    let spy = newQtModelSpy()
+    spy.enable()
+    defer: spy.disable()
+    model.setName("0x1", "zoe", ensName = "", localNickname = "")
+    check(model.orderedKeys == @["0x2", "0x3", "0x1"])
+    check(model.indexConsistent)
+    check(spy.countResets == 0)
+    let moves = spy.getMoves()
+    check(moves.len == 1)
+    check(moves[0].sourceFirst == 0)
+    check(moves[0].sourceLast == 0)
+    check(moves[0].destChild == 3)
+
+  test "status flip moves the row into the online group":
+    let model = newModel()
+    model.setItems(@[
+      namedMember("0x1", "alice"),
+      namedMember("0x2", "bob"),
+      namedMember("0x3", "carol"),
+    ])
+    let spy = newQtModelSpy()
+    spy.enable()
+    defer: spy.disable()
+    model.setOnlineStatus("0x3", OnlineStatus.Online)
+    check(model.orderedKeys == @["0x3", "0x1", "0x2"])
+    check(model.indexConsistent)
+    check(spy.countResets == 0)
+    let moves = spy.getMoves()
+    check(moves.len == 1)
+    check(moves[0].sourceFirst == 2)
+    check(moves[0].destChild == 0)
+
+  test "non-key update does not move":
+    let model = newModel()
+    model.setItems(@[namedMember("0x1", "alice"), namedMember("0x2", "bob")])
+    let spy = newQtModelSpy()
+    spy.enable()
+    defer: spy.disable()
+    model.setIcon("0x2", "icon")
+    check(spy.countMoves == 0)
+    check(model.orderedKeys == @["0x1", "0x2"])
+
+  test "updateItems repositions renamed rows":
+    let model = newModel()
+    model.setItems(@[
+      namedMember("0x1", "alice"),
+      namedMember("0x2", "bob"),
+      namedMember("0x3", "carol"),
+    ])
+    let renamed = namedMember("0x1", "walter")
+    model.updateItems(@[renamed])
+    check(model.orderedKeys == @["0x2", "0x3", "0x1"])
+    check(model.indexConsistent)

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -245,6 +245,36 @@ LayoutChooser {
         || (portraitView.visible && portraitView.canGoBackInternally)
         || (!!root.subsectionHistory && root.subsectionHistory.canGoBack)
 
+    /*!
+        \qmlsignal StatusSectionLayout::panelSwitchStarted()
+        Emitted when a switch between panels starts. In portrait that is the
+        swipe slide beginning (a drag or a \c currentIndex change): consumers
+        should defer expensive panel swaps (e.g. replacing a skeleton with
+        the real panel) until \l panelSwitchEnded, or the swap frame stutters
+        the slide. Landscape has no slide, so a \c currentIndex change emits
+        both signals back-to-back.
+    */
+    signal panelSwitchStarted()
+
+    /*!
+        \qmlsignal StatusSectionLayout::panelSwitchEnded()
+        Emitted when a switch between panels ends: the portrait swipe settled
+        on a page, or immediately after \l panelSwitchStarted in landscape.
+        The pair stays balanced across rotations: rotating to landscape
+        mid-slide ends the switch immediately, rotating into a still-running
+        slide starts one.
+    */
+    signal panelSwitchEnded()
+
+    // Landscape shows every panel at once — no slide — but consumers still
+    // get each switch bracketed by the signal pair, back-to-back.
+    onCurrentIndexChanged: {
+        if (!portraitView.visible) {
+            root.panelSwitchStarted()
+            root.panelSwitchEnded()
+        }
+    }
+
     readonly property int windowWidth: root.Window?.width ?? Screen.width
 
     criteria: [
@@ -312,6 +342,33 @@ LayoutChooser {
 
         onBackButtonClicked: root.backButtonClicked()
 
+        // Raw slide state, tracked regardless of orientation — the slide also
+        // runs invisibly in landscape, since currentIndex is an alias into
+        // this view.
+        property bool switchOngoing: false
+
+        onPanelSwitchStarted: switchOngoing = true
+        onPanelSwitchEnded: switchOngoing = false
+
         Component.onCompleted: currentIndexCache = currentIndex
+    }
+
+    QtObject {
+        id: d
+
+        // The emitted bracket pairs on the edges of this: a slide counts as
+        // a panel switch only while the portrait layout is the visible one.
+        // Rotating away mid-slide closes the bracket immediately (nothing
+        // visible left to defer for); rotating into a still-running slide
+        // opens one — start/end stay paired across orientation changes.
+        readonly property bool panelSwitchOngoing:
+            portraitView.visible && portraitView.switchOngoing
+
+        onPanelSwitchOngoingChanged: {
+            if (panelSwitchOngoing)
+                root.panelSwitchStarted()
+            else
+                root.panelSwitchEnded()
+        }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutPortrait.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutPortrait.qml
@@ -150,6 +150,22 @@ SwipeView {
     */
     signal backButtonClicked()
 
+    /*!
+        \qmlsignal StatusSectionLayoutPortrait::panelSwitchStarted()
+        Emitted when a swipe between panels starts moving — the user drags,
+        or the slide following a \c currentIndex change begins. Paired with
+        \l panelSwitchEnded; consumers should defer expensive panel swaps
+        (e.g. replacing a skeleton with the real panel) to the end signal,
+        or the swap frame stutters the slide.
+    */
+    signal panelSwitchStarted()
+
+    /*!
+        \qmlsignal StatusSectionLayoutPortrait::panelSwitchEnded()
+        Emitted when the swipe between panels settles on a page.
+    */
+    signal panelSwitchEnded()
+
     // Bound (not a function) so StatusSectionLayout.canGoBack stays reactive.
     readonly property bool canGoBackInternally: root.currentIndex > 0 || !!root.backButtonName
 
@@ -157,6 +173,20 @@ SwipeView {
         id: d
         // Cache wrapper items removed from the swipe view
         property list<Item> items: []
+
+        // A switch is in flight while the user drags the view or while the
+        // slide following a currentIndex change is off the target page.
+        readonly property bool panelSwitchOngoing:
+            root.contentItem.moving
+            || (!!root.currentItem
+                && Math.abs(root.contentItem.contentX - root.currentItem.x) > 0.5)
+
+        onPanelSwitchOngoingChanged: {
+            if (panelSwitchOngoing)
+                root.panelSwitchStarted()
+            else
+                root.panelSwitchEnded()
+        }
 
         function handleBackAction() {
             if (!!root.backButtonName) {

--- a/ui/app/AppLayouts/Chat/panels/SuggestionBoxPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionBoxPanel.qml
@@ -17,6 +17,10 @@ Control {
     readonly property alias listView: listView
     property var inputField
 
+    // While true the panel renders skeleton rows instead of relying on the
+    // (still empty) model — shown until the members model is wired in.
+    property bool loading: false
+
     signal clicked(int index)
 
     padding: Theme.halfPadding
@@ -50,7 +54,52 @@ Control {
         id: listView
         objectName: "suggestionBoxList"
 
-        implicitHeight: contentHeight
+        implicitHeight: root.loading ? loadingSkeleton.implicitHeight
+                                     : contentHeight
+
+        LoadingSkeletonGroup {
+            id: loadingSkeleton
+            objectName: "suggestionsLoadingSkeleton"
+
+            visible: root.loading
+            width: listView.width
+            implicitHeight: skeletonRows.implicitHeight
+
+            Column {
+                id: skeletonRows
+                width: parent.width
+
+                Repeater {
+                    model: 3
+
+                    Item {
+                        width: skeletonRows.width
+                        height: 42
+
+                        Row {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.left: parent.left
+                            anchors.leftMargin: Theme.smallPadding
+                            spacing: Theme.smallPadding
+
+                            LoadingSkeletonTile {
+                                anchors.verticalCenter: parent.verticalCenter
+                                width: 32
+                                height: 32
+                                radius: 16
+                            }
+
+                            LoadingSkeletonTile {
+                                anchors.verticalCenter: parent.verticalCenter
+                                width: 96
+                                height: 12
+                                radius: 6
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         keyNavigationEnabled: true
         Keys.priority: Keys.AfterItem

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -108,25 +108,15 @@ ColumnLayout {
         verticalScrollBar.implicitWidth: d.scrollBarWidth
         verticalScrollBar.width: d.scrollBarWidth
 
+        // The members model maintains the canonical member order (online
+        // first, then name) in Nim — no sorters here, filtering only.
         model: SortFilterProxyModel {
-            // Sorting a large members model is expensive; a hidden (or not yet
-            // reparented) panel must not pay for it on every chat switch.
-            sourceModel: root.visible && root.parent ? root.usersModel : null
+            sourceModel: root.usersModel
             filters: [
                 SQUtils.SearchFilter {
                     roleName: "preferredDisplayName"
                     searchPhrase: searchField.text
-                    enabled: searchField.visible && !!searchPhrase
-                }
-            ]
-            sorters: [
-                RoleSorter {
-                    roleName: "onlineStatus"
-                    sortOrder: Qt.DescendingOrder
-                },
-                StringSorter {
-                    roleName: "preferredDisplayName"
-                    caseSensitivity: Qt.CaseInsensitive
+                    enabled: searchField.visible && !!searchField.text
                 }
             ]
         }

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -51,42 +51,23 @@ ColumnLayout {
         readonly property int delegateRightSpacing: scrollBarWidth + 1
     }
 
-    RowLayout {
+    MembersPanelHeader {
+        id: header
         Layout.fillWidth: true
         Layout.margins: Theme.padding
-
-        StatusBaseText {
-            id: titleText
-            Layout.fillWidth: true
-
-            opacity: (root.width > 58) ? 1.0 : 0.0
-            visible: (opacity > 0.1)
-            font.weight: Font.Medium
-            text: root.label
-
-            wrapMode: Text.Wrap
-        }
-
-        StatusFlatButton {
-            id: searchBtn
-            icon.name: "search"
-            isRoundIcon: true
-            checkable: true
-            textColor: checked || hovered ? Theme.palette.primaryColor1 : Theme.palette.directColor1
-            tooltip.text: qsTr("Search")
-            tooltip.orientation: StatusToolTip.Orientation.Bottom
-        }
+        label: root.label
     }
 
     SearchBox {
         id: searchField
+        objectName: "membersSearchBox"
         KeyNavigation.tab: userListView
-        Keys.onEscapePressed: searchBtn.checked = false
+        Keys.onEscapePressed: header.searchChecked = false
         Layout.fillWidth: true
         Layout.leftMargin: Theme.padding
         Layout.rightMargin: Theme.padding
         placeholderText: qsTr("Search members...")
-        visible: searchBtn.checked
+        visible: header.searchChecked
         onVisibleChanged: {
             if (visible)
                 forceActiveFocus()
@@ -128,7 +109,9 @@ ColumnLayout {
         verticalScrollBar.width: d.scrollBarWidth
 
         model: SortFilterProxyModel {
-            sourceModel: root.usersModel
+            // Sorting a large members model is expensive; a hidden (or not yet
+            // reparented) panel must not pay for it on every chat switch.
+            sourceModel: root.visible && root.parent ? root.usersModel : null
             filters: [
                 SQUtils.SearchFilter {
                     roleName: "preferredDisplayName"

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -298,6 +298,8 @@ Item {
     }
 
     Component.onCompleted: {
+        if (root.showRightPanel)
+            rightPanelLoader.active = true
         if (root.navToMsgList) {
             root.navigateToMessageList()
         }
@@ -309,39 +311,63 @@ Item {
         root.navToMsgListRequested(false)
     }
 
-    readonly property Item rightPanel: UserListPanel {
-        chatType: root.chatContentModule?.chatDetails.type || Constants.chatType.unknown
-        isAdmin: root.chatContentModule?.amIChatAdmin() || false
+    readonly property Item rightPanel: Loader {
+        id: rightPanelLoader
 
-        label: qsTr("Members")
-        communityMemberReevaluationStatus: root.communityMemberReevaluationStatus
+        // Built on first show only (then kept), asynchronously behind the
+        // skeleton — the members list must never delay a chat switch.
+        active: false
+        asynchronous: true
 
-        usersModel: root.usersModel
-
-        onOpenProfileRequested: Global.openProfilePopup(pubKey, null)
-        onReviewContactRequestRequested: Global.openReviewContactRequestPopup(pubKey, null)
-        onSendContactRequestRequested: Global.openContactRequestPopup(pubKey, null)
-        onEditNicknameRequested: Global.openNicknamePopupRequested(pubKey, null)
-        onBlockContactRequested: Global.blockContactRequested(pubKey)
-        onUnblockContactRequested: Global.unblockContactRequested(pubKey)
-        onMarkAsUntrustedRequested: Global.markAsUntrustedRequested(pubKey)
-        onRemoveContactRequested: Global.removeContactRequested(pubKey)
-
-        onRemoveNicknameRequested: {
-            const oldName = ModelUtils.getByKey(usersModel, "pubKey", pubKey, "localNickname")
-            root.changeContactNicknameRequest(pubKey, "", oldName, true)
+        MembersListSkeleton {
+            objectName: "membersPanelSkeleton"
+            anchors.fill: parent
+            visible: rightPanelLoader.active && rightPanelLoader.status !== Loader.Ready
         }
 
-        onCreateOneToOneChatRequested: {
-            Global.changeAppSectionBySectionType(Constants.appSection.chat)
-            root.rootStore.chatCommunitySectionModule.createOneToOneChat("", pubKey, "")
+        sourceComponent: UserListPanel {
+            // async incubation parents the partially-built panel into the
+            // scene early — keep it invisible behind the skeleton
+            visible: rightPanelLoader.status === Loader.Ready
+
+            chatType: root.chatContentModule?.chatDetails.type || Constants.chatType.unknown
+            isAdmin: root.chatContentModule?.amIChatAdmin() || false
+
+            label: qsTr("Members")
+            communityMemberReevaluationStatus: root.communityMemberReevaluationStatus
+
+            usersModel: root.usersModel
+
+            onOpenProfileRequested: Global.openProfilePopup(pubKey, null)
+            onReviewContactRequestRequested: Global.openReviewContactRequestPopup(pubKey, null)
+            onSendContactRequestRequested: Global.openContactRequestPopup(pubKey, null)
+            onEditNicknameRequested: Global.openNicknamePopupRequested(pubKey, null)
+            onBlockContactRequested: Global.blockContactRequested(pubKey)
+            onUnblockContactRequested: Global.unblockContactRequested(pubKey)
+            onMarkAsUntrustedRequested: Global.markAsUntrustedRequested(pubKey)
+            onRemoveContactRequested: Global.removeContactRequested(pubKey)
+
+            onRemoveNicknameRequested: {
+                const oldName = ModelUtils.getByKey(usersModel, "pubKey", pubKey, "localNickname")
+                root.changeContactNicknameRequest(pubKey, "", oldName, true)
+            }
+
+            onCreateOneToOneChatRequested: {
+                Global.changeAppSectionBySectionType(Constants.appSection.chat)
+                root.rootStore.chatCommunitySectionModule.createOneToOneChat("", pubKey, "")
+            }
+
+            onRemoveTrustStatusRequested: root.removeTrustStatusRequest(pubKey)
+            onRemoveContactFromGroupRequested: root.rootStore.removeMemberFromGroupChat(pubKey)
+
+            onMarkAsTrustedRequested: Global.openMarkAsIDVerifiedPopup(pubKey, null)
+            onRemoveTrustedMarkRequested: Global.openRemoveIDVerificationDialog(pubKey, null)
         }
+    }
 
-        onRemoveTrustStatusRequested: root.removeTrustStatusRequest(pubKey)
-        onRemoveContactFromGroupRequested: root.rootStore.removeMemberFromGroupChat(pubKey)
-
-        onMarkAsTrustedRequested: Global.openMarkAsIDVerifiedPopup(pubKey, null)
-        onRemoveTrustedMarkRequested: Global.openRemoveIDVerificationDialog(pubKey, null)
+    onShowRightPanelChanged: {
+        if (root.showRightPanel)
+            rightPanelLoader.active = true
     }
 
     onChatContentModuleChanged: {

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -301,8 +301,6 @@ Item {
     }
 
     Component.onCompleted: {
-        if (root.showRightPanel)
-            rightPanelLoader.active = true
         if (root.navToMsgList) {
             root.navigateToMessageList()
         }
@@ -317,10 +315,11 @@ Item {
     readonly property Item rightPanel: Loader {
         id: rightPanelLoader
         width: Constants.chatSectionRightColumnWidth
-        height: parent.height
+        height: root.sectionLayout?.height ?? 0
 
-        // Built on first show only (then kept), asynchronously behind the
-        // skeleton — the members list must never delay a chat switch.
+        // Loaded only while shown — hiding the members list discards it —
+        // and asynchronously behind the skeleton: the members list must
+        // never delay a chat switch.
         active: root.showRightPanel
         asynchronous: true
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -63,8 +63,8 @@ Item {
     readonly property bool leftPanelReady: contactColumnLoader.status === Loader.Ready
     readonly property bool centerPanelReady: centerPanelLoader.status === Loader.Ready
                                              || !centerPanelLoader.active
-    // The members panel is not deferred here: it is instantiated with the view.
-    readonly property bool rightPanelReady: true
+    readonly property bool rightPanelReady: rightPanelLoader.status === Loader.Ready
+                                            || !rightPanelLoader.active
 
     property ChatStores.RootStore rootStore
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
@@ -113,6 +113,11 @@ Item {
 
     property int extraLeftPadding: 0
     property bool isPortraitMode: false
+
+    // Delay between a chat switch and re-binding the members list. Sorting a
+    // large members model blocks the GUI thread; the delay keeps that work off
+    // the switch itself, behind MembersListSkeleton.
+    property int membersWireDelay: 100
 
     // Subsection back history keyed by the active chat/channel id.
     // Consumed by the chrome owner (bound to StatusSectionLayout.subsectionHistory).
@@ -180,6 +185,27 @@ Item {
         function requestCenterPanel() {
             centerPanelRequested = true
         }
+
+        // Dropped on every chat/channel switch: the members panel is shared
+        // across chats, so it would otherwise sort the incoming members model
+        // on the switch frame, showing the previous chat's members meanwhile.
+        property bool membersReady: true
+
+        readonly property string activeChatId: {
+            const m = root.rootStore.chatCommunitySectionModule
+            return m && m.activeItem ? m.activeItem.id : ""
+        }
+
+        onActiveChatIdChanged: {
+            membersReady = false
+            membersWireTimer.restart()
+        }
+    }
+
+    Timer {
+        id: membersWireTimer
+        interval: root.membersWireDelay
+        onTriggered: d.membersReady = true
     }
 
     // Users related signals
@@ -322,13 +348,15 @@ Item {
         MembersListSkeleton {
             objectName: "membersPanelSkeleton"
             anchors.fill: parent
-            visible: rightPanelLoader.active && rightPanelLoader.status !== Loader.Ready
+            visible: rightPanelLoader.active
+                     && (rightPanelLoader.status !== Loader.Ready || !d.membersReady)
         }
 
         sourceComponent: UserListPanel {
             // async incubation parents the partially-built panel into the
-            // scene early — keep it invisible behind the skeleton
-            visible: rightPanelLoader.status === Loader.Ready
+            // scene early — keep it invisible behind the skeleton. Hidden it
+            // also drops its users model, so a chat switch costs no sorting.
+            visible: rightPanelLoader.status === Loader.Ready && d.membersReady
 
             chatType: root.chatContentModule?.chatDetails.type || Constants.chatType.unknown
             isAdmin: root.chatContentModule?.amIChatAdmin() || false

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -63,8 +63,11 @@ Item {
     readonly property bool leftPanelReady: contactColumnLoader.status === Loader.Ready
     readonly property bool centerPanelReady: centerPanelLoader.status === Loader.Ready
                                              || !centerPanelLoader.active
-    readonly property bool rightPanelReady: rightPanelLoader.status === Loader.Ready
-                                            || !rightPanelLoader.active
+    // The members panel is only ready once the latch is back up: until then it
+    // shows its own skeleton, so the chrome must keep showing one too.
+    readonly property bool rightPanelReady: !rightPanelLoader.active
+                                            || (rightPanelLoader.status === Loader.Ready
+                                                && d.membersReady)
 
     property ChatStores.RootStore rootStore
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
@@ -113,11 +116,6 @@ Item {
 
     property int extraLeftPadding: 0
     property bool isPortraitMode: false
-
-    // Delay between a chat switch and re-binding the members list. Sorting a
-    // large members model blocks the GUI thread; the delay keeps that work off
-    // the switch itself, behind MembersListSkeleton.
-    property int membersWireDelay: 100
 
     // Subsection back history keyed by the active chat/channel id.
     // Consumed by the chrome owner (bound to StatusSectionLayout.subsectionHistory).
@@ -176,6 +174,7 @@ Item {
 
     QtObject {
         id: d
+        objectName: "chatViewInternal"
 
         readonly property bool shouldLoadCenterPanel: !root.isPortraitMode ||
                                                       centerPanelRequested ||
@@ -186,25 +185,29 @@ Item {
             centerPanelRequested = true
         }
 
-        // Dropped on every chat/channel switch: the members panel is shared
-        // across chats, so it would otherwise sort the incoming members model
-        // on the switch frame, showing the previous chat's members meanwhile.
+        // Dropped when the members model itself changes: the members panel is
+        // shared across chats, so it would otherwise sort the incoming model on
+        // the switch frame, showing the previous chat's members meanwhile. A
+        // switch that keeps the same model — every community channel without
+        // permissions — costs nothing and keeps showing the correct members.
         property bool membersReady: true
 
-        readonly property string activeChatId: {
-            const m = root.rootStore.chatCommunitySectionModule
-            return m && m.activeItem ? m.activeItem.id : ""
-        }
+        readonly property var activeUsersModel: root.usersModel
 
-        onActiveChatIdChanged: {
+        onActiveUsersModelChanged: {
             membersReady = false
             membersWireTimer.restart()
         }
+
+        // Delay between the model change and re-binding the members list.
+        // Sorting a large members model blocks the GUI thread; the delay keeps
+        // that work off the switch itself, behind MembersListSkeleton.
+        property int membersWireDelay: 100
     }
 
     Timer {
         id: membersWireTimer
-        interval: root.membersWireDelay
+        interval: d.membersWireDelay
         onTriggered: d.membersReady = true
     }
 
@@ -345,11 +348,13 @@ Item {
         active: false
         asynchronous: true
 
-        MembersListSkeleton {
+        Loader {
             objectName: "membersPanelSkeleton"
             anchors.fill: parent
-            visible: rightPanelLoader.active
-                     && (rightPanelLoader.status !== Loader.Ready || !d.membersReady)
+            active: rightPanelLoader.active
+                    && (rightPanelLoader.status !== Loader.Ready || !d.membersReady)
+            visible: active
+            sourceComponent: MembersListSkeleton {}
         }
 
         sourceComponent: UserListPanel {

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -66,8 +66,7 @@ Item {
     // The members panel is only ready once the latch is back up: until then it
     // shows its own skeleton, so the chrome must keep showing one too.
     readonly property bool rightPanelReady: !rightPanelLoader.active
-                                            || (rightPanelLoader.status === Loader.Ready
-                                                && d.membersReady)
+                                            || rightPanelLoader.status === Loader.Ready
 
     property ChatStores.RootStore rootStore
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
@@ -184,31 +183,6 @@ Item {
         function requestCenterPanel() {
             centerPanelRequested = true
         }
-
-        // Dropped when the members model itself changes: the members panel is
-        // shared across chats, so it would otherwise sort the incoming model on
-        // the switch frame, showing the previous chat's members meanwhile. A
-        // switch that keeps the same model — every community channel without
-        // permissions — costs nothing and keeps showing the correct members.
-        property bool membersReady: true
-
-        readonly property var activeUsersModel: root.usersModel
-
-        onActiveUsersModelChanged: {
-            membersReady = false
-            membersWireTimer.restart()
-        }
-
-        // Delay between the model change and re-binding the members list.
-        // Sorting a large members model blocks the GUI thread; the delay keeps
-        // that work off the switch itself, behind MembersListSkeleton.
-        property int membersWireDelay: 100
-    }
-
-    Timer {
-        id: membersWireTimer
-        interval: d.membersWireDelay
-        onTriggered: d.membersReady = true
     }
 
     // Users related signals
@@ -342,26 +316,29 @@ Item {
 
     readonly property Item rightPanel: Loader {
         id: rightPanelLoader
+        width: Constants.chatSectionRightColumnWidth
+        height: parent.height
 
         // Built on first show only (then kept), asynchronously behind the
         // skeleton — the members list must never delay a chat switch.
-        active: false
+        active: root.showRightPanel
         asynchronous: true
 
         Loader {
             objectName: "membersPanelSkeleton"
             anchors.fill: parent
             active: rightPanelLoader.active
-                    && (rightPanelLoader.status !== Loader.Ready || !d.membersReady)
+                    && rightPanelLoader.status !== Loader.Ready
             visible: active
             sourceComponent: MembersListSkeleton {}
         }
 
         sourceComponent: UserListPanel {
             // async incubation parents the partially-built panel into the
-            // scene early — keep it invisible behind the skeleton. Hidden it
-            // also drops its users model, so a chat switch costs no sorting.
-            visible: rightPanelLoader.status === Loader.Ready && d.membersReady
+            // scene early — keep it invisible behind the skeleton until ready.
+            // Binding the model eagerly is fine: it arrives pre-sorted from
+            // Nim, so a chat switch pays no sorting.
+            visible: rightPanelLoader.status === Loader.Ready
 
             chatType: root.chatContentModule?.chatDetails.type || Constants.chatType.unknown
             isAdmin: root.chatContentModule?.amIChatAdmin() || false
@@ -396,11 +373,6 @@ Item {
             onMarkAsTrustedRequested: Global.openMarkAsIDVerifiedPopup(pubKey, null)
             onRemoveTrustedMarkRequested: Global.openRemoveIDVerificationDialog(pubKey, null)
         }
-    }
-
-    onShowRightPanelChanged: {
-        if (root.showRightPanel)
-            rightPanelLoader.active = true
     }
 
     onChatContentModuleChanged: {

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -4,6 +4,7 @@ import QtQuick
 import StatusQ.Core.Theme
 import StatusQ.Core.Utils as SQUtils
 import StatusQ.Layout
+import StatusQ.Core.Backpressure
 
 import AppLayouts.Chat.panels
 
@@ -177,6 +178,7 @@ Loader {
         id: d
 
         property ChatStores.RootStore chatRootStore: null
+        property bool showUsersPanel: root.accountSettingsStore.showUsersList
     }
 
     Component.onCompleted: {
@@ -195,7 +197,7 @@ Loader {
             visible: false,
             isChatView: true,
             sectionLayout: sectionLayout,
-            showUsersList:                  Qt.binding(() => root.accountSettingsStore.showUsersList),
+            showUsersList:                  Qt.binding(() => d.showUsersPanel),
             rootStore:                      Qt.binding(() => d.chatRootStore),
             createChatPropertiesStore:      Qt.binding(() => root.createChatPropertiesStore),
             tokensStore:                    Qt.binding(() => root.tokensStore),
@@ -246,7 +248,10 @@ Loader {
         ignoreUnknownSignals: true
 
         function onShowUsersListRequested(show) {
-            root.accountSettingsStore.setShowUsersList(show)
+            d.showUsersPanel = show //optimistic; update settings after a short delay to avoid jank from the panel resize
+            Backpressure.setTimeout(root, 300, () => {
+                root.accountSettingsStore.setShowUsersList(show)
+            })
         }
         function onProfileButtonClicked() {
             Global.changeAppSectionBySectionType(Constants.appSection.profile)

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -81,14 +81,43 @@ Loader {
 
         anchors.fill: parent
 
-        headerContent: (root.item?.headerReady ?? false) ? root.item.headerContent : headerSkeleton
-        leftPanel: (root.item?.leftPanelReady ?? false) ? root.item.leftPanel : listSkeleton
-        centerPanel: (root.item?.centerPanelReady ?? false) ? root.item.centerPanel : chatSkeleton
-        rightPanel: (root.item?.rightPanelReady ?? false) ? root.item.rightPanel : membersSkeleton
+        headerContent: headerGate.up ? root.item.headerContent : headerSkeleton
+        leftPanel: leftPanelGate.up ? root.item.leftPanel : listSkeleton
+        centerPanel: centerPanelGate.up ? root.item.centerPanel : chatSkeleton
+        rightPanel: rightPanelGate.up ? root.item.rightPanel : membersSkeleton
         showRightPanel: root.item?.showRightPanel ?? root.accountSettingsStore.showUsersList
         subsectionHistory: root.item?.viewSubsectionHistory ?? null
 
         leftPanelWidthOverride: root.leftPanelWidthOverride
+
+        onPanelSwitchStarted: d.panelSwitchOngoing = true
+        onPanelSwitchEnded: d.panelSwitchOngoing = false
+    }
+
+    // One gate per chrome slot: skeleton→panel promotion waits out the
+    // chrome's panel-switch animation.
+    PanelSwapGate {
+        id: headerGate
+        ready: root.item?.headerReady ?? false
+        switchOngoing: d.panelSwitchOngoing
+    }
+
+    PanelSwapGate {
+        id: leftPanelGate
+        ready: root.item?.leftPanelReady ?? false
+        switchOngoing: d.panelSwitchOngoing
+    }
+
+    PanelSwapGate {
+        id: centerPanelGate
+        ready: root.item?.centerPanelReady ?? false
+        switchOngoing: d.panelSwitchOngoing
+    }
+
+    PanelSwapGate {
+        id: rightPanelGate
+        ready: root.item?.rightPanelReady ?? false
+        switchOngoing: d.panelSwitchOngoing
     }
 
     // Skeleton slot items carry the same page paddings as the real panels.
@@ -98,7 +127,7 @@ Loader {
     Loader {
         id: headerSkeleton
         objectName: "headerSkeleton"
-        active: !(root.item?.headerReady ?? false)
+        active: !headerGate.up
         visible: active
         sourceComponent: ChatHeaderSkeleton {}
     }
@@ -106,7 +135,7 @@ Loader {
     Loader {
         id: listSkeleton
         objectName: "leftPanelSkeleton"
-        active: !(root.item?.leftPanelReady ?? false)
+        active: !leftPanelGate.up
         visible: active
 
         // The real header: invite and start-chat act app-globally, so they
@@ -128,7 +157,7 @@ Loader {
     Loader {
         id: chatSkeleton
         objectName: "centerPanelSkeleton"
-        active: !(root.item?.centerPanelReady ?? false)
+        active: !centerPanelGate.up
         visible: active
 
         sourceComponent: MessagesChatSkeleton {
@@ -142,7 +171,7 @@ Loader {
     Loader {
         id: membersSkeleton
         objectName: "rightPanelSkeleton"
-        active: !(root.item?.rightPanelReady ?? false)
+        active: !rightPanelGate.up
         visible: active
 
         sourceComponent: MembersListSkeleton {}
@@ -179,6 +208,12 @@ Loader {
 
         property ChatStores.RootStore chatRootStore: null
         property bool showUsersPanel: root.accountSettingsStore.showUsersList
+
+        // The portrait chrome animates panel switches and brackets them with
+        // panelSwitchStarted/Ended: a panel that becomes ready mid-slide
+        // keeps its skeleton (via its PanelSwapGate) until the slide ends,
+        // or the swap frame stutters it.
+        property bool panelSwitchOngoing: false
     }
 
     Component.onCompleted: {

--- a/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
@@ -3,6 +3,7 @@ import QtQuick
 
 import StatusQ.Core.Theme
 import StatusQ.Core.Utils as SQUtils
+import StatusQ.Core.Backpressure
 import StatusQ.Layout
 
 import utils
@@ -200,6 +201,7 @@ Loader {
         property var newCommunityStore: null
         property int pendingSettingsSection: -1
         property int pendingSettingsSubsection: -1
+        property bool showUsersPanel: root.accountSettingsStore.showUsersList
         property int pendingViewIndex: -1
 
         // The view switch may arrive while the section still incubates —
@@ -263,7 +265,7 @@ Loader {
             isChatView:                     false,
             visible:                        false,
             sectionLayout:                  Qt.binding(() => chromeLoader.item),
-            showUsersList:                  Qt.binding(() => root.accountSettingsStore.showUsersList),
+            showUsersList:                  Qt.binding(() => d.showUsersPanel),
             emojiPopup:                     Qt.binding(() => root.emojiPopupLoader.item),
             stickersPopup:                  Qt.binding(() => root.stickersPopupLoader.item),
             sectionItemModel:               Qt.binding(() => root.sectionItemModel),
@@ -339,7 +341,10 @@ Loader {
         ignoreUnknownSignals: true
 
         function onShowUsersListRequested(show) {
-            root.accountSettingsStore.setShowUsersList(show)
+            d.showUsersPanel = show //optimistic; update settings after a short delay to avoid jank from the panel resize
+            Backpressure.setTimeout(root, 300, () => {
+                root.accountSettingsStore.setShowUsersList(show)
+            })
         }
         function onProfileButtonClicked() {
             Global.changeAppSectionBySectionType(Constants.appSection.profile)

--- a/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
@@ -103,15 +103,44 @@ Loader {
 
             visible: !root.item || !root.item.ownsFullPage
 
-            headerContent: (root.item?.headerReady ?? false) ? root.item.headerContent : headerSkeleton
-            leftPanel: (root.item?.leftPanelReady ?? false) ? root.item.leftPanel : channelsSkeleton
-            centerPanel: (root.item?.centerPanelReady ?? false) ? root.item.centerPanel : chatSkeleton
-            rightPanel: (root.item?.rightPanelReady ?? false) ? root.item.rightPanel : membersSkeleton
+            headerContent: headerGate.up ? root.item.headerContent : headerSkeleton
+            leftPanel: leftPanelGate.up ? root.item.leftPanel : channelsSkeleton
+            centerPanel: centerPanelGate.up ? root.item.centerPanel : chatSkeleton
+            rightPanel: rightPanelGate.up ? root.item.rightPanel : membersSkeleton
             showRightPanel: root.item?.showRightPanel ?? root.accountSettingsStore.showUsersList
             subsectionHistory: root.item?.viewSubsectionHistory ?? null
 
             leftPanelWidthOverride: root.leftPanelWidthOverride
+
+            onPanelSwitchStarted: d.panelSwitchOngoing = true
+            onPanelSwitchEnded: d.panelSwitchOngoing = false
         }
+    }
+
+    // One gate per chrome slot: skeleton→panel promotion waits out the
+    // chrome's panel-switch animation.
+    PanelSwapGate {
+        id: headerGate
+        ready: root.item?.headerReady ?? false
+        switchOngoing: d.panelSwitchOngoing
+    }
+
+    PanelSwapGate {
+        id: leftPanelGate
+        ready: root.item?.leftPanelReady ?? false
+        switchOngoing: d.panelSwitchOngoing
+    }
+
+    PanelSwapGate {
+        id: centerPanelGate
+        ready: root.item?.centerPanelReady ?? false
+        switchOngoing: d.panelSwitchOngoing
+    }
+
+    PanelSwapGate {
+        id: rightPanelGate
+        ready: root.item?.rightPanelReady ?? false
+        switchOngoing: d.panelSwitchOngoing
     }
 
     // Skeleton slot items carry the same page paddings as the real panels.
@@ -121,7 +150,7 @@ Loader {
     Loader {
         id: headerSkeleton
         objectName: "headerSkeleton"
-        active: root.chromeNeeded && !(root.item?.headerReady ?? false)
+        active: root.chromeNeeded && !headerGate.up
         visible: active
         sourceComponent: ChatHeaderSkeleton {}
     }
@@ -129,7 +158,7 @@ Loader {
     Loader {
         id: channelsSkeleton
         objectName: "leftPanelSkeleton"
-        active: root.chromeNeeded && !(root.item?.leftPanelReady ?? false)
+        active: root.chromeNeeded && !leftPanelGate.up
         visible: active
 
         sourceComponent: CommunityChannelsSkeleton {
@@ -147,7 +176,7 @@ Loader {
     Loader {
         id: chatSkeleton
         objectName: "centerPanelSkeleton"
-        active: root.chromeNeeded && !(root.item?.centerPanelReady ?? false)
+        active: root.chromeNeeded && !centerPanelGate.up
         visible: active
 
         sourceComponent: MessagesChatSkeleton {
@@ -161,7 +190,7 @@ Loader {
     Loader {
         id: membersSkeleton
         objectName: "rightPanelSkeleton"
-        active: root.chromeNeeded && !(root.item?.rightPanelReady ?? false)
+        active: root.chromeNeeded && !rightPanelGate.up
         visible: active
 
         sourceComponent: MembersListSkeleton {}
@@ -213,6 +242,12 @@ Loader {
             }
             pendingViewIndex = index
         }
+
+        // The portrait chrome animates panel switches and brackets them with
+        // panelSwitchStarted/Ended: a panel that becomes ready mid-slide
+        // keeps its skeleton (via its PanelSwapGate) until the slide ends,
+        // or the swap frame stutters it.
+        property bool panelSwitchOngoing: false
 
         function clearStores() {
             pendingSettingsSection = -1

--- a/ui/app/mainui/sectionLoaders/PanelSwapGate.qml
+++ b/ui/app/mainui/sectionLoaders/PanelSwapGate.qml
@@ -1,0 +1,36 @@
+import QtQml
+
+/*
+   Latched skeleton→panel promotion for one section-chrome slot.
+
+   `up` rises when the panel is ready and no chrome panel-switch animation is
+   running — retargeting a slot mid-animation stutters it — holds through
+   later animations, and drops as soon as the panel is gone (unloaded or
+   re-incubating). Feed `switchOngoing` from the chrome's
+   panelSwitchStarted/panelSwitchEnded pair.
+*/
+QtObject {
+    id: root
+
+    required property bool ready
+    required property bool switchOngoing
+
+    readonly property bool up: d.up
+
+    readonly property QtObject d: QtObject {
+        id: d
+
+        property bool up: false
+
+        function update() {
+            if (!root.ready)
+                up = false
+            else if (!root.switchOngoing)
+                up = true
+        }
+    }
+
+    onReadyChanged: d.update()
+    onSwitchOngoingChanged: d.update()
+    Component.onCompleted: d.update()
+}

--- a/ui/app/mainui/sectionLoaders/WalletLoader.qml
+++ b/ui/app/mainui/sectionLoaders/WalletLoader.qml
@@ -80,12 +80,29 @@ Loader {
         onBackButtonClicked: root.item?.handleBackButtonClicked()
         subsectionHistory: root.item?.subsectionHistory ?? null
 
-        leftPanel: root.item?.leftPanel ?? accountsSkeleton
-        centerPanel: root.item?.centerPanel ?? centerSkeleton
+        leftPanel: leftPanelGate.up ? root.item.leftPanel : accountsSkeleton
+        centerPanel: centerPanelGate.up ? root.item.centerPanel : centerSkeleton
         headerBackground: root.item?.headerBackground ?? null
         footer: root.item?.footer ?? null
 
         leftPanelWidthOverride: root.leftPanelWidthOverride
+
+        onPanelSwitchStarted: d.panelSwitchOngoing = true
+        onPanelSwitchEnded: d.panelSwitchOngoing = false
+    }
+
+    // One gate per chrome slot: skeleton→panel promotion waits out the
+    // chrome's panel-switch animation, or the swap frame stutters it.
+    PanelSwapGate {
+        id: leftPanelGate
+        ready: !!(root.item?.leftPanel ?? null)
+        switchOngoing: d.panelSwitchOngoing
+    }
+
+    PanelSwapGate {
+        id: centerPanelGate
+        ready: !!(root.item?.centerPanel ?? null)
+        switchOngoing: d.panelSwitchOngoing
     }
 
     // Skeleton slot items carry the same page paddings as the real panels
@@ -95,7 +112,9 @@ Loader {
     // of the section.
     Loader {
         id: accountsSkeleton
-        active: root.status !== Loader.Ready
+        // the privacy wall is a full-page item: no panels will ever arrive,
+        // so don't keep a skeleton alive behind the hidden chrome
+        active: !leftPanelGate.up && d.targetUrl !== d.privacyWallUrl
         visible: active
 
         sourceComponent: WalletAccountsSkeleton {
@@ -106,7 +125,7 @@ Loader {
 
     Loader {
         id: centerSkeleton
-        active: root.status !== Loader.Ready
+        active: !centerPanelGate.up && d.targetUrl !== d.privacyWallUrl
         visible: active
 
         sourceComponent: WalletCenterPanelSkeleton {
@@ -132,6 +151,11 @@ Loader {
         readonly property url realUrl: QmlCompiler.walletUrl
         readonly property url privacyWallUrl: QmlCompiler.walletPrivacyWallUrl
         readonly property url targetUrl: rootStore.thirdpartyServicesEnabled ? realUrl : privacyWallUrl
+
+        // The portrait chrome animates panel switches and brackets them with
+        // panelSwitchStarted/Ended: a panel that becomes ready mid-slide
+        // keeps its skeleton (via its PanelSwapGate) until the slide ends.
+        property bool panelSwitchOngoing: false
     }
 
     Component.onCompleted: {

--- a/ui/app/mainui/sectionLoaders/qmldir
+++ b/ui/app/mainui/sectionLoaders/qmldir
@@ -9,6 +9,7 @@ CommunityChatLoader 1.0 CommunityChatLoader.qml
 HandlersManagerLoader 1.0 HandlersManagerLoader.qml
 HomePageLoader 1.0 HomePageLoader.qml
 MarketLoader 1.0 MarketLoader.qml
+PanelSwapGate 1.0 PanelSwapGate.qml
 PopupsLoader 1.0 PopupsLoader.qml
 ProfileLoader 1.0 ProfileLoader.qml
 WalletLoader 1.0 WalletLoader.qml

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -18471,10 +18471,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>UserListPanel</name>
     <message>
-        <source>Search</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Search members...</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -18571,10 +18571,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>UserListPanel</name>
     <message>
-        <source>Search</source>
-        <translation type="unfinished">Hledat</translation>
-    </message>
-    <message>
         <source>Search members...</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -18499,10 +18499,6 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
 <context>
     <name>UserListPanel</name>
     <message>
-        <source>Search</source>
-        <translation>Buscar</translation>
-    </message>
-    <message>
         <source>Search members...</source>
         <translation>Buscar miembros...</translation>
     </message>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -18498,10 +18498,6 @@ Si une transaction avec un nonce inférieur est en attente, les transactions ave
 <context>
     <name>UserListPanel</name>
     <message>
-        <source>Search</source>
-        <translation>Recherche</translation>
-    </message>
-    <message>
         <source>Search members...</source>
         <translation>Rechercher des membres...</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -18419,10 +18419,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>UserListPanel</name>
     <message>
-        <source>Search</source>
-        <translation type="unfinished">검색</translation>
-    </message>
-    <message>
         <source>Search members...</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -350,7 +350,7 @@ Control {
             d.insertEmoji(emojiSuggestions.unicode)
             return true
         }
-        if (suggestionsBox.visible) {
+        if (suggestionsBox.visible && !suggestionsBox.loading) {
             suggestionsBox.selectCurrentItem()
             return true
         }
@@ -564,9 +564,13 @@ Control {
 
     // The input is shared across chats; a chat switch swaps usersModel and
     // must drop the latch or the new members model gets sorted right away.
+    // A swap mid-mention (late model delivery, permission re-evaluation) must
+    // re-arm the wiring itself: enteringSuggestion won't change again.
     onUsersModelChanged: {
         suggestionsWireTimer.stop()
         d.suggestionsModelWired = false
+        if (messageInputField.enteringSuggestion)
+            suggestionsWireTimer.restart()
     }
 
     Connections {
@@ -576,6 +580,8 @@ Control {
         function onEnteringSuggestionChanged() {
             if (messageInputField.enteringSuggestion)
                 suggestionsWireTimer.start()
+            else
+                suggestionsWireTimer.stop()
         }
     }
 
@@ -592,11 +598,12 @@ Control {
         height: Math.min(400, implicitHeight)
         z: parent.z + 100
 
-        // Only visible when there are actual matches. Otherwise the box would be
-        // visible-but-empty and hijack Enter/Send (checkTextInsert) into committing a
-        // non-existent row, inserting an "@undefined" pill instead of sending the text.
+        // Visible while loading (skeleton) or with actual matches, never
+        // visible-but-empty — that would hijack Enter/Send (checkTextInsert) into
+        // committing a non-existent row, inserting an "@undefined" pill instead of
+        // sending the text. During loading selectItem() bails on the empty model.
         visible: !shouldHide && messageInputField.enteringSuggestion
-                 && mentionsAdaptor.model.ModelCount.count > 0
+                 && (loading || mentionsAdaptor.model.ModelCount.count > 0)
 
         property bool shouldHide: false
 

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -43,6 +43,12 @@ Control {
     property var usersModel
     property bool usersModelIncludeAtEveryone: true
 
+    // Delay between the first mention entry and wiring usersModel into the
+    // suggestions adaptor. Sorting a large members model blocks the GUI
+    // thread; the delay lets the suggestion box paint its loading skeleton
+    // first.
+    property int suggestionsModelWireDelay: 100
+
     property var emojiPopup: null
     property var stickersPopup: null
     // Use this to only enable the Connections only when this Input opens the Emoji popup
@@ -113,6 +119,11 @@ Control {
 
         property bool emojiPopupOpened: false
         property bool stickersPopupOpened: false
+
+        // Latched on the first mention entry; the members model stays out of
+        // the suggestions adaptor until then so chat switches never pay for
+        // sorting it.
+        property bool suggestionsModelWired: false
 
         // ── formatting state driving the toolbar bold/italic/strike/quote/code buttons ──
         // The formatting at the caret (from the parsed AST and from the raw delimiters around it)
@@ -540,9 +551,32 @@ Control {
     // ("everyone" is added by the adaptor).
     SuggestionsFilterAdaptor {
         id: mentionsAdaptor
-        sourceModel: root.usersModel
+        sourceModel: d.suggestionsModelWired ? root.usersModel : null
         filter: messageInputField.mentionsFilter
         usersModelIncludeAtEveryone: root.usersModelIncludeAtEveryone
+    }
+
+    Timer {
+        id: suggestionsWireTimer
+        interval: root.suggestionsModelWireDelay
+        onTriggered: d.suggestionsModelWired = true
+    }
+
+    // The input is shared across chats; a chat switch swaps usersModel and
+    // must drop the latch or the new members model gets sorted right away.
+    onUsersModelChanged: {
+        suggestionsWireTimer.stop()
+        d.suggestionsModelWired = false
+    }
+
+    Connections {
+        target: messageInputField
+        enabled: !d.suggestionsModelWired
+
+        function onEnteringSuggestionChanged() {
+            if (messageInputField.enteringSuggestion)
+                suggestionsWireTimer.start()
+        }
     }
 
     SuggestionBoxPanel {
@@ -550,6 +584,7 @@ Control {
         objectName: "suggestionsBox"
 
         model: mentionsAdaptor.model
+        loading: !d.suggestionsModelWired
         inputField: messageInputField
 
         y: -height - root.Theme.smallPadding

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -208,6 +208,7 @@ QtObject {
     }
 
     readonly property int chatSectionLeftColumnWidth: 304
+    readonly property int chatSectionRightColumnWidth: 250
 
     // has to match section_item.nim#SectionType
     readonly property QtObject appSection: QtObject {


### PR DESCRIPTION
### What does the PR do

UserListPanel binds its users model only while the right panel is actually visible, and the mention suggestions adaptor stays detached from the members model until the first mention entry (short wire delay, loading skeleton in the suggestion box meanwhile; the latch drops on usersModel swap so chat switches never pay for sorting the members model). Together these were ~1.5s of the chat-switch freeze on large communities.

### Affected areas

Users list
### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/d635c893-7a9e-423e-a756-6f2ecbed4453


### Impact on end user

Faster community and chats loading

### How to test

Navigate to heavy communities, try the mentions and users panel.

### Risk 

medium