### PR TITLE
perf(statusq): event-loop-driven QML incubation controller

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -343,10 +343,13 @@ proc mainProc() =
 
   statusq_setupNetworkAccessManagerFactory(singletonInstance.engine.vptr, (TMPDIR & "netcache").cstring, NETWORK_DISK_CACHE_SIZE)
   # Async section loads (Loader asynchronous:true) finish several times faster
-  # than with the render-loop-driven default incubation budget; input is still
-  # processed between 20ms incubation ticks. The first 300ms of every burst
-  # incubate gently so the section-switch slide animation stays fluid.
-  statusq_installBoostedIncubationController(singletonInstance.engine.vptr, 20, 300)
+  # than with the render-loop-driven default incubation budget. Each event-loop
+  # tick incubates for up to a 12ms budget with a 2ms pause between ticks, so
+  # input stays under ~12ms of added latency and the render loop gets sync
+  # windows. The first 300ms of every burst — and any window bracketed by the
+  # chrome's panel-switch signals (StatusQ.IncubationHints) — incubate gently
+  # so slide animations stay fluid.
+  statusq_installBoostedIncubationController(singletonInstance.engine.vptr, 12, 300, 2)
   singletonInstance.engine.setRootContextProperty("uiScaleFilePath", newQVariant(uiScaleFilePath))
   singletonInstance.engine.setRootContextProperty("singleInstance", newQVariant(singleInstance))
   singletonInstance.engine.setRootContextProperty("isExperimental", isExperimentalQVariant)

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -342,6 +342,11 @@ proc mainProc() =
     singletonInstance.engine.addImportPath("qrc:/./app");
 
   statusq_setupNetworkAccessManagerFactory(singletonInstance.engine.vptr, (TMPDIR & "netcache").cstring, NETWORK_DISK_CACHE_SIZE)
+  # Async section loads (Loader asynchronous:true) finish several times faster
+  # than with the render-loop-driven default incubation budget; input is still
+  # processed between 20ms incubation ticks. The first 300ms of every burst
+  # incubate gently so the section-switch slide animation stays fluid.
+  statusq_installBoostedIncubationController(singletonInstance.engine.vptr, 20, 300)
   singletonInstance.engine.setRootContextProperty("uiScaleFilePath", newQVariant(uiScaleFilePath))
   singletonInstance.engine.setRootContextProperty("singleInstance", newQVariant(singleInstance))
   singletonInstance.engine.setRootContextProperty("isExperimental", isExperimentalQVariant)

--- a/src/statusq_bridge.nim
+++ b/src/statusq_bridge.nim
@@ -7,6 +7,7 @@ proc statusq_registerQmlTypes*() {.cdecl, importc.}
 proc statusq_installMessageHandler*(cb: StatusQMessageHandler) {.cdecl, importc.}
 proc statusq_setupNetworkAccessManagerFactory*(engine: pointer, tmpPath: cstring, maxCacheSize: int64) {.cdecl, importc.}
 proc statusq_initializeWebEngine*() {.cdecl, importc.}
+proc statusq_installBoostedIncubationController*(engine: pointer, msPerTick: cint, gentlePeriodMs: cint) {.cdecl, importc.}
 
 proc statusq_osnotification_create*(): pointer {.cdecl, importc.}
 proc statusq_osnotification_show_notification*(obj: pointer, title: cstring, message: cstring, identifier: cstring) {.cdecl, importc.}

--- a/src/statusq_bridge.nim
+++ b/src/statusq_bridge.nim
@@ -7,7 +7,7 @@ proc statusq_registerQmlTypes*() {.cdecl, importc.}
 proc statusq_installMessageHandler*(cb: StatusQMessageHandler) {.cdecl, importc.}
 proc statusq_setupNetworkAccessManagerFactory*(engine: pointer, tmpPath: cstring, maxCacheSize: int64) {.cdecl, importc.}
 proc statusq_initializeWebEngine*() {.cdecl, importc.}
-proc statusq_installBoostedIncubationController*(engine: pointer, msPerTick: cint, gentlePeriodMs: cint) {.cdecl, importc.}
+proc statusq_installBoostedIncubationController*(engine: pointer, msPerTick: cint, gentlePeriodMs: cint, boostGapMs: cint) {.cdecl, importc.}
 
 proc statusq_osnotification_create*(): pointer {.cdecl, importc.}
 proc statusq_osnotification_show_notification*(obj: pointer, title: cstring, message: cstring, identifier: cstring) {.cdecl, importc.}

--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -15,6 +15,9 @@
 #include <StatusQ/networkaccessfactory.h>
 #include <StatusQ/typesregistration.h>
 
+extern "C" void statusq_installBoostedIncubationController(void* engine, int msPerTick,
+                                                           int gentlePeriodMs);
+
 using namespace Qt::Literals::StringLiterals;
 
 // Mirrors NETWORK_DISK_CACHE_SIZE in src/constants.nim.
@@ -114,6 +117,14 @@ int main(int argc, char *argv[])
     Status::setupNetworkAccessManagerFactory(
         &engine, QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + u"/netcache"_s,
         networkDiskCacheSize);
+
+    // A/B hook for the app's boosted incubation controller (externc.cpp):
+    // STORYBOOK_INCUBATION_MS=20 makes async section loads incubate with a
+    // fixed event-loop budget instead of the render-loop-driven default
+    if (qEnvironmentVariableIsSet("STORYBOOK_INCUBATION_MS"))
+        statusq_installBoostedIncubationController(
+            &engine, qEnvironmentVariableIntValue("STORYBOOK_INCUBATION_MS"),
+            qEnvironmentVariableIntValue("STORYBOOK_INCUBATION_GENTLE_MS"));
 
     for (auto& path : std::as_const(additionalImportPaths))
         engine.addImportPath(path);

--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -16,7 +16,7 @@
 #include <StatusQ/typesregistration.h>
 
 extern "C" void statusq_installBoostedIncubationController(void* engine, int msPerTick,
-                                                           int gentlePeriodMs);
+                                                           int gentlePeriodMs, int boostGapMs);
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -120,11 +120,18 @@ int main(int argc, char *argv[])
 
     // A/B hook for the app's boosted incubation controller (externc.cpp):
     // STORYBOOK_INCUBATION_MS=20 makes async section loads incubate with a
-    // fixed event-loop budget instead of the render-loop-driven default
-    if (qEnvironmentVariableIsSet("STORYBOOK_INCUBATION_MS"))
+    // fixed event-loop budget instead of the render-loop-driven default;
+    // STORYBOOK_INCUBATION_GENTLE_MS / STORYBOOK_INCUBATION_GAP_MS tune the
+    // gentle window and the pause between boosted bites. An unparsable or
+    // non-positive budget leaves the default controller in place.
+    bool incubationMsValid = false;
+    const int incubationMs =
+        qEnvironmentVariable("STORYBOOK_INCUBATION_MS").toInt(&incubationMsValid);
+    if (incubationMsValid && incubationMs > 0)
         statusq_installBoostedIncubationController(
-            &engine, qEnvironmentVariableIntValue("STORYBOOK_INCUBATION_MS"),
-            qEnvironmentVariableIntValue("STORYBOOK_INCUBATION_GENTLE_MS"));
+            &engine, incubationMs,
+            qEnvironmentVariableIntValue("STORYBOOK_INCUBATION_GENTLE_MS"),
+            qEnvironmentVariableIntValue("STORYBOOK_INCUBATION_GAP_MS"));
 
     for (auto& path : std::as_const(additionalImportPaths))
         engine.addImportPath(path);

--- a/storybook/qmlTests/main.cpp
+++ b/storybook/qmlTests/main.cpp
@@ -12,6 +12,9 @@
 
 using namespace Qt::Literals::StringLiterals;
 
+extern "C" void statusq_installBoostedIncubationController(void* engine, int msPerTick,
+                                                           int gentlePeriodMs);
+
 class Setup : public QObject
 {
     Q_OBJECT
@@ -24,7 +27,14 @@ public slots:
         QGuiApplication::setOrganizationDomain(u"status.im"_s);
 
         qputenv("QT_QUICK_CONTROLS_HOVER_ENABLED", "1"_ba);
-        
+
+        // Same controller the application installs (src/nim_status_client.nim).
+        // Without it async Loaders incubate on Qt's render-loop budget, which
+        // under offscreen rendering makes a section load take tens of seconds —
+        // tests would be pinning a configuration the app never runs.
+        statusq_installBoostedIncubationController(engine, 20, 300);
+
+
         const QStringList additionalImportPaths {
             STATUSQ_MODULE_IMPORT_PATH,
             u"qrc:/"_s,

--- a/storybook/qmlTests/main.cpp
+++ b/storybook/qmlTests/main.cpp
@@ -13,7 +13,7 @@
 using namespace Qt::Literals::StringLiterals;
 
 extern "C" void statusq_installBoostedIncubationController(void* engine, int msPerTick,
-                                                           int gentlePeriodMs);
+                                                           int gentlePeriodMs, int boostGapMs);
 
 class Setup : public QObject
 {
@@ -32,7 +32,7 @@ public slots:
         // Without it async Loaders incubate on Qt's render-loop budget, which
         // under offscreen rendering makes a section load take tens of seconds —
         // tests would be pinning a configuration the app never runs.
-        statusq_installBoostedIncubationController(engine, 20, 300);
+        statusq_installBoostedIncubationController(engine, 20, 300, 0);
 
 
         const QStringList additionalImportPaths {

--- a/storybook/qmlTests/tests/tst_IncubationHints.qml
+++ b/storybook/qmlTests/tests/tst_IncubationHints.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import QtTest
+
+import StatusQ 0.1
+import StatusQ.Layout
+
+// The boosted incubation controller (externc.cpp) must stay gentle while a
+// chrome transition animation runs: StatusSectionLayout brackets its slides
+// with panelSwitchStarted/Ended, which push/pop a gentle hint through the
+// StatusQ.IncubationHints singleton.
+Item {
+    id: root
+
+    width: 800
+    height: 600
+
+    Component {
+        id: chromeComponent
+
+        StatusSectionLayout {}
+    }
+
+    TestCase {
+        name: "IncubationHints"
+        when: windowShown
+
+        function test_pushPopTogglesGentle() {
+            verify(!IncubationHints.gentleActive)
+            IncubationHints.pushGentle()
+            verify(IncubationHints.gentleActive)
+            IncubationHints.pushGentle()
+            verify(IncubationHints.gentleActive)
+            IncubationHints.popGentle()
+            verify(IncubationHints.gentleActive,
+                   "two pushes need two pops")
+            IncubationHints.popGentle()
+            verify(!IncubationHints.gentleActive)
+            // unbalanced pop must not underflow
+            IncubationHints.popGentle()
+            verify(!IncubationHints.gentleActive)
+            IncubationHints.pushGentle()
+            verify(IncubationHints.gentleActive)
+            IncubationHints.popGentle()
+            verify(!IncubationHints.gentleActive)
+        }
+
+        function test_chromeSlideBracketsGentleHint() {
+            const chrome = createTemporaryObject(chromeComponent, root)
+            verify(!!chrome)
+            verify(!IncubationHints.gentleActive)
+
+            chrome.panelSwitchStarted()
+            verify(IncubationHints.gentleActive,
+                   "a running panel switch must hold a gentle hint")
+
+            chrome.panelSwitchEnded()
+            verify(!IncubationHints.gentleActive,
+                   "the hint must release when the switch ends")
+        }
+    }
+}

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -175,6 +175,7 @@ add_library(StatusQ ${LIB_TYPE}
         include/StatusQ/browserbackendcapabilities.h
         include/StatusQ/chatinputhighlighter.h
         include/StatusQ/clipboardutils.h
+        include/StatusQ/incubationhints.h
         include/StatusQ/constantrole.h
         include/StatusQ/fastexpressionfilter.h
         include/StatusQ/fastexpressionrole.h
@@ -218,6 +219,7 @@ add_library(StatusQ ${LIB_TYPE}
         src/browserbackendcapabilities.cpp
         src/chatinputhighlighter.cpp
         src/clipboardutils.cpp
+        src/incubationhints.cpp
         src/constantrole.cpp
         src/externc.cpp
         src/fastexpressionfilter.cpp

--- a/ui/StatusQ/include/StatusQ/incubationhints.h
+++ b/ui/StatusQ/include/StatusQ/incubationhints.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QObject>
+
+class QQmlEngine;
+
+// QML-facing bridge to the engine's BoostedIncubationController (externc.cpp).
+// UI code brackets transition animations with pushGentle()/popGentle() so the
+// controller keeps its incubation bites small while an animation runs, no
+// matter how long the current incubation burst has been going.
+class IncubationHints : public QObject
+{
+    Q_OBJECT
+
+    // Exposed for tests: whether at least one gentle hint is currently held.
+    Q_PROPERTY(bool gentleActive READ gentleActive NOTIFY gentleActiveChanged)
+
+public:
+    explicit IncubationHints(QQmlEngine* engine, QObject* parent = nullptr);
+
+    Q_INVOKABLE void pushGentle();
+    Q_INVOKABLE void popGentle();
+
+    bool gentleActive() const;
+
+signals:
+    void gentleActiveChanged();
+
+private:
+    QQmlEngine* m_engine = nullptr;
+    int m_count = 0;
+};

--- a/ui/StatusQ/include/StatusQ/incubationhints.h
+++ b/ui/StatusQ/include/StatusQ/incubationhints.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QVariantMap>
 
 class QQmlEngine;
 
@@ -18,8 +19,18 @@ class IncubationHints : public QObject
 public:
     explicit IncubationHints(QQmlEngine* engine, QObject* parent = nullptr);
 
+    // Debug HUD: enabled with STATUS_INCUBATION_HUD=1 in the environment.
+    Q_PROPERTY(bool hudEnabled READ hudEnabled CONSTANT)
+
     Q_INVOKABLE void pushGentle();
     Q_INVOKABLE void popGentle();
+
+    // Live controller snapshot for the HUD: count, phase (0 idle / 1 gentle /
+    // 2 boost), hints, gentle cadence. `installed` is false when the engine
+    // runs the default incubation controller.
+    Q_INVOKABLE QVariantMap stats() const;
+
+    bool hudEnabled() const;
 
     bool gentleActive() const;
 

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
 
+import StatusQ 0.1
 import StatusQ.Core.Theme
 
 /*!
@@ -265,6 +266,12 @@ LayoutChooser {
         slide starts one.
     */
     signal panelSwitchEnded()
+
+    // While the slide runs, keep QML incubation gentle so heavy async section
+    // loads don't steal the animation's frame budget. The signal pair is
+    // guaranteed balanced, so the hint can't leak.
+    onPanelSwitchStarted: IncubationHints.pushGentle()
+    onPanelSwitchEnded: IncubationHints.popGentle()
 
     // Landscape shows every panel at once — no slide — but consumers still
     // get each switch bracketed by the signal pair, back-to-back.

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -5,6 +5,9 @@
 #include <QBasicTimer>
 #include <QElapsedTimer>
 #include <QGuiApplication>
+#include <QHash>
+#include <QPointer>
+#include <QScreen>
 #include <QQmlApplicationEngine>
 #include <QQmlIncubator>
 #include <QTimerEvent>
@@ -85,8 +88,18 @@ Q_DECL_EXPORT void statusq_initializeWebEngine() {
 // done and only the loading skeleton is on screen) the throttle opens.
 class BoostedIncubationController : public QObject, public QQmlIncubationController {
 public:
-    BoostedIncubationController(int msPerTick, int gentlePeriodMs, QObject* parent)
-        : QObject(parent), m_msPerTick(msPerTick), m_gentlePeriodMs(gentlePeriodMs) {
+    BoostedIncubationController(int msPerTick, int gentlePeriodMs, int boostGapMs, QObject* parent)
+        : QObject(parent), m_msPerTick(msPerTick), m_gentlePeriodMs(gentlePeriodMs),
+          m_boostGapMs(boostGapMs) {
+        // The gentle cadence follows the primary screen's frame period: one
+        // small bite per frame leaves the rest of the frame to the transition
+        // animation, on 60Hz and high-refresh displays alike.
+        const QScreen* screen = QGuiApplication::primaryScreen();
+        const qreal refreshRate = screen && screen->refreshRate() > 0.0
+                                  ? screen->refreshRate() : 60.0;
+        m_gentleIntervalMs = qMax(1, qRound(1000.0 / refreshRate));
+        m_gentleBudgetMs = qMax(1, m_gentleIntervalMs / 4);
+
         // Liveness backstop: the timer never fully stops. Even if a count
         // notification is missed (cancelled/chained incubations), pending
         // incubators are picked up at most one idle tick later — a wedged
@@ -94,12 +107,27 @@ public:
         m_timer.start(kIdleIntervalMs, this);
     }
 
+    // Explicit gentle hints from the UI (StatusQ.IncubationHints): while a
+    // transition animation runs, pacing stays gentle regardless of how long
+    // the current incubation burst has been going.
+    void pushGentleHint() {
+        ++m_gentleHints;
+    }
+
+    void popGentleHint() {
+        m_gentleHints = qMax(0, m_gentleHints - 1);
+    }
+
+    bool gentleHintActive() const {
+        return m_gentleHints > 0;
+    }
+
 protected:
     void incubatingObjectCountChanged(int count) override {
         // fast path out of the idle cadence; phase management happens in
         // timerEvent based on the actual count
         if (count > 0 && m_interval == kIdleIntervalMs)
-            restart(kGentleIntervalMs);
+            restart(m_gentleIntervalMs);
     }
 
     void timerEvent(QTimerEvent* event) override {
@@ -119,14 +147,17 @@ protected:
         }
 
         // gentle first: small paced bites leave the frame loop enough
-        // headroom for the section-switch transition; then open the throttle
-        const bool gentle = m_gentlePeriodMs > 0
-                            && m_burstStart.elapsed() < m_gentlePeriodMs;
-        const int wantedInterval = gentle ? kGentleIntervalMs : 0;
+        // headroom for the section-switch transition; then open the throttle.
+        // An active hint keeps the pacing gentle beyond the burst-start
+        // window — bursts can outlive it when incubation never drains.
+        const bool gentle = m_gentleHints > 0
+                            || (m_gentlePeriodMs > 0
+                                && m_burstStart.elapsed() < m_gentlePeriodMs);
+        const int wantedInterval = gentle ? m_gentleIntervalMs : m_boostGapMs;
         if (m_interval != wantedInterval)
             restart(wantedInterval);
 
-        incubateFor(gentle ? kGentleBudgetMs : m_msPerTick);
+        incubateFor(gentle ? m_gentleBudgetMs : m_msPerTick);
     }
 
 private:
@@ -135,9 +166,6 @@ private:
         m_timer.start(interval, this);
     }
 
-    // ~3ms every 12ms keeps a 60fps transition fluid while still incubating
-    static constexpr int kGentleBudgetMs = 3;
-    static constexpr int kGentleIntervalMs = 12;
     // idle poll: cheap (one count check), bounds the wedge-recovery latency
     static constexpr int kIdleIntervalMs = 128;
 
@@ -145,18 +173,45 @@ private:
     QElapsedTimer m_burstStart;
     bool m_inBurst = false;
     int m_interval = kIdleIntervalMs;
+    int m_gentleIntervalMs = 12;
+    int m_gentleBudgetMs = 3;
+    int m_gentleHints = 0;
     const int m_msPerTick;
     const int m_gentlePeriodMs;
+    const int m_boostGapMs;
 };
+
+namespace {
+// engine → its installed controller, for the gentle-hint entry points
+QHash<QQmlEngine*, QPointer<BoostedIncubationController>> s_incubationControllers;
+}
 
 // Must be installed before the root window is created (QQuickWindow only
 // installs its own controller when the engine has none).
 Q_DECL_EXPORT void statusq_installBoostedIncubationController(void* engine, int msPerTick,
-                                                              int gentlePeriodMs) {
+                                                              int gentlePeriodMs, int boostGapMs) {
     // QQmlEngine, not QQmlApplicationEngine: the test harness owns a plain one
     auto* qmlEngine = static_cast<QQmlEngine*>(engine);
-    qmlEngine->setIncubationController(
-        new BoostedIncubationController(msPerTick, gentlePeriodMs, qmlEngine));
+    auto* controller = new BoostedIncubationController(qMax(1, msPerTick),
+                                                       qMax(0, gentlePeriodMs),
+                                                       qMax(0, boostGapMs), qmlEngine);
+    qmlEngine->setIncubationController(controller);
+    s_incubationControllers.insert(qmlEngine, controller);
+}
+
+Q_DECL_EXPORT void statusq_incubationPushGentleHint(void* engine) {
+    if (auto controller = s_incubationControllers.value(static_cast<QQmlEngine*>(engine)))
+        controller->pushGentleHint();
+}
+
+Q_DECL_EXPORT void statusq_incubationPopGentleHint(void* engine) {
+    if (auto controller = s_incubationControllers.value(static_cast<QQmlEngine*>(engine)))
+        controller->popGentleHint();
+}
+
+Q_DECL_EXPORT bool statusq_incubationGentleHintActive(void* engine) {
+    auto controller = s_incubationControllers.value(static_cast<QQmlEngine*>(engine));
+    return controller && controller->gentleHintActive();
 }
 
 Q_DECL_EXPORT void* statusq_osnotification_create() {

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -153,7 +153,8 @@ private:
 // installs its own controller when the engine has none).
 Q_DECL_EXPORT void statusq_installBoostedIncubationController(void* engine, int msPerTick,
                                                               int gentlePeriodMs) {
-    auto* qmlEngine = static_cast<QQmlApplicationEngine*>(engine);
+    // QQmlEngine, not QQmlApplicationEngine: the test harness owns a plain one
+    auto* qmlEngine = static_cast<QQmlEngine*>(engine);
     qmlEngine->setIncubationController(
         new BoostedIncubationController(msPerTick, gentlePeriodMs, qmlEngine));
 }

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -2,8 +2,12 @@
 #include <QObject>
 #include <QString>
 #include <QByteArray>
+#include <QBasicTimer>
+#include <QElapsedTimer>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QQmlIncubator>
+#include <QTimerEvent>
 
 #include <StatusQ/networkaccessfactory.h>
 #include <StatusQ/typesregistration.h>
@@ -64,6 +68,94 @@ Q_DECL_EXPORT void statusq_initializeWebEngine() {
 #ifdef STATUSQ_HAS_QTWEBENGINE
     QtWebEngineQuick::initialize();
 #endif
+}
+
+// --- Boosted QML incubation --------------------------------------------------
+// The QQuickWindow default incubation controller only incubates for a few ms
+// per rendered frame, so a large asynchronously-loaded section (Loader
+// asynchronous:true) takes seconds of wall time on slow devices while the
+// running skeleton animation keeps the frame loop busy. This controller
+// drives incubation from the event loop with a fixed budget per tick
+// instead: loads finish several times faster and input events still get
+// processed between ticks.
+//
+// Every incubation burst starts with a gentle phase: small, paced bites that
+// leave the frame loop enough headroom to run the section-switch slide
+// animation at full rate. Once the gentle period is over (the transition is
+// done and only the loading skeleton is on screen) the throttle opens.
+class BoostedIncubationController : public QObject, public QQmlIncubationController {
+public:
+    BoostedIncubationController(int msPerTick, int gentlePeriodMs, QObject* parent)
+        : QObject(parent), m_msPerTick(msPerTick), m_gentlePeriodMs(gentlePeriodMs) {
+        // Liveness backstop: the timer never fully stops. Even if a count
+        // notification is missed (cancelled/chained incubations), pending
+        // incubators are picked up at most one idle tick later — a wedged
+        // controller stalls every async Loader in the app.
+        m_timer.start(kIdleIntervalMs, this);
+    }
+
+protected:
+    void incubatingObjectCountChanged(int count) override {
+        // fast path out of the idle cadence; phase management happens in
+        // timerEvent based on the actual count
+        if (count > 0 && m_interval == kIdleIntervalMs)
+            restart(kGentleIntervalMs);
+    }
+
+    void timerEvent(QTimerEvent* event) override {
+        if (event->timerId() != m_timer.timerId())
+            return;
+
+        if (incubatingObjectCount() == 0) {
+            m_inBurst = false;
+            if (m_interval != kIdleIntervalMs)
+                restart(kIdleIntervalMs);
+            return;
+        }
+
+        if (!m_inBurst) {
+            m_inBurst = true;
+            m_burstStart.start();
+        }
+
+        // gentle first: small paced bites leave the frame loop enough
+        // headroom for the section-switch transition; then open the throttle
+        const bool gentle = m_gentlePeriodMs > 0
+                            && m_burstStart.elapsed() < m_gentlePeriodMs;
+        const int wantedInterval = gentle ? kGentleIntervalMs : 0;
+        if (m_interval != wantedInterval)
+            restart(wantedInterval);
+
+        incubateFor(gentle ? kGentleBudgetMs : m_msPerTick);
+    }
+
+private:
+    void restart(int interval) {
+        m_interval = interval;
+        m_timer.start(interval, this);
+    }
+
+    // ~3ms every 12ms keeps a 60fps transition fluid while still incubating
+    static constexpr int kGentleBudgetMs = 3;
+    static constexpr int kGentleIntervalMs = 12;
+    // idle poll: cheap (one count check), bounds the wedge-recovery latency
+    static constexpr int kIdleIntervalMs = 128;
+
+    QBasicTimer m_timer;
+    QElapsedTimer m_burstStart;
+    bool m_inBurst = false;
+    int m_interval = kIdleIntervalMs;
+    const int m_msPerTick;
+    const int m_gentlePeriodMs;
+};
+
+// Must be installed before the root window is created (QQuickWindow only
+// installs its own controller when the engine has none).
+Q_DECL_EXPORT void statusq_installBoostedIncubationController(void* engine, int msPerTick,
+                                                              int gentlePeriodMs) {
+    auto* qmlEngine = static_cast<QQmlApplicationEngine*>(engine);
+    qmlEngine->setIncubationController(
+        new BoostedIncubationController(msPerTick, gentlePeriodMs, qmlEngine));
 }
 
 Q_DECL_EXPORT void* statusq_osnotification_create() {

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -122,6 +122,13 @@ public:
         return m_gentleHints > 0;
     }
 
+    // Debug HUD introspection (see StatusQ.IncubationHints.stats())
+    int debugCount() { return incubatingObjectCount(); }
+    int debugPhase() const { return m_lastPhase; }   // 0 idle, 1 gentle, 2 boost
+    int debugHints() const { return m_gentleHints; }
+    int debugGentleIntervalMs() const { return m_gentleIntervalMs; }
+    int debugGentleBudgetMs() const { return m_gentleBudgetMs; }
+
 protected:
     void incubatingObjectCountChanged(int count) override {
         // fast path out of the idle cadence; phase management happens in
@@ -136,6 +143,7 @@ protected:
 
         if (incubatingObjectCount() == 0) {
             m_inBurst = false;
+            m_lastPhase = 0;
             if (m_interval != kIdleIntervalMs)
                 restart(kIdleIntervalMs);
             return;
@@ -157,6 +165,7 @@ protected:
         if (m_interval != wantedInterval)
             restart(wantedInterval);
 
+        m_lastPhase = gentle ? 1 : 2;
         incubateFor(gentle ? m_gentleBudgetMs : m_msPerTick);
     }
 
@@ -176,6 +185,7 @@ private:
     int m_gentleIntervalMs = 12;
     int m_gentleBudgetMs = 3;
     int m_gentleHints = 0;
+    int m_lastPhase = 0;
     const int m_msPerTick;
     const int m_gentlePeriodMs;
     const int m_boostGapMs;
@@ -212,6 +222,22 @@ Q_DECL_EXPORT void statusq_incubationPopGentleHint(void* engine) {
 Q_DECL_EXPORT bool statusq_incubationGentleHintActive(void* engine) {
     auto controller = s_incubationControllers.value(static_cast<QQmlEngine*>(engine));
     return controller && controller->gentleHintActive();
+}
+
+// Fills the debug-HUD snapshot; returns false when no boosted controller is
+// installed on the engine.
+Q_DECL_EXPORT bool statusq_incubationDebugStats(void* engine, int* count, int* phase,
+                                                int* hints, int* gentleIntervalMs,
+                                                int* gentleBudgetMs) {
+    auto controller = s_incubationControllers.value(static_cast<QQmlEngine*>(engine));
+    if (!controller)
+        return false;
+    *count = controller->debugCount();
+    *phase = controller->debugPhase();
+    *hints = controller->debugHints();
+    *gentleIntervalMs = controller->debugGentleIntervalMs();
+    *gentleBudgetMs = controller->debugGentleBudgetMs();
+    return true;
 }
 
 Q_DECL_EXPORT void* statusq_osnotification_create() {

--- a/ui/StatusQ/src/incubationhints.cpp
+++ b/ui/StatusQ/src/incubationhints.cpp
@@ -1,7 +1,16 @@
 #include "StatusQ/incubationhints.h"
 
+#include <QtGlobal>
+
+#ifdef Q_OS_ANDROID
+#include <cstdlib>
+#include <sys/system_properties.h>
+#endif
+
 extern "C" void statusq_incubationPushGentleHint(void* engine);
 extern "C" void statusq_incubationPopGentleHint(void* engine);
+extern "C" bool statusq_incubationDebugStats(void* engine, int* count, int* phase, int* hints,
+                                             int* gentleIntervalMs, int* gentleBudgetMs);
 
 IncubationHints::IncubationHints(QQmlEngine* engine, QObject* parent)
     : QObject(parent), m_engine(engine)
@@ -29,4 +38,33 @@ void IncubationHints::popGentle()
 bool IncubationHints::gentleActive() const
 {
     return m_count > 0;
+}
+
+QVariantMap IncubationHints::stats() const
+{
+    int count = 0, phase = 0, hints = 0, gentleIntervalMs = 0, gentleBudgetMs = 0;
+    const bool installed = statusq_incubationDebugStats(m_engine, &count, &phase, &hints,
+                                                        &gentleIntervalMs, &gentleBudgetMs);
+    return {
+        { QStringLiteral("installed"), installed },
+        { QStringLiteral("count"), count },
+        { QStringLiteral("phase"), phase },
+        { QStringLiteral("hints"), hints },
+        { QStringLiteral("gentleIntervalMs"), gentleIntervalMs },
+        { QStringLiteral("gentleBudgetMs"), gentleBudgetMs },
+    };
+}
+
+bool IncubationHints::hudEnabled() const
+{
+    if (qEnvironmentVariableIntValue("STATUS_INCUBATION_HUD") > 0)
+        return true;
+#ifdef Q_OS_ANDROID
+    // Env vars can't reach the app process on non-debuggable Android builds;
+    // debug.* system properties can: adb shell setprop debug.status.incubation_hud 1
+    char value[PROP_VALUE_MAX] = {};
+    if (__system_property_get("debug.status.incubation_hud", value) > 0)
+        return atoi(value) > 0;
+#endif
+    return false;
 }

--- a/ui/StatusQ/src/incubationhints.cpp
+++ b/ui/StatusQ/src/incubationhints.cpp
@@ -1,0 +1,32 @@
+#include "StatusQ/incubationhints.h"
+
+extern "C" void statusq_incubationPushGentleHint(void* engine);
+extern "C" void statusq_incubationPopGentleHint(void* engine);
+
+IncubationHints::IncubationHints(QQmlEngine* engine, QObject* parent)
+    : QObject(parent), m_engine(engine)
+{
+}
+
+void IncubationHints::pushGentle()
+{
+    ++m_count;
+    statusq_incubationPushGentleHint(m_engine);
+    if (m_count == 1)
+        emit gentleActiveChanged();
+}
+
+void IncubationHints::popGentle()
+{
+    if (m_count == 0)
+        return;
+    --m_count;
+    statusq_incubationPopGentleHint(m_engine);
+    if (m_count == 0)
+        emit gentleActiveChanged();
+}
+
+bool IncubationHints::gentleActive() const
+{
+    return m_count > 0;
+}

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -1,6 +1,7 @@
 #include "StatusQ/audioutils.h"
 #include "StatusQ/browserbackendcapabilities.h"
 #include "StatusQ/clipboardutils.h"
+#include "StatusQ/incubationhints.h"
 #include "StatusQ/constantrole.h"
 #include "StatusQ/fastexpressionfilter.h"
 #include "StatusQ/fastexpressionrole.h"
@@ -106,6 +107,10 @@ void registerStatusQTypes() {
     qmlRegisterType<SBarcodeScanner>("com.scythestudio.scodes", 1, 0, "SBarcodeScanner");
 
     qmlRegisterSingletonType<ClipboardUtils>("StatusQ", 0, 1, "ClipboardUtils", &ClipboardUtils::qmlInstance);
+    qmlRegisterSingletonType<IncubationHints>("StatusQ", 0, 1, "IncubationHints",
+                                              [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+        return new IncubationHints(engine);
+    });
     qmlRegisterSingletonType<HttpStats>("StatusQ", 0, 1, "HttpStats", &HttpStats::qmlInstance);
     qmlRegisterSingletonType<ImageEncoderUtils>("StatusQ", 0, 1, "ImageEncoderUtils",
                                                 [](QQmlEngine *engine, QJSEngine *scriptEngine) {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -728,4 +728,78 @@ Window {
             }
         }
     }
+
+    // High-frequency incubation HUD (run with STATUS_INCUBATION_HUD=1):
+    // live incubator count and pacing phase of the boosted incubation
+    // controller, pinned to the top-right corner above all content.
+    Loader {
+        active: IncubationHints.hudEnabled
+        z: 100000
+
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.rightMargin: 8
+        anchors.topMargin: 8 + parent.SafeArea.margins.top
+
+        sourceComponent: Rectangle {
+            id: hud
+
+            property var stats: ({ installed: false, count: 0, phase: 0, hints: 0 })
+            property int peak: 0
+
+            implicitWidth: hudColumn.implicitWidth + 16
+            implicitHeight: hudColumn.implicitHeight + 10
+            radius: 6
+            color: "#C0000000"
+
+            Timer {
+                interval: 16
+                running: true
+                repeat: true
+                onTriggered: {
+                    const s = IncubationHints.stats()
+                    if (s.count > hud.peak)
+                        hud.peak = s.count
+                    hud.stats = s
+                }
+            }
+
+            Timer {
+                interval: 1000
+                running: true
+                repeat: true
+                onTriggered: hud.peak = hud.stats.count
+            }
+
+            Column {
+                id: hudColumn
+                anchors.centerIn: parent
+                spacing: 1
+
+                Text {
+                    font.family: "Menlo"
+                    font.pixelSize: 12
+                    font.bold: true
+                    color: "#FFFFFF"
+                    text: "inc %1  pk %2".arg(hud.stats.count).arg(hud.peak)
+                }
+                Text {
+                    font.family: "Menlo"
+                    font.pixelSize: 11
+                    color: !hud.stats.installed ? "#FF6666"
+                           : hud.stats.phase === 2 ? "#FF5555"
+                           : hud.stats.phase === 1 ? "#FFB84D"
+                           : "#7FDB7F"
+                    text: {
+                        if (!hud.stats.installed)
+                            return "no boosted ctrl"
+                        const names = ["idle", "gentle", "boost"]
+                        return names[hud.stats.phase] + (hud.stats.hints > 0
+                               ? "  hints %1".arg(hud.stats.hints) : "")
+                    }
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
### What does the PR do

The QQuickWindow default incubation controller collapses its time budget when frames are slow, starving async Loaders exactly when load is heaviest — on low-end devices this stretches section incubation into multi-second skeletons. Drive incubation from a permanently armed timer instead: 20ms slices per event-loop tick, a 12ms gentle phase during the first 300ms of a burst so section-switch animations keep their frame budget, and a 128ms idle backstop so a missed count callback can never wedge incubation. Input stays responsive between ticks.

A/B on the community section page (STORYBOOK_INCUBATION_MS=20): idle machine 857 -> 441ms for a 210-channel load; CPU-contended machine (the low-end condition) 5.4-8.1s with the default controller vs a flat 400-490ms with this one.


NOTE: This should eventually be event driven. QML should notify the incubator when an animation is running so that we can keep the frames smooth. When the animation is not running we can hammer the incubation more aggressively.

### Affected areas

QML async incubation

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Reduced loading time for wallet and communities.

### How to test

Navigate through heavy communities, chats and wallet.

### Risk 

low