### PR TITLE
android: make e2e job manual

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -39,6 +39,11 @@ pipeline {
       description: 'Override vendor/status-go submodule to this SHA/ref.',
       defaultValue: ''
     )
+    booleanParam(
+      name: 'RUN_E2E',
+      description: 'Trigger the Android E2E job after the build. Off for PRs, enable for manual runs.',
+      defaultValue: params.RUN_E2E ?: false
+    )
   }
 
   options {
@@ -174,7 +179,7 @@ pipeline {
     }
 
     stage('E2E') {
-      when { expression { utils.isPRBuild() } }
+      when { expression { params.RUN_E2E } }
       steps { script {
         build(
           job: 'status-app/e2e/prs-android',


### PR DESCRIPTION
## Summary

currently the android e2e job needs 4 device runners and we have only 5. This means other android e2e jobs will just hold a jenkins executor till the previous E2E job has finished.
https://ci.status.im/job/status-app/job/e2e/job/prs-android/ 
This was causing a massive queue of jobs in CI.

<img width="371" height="690" alt="Screenshot_2026-08-11_at_4 35 32_PM" src="https://github.com/user-attachments/assets/7d4e36d3-66fe-44b8-9023-8aac2f234fd8" />

We can enable android e2e for PRs later when we are able to handle the traffic, this can be done by increasing the number of runner devices, modifying the tests to use less runners possibly just rely on the 1 runner OR just speeding up the tests themselves.
