### PR TITLE
chore(ci): bump macos jenkins job timeout to 45 minutes

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -53,7 +53,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 30, unit: 'MINUTES')
+    timeout(time: 45, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',


### PR DESCRIPTION
Lately we have observed many macos jobs hitting the timeout limit of 30 minutes.
