### PR TITLE
feat(l10n): introduce new Chinese (Simplified) translation

### DIFF
--- a/ui/i18n/CMakeLists.txt
+++ b/ui/i18n/CMakeLists.txt
@@ -25,6 +25,7 @@ qt6_add_lupdate(
         ${CMAKE_SOURCE_DIR}/qml_cs.ts
         ${CMAKE_SOURCE_DIR}/qml_ko.ts
         ${CMAKE_SOURCE_DIR}/qml_es.ts
+        ${CMAKE_SOURCE_DIR}/qml_zh_CN.ts
     PLURALS_TS_FILE
         ${CMAKE_SOURCE_DIR}/qml_en.ts
     SOURCES ${COLLECTED_SOURCE_FILES}
@@ -38,6 +39,7 @@ qt6_add_lrelease(
         ${CMAKE_SOURCE_DIR}/qml_cs.ts
         ${CMAKE_SOURCE_DIR}/qml_ko.ts
         ${CMAKE_SOURCE_DIR}/qml_es.ts
+        ${CMAKE_SOURCE_DIR}/qml_zh_CN.ts
     QM_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}
     MERGE_QT_TRANSLATIONS
     QT_TRANSLATION_CATALOGS qtbase qtmultimedia qtwebengine qtdeclarative

--- a/ui/i18n/qml_zh_CN.ts
+++ b/ui/i18n/qml_zh_CN.ts
@@ -1,0 +1,19244 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN" sourcelanguage="en_US">
+<context>
+    <name>A11YInformationTag</name>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s %1.</source>
+        <translation type="unfinished">您设备上的辅助功能服务可能会访问屏幕内容。请查看您的设备的%1。</translation>
+    </message>
+    <message>
+        <source>Settings &gt; Accessibility</source>
+        <translation type="unfinished">设置 &gt; 无障碍</translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s %1.</source>
+        <translation type="unfinished">您计算机上的辅助功能服务可能会访问屏幕内容。请查看您的操作系统的%1。</translation>
+    </message>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s Accessibility settings.</source>
+        <translation type="unfinished">您设备上的辅助功能服务可能会访问屏幕内容。请查看您设备的无障碍设置。</translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s Accessibility settings.</source>
+        <translation type="unfinished">您计算机上的辅助功能服务可能会访问屏幕内容。请查看您的操作系统中的无障碍设置。</translation>
+    </message>
+</context>
+<context>
+    <name>AboutView</name>
+    <message>
+        <source>Check for updates</source>
+        <translation type="unfinished">检查更新</translation>
+    </message>
+    <message>
+        <source>Current Version</source>
+        <translation type="unfinished">当前版本</translation>
+    </message>
+    <message>
+        <source>Status Go Version</source>
+        <translation type="unfinished">状态 Go 版本</translation>
+    </message>
+    <message>
+        <source>Qt Version</source>
+        <translation type="unfinished">Qt 版本</translation>
+    </message>
+    <message>
+        <source>Release Notes</source>
+        <translation type="unfinished">发行说明</translation>
+    </message>
+    <message>
+        <source>Status Manifesto</source>
+        <translation type="unfinished">状态宣言</translation>
+    </message>
+    <message>
+        <source>Status Help</source>
+        <translation type="unfinished">状态帮助</translation>
+    </message>
+    <message>
+        <source>status-app</source>
+        <translation type="unfinished">status-app</translation>
+    </message>
+    <message>
+        <source>logos-delivery-go</source>
+        <translation type="unfinished">logos-delivery-go</translation>
+    </message>
+    <message>
+        <source>Status App&apos;s GitHub Repositories</source>
+        <translation type="unfinished">状态应用程序的 GitHub 仓库</translation>
+    </message>
+    <message>
+        <source>status-go</source>
+        <translation type="unfinished">status-go</translation>
+    </message>
+    <message>
+        <source>StatusQ</source>
+        <translation type="unfinished">StatusQ</translation>
+    </message>
+    <message>
+        <source>Legal &amp; Privacy Documents</source>
+        <translation type="unfinished">法律和隐私文档</translation>
+    </message>
+    <message>
+        <source>Terms of Use</source>
+        <translation type="unfinished">使用条款</translation>
+    </message>
+    <message>
+        <source>Privacy Policy</source>
+        <translation type="unfinished">隐私政策</translation>
+    </message>
+    <message>
+        <source>Software License</source>
+        <translation type="unfinished">软件许可</translation>
+    </message>
+</context>
+<context>
+    <name>AcceptRejectOptionsButtonsPanel</name>
+    <message>
+        <source>Details</source>
+        <translation type="unfinished">详细信息</translation>
+    </message>
+    <message>
+        <source>Decline and block</source>
+        <translation type="unfinished">拒绝并阻止</translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished">接受</translation>
+    </message>
+</context>
+<context>
+    <name>AccountAddressSelection</name>
+    <message>
+        <source>Scan addresses for activity</source>
+        <translation type="unfinished">扫描地址以查找活动</translation>
+    </message>
+    <message>
+        <source>Scanning for activity...</source>
+        <translation type="unfinished">正在扫描活动...</translation>
+    </message>
+    <message>
+        <source>Activity fetched for %1 / %2 addresses</source>
+        <translation type="unfinished">已获取 %1 个地址中的 %2 个地址的活动信息</translation>
+    </message>
+    <message>
+        <source>Activity unknown</source>
+        <translation type="unfinished">活动未知</translation>
+    </message>
+    <message>
+        <source>loading...</source>
+        <translation type="unfinished">加载中...</translation>
+    </message>
+    <message>
+        <source>Has activity</source>
+        <translation type="unfinished">有活动</translation>
+    </message>
+    <message>
+        <source>No activity</source>
+        <translation type="unfinished">无活动</translation>
+    </message>
+</context>
+<context>
+    <name>AccountContextMenu</name>
+    <message>
+        <source>Address copied</source>
+        <translation type="unfinished">地址已复制</translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished">复制地址</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">编辑</translation>
+    </message>
+    <message>
+        <source>Include in balances and activity</source>
+        <translation type="unfinished">包含在余额和活动中</translation>
+    </message>
+    <message>
+        <source>Exclude from balances and activity</source>
+        <translation type="unfinished">从余额和活动中排除</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Add new account</source>
+        <translation type="unfinished">添加新账户</translation>
+    </message>
+    <message>
+        <source>Add watched address</source>
+        <translation type="unfinished">添加监控地址</translation>
+    </message>
+</context>
+<context>
+    <name>AccountOrderView</name>
+    <message>
+        <source>Move your most frequently used accounts to the top of your wallet list</source>
+        <translation type="unfinished">将您最常用的帐户移动到钱包列表的顶部</translation>
+    </message>
+    <message>
+        <source>This account looks a little lonely. Add another account to enable re-ordering.</source>
+        <translation type="unfinished">此帐户看起来有点孤单。添加另一个帐户以启用重新排序。</translation>
+    </message>
+</context>
+<context>
+    <name>AccountView</name>
+    <message>
+        <source>Edit watched address</source>
+        <translation type="unfinished">编辑已添加的地址</translation>
+    </message>
+    <message>
+        <source>Edit account</source>
+        <translation type="unfinished">编辑账户</translation>
+    </message>
+    <message>
+        <source>Account details</source>
+        <translation type="unfinished">账户详情</translation>
+    </message>
+    <message>
+        <source>Balance</source>
+        <translation type="unfinished">余额</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">地址</translation>
+    </message>
+    <message>
+        <source>Key pair</source>
+        <translation type="unfinished">密钥对</translation>
+    </message>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished">来源</translation>
+    </message>
+    <message>
+        <source>Derived from your default Status key pair</source>
+        <translation type="unfinished">从您的默认 Status 密钥对派生而来</translation>
+    </message>
+    <message>
+        <source>Imported from recovery phrase</source>
+        <translation type="unfinished">从助记词导入</translation>
+    </message>
+    <message>
+        <source>Imported from private key</source>
+        <translation type="unfinished">从私钥导入</translation>
+    </message>
+    <message>
+        <source>Watched address</source>
+        <translation type="unfinished">已添加的地址</translation>
+    </message>
+    <message>
+        <source>Derivation Path</source>
+        <translation type="unfinished">推导路径</translation>
+    </message>
+    <message>
+        <source>Stored</source>
+        <translation type="unfinished">已存储</translation>
+    </message>
+    <message>
+        <source>Include in total balances and activity</source>
+        <translation type="unfinished">包含在总余额和活动中</translation>
+    </message>
+    <message>
+        <source>Remove watched address</source>
+        <translation type="unfinished">移除已添加的地址</translation>
+    </message>
+    <message>
+        <source>Remove account</source>
+        <translation type="unfinished">移除账户</translation>
+    </message>
+</context>
+<context>
+    <name>ActiveNetworkLimitPopup</name>
+    <message>
+        <source>Network limit reached</source>
+        <translation type="unfinished">已达到网络限制</translation>
+    </message>
+    <message>
+        <source>A maximum of %1 networks can be enabled simultaneously. Disable one of the networks to enable this one.</source>
+        <translation type="unfinished">最多只能同时启用 %1 个网络。禁用其中一个网络以启用此网络。</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityCenterAdaptor</name>
+    <message>
+        <source>Removed you from contacts</source>
+        <translation type="unfinished">已将您从联系人中移除</translation>
+    </message>
+    <message>
+        <source>You’re added to private group chat</source>
+        <translation type="unfinished">您已被添加到私有群聊</translation>
+    </message>
+    <message>
+        <source>Invitation to join community</source>
+        <translation type="unfinished">加入社区的邀请</translation>
+    </message>
+    <message>
+        <source>Community membership request</source>
+        <translation type="unfinished">社区成员资格请求</translation>
+    </message>
+    <message>
+        <source>Accept pending</source>
+        <translation type="unfinished">接受待处理请求</translation>
+    </message>
+    <message>
+        <source>Reject pending</source>
+        <translation type="unfinished">拒绝待处理请求</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished">待处理中</translation>
+    </message>
+    <message>
+        <source>Request to join community</source>
+        <translation type="unfinished">加入社区的请求</translation>
+    </message>
+    <message>
+        <source>In progress</source>
+        <translation type="unfinished">进行中</translation>
+    </message>
+    <message>
+        <source>You have been kicked out of community</source>
+        <translation type="unfinished">您已被踢出社区</translation>
+    </message>
+    <message>
+        <source>You have been &lt;font color=&apos;%1&apos;&gt;banned&lt;/font&gt; from community</source>
+        <translation type="unfinished">您已在社区中被&lt;font color=&apos;%1&apos;&gt;封禁&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <source>You have been &lt;font color=&apos;%1&apos;&gt;unbanned&lt;/font&gt; in community</source>
+        <translation type="unfinished">您已在社区中被&lt;font color=&apos;%1&apos;&gt;解封&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <source>You’re received a token in community</source>
+        <translation type="unfinished">您收到了社区中的代币</translation>
+    </message>
+    <message>
+        <source>You received your first community token</source>
+        <translation type="unfinished">您收到了您的第一个社区代币</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1 %2 (%3) minted by %4.&lt;/b&gt;&lt;br&gt;</source>
+        <translation type="unfinished">&lt;b&gt;%1 %2 (%3) 由 %4 铸造。&lt;/b&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <source>Community tokens are created by the community and aren’t verified. Always check their source before interacting.</source>
+        <translation type="unfinished">社区代币由社区创建，未经验证。在进行任何操作之前，请务必检查其来源。</translation>
+    </message>
+    <message>
+        <source>You received the owner token</source>
+        <translation type="unfinished">您收到了所有者代币</translation>
+    </message>
+    <message>
+        <source>Ownership transfer</source>
+        <translation type="unfinished">所有权转移</translation>
+    </message>
+    <message>
+        <source>To continue to be a member of community, you need to share your accounts</source>
+        <translation type="unfinished">要继续成为社区成员，您需要共享您的帐户</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished">状态</translation>
+    </message>
+    <message>
+        <source>New device detected</source>
+        <translation type="unfinished">检测到新设备</translation>
+    </message>
+    <message>
+        <source>New device with %1 profile has been detected.</source>
+        <translation type="unfinished">已检测到具有 %1 配置的新设备。</translation>
+    </message>
+    <message>
+        <source>Sync your profile</source>
+        <translation type="unfinished">同步您的资料</translation>
+    </message>
+    <message>
+        <source>Check your other device for a pairing request.</source>
+        <translation type="unfinished">请检查您的其他设备，查看配对请求。</translation>
+    </message>
+    <message>
+        <source>Accepted</source>
+        <translation type="unfinished">接受</translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+    <message>
+        <source>You are now the owner of the community</source>
+        <translation type="unfinished">您现在是社区的所有者</translation>
+    </message>
+    <message>
+        <source>You no longer control the community</source>
+        <translation type="unfinished">您不再控制该社区</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished">失败</translation>
+    </message>
+    <message>
+        <source>Declined</source>
+        <translation type="unfinished">已拒绝</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityCenterPanel</name>
+    <message>
+        <source>Enable Status News notifications</source>
+        <translation type="unfinished">启用状态新闻通知</translation>
+    </message>
+    <message>
+        <source>Enable RSS</source>
+        <translation type="unfinished">启用 RSS</translation>
+    </message>
+    <message>
+        <source>No notifications right now.</source>
+        <translation type="unfinished">当前没有通知。</translation>
+    </message>
+    <message>
+        <source>Check back later for updates.</source>
+        <translation type="unfinished">稍后查看以获取更新。</translation>
+    </message>
+    <message>
+        <source>Turn it on to get updates about new features and announcements. You can also enable this anytime in Privacy &amp; Security settings.</source>
+        <translation type="unfinished">启用它，以便接收有关新功能和公告的更新。您也可以随时在“隐私与安全”设置中启用此选项。</translation>
+    </message>
+    <message>
+        <source>Status News RSS is off</source>
+        <translation type="unfinished">状态新闻 RSS 已关闭</translation>
+    </message>
+    <message>
+        <source>Status News notifications are off</source>
+        <translation type="unfinished">状态新闻通知已关闭</translation>
+    </message>
+    <message>
+        <source>Turn them on to get updates about new features and announcements. You can also enable this anytime in Notifications and Sound settings.</source>
+        <translation type="unfinished">启用它们，以便接收有关新功能和公告的更新。您也可以随时在“通知与声音”设置中启用此选项。</translation>
+    </message>
+    <message>
+        <source>Activity</source>
+        <translation type="unfinished">活动</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityCenterPopupTopBarPanel</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">全部</translation>
+    </message>
+    <message>
+        <source>News</source>
+        <translation type="unfinished">新闻</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <translation type="unfinished">管理员</translation>
+    </message>
+    <message>
+        <source>Mentions</source>
+        <translation type="unfinished">提及</translation>
+    </message>
+    <message>
+        <source>Replies</source>
+        <translation type="unfinished">回复</translation>
+    </message>
+    <message>
+        <source>Contact requests</source>
+        <translation type="unfinished">联系请求</translation>
+    </message>
+    <message>
+        <source>Transactions</source>
+        <translation type="unfinished">交易</translation>
+    </message>
+    <message>
+        <source>Membership</source>
+        <translation type="unfinished">会员</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">系统</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityCounterpartyFilterSubMenu</name>
+    <message>
+        <source>Search name, ENS or address</source>
+        <translation type="unfinished">搜索名称、ENS 或地址</translation>
+    </message>
+    <message>
+        <source>Recent</source>
+        <translation type="unfinished">最近使用</translation>
+    </message>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished">已保存</translation>
+    </message>
+    <message>
+        <source>No Recents</source>
+        <translation type="unfinished">没有最近使用的项目</translation>
+    </message>
+    <message>
+        <source>Loading Recents</source>
+        <translation type="unfinished">正在加载最近使用的项目</translation>
+    </message>
+    <message>
+        <source>No Saved Address</source>
+        <translation type="unfinished">没有已保存的地址</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityFilterMenu</name>
+    <message>
+        <source>Period</source>
+        <translation type="unfinished">期间</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">类型</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished">状态</translation>
+    </message>
+    <message>
+        <source>Tokens</source>
+        <translation type="unfinished">代币</translation>
+    </message>
+    <message>
+        <source>Counterparty</source>
+        <translation type="unfinished">交易对手方</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityFilterPanel</name>
+    <message>
+        <source>Filter</source>
+        <translation type="unfinished">筛选</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation type="unfinished">到</translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+    <message>
+        <source>Receive</source>
+        <translation type="unfinished">接收</translation>
+    </message>
+    <message>
+        <source>Swap</source>
+        <translation type="unfinished">兑换</translation>
+    </message>
+    <message>
+        <source>Bridge</source>
+        <translation type="unfinished">桥接</translation>
+    </message>
+    <message>
+        <source>Contract Deployment</source>
+        <translation type="unfinished">合约部署</translation>
+    </message>
+    <message>
+        <source>Mint</source>
+        <translation type="unfinished">铸造</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished">失败</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished">待处理</translation>
+    </message>
+    <message>
+        <source>Complete</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>Finalised</source>
+        <translation type="unfinished">已完成</translation>
+    </message>
+    <message>
+        <source>No activity items for the current filter</source>
+        <translation type="unfinished">当前筛选条件下没有活动项目</translation>
+    </message>
+    <message>
+        <source>Clear all filters</source>
+        <translation type="unfinished">清除所有筛选条件</translation>
+    </message>
+    <message>
+        <source>Contract Interaction</source>
+        <translation type="unfinished">合约交互</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityPeriodFilterSubMenu</name>
+    <message>
+        <source>All time</source>
+        <translation type="unfinished">所有时间</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation type="unfinished">今天</translation>
+    </message>
+    <message>
+        <source>Yesterday</source>
+        <translation type="unfinished">昨天</translation>
+    </message>
+    <message>
+        <source>This week</source>
+        <translation type="unfinished">这周</translation>
+    </message>
+    <message>
+        <source>Last week</source>
+        <translation type="unfinished">上周</translation>
+    </message>
+    <message>
+        <source>This month</source>
+        <translation type="unfinished">这个月</translation>
+    </message>
+    <message>
+        <source>Last month</source>
+        <translation type="unfinished">上个月</translation>
+    </message>
+    <message>
+        <source>Custom range</source>
+        <translation type="unfinished">自定义范围</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityStatusFilterSubMenu</name>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished">失败</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished">待处理</translation>
+    </message>
+    <message>
+        <source>Complete</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>Finalised</source>
+        <translation type="unfinished">已完成</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityTokensFilterSubMenu</name>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>No Assets</source>
+        <translation type="unfinished">无资产</translation>
+    </message>
+    <message>
+        <source>Search asset name</source>
+        <translation type="unfinished">搜索资产名称</translation>
+    </message>
+    <message>
+        <source>No Collectibles</source>
+        <translation type="unfinished">无收藏品</translation>
+    </message>
+    <message>
+        <source>Search collectible name</source>
+        <translation type="unfinished">搜索收藏品名称</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityTypeFilterSubMenu</name>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+    <message>
+        <source>Receive</source>
+        <translation type="unfinished">接收</translation>
+    </message>
+    <message>
+        <source>Contract Deployment</source>
+        <translation type="unfinished">合同部署</translation>
+    </message>
+    <message>
+        <source>Mint</source>
+        <translation type="unfinished">铸造</translation>
+    </message>
+    <message>
+        <source>Swap</source>
+        <translation type="unfinished">兑换</translation>
+    </message>
+    <message>
+        <source>Bridge</source>
+        <translation type="unfinished">桥接</translation>
+    </message>
+</context>
+<context>
+    <name>AddAccountPopup</name>
+    <message>
+        <source>Edit account</source>
+        <translation type="unfinished">编辑账户</translation>
+    </message>
+    <message>
+        <source>Add a new account</source>
+        <translation type="unfinished">添加新账户</translation>
+    </message>
+    <message>
+        <source>Re-import the %1 key pair to add accounts</source>
+        <translation type="unfinished">重新导入%1密钥对以添加账户</translation>
+    </message>
+    <message>
+        <source>Adding accounts to the &lt;b&gt;%1&lt;/b&gt; key pair isn&apos;t possible due to recent improvements in how key pairs are stored. Please remove this key pair from the app and import it again from your Keycard — after that you&apos;ll be able to add accounts to it. Your keys are safe: removing the key pair from the app doesn&apos;t affect the Keycard, and importing it back takes only a moment.&lt;br/&gt;&lt;br/&gt;• Go to Settings → Wallet → click the three dots on the &lt;b&gt;%1&lt;/b&gt; key pair → Remove key pair and derived accounts&lt;br/&gt;• Go to Settings → Keycard → Read Keycard → Add key pair to Status wallet</source>
+        <translation type="unfinished">由于密钥存储方式的改进，无法将账户添加到&lt;b&gt;%1&lt;/b&gt;密钥对。请从应用程序中删除此密钥对，然后从您的Keycard重新导入——之后您就可以将其添加到该密钥对。您的密钥是安全的：从应用程序中删除密钥对不会影响Keycard，并且重新导入只需片刻。&lt;br/&gt;&lt;br/&gt;• 转到“设置”→“钱包”，点击&lt;b&gt;%1&lt;/b&gt;密钥对上的三个点 → 删除密钥对和派生账户&lt;br/&gt;• 转到“设置”→“Keycard”→“读取Keycard”→将密钥对添加到Status钱包</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Removing saved address</source>
+        <translation type="unfinished">删除已保存的地址</translation>
+    </message>
+    <message>
+        <source>The account you&apos;re trying to add &lt;b&gt;%1&lt;/b&gt; is already saved under the name &lt;b&gt;%2&lt;/b&gt;.&lt;br/&gt;&lt;br/&gt;Do you want to remove it from saved addresses in favour of adding it to the Wallet?</source>
+        <translation type="unfinished">您尝试添加的账户&lt;b&gt;%1&lt;/b&gt;已保存，名称为&lt;b&gt;%2&lt;/b&gt;。&lt;br/&gt;&lt;br/&gt;您是否要将其从已保存的地址中删除，以便将其添加到钱包？</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">否</translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished">保存更改</translation>
+    </message>
+    <message>
+        <source>Add account</source>
+        <translation type="unfinished">添加账户</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+    <message>
+        <source>Reveal recovery phrase</source>
+        <translation type="unfinished">显示恢复短语</translation>
+    </message>
+    <message>
+        <source>Confirm recovery phrase</source>
+        <translation type="unfinished">确认恢复短语</translation>
+    </message>
+</context>
+<context>
+    <name>AddAccountStore</name>
+    <message>
+        <source>Type your own derivation path</source>
+        <translation type="unfinished">输入您自己的派生路径</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished">自定义</translation>
+    </message>
+    <message>
+        <source>Ethereum</source>
+        <translation type="unfinished">以太坊</translation>
+    </message>
+    <message>
+        <source>Ethereum (Ledger)</source>
+        <translation type="unfinished">以太坊（硬件钱包）</translation>
+    </message>
+    <message>
+        <source>Ethereum (Ledger Live/KeepKey)</source>
+        <translation type="unfinished">以太坊（硬件钱包，Ledger Live/KeepKey）</translation>
+    </message>
+</context>
+<context>
+    <name>AddEditSavedAddressPopup</name>
+    <message>
+        <source>Edit saved address</source>
+        <translation type="unfinished">编辑已保存的地址</translation>
+    </message>
+    <message>
+        <source>Add new saved address</source>
+        <translation type="unfinished">添加新的已保存地址</translation>
+    </message>
+    <message>
+        <source>You cannot add your own account as a saved address</source>
+        <translation type="unfinished">您不能将自己的帐户添加为已保存的地址</translation>
+    </message>
+    <message>
+        <source>This address is already saved</source>
+        <translation type="unfinished">此地址已保存</translation>
+    </message>
+    <message>
+        <source>Not registered ens address</source>
+        <translation type="unfinished">未注册的 ENS 地址</translation>
+    </message>
+    <message>
+        <source>Please enter an ethereum address</source>
+        <translation type="unfinished">请输入以太坊地址</translation>
+    </message>
+    <message>
+        <source>Ethereum address invalid</source>
+        <translation type="unfinished">以太坊地址无效</translation>
+    </message>
+    <message>
+        <source>This address belongs to a contact</source>
+        <translation type="unfinished">此地址属于一个联系人</translation>
+    </message>
+    <message>
+        <source>This address belongs to the following contacts</source>
+        <translation type="unfinished">此地址属于以下联系人</translation>
+    </message>
+    <message>
+        <source>Address name</source>
+        <translation type="unfinished">地址名称</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message>
+        <source>Please name your saved address</source>
+        <translation type="unfinished">请为您的已保存地址命名</translation>
+    </message>
+    <message>
+        <source>Name already in use</source>
+        <translation type="unfinished">该名称已被使用</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">地址</translation>
+    </message>
+    <message>
+        <source>Ethereum address</source>
+        <translation type="unfinished">以太坊地址</translation>
+    </message>
+    <message>
+        <source>Checksum of the entered address is incorrect</source>
+        <translation type="unfinished">输入的地址的校验和不正确</translation>
+    </message>
+    <message>
+        <source>Colour</source>
+        <translation type="unfinished">颜色</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">保存</translation>
+    </message>
+    <message>
+        <source>Add address</source>
+        <translation type="unfinished">添加地址</translation>
+    </message>
+</context>
+<context>
+    <name>AddFavoriteModal</name>
+    <message>
+        <source>Edit bookmark</source>
+        <translation type="unfinished">编辑书签</translation>
+    </message>
+    <message>
+        <source>Add bookmark</source>
+        <translation type="unfinished">添加书签</translation>
+    </message>
+    <message>
+        <source>URL</source>
+        <translation type="unfinished">网址</translation>
+    </message>
+    <message>
+        <source>Paste URL</source>
+        <translation type="unfinished">粘贴网址</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+    <message>
+        <source>Pasted</source>
+        <translation type="unfinished">已粘贴</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message>
+        <source>Name of the website</source>
+        <translation type="unfinished">网站名称</translation>
+    </message>
+    <message>
+        <source>Please enter a name</source>
+        <translation type="unfinished">请输入名称</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished">保存更改</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+</context>
+<context>
+    <name>AddMoreAccountsLink</name>
+    <message>
+        <source>Add accounts to showcase</source>
+        <translation type="unfinished">添加帐户以进行展示</translation>
+    </message>
+</context>
+<context>
+    <name>AddSocialLinkModal</name>
+    <message>
+        <source>Add a link</source>
+        <translation type="unfinished">添加链接</translation>
+    </message>
+    <message>
+        <source>Add %1 link</source>
+        <translation type="unfinished">添加 %1 链接</translation>
+    </message>
+    <message>
+        <source>custom</source>
+        <translation type="unfinished">自定义</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+    <message>
+        <source>Custom link</source>
+        <translation type="unfinished">自定义链接</translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished">标题</translation>
+    </message>
+    <message>
+        <source>Invalid title</source>
+        <translation type="unfinished">无效的标题</translation>
+    </message>
+    <message>
+        <source>Username already added</source>
+        <translation type="unfinished">用户名已添加</translation>
+    </message>
+    <message>
+        <source>Link</source>
+        <translation type="unfinished">链接</translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished">用户名</translation>
+    </message>
+    <message>
+        <source>Invalid %1</source>
+        <translation type="unfinished">无效的%1</translation>
+    </message>
+    <message>
+        <source>link</source>
+        <translation type="unfinished">链接</translation>
+    </message>
+    <message>
+        <source>Title and link combination already added</source>
+        <translation type="unfinished">标题和链接组合已添加</translation>
+    </message>
+    <message>
+        <source>URL</source>
+        <translation type="unfinished">网址</translation>
+    </message>
+    <message>
+        <source>URL already added</source>
+        <translation type="unfinished">网址已添加</translation>
+    </message>
+</context>
+<context>
+    <name>AddressDetails</name>
+    <message>
+        <source>Already added</source>
+        <translation type="unfinished">已添加</translation>
+    </message>
+    <message>
+        <source>Activity unknown</source>
+        <translation type="unfinished">活动未知</translation>
+    </message>
+    <message>
+        <source>Scanning for activity...</source>
+        <translation type="unfinished">正在扫描活动...</translation>
+    </message>
+    <message>
+        <source>Has activity</source>
+        <translation type="unfinished">有活动</translation>
+    </message>
+    <message>
+        <source>No activity</source>
+        <translation type="unfinished">无活动</translation>
+    </message>
+</context>
+<context>
+    <name>AddressesInputList</name>
+    <message>
+        <source>Example: 0x39cf...fbd2</source>
+        <translation type="unfinished">示例：0x39cf...fbd2</translation>
+    </message>
+</context>
+<context>
+    <name>AddressesSelectorPanel</name>
+    <message>
+        <source>ETH addresses</source>
+        <translation type="unfinished">以太坊地址</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n valid address(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 个有效地址</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n invalid</source>
+        <comment>invalid addresses, where &quot;addresses&quot; is implicit</comment>
+        <translation type="unfinished">
+            <numerusform>%n 个无效地址，其中“地址”一词已省略</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n invalid address(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 个无效地址</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedStore</name>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished">徽标存储</translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished">种子文件</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished">已禁用</translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedView</name>
+    <message>
+        <source>This feature is experimental and is meant for testing purposes by core contributors and the community. It&apos;s not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</source>
+        <translation type="unfinished">此功能是实验性的，旨在供核心贡献者和社区进行测试。它不适用于实际使用，并且不对资金或数据的安全性和完整性做出任何声明。请自行承担风险。</translation>
+    </message>
+    <message>
+        <source>Fleet</source>
+        <translation type="unfinished">舰队</translation>
+    </message>
+    <message>
+        <source>Chat scrolling</source>
+        <translation type="unfinished">聊天滚动</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished">自定义</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">系统</translation>
+    </message>
+    <message>
+        <source>Minimize to tray icon on close</source>
+        <translation type="unfinished">关闭时最小化到托盘图标</translation>
+    </message>
+    <message>
+        <source>Application Logs</source>
+        <translation type="unfinished">应用程序日志</translation>
+    </message>
+    <message>
+        <source>Experimental features</source>
+        <translation type="unfinished">实验功能</translation>
+    </message>
+    <message>
+        <source>Web/dApp Browser</source>
+        <translation type="unfinished">网页/DApp 浏览器</translation>
+    </message>
+    <message>
+        <source>ENS Community Permissions Enabled</source>
+        <translation type="unfinished">已启用 ENS 社区权限</translation>
+    </message>
+    <message>
+        <source>Enable Copying Message Links</source>
+        <translation type="unfinished">启用复制消息链接</translation>
+    </message>
+    <message>
+        <source>The account will be logged out. When you login again, the selected mode will be enabled</source>
+        <translation type="unfinished">该帐户将被注销。下次登录时，将启用所选模式。</translation>
+    </message>
+    <message>
+        <source>I understand</source>
+        <translation type="unfinished">我明白了</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation type="unfinished">确认</translation>
+    </message>
+    <message>
+        <source>Light mode</source>
+        <translation type="unfinished">浅色模式</translation>
+    </message>
+    <message>
+        <source>Relay mode</source>
+        <translation type="unfinished">中继模式</translation>
+    </message>
+    <message>
+        <source>Developer features</source>
+        <translation type="unfinished">开发者功能</translation>
+    </message>
+    <message>
+        <source>The app will restart if you confirm.</source>
+        <translation type="unfinished">如果您确认，应用程序将重新启动。</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">调试</translation>
+    </message>
+    <message>
+        <source>Archive Protocol</source>
+        <translation type="unfinished">存档协议</translation>
+    </message>
+    <message>
+        <source>Logos Messaging options</source>
+        <translation type="unfinished">Logos 消息选项</translation>
+    </message>
+    <message>
+        <source>The value is overridden with runtime options</source>
+        <translation type="unfinished">该值将被运行时选项覆盖</translation>
+    </message>
+    <message>
+        <source>Manage communities on testnet</source>
+        <translation type="unfinished">管理测试网络上的社区</translation>
+    </message>
+    <message>
+        <source>Enable community tokens refreshing</source>
+        <translation type="unfinished">启用社区令牌刷新</translation>
+    </message>
+    <message>
+        <source>How many log files to keep archived</source>
+        <translation type="unfinished">保留多少个归档的日志文件</translation>
+    </message>
+    <message>
+        <source>RPC statistics</source>
+        <translation type="unfinished">RPC统计信息</translation>
+    </message>
+    <message>
+        <source>HTTP statistics</source>
+        <translation type="unfinished">HTTP统计信息</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to disable debug mode?</source>
+        <translation type="unfinished">您确定要禁用调试模式吗？</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to enable debug mode?</source>
+        <translation type="unfinished">您确定要启用调试模式吗？</translation>
+    </message>
+    <message>
+        <source>How many log files do you want to keep archived?</source>
+        <translation type="unfinished">你想保留多少个归档的日志文件？</translation>
+    </message>
+    <message>
+        <source>Choose a number between 1 and 100</source>
+        <translation type="unfinished">选择一个介于 1 和 100 之间的数字</translation>
+    </message>
+    <message>
+        <source>Number of archives files</source>
+        <translation type="unfinished">存档文件的数量</translation>
+    </message>
+    <message>
+        <source>Number between 1 and 100</source>
+        <translation type="unfinished">1 到 100 之间的数字</translation>
+    </message>
+    <message>
+        <source>Number needs to be between 1 and 100</source>
+        <translation type="unfinished">数字必须在 1 到 100 之间</translation>
+    </message>
+    <message>
+        <source>This change will only come into action after a restart</source>
+        <translation type="unfinished">此更改仅在重新启动后生效</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Change</source>
+        <translation type="unfinished">更改</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished">已禁用</translation>
+    </message>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished">徽标存储</translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished">种子文件</translation>
+    </message>
+    <message>
+        <source>Refetch transaction history</source>
+        <translation type="unfinished">重新获取交易历史记录</translation>
+    </message>
+    <message>
+        <source>Refetch</source>
+        <translation type="unfinished">重新获取</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+</context>
+<context>
+    <name>AirdropRecipientsSelector</name>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">到</translation>
+    </message>
+    <message>
+        <source>Example: 12 addresses and 3 members</source>
+        <translation type="unfinished">示例：12 个地址和 3 个成员</translation>
+    </message>
+    <message>
+        <source>∞ recipients</source>
+        <comment>infinite number of recipients</comment>
+        <translation type="unfinished">无限数量的收件人</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n recipient(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 位接收者</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>AirdropTokensSelector</name>
+    <message>
+        <source>Example: 1 SOCK</source>
+        <translation type="unfinished">示例：1 SOCK</translation>
+    </message>
+    <message>
+        <source>What</source>
+        <translation type="unfinished">内容</translation>
+    </message>
+    <message>
+        <source>%1 on</source>
+        <comment>It means that a given token is deployed &apos;on&apos; a given network, e.g. &apos;2 MCT on Ethereum&apos;. The name of the network is preceded by an icon, so it is not part of this phrase.</comment>
+        <translation type="unfinished">在 %1 上</translation>
+    </message>
+</context>
+<context>
+    <name>AirdropsSettingsPanel</name>
+    <message>
+        <source>Airdrops</source>
+        <translation type="unfinished">空投</translation>
+    </message>
+    <message>
+        <source>New Airdrop</source>
+        <translation type="unfinished">新的空投</translation>
+    </message>
+    <message>
+        <source>Loading tokens...</source>
+        <translation type="unfinished">正在加载代币...</translation>
+    </message>
+    <message>
+        <source>Airdrop community tokens</source>
+        <translation type="unfinished">空投社区代币</translation>
+    </message>
+    <message>
+        <source>You can mint custom tokens and collectibles for your community</source>
+        <translation type="unfinished">您可以为您的社区铸造自定义代币和收藏品</translation>
+    </message>
+    <message>
+        <source>Reward individual members with custom tokens for their contribution</source>
+        <translation type="unfinished">使用自定义代币奖励社区成员的贡献</translation>
+    </message>
+    <message>
+        <source>Incentivise joining, retention, moderation and desired behaviour</source>
+        <translation type="unfinished">激励加入、留存、版主行为和期望的行为</translation>
+    </message>
+    <message>
+        <source>Require holding a token or NFT to obtain exclusive membership rights</source>
+        <translation type="unfinished">要求持有代币或 NFT 以获得独家会员资格</translation>
+    </message>
+    <message>
+        <source>Get started</source>
+        <translation type="unfinished">开始使用</translation>
+    </message>
+    <message>
+        <source>Token airdropping can only be performed by admins that hodl the Community&apos;s TokenMaster token. If you would like this permission, contact the Community founder (they will need to mint the Community Owner token before they can airdrop this to you).</source>
+        <translation type="unfinished">代币空投只能由持有社区的 TokenMaster 代币的管理人员执行。如果您需要此权限，请联系社区创始人（他们需要在向您空投之前铸造社区所有者代币）。</translation>
+    </message>
+    <message>
+        <source>In order to Mint, Import and Airdrop community tokens, you first need to mint your Owner token which will give you permissions to access the token management features for your community.</source>
+        <translation type="unfinished">为了铸造、导入和空投社区代币，您首先需要铸造您的所有者代币，这将授予您访问社区的代币管理功能的权限。</translation>
+    </message>
+    <message>
+        <source>Mint Owner token</source>
+        <translation type="unfinished">铸造所有者代币</translation>
+    </message>
+    <message>
+        <source>New airdrop</source>
+        <translation type="unfinished">新的空投</translation>
+    </message>
+</context>
+<context>
+    <name>AlertPopup</name>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>AmountInput</name>
+    <message>
+        <source>Amount exceeds balance</source>
+        <translation type="unfinished">金额超过余额</translation>
+    </message>
+    <message>
+        <source>Invalid amount format</source>
+        <translation type="unfinished">无效的金额格式</translation>
+    </message>
+    <message numerus="yes">
+        <source>Max %n decimal place(s) for this asset</source>
+        <translation type="unfinished">
+            <numerusform>此资产最多允许输入%n位小数</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Amount must be greater than 0</source>
+        <translation type="unfinished">金额必须大于 0</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">金额</translation>
+    </message>
+</context>
+<context>
+    <name>AppMain</name>
+    <message>
+        <source>&quot;%1&quot; successfully added</source>
+        <translation type="unfinished">&quot;%1&quot;已成功添加</translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot; successfully removed</source>
+        <translation type="unfinished">&quot;%1&quot;已成功删除</translation>
+    </message>
+    <message>
+        <source>You successfully renamed your key pair
+from &quot;%1&quot; to &quot;%2&quot;</source>
+        <translation type="unfinished">:{</translation>
+    </message>
+    <message>
+        <source>Test network settings for %1 updated</source>
+        <translation type="unfinished">已更新%1的测试网络设置</translation>
+    </message>
+    <message>
+        <source>Live network settings for %1 updated</source>
+        <translation type="unfinished">已更新%1的实时网络设置</translation>
+    </message>
+    <message>
+        <source>“%1” key pair and its derived accounts were successfully removed from all devices</source>
+        <translation type="unfinished">密钥对“%1”及其派生帐户已成功从所有设备中删除</translation>
+    </message>
+    <message>
+        <source>Please re-generate QR code and try importing again</source>
+        <translation type="unfinished">请重新生成二维码，然后再次尝试导入</translation>
+    </message>
+    <message>
+        <source>Make sure you&apos;re importing the exported key pair on paired device</source>
+        <translation type="unfinished">请确保您正在配对的设备上导入导出的密钥对</translation>
+    </message>
+    <message>
+        <source>%1 key pair successfully imported</source>
+        <translation type="unfinished">密钥对%1已成功导入</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n key pair(s) successfully imported</source>
+        <translation type="unfinished">
+            <numerusform>已成功导入 %n 个密钥对</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>View on %1</source>
+        <translation type="unfinished">在%1上查看</translation>
+    </message>
+    <message>
+        <source>Sending %1 from %2 to %3</source>
+        <translation type="unfinished">从%2发送%1到%3</translation>
+    </message>
+    <message>
+        <source>Registering %1 ENS name using %2</source>
+        <translation type="unfinished">使用%2注册%1 ENS名称</translation>
+    </message>
+    <message>
+        <source>Releasing %1 ENS username using %2</source>
+        <translation type="unfinished">使用%2释放%1 ENS用户名</translation>
+    </message>
+    <message>
+        <source>Setting public key %1 using %2</source>
+        <translation type="unfinished">使用%2设置公钥%1</translation>
+    </message>
+    <message>
+        <source>Purchasing %1 sticker pack using %2</source>
+        <translation type="unfinished">使用%2购买%1贴纸包</translation>
+    </message>
+    <message>
+        <source>Setting spending cap: %1 in %2 for %3</source>
+        <translation type="unfinished">设置支出上限：%3的%2中的%1</translation>
+    </message>
+    <message>
+        <source>Sending %1 %2 from %3 to %4</source>
+        <translation type="unfinished">从%3发送%1 %2到%4</translation>
+    </message>
+    <message>
+        <source>Swapping %1 to %2 in %3</source>
+        <translation type="unfinished">在%3中将%1交换为%2</translation>
+    </message>
+    <message>
+        <source>Minting infinite %1 tokens for %2 using %3</source>
+        <translation type="unfinished">使用%3为%2铸造无限数量的%1代币</translation>
+    </message>
+    <message>
+        <source>Minting %1 %2 tokens for %3 using %4</source>
+        <translation type="unfinished">为%3使用%4铸造%1和%2代币</translation>
+    </message>
+    <message>
+        <source>Minting %1 and %2 tokens for %3 using %4</source>
+        <translation type="unfinished">为%3使用%4铸造%1和%2代币</translation>
+    </message>
+    <message>
+        <source>Airdropping %1x %2 to %3 using %4</source>
+        <translation type="unfinished">使用%4向%3空投%1x %2</translation>
+    </message>
+    <message>
+        <source>Airdropping %1x %2 to %3 addresses using %4</source>
+        <translation type="unfinished">使用%4向%3个地址空投%1x %2</translation>
+    </message>
+    <message>
+        <source>Airdropping %1x %2 and %3x %4 to %5 using %6</source>
+        <translation type="unfinished">使用%6向%5空投%1x %2和%3x %4</translation>
+    </message>
+    <message>
+        <source>Airdropping %1x %2 and %3x %4 to %5 addresses using %6</source>
+        <translation type="unfinished">使用%6向%5个地址空投%1x %2和%3x %4</translation>
+    </message>
+    <message>
+        <source>Airdropping %1 tokens to %2 using %3</source>
+        <translation type="unfinished">使用%3向%2空投%1代币</translation>
+    </message>
+    <message>
+        <source>Destroying %1x %2 at %3 using %4</source>
+        <translation type="unfinished">使用%4在%3销毁%1x %2</translation>
+    </message>
+    <message>
+        <source>Destroying %1x %2 at %3 addresses using %4</source>
+        <translation type="unfinished">使用%4在%3个地址销毁%1x %2</translation>
+    </message>
+    <message>
+        <source>Burning %1x %2 for %3 using %4</source>
+        <translation type="unfinished">使用%4为%3销毁%1x %2</translation>
+    </message>
+    <message>
+        <source>Finalizing ownership for %1 using %2</source>
+        <translation type="unfinished">使用%2完成对%1的所有权</translation>
+    </message>
+    <message>
+        <source>Sent %1 from %2 to %3</source>
+        <translation type="unfinished">从%2发送到%3的%1</translation>
+    </message>
+    <message>
+        <source>Registered %1 ENS name using %2</source>
+        <translation type="unfinished">使用%2注册了%1个ENS名称</translation>
+    </message>
+    <message>
+        <source>Released %1 ENS username using %2</source>
+        <translation type="unfinished">使用%2释放了%1个ENS用户名</translation>
+    </message>
+    <message>
+        <source>Set public key %1 using %2</source>
+        <translation type="unfinished">使用%2设置公钥%1</translation>
+    </message>
+    <message>
+        <source>Purchased %1 sticker pack using %2</source>
+        <translation type="unfinished">使用%2购买了%1个贴纸包</translation>
+    </message>
+    <message>
+        <source>Sent %1 %2 from %3 to %4</source>
+        <translation type="unfinished">从%3发送到%4的%1 %2</translation>
+    </message>
+    <message>
+        <source>Swapped %1 to %2 in %3</source>
+        <translation type="unfinished">在%3中将%1兑换为%2</translation>
+    </message>
+    <message>
+        <source>Spending cap set: %1 in %2 for %3</source>
+        <translation type="unfinished">支出上限设置为：%1，期限：%2，对象：%3</translation>
+    </message>
+    <message>
+        <source>Minted infinite %1 tokens for %2 using %3</source>
+        <translation type="unfinished">使用%3为%2铸造无限数量的%1代币</translation>
+    </message>
+    <message>
+        <source>Minted %1 %2 tokens for %3 using %4</source>
+        <translation type="unfinished">为%3使用%4铸造了%1和%2代币</translation>
+    </message>
+    <message>
+        <source>Minted %1 and %2 tokens for %3 using %4</source>
+        <translation type="unfinished">为%3使用%4铸造了%1和%2代币</translation>
+    </message>
+    <message>
+        <source>Airdropped %1x %2 to %3 using %4</source>
+        <translation type="unfinished">使用%4向%3空投了%1倍的%2</translation>
+    </message>
+    <message>
+        <source>Airdropped %1x %2 to %3 addresses using %4</source>
+        <translation type="unfinished">使用%4向%3个地址空投了%1倍的%2</translation>
+    </message>
+    <message>
+        <source>Airdropped %1x %2 and %3x %4 to %5 using %6</source>
+        <translation type="unfinished">使用%6向%5空投了%1倍的%2和%3倍的%4</translation>
+    </message>
+    <message>
+        <source>Airdropped %1x %2 and %3x %4 to %5 addresses using %6</source>
+        <translation type="unfinished">使用%6向%5个地址空投了%1倍的%2和%3倍的%4</translation>
+    </message>
+    <message>
+        <source>Airdropped %1 tokens to %2 using %3</source>
+        <translation type="unfinished">使用%3向%2空投了%1代币</translation>
+    </message>
+    <message>
+        <source>Destroyed %1x %2 at %3 using %4</source>
+        <translation type="unfinished">使用%4在%3销毁了%1倍的%2</translation>
+    </message>
+    <message>
+        <source>Destroyed %1x %2 at %3 addresses using %4</source>
+        <translation type="unfinished">使用%4在%3个地址销毁了%1倍的%2</translation>
+    </message>
+    <message>
+        <source>Burned %1x %2 for %3 using %4</source>
+        <translation type="unfinished">使用%4为%3销毁了%1倍的%2</translation>
+    </message>
+    <message>
+        <source>Finalized ownership for %1 using %2</source>
+        <translation type="unfinished">使用%2完成了%1的所有权</translation>
+    </message>
+    <message>
+        <source>Send failed: %1 from %2 to %3</source>
+        <translation type="unfinished">发送失败：%1，从%2到%3</translation>
+    </message>
+    <message>
+        <source>ENS username registeration failed: %1 using %2</source>
+        <translation type="unfinished">ENS用户名注册失败：%1，使用%2</translation>
+    </message>
+    <message>
+        <source>ENS username release failed: %1 using %2</source>
+        <translation type="unfinished">ENS用户名释放失败：%1，使用%2</translation>
+    </message>
+    <message>
+        <source>Set public key failed: %1 using %2</source>
+        <translation type="unfinished">设置公钥失败：%1，使用%2</translation>
+    </message>
+    <message>
+        <source>Sticker pack purchase failed: %1 using %2</source>
+        <translation type="unfinished">贴纸包购买失败：%1，使用%2</translation>
+    </message>
+    <message>
+        <source>Send failed: %1 %2 from %3 to %4</source>
+        <translation type="unfinished">发送失败：%1 %2，从%3到%4</translation>
+    </message>
+    <message>
+        <source>Swap failed: %1 to %2 in %3</source>
+        <translation type="unfinished">兑换失败：%1到%2在%3中</translation>
+    </message>
+    <message>
+        <source>Spending cap failed: %1 in %2 for %3</source>
+        <translation type="unfinished">支出上限失败：%1在%2中用于%3</translation>
+    </message>
+    <message>
+        <source>Mint failed: infinite %1 tokens for %2 using %3</source>
+        <translation type="unfinished">铸造失败：为%2使用%3铸造无限数量的%1代币</translation>
+    </message>
+    <message>
+        <source>Mint failed: %1 %2 tokens for %3 using %4</source>
+        <translation type="unfinished">铸造失败：%1，为 %3 使用 %4 时铸造了 %2 个代币。</translation>
+    </message>
+    <message>
+        <source>Mint failed: %1 and %2 tokens for %3 using %4</source>
+        <translation type="unfinished">铸造失败：为 %3 使用 %4 时铸造了 %1 和 %2 个代币。</translation>
+    </message>
+    <message>
+        <source>Airdrop failed: %1x %2 to %3 using %4</source>
+        <translation type="unfinished">空投失败：使用 %4 向 %3 空投了 %1 个，共 %2 个。</translation>
+    </message>
+    <message>
+        <source>Airdrop failed: %1x %2 to %3 addresses using %4</source>
+        <translation type="unfinished">空投失败：使用 %4 向 %3 个地址空投了 %1 个，共 %2 个。</translation>
+    </message>
+    <message>
+        <source>Airdrop failed: %1x %2 and %3x %4 to %5 using %6</source>
+        <translation type="unfinished">空投失败：使用 %6 向 %5 空投了 %1 个和 %3 个，共 %2 和 %4 个。</translation>
+    </message>
+    <message>
+        <source>Airdrop failed: %1x %2 and %3x %4 to %5 addresses using %6</source>
+        <translation type="unfinished">空投失败：使用 %6 向 %5 个地址空投了 %1 个和 %3 个，共 %2 和 %4 个。</translation>
+    </message>
+    <message>
+        <source>Airdrop failed: %1 tokens to %2 using %3</source>
+        <translation type="unfinished">空投失败：使用 %3 向 %2 空投了 %1 个代币。</translation>
+    </message>
+    <message>
+        <source>Destruction failed: %1x %2 at %3 using %4</source>
+        <translation type="unfinished">销毁失败：使用 %4 在 %3 处销毁了 %1 个，共 %2 个。</translation>
+    </message>
+    <message>
+        <source>Destruction failed: %1x %2 at %3 addresses using %4</source>
+        <translation type="unfinished">销毁失败：使用 %4 在 %3 个地址处销毁了 %1 个，共 %2 个。</translation>
+    </message>
+    <message>
+        <source>Burn failed: %1x %2 for %3 using %4</source>
+        <translation type="unfinished">销毁失败：使用 %4 为 %3 销毁了 %1 个，共 %2 个。</translation>
+    </message>
+    <message>
+        <source>Finalize ownership failed: %1 using %2</source>
+        <translation type="unfinished">完成所有权操作失败：%1，使用 %2。</translation>
+    </message>
+    <message>
+        <source>Unknown error resolving community</source>
+        <translation type="unfinished">无法解析社区时发生未知错误。</translation>
+    </message>
+    <message>
+        <source>%1 was banned from %2</source>
+        <translation type="unfinished">%1 已被从 %2 中移除。</translation>
+    </message>
+    <message>
+        <source>%1 unbanned from %2</source>
+        <translation type="unfinished">%1 已从 %2 中恢复。</translation>
+    </message>
+    <message>
+        <source>%1 was kicked from %2</source>
+        <translation type="unfinished">%1 已被踢出 %2。</translation>
+    </message>
+    <message>
+        <source>Device paired</source>
+        <translation type="unfinished">设备已配对。</translation>
+    </message>
+    <message>
+        <source>Sync in process. Keep device powered and app open.</source>
+        <translation type="unfinished">同步中。请保持设备通电并打开应用程序。</translation>
+    </message>
+    <message>
+        <source>%1 added to your trusted sites.</source>
+        <translation type="unfinished">%1 已添加到您的信任站点列表中。</translation>
+    </message>
+    <message>
+        <source>This device is now the control node for the %1 Community</source>
+        <translation type="unfinished">此设备现在是 %1 社区的控制节点。</translation>
+    </message>
+    <message>
+        <source>&apos;%1&apos; community imported</source>
+        <translation type="unfinished">导入了 &apos;%1&apos; 社区。</translation>
+    </message>
+    <message>
+        <source>Importing community is in progress</source>
+        <translation type="unfinished">正在导入社区</translation>
+    </message>
+    <message>
+        <source>Failed to import community &apos;%1&apos;</source>
+        <translation type="unfinished">无法导入社区 &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Import community &apos;%1&apos; was canceled</source>
+        <translation type="unfinished">已取消导入社区 &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>CoinGecko connection successful</source>
+        <translation type="unfinished">CoinGecko 连接成功</translation>
+    </message>
+    <message>
+        <source>CoinGecko connection down. Market values are as of %1.</source>
+        <translation type="unfinished">CoinGecko 连接中断。市场价值数据截至 %1。</translation>
+    </message>
+    <message>
+        <source>CoinGecko connection down. Market values cannot be retrieved.</source>
+        <translation type="unfinished">CoinGecko 连接中断。无法检索市场价值数据。</translation>
+    </message>
+    <message>
+        <source>Retrying connection to CoinGecko...</source>
+        <translation type="unfinished">正在重试连接到 CoinGecko...</translation>
+    </message>
+    <message>
+        <source>This channel no longer exists</source>
+        <translation type="unfinished">此频道不再存在</translation>
+    </message>
+    <message>
+        <source>Invite People</source>
+        <translation type="unfinished">邀请用户</translation>
+    </message>
+    <message>
+        <source>Community Info</source>
+        <translation type="unfinished">社区信息</translation>
+    </message>
+    <message>
+        <source>Community Rules</source>
+        <translation type="unfinished">社区规则</translation>
+    </message>
+    <message>
+        <source>Mute Community</source>
+        <translation type="unfinished">静音社区</translation>
+    </message>
+    <message>
+        <source>Unmute Community</source>
+        <translation type="unfinished">取消静音社区</translation>
+    </message>
+    <message>
+        <source>Mark as read</source>
+        <translation type="unfinished">标记为已读</translation>
+    </message>
+    <message>
+        <source>Edit Shared Addresses</source>
+        <translation type="unfinished">编辑共享地址</translation>
+    </message>
+    <message>
+        <source>Close Community</source>
+        <translation type="unfinished">关闭社区</translation>
+    </message>
+    <message>
+        <source>Leave Community</source>
+        <translation type="unfinished">离开社区</translation>
+    </message>
+    <message>
+        <source>The import of ‘%1’ from Discord to Status was stopped: &lt;a href=&apos;#&apos;&gt;Critical issues found&lt;/a&gt;</source>
+        <translation type="unfinished">从 Discord 导入到 Status 的‘%1’已停止：&lt;a href=&apos;#&apos;&gt;发现严重问题&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>‘%1’ was successfully imported from Discord to Status</source>
+        <translation type="unfinished">‘%1’已成功从 Discord 导入到 Status</translation>
+    </message>
+    <message>
+        <source>Details (%1)</source>
+        <translation type="unfinished">详情（%1）</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n issue(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 个问题</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Details</source>
+        <translation type="unfinished">详细信息</translation>
+    </message>
+    <message>
+        <source>Importing ‘%1’ from Discord to Status</source>
+        <translation type="unfinished">正在将‘%1’从Discord导入到Status</translation>
+    </message>
+    <message>
+        <source>Check progress (%1)</source>
+        <translation type="unfinished">检查进度（%1）</translation>
+    </message>
+    <message>
+        <source>Check progress</source>
+        <translation type="unfinished">检查进度</translation>
+    </message>
+    <message>
+        <source>Visit your new channel</source>
+        <translation type="unfinished">访问您的新频道</translation>
+    </message>
+    <message>
+        <source>Visit your Community</source>
+        <translation type="unfinished">访问您的社区</translation>
+    </message>
+    <message>
+        <source>Can not connect to store node. Retrying automatically</source>
+        <translation type="unfinished">无法连接到存储节点。正在自动重试</translation>
+    </message>
+    <message>
+        <source>Pocket Network (POKT) &amp; Infura are currently both unavailable for %1. Balances for those chains are as of %2.</source>
+        <translation type="unfinished">目前，Pocket Network (POKT) 和 Infura 都无法用于 %1。这些链的余额截至 %2。</translation>
+    </message>
+    <message>
+        <source>Pocket Network (POKT) connection successful</source>
+        <translation type="unfinished">Pocket Network (POKT) 连接成功</translation>
+    </message>
+    <message>
+        <source>POKT &amp; Infura down. Token balances are as of %1.</source>
+        <translation type="unfinished">POKT 和 Infura 出现故障。代币余额截至 %1。</translation>
+    </message>
+    <message>
+        <source>POKT &amp; Infura down. Token balances cannot be retrieved.</source>
+        <translation type="unfinished">POKT 和 Infura 出现故障。无法检索代币余额。</translation>
+    </message>
+    <message>
+        <source>POKT &amp; Infura down for %1. %1 token balances are as of %2.</source>
+        <translation type="unfinished">POKT 和 Infura 对 %1 出现故障。%1 的代币余额截至 %2。</translation>
+    </message>
+    <message>
+        <source>POKT &amp; Infura down for %1. %1 token balances cannot be retrieved.</source>
+        <translation type="unfinished">POKT 和 Infura 对 %1 出现故障。无法检索 %1 的代币余额。</translation>
+    </message>
+    <message>
+        <source>Not Connected to Logos network</source>
+        <translation type="unfinished">未连接到 Logos 网络</translation>
+    </message>
+    <message>
+        <source>How to fix</source>
+        <translation type="unfinished">如何修复</translation>
+    </message>
+    <message>
+        <source>Retrying connection to POKT Network (grove.city).</source>
+        <translation type="unfinished">正在重试连接到 POKT 网络（grove.city）。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers are currently unavailable for %1. Collectibles for those chains are as of %2.</source>
+        <translation type="unfinished">目前，收藏品提供商无法用于 %1。这些链的收藏品截至 %2。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers are currently unavailable for %1.</source>
+        <translation type="unfinished">目前，收藏品提供商无法用于 %1。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers connection successful</source>
+        <translation type="unfinished">收藏品提供商连接成功</translation>
+    </message>
+    <message>
+        <source>Collectibles providers down. Collectibles are as of %1.</source>
+        <translation type="unfinished">收藏品提供商出现故障。收藏品截至 %1。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers down. Collectibles cannot be retrieved.</source>
+        <translation type="unfinished">收藏品提供商出现故障。无法检索收藏品。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers down for &lt;a href=&apos;#&apos;&gt;multiple chains&lt;/a&gt;. Collectibles for these chains cannot be retrieved.</source>
+        <translation type="unfinished">多个链上的收藏品提供商出现故障。无法检索这些链上的收藏品。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers down for %1. Collectibles for this chain are as of %2.</source>
+        <translation type="unfinished">%1 上的收藏品提供商出现故障。此链上的收藏品截至 %2。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers down for %1. Collectibles for this chain cannot be retrieved.</source>
+        <translation type="unfinished">%1 上的收藏品提供商出现故障。无法检索此链上的收藏品。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers down for %1. Collectibles for these chains are as of %2.</source>
+        <translation type="unfinished">%1 上的收藏品提供商出现故障。这些链上的收藏品截至 %2。</translation>
+    </message>
+    <message>
+        <source>Collectibles providers down for %1. Collectibles for these chains cannot be retrieved.</source>
+        <translation type="unfinished">%1 上的收藏品提供商出现故障。无法检索这些链上的收藏品。</translation>
+    </message>
+    <message>
+        <source>Retrying connection to collectibles providers...</source>
+        <translation type="unfinished">正在重试连接到收藏品提供商...</translation>
+    </message>
+    <message>
+        <source>%1 was removed from your trusted sites.</source>
+        <translation type="unfinished">%1 已从您的信任站点中删除。</translation>
+    </message>
+    <message>
+        <source>Where do you want to go?</source>
+        <translation type="unfinished">您想去哪里？</translation>
+    </message>
+    <message>
+        <source>adding</source>
+        <translation type="unfinished">添加中</translation>
+    </message>
+    <message>
+        <source>editing</source>
+        <translation type="unfinished">编辑中</translation>
+    </message>
+    <message>
+        <source>An error occurred while %1 %2 address</source>
+        <translation type="unfinished">在处理 %1 %2 地址时发生错误。</translation>
+    </message>
+    <message>
+        <source>%1 successfully added to your saved addresses</source>
+        <translation type="unfinished">%1 已成功添加到您的已保存地址。</translation>
+    </message>
+    <message>
+        <source>%1 saved address successfully edited</source>
+        <translation type="unfinished">%1 的已保存地址已成功编辑。</translation>
+    </message>
+    <message>
+        <source>An error occurred while removing %1 address</source>
+        <translation type="unfinished">删除 %1 地址时发生错误。</translation>
+    </message>
+    <message>
+        <source>%1 was successfully removed from your saved addresses</source>
+        <translation type="unfinished">%1 已成功从您的已保存地址中删除。</translation>
+    </message>
+    <message>
+        <source>POKT &amp; Infura down for &lt;a href=&apos;#&apos;&gt;multiple chains&lt;/a&gt;. Token balances for those chains cannot be retrieved.</source>
+        <translation type="unfinished">多个链上的 POKT 和 Infura 出现故障。无法检索这些链上的代币余额。</translation>
+    </message>
+</context>
+<context>
+    <name>AppSearch</name>
+    <message>
+        <source>No results</source>
+        <translation type="unfinished">没有结果</translation>
+    </message>
+    <message>
+        <source>Anywhere</source>
+        <translation type="unfinished">任何地方</translation>
+    </message>
+</context>
+<context>
+    <name>AppearanceView</name>
+    <message>
+        <source>Mode</source>
+        <translation type="unfinished">模式</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">浅色</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">深色</translation>
+    </message>
+    <message>
+        <source>Interface zoom</source>
+        <translation type="unfinished">界面缩放</translation>
+    </message>
+    <message>
+        <source>Scale the app interface and text</source>
+        <translation type="unfinished">缩放应用程序界面和文本</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation type="unfinished">加入</translation>
+    </message>
+    <message>
+        <source>Follow display zoom</source>
+        <translation type="unfinished">跟随显示器缩放</translation>
+    </message>
+    <message>
+        <source>Apply your system settings defaults values</source>
+        <translation type="unfinished">应用您的系统设置默认值</translation>
+    </message>
+    <message>
+        <source>Restart to apply</source>
+        <translation type="unfinished">重启以应用</translation>
+    </message>
+    <message>
+        <source>Restart Status to apply the new interface zoom level</source>
+        <translation type="unfinished">重启状态以应用新的界面缩放级别</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">系统</translation>
+    </message>
+</context>
+<context>
+    <name>AssetContextMenu</name>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+    <message>
+        <source>Receive</source>
+        <translation type="unfinished">接收</translation>
+    </message>
+    <message>
+        <source>Manage tokens</source>
+        <translation type="unfinished">管理代币</translation>
+    </message>
+    <message>
+        <source>Hide asset</source>
+        <translation type="unfinished">隐藏资产</translation>
+    </message>
+    <message>
+        <source>Hide all assets from this community</source>
+        <translation type="unfinished">隐藏此社区的所有资产</translation>
+    </message>
+    <message>
+        <source>Swap</source>
+        <translation type="unfinished">兑换</translation>
+    </message>
+</context>
+<context>
+    <name>AssetSelector</name>
+    <message>
+        <source>Select asset</source>
+        <translation type="unfinished">选择资产</translation>
+    </message>
+</context>
+<context>
+    <name>AssetsDetailView</name>
+    <message>
+        <source>Price</source>
+        <translation type="unfinished">价格</translation>
+    </message>
+    <message>
+        <source>Market Cap</source>
+        <translation type="unfinished">市值</translation>
+    </message>
+    <message>
+        <source>Day Low</source>
+        <translation type="unfinished">当日最低价</translation>
+    </message>
+    <message>
+        <source>Day High</source>
+        <translation type="unfinished">当日最高价</translation>
+    </message>
+    <message>
+        <source>Hour</source>
+        <translation type="unfinished">小时</translation>
+    </message>
+    <message>
+        <source>Day</source>
+        <translation type="unfinished">天</translation>
+    </message>
+    <message>
+        <source>24 Hours</source>
+        <translation type="unfinished">24 小时</translation>
+    </message>
+    <message>
+        <source>Website</source>
+        <translation type="unfinished">网站</translation>
+    </message>
+    <message>
+        <source>Minted by</source>
+        <translation type="unfinished">由...铸造</translation>
+    </message>
+    <message>
+        <source>Contract</source>
+        <translation type="unfinished">合约</translation>
+    </message>
+    <message>
+        <source>Copy contract address</source>
+        <translation type="unfinished">复制合约地址</translation>
+    </message>
+</context>
+<context>
+    <name>AssetsView</name>
+    <message>
+        <source>Sort by:</source>
+        <translation type="unfinished">按以下方式排序:</translation>
+    </message>
+    <message>
+        <source>Asset balance value</source>
+        <translation type="unfinished">资产余额值</translation>
+    </message>
+    <message>
+        <source>Asset balance</source>
+        <translation type="unfinished">资产余额</translation>
+    </message>
+    <message>
+        <source>Asset value</source>
+        <translation type="unfinished">资产价值</translation>
+    </message>
+    <message>
+        <source>1d change: balance value</source>
+        <translation type="unfinished">1天变化：余额值</translation>
+    </message>
+    <message>
+        <source>Asset name</source>
+        <translation type="unfinished">资产名称</translation>
+    </message>
+    <message>
+        <source>Custom order</source>
+        <translation type="unfinished">自定义顺序</translation>
+    </message>
+    <message>
+        <source>Edit custom order →</source>
+        <translation type="unfinished">编辑自定义顺序 →</translation>
+    </message>
+    <message>
+        <source>Create custom order →</source>
+        <translation type="unfinished">创建自定义顺序 →</translation>
+    </message>
+    <message>
+        <source>Community minted</source>
+        <translation type="unfinished">社区铸造</translation>
+    </message>
+</context>
+<context>
+    <name>AuthenticationPopup</name>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished">验证</translation>
+    </message>
+    <message>
+        <source>Update password &amp; authenticate</source>
+        <translation type="unfinished">更新密码并验证</translation>
+    </message>
+    <message>
+        <source>Update PIN &amp; authenticate</source>
+        <translation type="unfinished">更新PIN码并验证</translation>
+    </message>
+</context>
+<context>
+    <name>BackupSeedModal</name>
+    <message>
+        <source>I&apos;ve backed up phrase</source>
+        <translation type="unfinished">我已备份助记词</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+</context>
+<context>
+    <name>BackupSeedphraseIntro</name>
+    <message>
+        <source>Your recovery phrase has been created</source>
+        <translation type="unfinished">您的助记词已创建</translation>
+    </message>
+    <message>
+        <source>Your recovery phrase is a 12 word passcode to your funds that cannot be recovered if lost. Write it down offline and store it somewhere secure.</source>
+        <translation type="unfinished">您的助记词是用于访问您资金的 12 个单词密码，如果丢失将无法恢复。请将其离线记录并安全地存储在某个地方。</translation>
+    </message>
+    <message>
+        <source>Backup recovery phrase</source>
+        <translation type="unfinished">备份助记词</translation>
+    </message>
+</context>
+<context>
+    <name>BackupSeedphraseKeepOrDelete</name>
+    <message>
+        <source>Keep or delete recovery phrase</source>
+        <translation type="unfinished">保留或删除助记词</translation>
+    </message>
+    <message>
+        <source>Decide whether you want to keep the recovery phrase in your Status app for future access or remove it permanently.</source>
+        <translation type="unfinished">决定是否要将助记词保存在您的 Status 应用中，以便将来访问，或者永久删除它。</translation>
+    </message>
+    <message>
+        <source>Permanently remove your recovery phrase from the Status app — you will not be able to view it again</source>
+        <translation type="unfinished">从 Status 应用中永久删除您的助记词——您将无法再次查看。</translation>
+    </message>
+</context>
+<context>
+    <name>BackupSeedphraseOutro</name>
+    <message>
+        <source>Confirm backup</source>
+        <translation type="unfinished">确认备份</translation>
+    </message>
+    <message>
+        <source>Ensure you have written down your recovery phrase and have a safe place to keep it. Remember, anyone who has your recovery phrase has access to your funds.</source>
+        <translation type="unfinished">请确保您已记录您的助记词，并将其保存在安全的地方。请记住，任何拥有您的助记词的人都可以访问您的资金。</translation>
+    </message>
+    <message>
+        <source>I understand my recovery phrase will now be removed and I will no longer be able to access it via Status</source>
+        <translation type="unfinished">我理解我的助记词现在将被删除，并且我将不再能够通过 Status 访问它。</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+</context>
+<context>
+    <name>BackupSeedphraseReveal</name>
+    <message>
+        <source>Show recovery phrase</source>
+        <translation type="unfinished">显示助记词</translation>
+    </message>
+    <message>
+        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.</source>
+        <translation type="unfinished">这是一组包含 12 个单词的短语，可让您完全访问您的资金，也是恢复资金的唯一方法。请确保没有任何东西可以查看或记录您的屏幕。</translation>
+    </message>
+    <message>
+        <source>Reveal recovery phrase</source>
+        <translation type="unfinished">显示助记词</translation>
+    </message>
+    <message>
+        <source>Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.</source>
+        <translation type="unfinished">切勿分享您的助记词。任何要求您提供此信息的人都在试图诈骗您。要备份您的助记词，请将其写下来并安全地存储。</translation>
+    </message>
+    <message>
+        <source>Confirm recovery phrase</source>
+        <translation type="unfinished">确认助记词</translation>
+    </message>
+</context>
+<context>
+    <name>BackupSeedphraseVerify</name>
+    <message>
+        <source>Confirm recovery phrase</source>
+        <translation type="unfinished">确认助记词</translation>
+    </message>
+    <message>
+        <source>Confirm these words from your recovery phrase...</source>
+        <translation type="unfinished">请确认您助记词中的这些单词... </translation>
+    </message>
+    <message>
+        <source>Empty</source>
+        <translation type="unfinished">空</translation>
+    </message>
+    <message>
+        <source>Correct word</source>
+        <translation type="unfinished">正确的单词</translation>
+    </message>
+    <message>
+        <source>Wrong word</source>
+        <translation type="unfinished">错误的单词</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+</context>
+<context>
+    <name>BackupView</name>
+    <message>
+        <source>Instant backup</source>
+        <translation type="unfinished">立即备份</translation>
+    </message>
+    <message>
+        <source>By default, backups run automatically every 30 minutes, but you can trigger one instantly with Backup now.</source>
+        <translation type="unfinished">默认情况下，备份每 30 分钟自动运行一次，但您可以使用“立即备份”功能随时启动备份。</translation>
+    </message>
+    <message>
+        <source>Backup now</source>
+        <translation type="unfinished">立即备份</translation>
+    </message>
+    <message>
+        <source>Backup data</source>
+        <translation type="unfinished">备份数据</translation>
+    </message>
+    <message>
+        <source>By default, Status backs up your chat list and contacts, joined community IDs and descriptions, app settings, profile data, and wallet watch accounts. To also back up your 1-on-1, group chat, and community messages, enable Back up your messages</source>
+        <translation type="unfinished">默认情况下，Status 会备份您的聊天列表和联系人、已加入的社区 ID 和描述、应用程序设置、个人资料数据以及钱包监控帐户。要同时备份您的 1 对 1 聊天、群组聊天和社区消息，请启用“备份您的消息”功能。</translation>
+    </message>
+    <message>
+        <source>Backup your messages</source>
+        <translation type="unfinished">备份您的消息</translation>
+    </message>
+    <message>
+        <source>Backup location</source>
+        <translation type="unfinished">备份位置</translation>
+    </message>
+    <message>
+        <source>Choose a folder to store your backup files or use the default one.</source>
+        <translation type="unfinished">选择一个文件夹来存储您的备份文件，或使用默认文件夹。</translation>
+    </message>
+    <message>
+        <source>Browse</source>
+        <translation type="unfinished">浏览</translation>
+    </message>
+    <message>
+        <source>Restore your Status profile</source>
+        <translation type="unfinished">恢复您的 Status 个人资料</translation>
+    </message>
+    <message>
+        <source>Click Import backup file, then locate and select the backup file for your Status profile.</source>
+        <translation type="unfinished">单击“导入备份文件”，然后找到并选择您的 Status 个人资料的备份文件。</translation>
+    </message>
+    <message>
+        <source>Import backup file</source>
+        <translation type="unfinished">导入备份文件</translation>
+    </message>
+    <message>
+        <source>Success importing local data</source>
+        <translation type="unfinished">成功导入本地数据</translation>
+    </message>
+    <message>
+        <source>Error importing backup file: %1</source>
+        <translation type="unfinished">导入备份文件时出错：%1</translation>
+    </message>
+    <message>
+        <source>Select your backup directory</source>
+        <translation type="unfinished">选择您的备份目录</translation>
+    </message>
+    <message>
+        <source>Select your backup file</source>
+        <translation type="unfinished">选择您的备份文件</translation>
+    </message>
+    <message>
+        <source>Supported backup formats (%1)</source>
+        <translation type="unfinished">支持的备份格式（%1）</translation>
+    </message>
+    <message>
+        <source>Backups are automatic (every 30 mins), secure (encrypted with your profile private key), and private (your data is stored &lt;b&gt;only&lt;/b&gt; on your device).</source>
+        <translation type="unfinished">备份是自动的（每 30 分钟），安全的（使用您的个人资料私钥进行加密），并且私密的（您的数据仅存储在您的设备上）。</translation>
+    </message>
+    <message>
+        <source>Choose a folder to store your backup files in.</source>
+        <translation type="unfinished">选择一个文件夹来存储您的备份文件。</translation>
+    </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished">备份存储在“文件”中的 Status 文件夹中。</translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished">在文件中查找</translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished">在“文件”中找到您的备份目录</translation>
+    </message>
+</context>
+<context>
+    <name>BalanceExceeded</name>
+    <message>
+        <source>Balance exceeded</source>
+        <translation type="unfinished">余额不足</translation>
+    </message>
+    <message>
+        <source>No route found</source>
+        <translation type="unfinished">未找到路线</translation>
+    </message>
+</context>
+<context>
+    <name>BannerPicker</name>
+    <message>
+        <source>Community banner</source>
+        <translation type="unfinished">社区横幅</translation>
+    </message>
+    <message>
+        <source>Choose an image for banner</source>
+        <translation type="unfinished">选择一个用于横幅的图片</translation>
+    </message>
+    <message>
+        <source>Make this my Community banner</source>
+        <translation type="unfinished">将此设置为我的社区横幅</translation>
+    </message>
+    <message>
+        <source>Optimal aspect ratio 16:9</source>
+        <translation type="unfinished">最佳宽高比为 16:9</translation>
+    </message>
+    <message>
+        <source>Upload a community banner</source>
+        <translation type="unfinished">上传社区横幅</translation>
+    </message>
+</context>
+<context>
+    <name>Biometrics</name>
+    <message>
+        <source>Biometric %1 failed</source>
+        <translation type="unfinished">生物识别%1失败</translation>
+    </message>
+    <message>
+        <source>signing</source>
+        <translation type="unfinished">签名</translation>
+    </message>
+    <message>
+        <source>authentication</source>
+        <translation type="unfinished">身份验证</translation>
+    </message>
+    <message>
+        <source>%1 with biometrics</source>
+        <translation type="unfinished">使用生物识别进行%1</translation>
+    </message>
+    <message>
+        <source>Signing</source>
+        <translation type="unfinished">签名</translation>
+    </message>
+    <message>
+        <source>Authentication</source>
+        <translation type="unfinished">身份验证</translation>
+    </message>
+    <message>
+        <source>Use your %1 instead</source>
+        <translation type="unfinished">改用您的%1</translation>
+    </message>
+    <message>
+        <source>PIN</source>
+        <translation type="unfinished">密码</translation>
+    </message>
+    <message>
+        <source>password</source>
+        <translation type="unfinished">密码</translation>
+    </message>
+</context>
+<context>
+    <name>BiometricsSectionView</name>
+    <message>
+        <source>Enable biometrics to fill in your password</source>
+        <translation type="unfinished">启用生物识别功能以自动填写密码</translation>
+    </message>
+    <message>
+        <source>Biometrics unavailable — it may not be supported, set up, or allowed by your OS settings or app permissions.</source>
+        <translation type="unfinished">无法使用生物识别功能——可能是由于您的操作系统设置或应用程序权限不支持、未配置或不允许使用。</translation>
+    </message>
+</context>
+<context>
+    <name>BlockContactConfirmationDialog</name>
+    <message>
+        <source>Block user</source>
+        <translation type="unfinished">屏蔽用户</translation>
+    </message>
+    <message>
+        <source>You will not see %1’s messages but %1 can still see your messages in mutual group chats and communities. %1 will be unable to message you.</source>
+        <translation type="unfinished">您将不再看到%1的消息，但%1仍然可以在你们共同的群聊和社区中看到您的消息。%1将无法向您发送消息。</translation>
+    </message>
+    <message>
+        <source>Blocking a user purges the database of all messages that you’ve previously received from %1 in all contexts. This can take a moment.</source>
+        <translation type="unfinished">阻止用户会从数据库中删除您之前收到的所有来自%1的消息，无论是在什么情况下。这可能需要一些时间。</translation>
+    </message>
+    <message>
+        <source>Remove contact</source>
+        <translation type="unfinished">删除联系人</translation>
+    </message>
+    <message>
+        <source>Remove trust mark</source>
+        <translation type="unfinished">移除信任标记</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation type="unfinished">阻止</translation>
+    </message>
+</context>
+<context>
+    <name>BlockchainExplorersMenu</name>
+    <message>
+        <source>View on blockchain explorer</source>
+        <translation type="unfinished">在区块链浏览器上查看</translation>
+    </message>
+</context>
+<context>
+    <name>BloomSelectorButton</name>
+    <message>
+        <source>TODO</source>
+        <translation type="unfinished">待办</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserAddressField</name>
+    <message>
+        <source>Search or enter address</source>
+        <translation type="unfinished">搜索或输入地址</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserLandscapeToolbar</name>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+    <message>
+        <source>Forward</source>
+        <translation type="unfinished">前进</translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">停止</translation>
+    </message>
+    <message>
+        <source>Reload</source>
+        <translation type="unfinished">重新加载</translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <comment>web browser home page</comment>
+        <translation type="unfinished">主页</translation>
+    </message>
+    <message>
+        <source>Exit Incognito mode</source>
+        <translation type="unfinished">退出隐身模式</translation>
+    </message>
+    <message>
+        <source>Go Incognito</source>
+        <translation type="unfinished">进入隐身模式</translation>
+    </message>
+    <message>
+        <source>Bookmarked</source>
+        <translation type="unfinished">已添加书签</translation>
+    </message>
+    <message>
+        <source>Add to bookmarks</source>
+        <translation type="unfinished">添加到书签</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">钱包</translation>
+    </message>
+    <message>
+        <source>Downloads</source>
+        <translation type="unfinished">下载</translation>
+    </message>
+    <message>
+        <source>Open Tabs view</source>
+        <translation type="unfinished">打开标签视图</translation>
+    </message>
+    <message>
+        <source>Menu</source>
+        <translation type="unfinished">菜单</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserLayout</name>
+    <message>
+        <source>Server&apos;s certificate not trusted</source>
+        <translation type="unfinished">服务器证书不受信任</translation>
+    </message>
+    <message>
+        <source>Do you wish to continue?</source>
+        <translation type="unfinished">您是否希望继续？</translation>
+    </message>
+    <message>
+        <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate means you may not be connected with the host you tried to connect to.
+Do you wish to override the security check and continue?</source>
+        <translation type="unfinished">如果您愿意，您可以继续使用未经验证的证书。接受未经验证的证书意味着您可能无法连接到您尝试连接的主机。
+您是否希望覆盖安全检查并继续？</translation>
+    </message>
+    <message>
+        <source>Add bookmark</source>
+        <translation type="unfinished">添加书签</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserPortraitToolbar</name>
+    <message>
+        <source>Open Tabs view</source>
+        <translation type="unfinished">打开标签页视图</translation>
+    </message>
+    <message>
+        <source>Bookmarked</source>
+        <translation type="unfinished">已添加书签</translation>
+    </message>
+    <message>
+        <source>Add to bookmarks</source>
+        <translation type="unfinished">添加到书签</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+    <message>
+        <source>Forward</source>
+        <translation type="unfinished">前进</translation>
+    </message>
+    <message>
+        <source>Exit Incognito mode</source>
+        <translation type="unfinished">退出隐身模式</translation>
+    </message>
+    <message>
+        <source>Go Incognito</source>
+        <translation type="unfinished">进入隐身模式</translation>
+    </message>
+    <message>
+        <source>Menu</source>
+        <translation type="unfinished">菜单</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserPrivacyWall</name>
+    <message>
+        <source>Enable third-party services for browser features to work.</source>
+        <translation type="unfinished">启用第三方服务，以使浏览器功能正常运行。</translation>
+    </message>
+    <message>
+        <source>Dapp browser</source>
+        <translation type="unfinished">去中心化应用浏览器</translation>
+    </message>
+    <message>
+        <source>Browse decentralized apps</source>
+        <translation type="unfinished">浏览去中心化应用程序</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserSavedSessionContext</name>
+    <message>
+        <source>Start Page</source>
+        <translation type="unfinished">起始页</translation>
+    </message>
+    <message>
+        <source>New Tab</source>
+        <translation type="unfinished">新建标签页</translation>
+    </message>
+    <message>
+        <source>Downloads</source>
+        <translation type="unfinished">下载</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserSettingsMenu</name>
+    <message>
+        <source>New Tab</source>
+        <translation type="unfinished">新建标签页</translation>
+    </message>
+    <message>
+        <source>Exit Incognito mode</source>
+        <translation type="unfinished">退出隐身模式</translation>
+    </message>
+    <message>
+        <source>Go Incognito</source>
+        <translation type="unfinished">进入隐身模式</translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished">放大</translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished">缩小</translation>
+    </message>
+    <message>
+        <source>Zoom Fit</source>
+        <translation type="unfinished">最佳适配</translation>
+    </message>
+    <message>
+        <source>Downloads</source>
+        <translation type="unfinished">下载</translation>
+    </message>
+    <message>
+        <source>Find in page</source>
+        <translation type="unfinished">在页面中查找</translation>
+    </message>
+    <message>
+        <source>Compatibility mode</source>
+        <translation type="unfinished">兼容模式</translation>
+    </message>
+    <message>
+        <source>Developer Tools</source>
+        <translation type="unfinished">开发者工具</translation>
+    </message>
+    <message>
+        <source>Force reload</source>
+        <translation type="unfinished">强制刷新</translation>
+    </message>
+    <message>
+        <source>Clear site data</source>
+        <translation type="unfinished">清除网站数据</translation>
+    </message>
+    <message>
+        <source>Use it to reset the current site if it doesn&apos;t load or work properly.</source>
+        <translation type="unfinished">如果当前站点无法加载或正常工作，请使用它来重置该站点。</translation>
+    </message>
+    <message>
+        <source>Clearing browsing data...</source>
+        <translation type="unfinished">正在清除浏览数据...</translation>
+    </message>
+    <message>
+        <source>Clear browsing data</source>
+        <translation type="unfinished">清除浏览数据</translation>
+    </message>
+    <message>
+        <source>Clears the cache and cookies for the entire browser. Browsing is paused until it is done.</source>
+        <translation type="unfinished">清除整个浏览器的缓存和 Cookie。在操作完成之前，将暂停浏览。</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">缩放</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserTabView</name>
+    <message>
+        <source>Downloads</source>
+        <translation type="unfinished">下载</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserView</name>
+    <message>
+        <source>Search engine for address bar</source>
+        <translation type="unfinished">地址栏的搜索引擎</translation>
+    </message>
+    <message>
+        <source>Show bookmarks bar</source>
+        <translation type="unfinished">显示书签栏</translation>
+    </message>
+    <message>
+        <source>Restore open tabs</source>
+        <translation type="unfinished">恢复已打开的标签页</translation>
+    </message>
+    <message>
+        <source>Turn on to save your tabs only on this device and restore them next time. Turning off deletes all saved session data.</source>
+        <translation type="unfinished">启用后，仅将您的标签页保存在此设备上并在下次恢复。禁用会删除所有保存的会话数据。</translation>
+    </message>
+</context>
+<context>
+    <name>BurnTokensPopup</name>
+    <message>
+        <source>Burn %1 token on %2</source>
+        <translation type="unfinished">在%2上销毁%1个代币</translation>
+    </message>
+    <message numerus="yes">
+        <source>How many of %1’s remaining %Ln %2 token(s) would you like to burn?</source>
+        <translation type="unfinished">
+            <numerusform>您想销毁多少个%1剩余的%Ln %2代币？</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>How many of %1’s remaining %2 %3 tokens would you like to burn?</source>
+        <translation type="unfinished">您想销毁多少个剩余的%1的%2 %3代币？</translation>
+    </message>
+    <message>
+        <source>Specific amount</source>
+        <translation type="unfinished">指定数量</translation>
+    </message>
+    <message>
+        <source>Enter amount</source>
+        <translation type="unfinished">输入数量</translation>
+    </message>
+    <message>
+        <source>Exceeds available remaining</source>
+        <translation type="unfinished">超过可用余额</translation>
+    </message>
+    <message>
+        <source>All available remaining (%1)</source>
+        <translation type="unfinished">全部可用余额（%1）</translation>
+    </message>
+    <message>
+        <source>Show fees (will be enabled once the form is filled)</source>
+        <translation type="unfinished">显示费用（填写完表单后将启用）</translation>
+    </message>
+    <message>
+        <source>Choose number of tokens to burn to see gas fees</source>
+        <translation type="unfinished">选择要销毁的代币数量以查看gas费用</translation>
+    </message>
+    <message>
+        <source>Burn %1 tokens</source>
+        <translation type="unfinished">销毁%1个代币</translation>
+    </message>
+    <message>
+        <source>%1 %2 remaining in smart contract</source>
+        <translation type="unfinished">智能合约中剩余%1 %2</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Burn tokens</source>
+        <translation type="unfinished">销毁代币</translation>
+    </message>
+</context>
+<context>
+    <name>BuyCryptoModal</name>
+    <message>
+        <source>Buy via %1</source>
+        <translation type="unfinished">通过 %1 购买</translation>
+    </message>
+    <message>
+        <source>Your assets on %1</source>
+        <translation type="unfinished">您在%1上的资产</translation>
+    </message>
+    <message>
+        <source>Popular assets</source>
+        <translation type="unfinished">热门资产</translation>
+    </message>
+    <message>
+        <source>Ways to buy %1 for %2</source>
+        <translation type="unfinished">购买%1的途径，价格为%2</translation>
+    </message>
+    <message>
+        <source>Ways to buy assets for %1</source>
+        <translation type="unfinished">购买资产的途径，价格为%1</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+</context>
+<context>
+    <name>BuyReceiveBanner</name>
+    <message>
+        <source>Ways to buy</source>
+        <translation type="unfinished">购买方式</translation>
+    </message>
+    <message>
+        <source>Via card or bank</source>
+        <translation type="unfinished">通过银行卡或银行转账</translation>
+    </message>
+    <message>
+        <source>Receive</source>
+        <translation type="unfinished">接收</translation>
+    </message>
+    <message>
+        <source>Deposit to your Wallet</source>
+        <translation type="unfinished">将款项存入您的钱包</translation>
+    </message>
+</context>
+<context>
+    <name>ChangePasswordView</name>
+    <message>
+        <source>Biometric login and transaction authentication enabled for this device</source>
+        <translation type="unfinished">已为该设备启用生物识别登录和交易验证</translation>
+    </message>
+    <message>
+        <source>Failed to enable biometric login and transaction authentication for this device</source>
+        <translation type="unfinished">未能为该设备启用生物识别登录和交易验证</translation>
+    </message>
+    <message>
+        <source>Biometric login and transaction authentication disabled for this device</source>
+        <translation type="unfinished">已为该设备禁用生物识别登录和交易验证</translation>
+    </message>
+    <message>
+        <source>Failed to disable biometric login and transaction authentication for this device</source>
+        <translation type="unfinished">未能为该设备禁用生物识别登录和交易验证</translation>
+    </message>
+    <message>
+        <source>Change your password</source>
+        <translation type="unfinished">更改您的密码</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Change</source>
+        <translation type="unfinished">更改</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelIdentifierView</name>
+    <message>
+        <source>Welcome to the beginning of the &lt;span style=&apos;color: %1&apos;&gt;%2&lt;/span&gt; group!</source>
+        <translation type="unfinished">欢迎来到&lt;span style=&apos;color: %1&apos;&gt;%2&lt;/span&gt;群组！</translation>
+    </message>
+    <message>
+        <source>Welcome to the beginning of the &lt;span style=&apos;color: %1&apos;&gt;#%2&lt;/span&gt; channel!</source>
+        <translation type="unfinished">欢迎来到&lt;span style=&apos;color: %1&apos;&gt;#%2&lt;/span&gt;频道！</translation>
+    </message>
+    <message>
+        <source>Any messages you send here are encrypted and can only be read by you and &lt;span style=&apos;color: %1&apos;&gt;%2&lt;/span&gt;</source>
+        <translation type="unfinished">您发送的任何消息都将被加密，并且只能由您和&lt;span style=&apos;color: %1&apos;&gt;%2&lt;/span&gt;阅读。</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelsAndCategoriesBannerPanel</name>
+    <message>
+        <source>Expand your community by adding more channels and categories</source>
+        <translation type="unfinished">通过添加更多频道和类别来扩展您的社区</translation>
+    </message>
+    <message>
+        <source>Add channels</source>
+        <translation type="unfinished">添加频道</translation>
+    </message>
+    <message>
+        <source>Add categories</source>
+        <translation type="unfinished">添加类别</translation>
+    </message>
+</context>
+<context>
+    <name>ChartDataBase</name>
+    <message>
+        <source>7D</source>
+        <translation type="unfinished">7天</translation>
+    </message>
+    <message>
+        <source>1M</source>
+        <translation type="unfinished">1个月</translation>
+    </message>
+    <message>
+        <source>6M</source>
+        <translation type="unfinished">6个月</translation>
+    </message>
+    <message>
+        <source>1Y</source>
+        <translation type="unfinished">1年</translation>
+    </message>
+    <message>
+        <source>ALL</source>
+        <translation type="unfinished">全部</translation>
+    </message>
+</context>
+<context>
+    <name>ChatAnchorButtonsPanel</name>
+    <message>
+        <source>99+</source>
+        <translation type="unfinished">99+</translation>
+    </message>
+</context>
+<context>
+    <name>ChatColumnView</name>
+    <message>
+        <source>Link previews will be shown for all sites. You can manage link previews in %1.</source>
+        <comment>Go to settings</comment>
+        <translation type="unfinished">所有网站都将显示链接预览。您可以在%1中管理链接预览。</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <comment>Go to settings page</comment>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message>
+        <source>Link previews will never be shown. You can manage link previews in %1.</source>
+        <translation type="unfinished">永远不会显示链接预览。您可以在%1中管理链接预览。</translation>
+    </message>
+    <message>
+        <source>Link previews will be shown for this message. You can manage link previews in %1.</source>
+        <translation type="unfinished">此消息将显示链接预览。您可以在%1中管理链接预览。</translation>
+    </message>
+    <message>
+        <source>This user has been blocked.</source>
+        <translation type="unfinished">该用户已被阻止。</translation>
+    </message>
+    <message>
+        <source>You need to join this community to send messages</source>
+        <translation type="unfinished">您需要加入此社区才能发送消息。</translation>
+    </message>
+    <message>
+        <source>Sorry, you don&apos;t have permissions to post in this channel.</source>
+        <translation type="unfinished">抱歉，您没有权限在此频道中发帖。</translation>
+    </message>
+    <message>
+        <source>Sending...</source>
+        <translation type="unfinished">正在发送...</translation>
+    </message>
+</context>
+<context>
+    <name>ChatContentView</name>
+    <message>
+        <source>Blocked</source>
+        <translation type="unfinished">已阻止</translation>
+    </message>
+</context>
+<context>
+    <name>ChatContextMenuView</name>
+    <message>
+        <source>Add / remove from group</source>
+        <translation type="unfinished">添加/从群组中移除</translation>
+    </message>
+    <message>
+        <source>Add to group</source>
+        <translation type="unfinished">添加到群组</translation>
+    </message>
+    <message>
+        <source>Copy channel link</source>
+        <translation type="unfinished">复制频道链接</translation>
+    </message>
+    <message>
+        <source>Edit name and image</source>
+        <translation type="unfinished">编辑名称和图像</translation>
+    </message>
+    <message>
+        <source>Unmute Channel</source>
+        <translation type="unfinished">取消静音频道</translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">取消静音聊天</translation>
+    </message>
+    <message>
+        <source>Mark as Read</source>
+        <translation type="unfinished">标记为已读</translation>
+    </message>
+    <message>
+        <source>Edit Channel</source>
+        <translation type="unfinished">编辑频道</translation>
+    </message>
+    <message>
+        <source>Debug actions</source>
+        <translation type="unfinished">调试操作</translation>
+    </message>
+    <message>
+        <source>Copy channel ID</source>
+        <translation type="unfinished">复制频道ID</translation>
+    </message>
+    <message>
+        <source>Copy chat ID</source>
+        <translation type="unfinished">复制聊天ID</translation>
+    </message>
+    <message>
+        <source>Clear History</source>
+        <translation type="unfinished">清除历史记录</translation>
+    </message>
+    <message>
+        <source>Delete Channel</source>
+        <translation type="unfinished">删除频道</translation>
+    </message>
+    <message>
+        <source>Leave group</source>
+        <translation type="unfinished">离开群组</translation>
+    </message>
+    <message>
+        <source>Close Chat</source>
+        <translation type="unfinished">关闭聊天</translation>
+    </message>
+    <message>
+        <source>Leave Chat</source>
+        <translation type="unfinished">离开聊天</translation>
+    </message>
+    <message>
+        <source>Clear chat history</source>
+        <translation type="unfinished">清除聊天历史记录</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear your chat history with &lt;b&gt;%1&lt;/b&gt;? All messages will be deleted on your side and will be unrecoverable.</source>
+        <translation type="unfinished">您确定要清除与&lt;b&gt;%1&lt;/b&gt;的聊天历史吗？所有消息都将从您的设备中删除，并且无法恢复。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to leave group chat &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation type="unfinished">您确定要离开群聊&lt;b&gt;%1&lt;/b&gt;吗？</translation>
+    </message>
+    <message>
+        <source>Leave</source>
+        <translation type="unfinished">离开</translation>
+    </message>
+    <message>
+        <source>Delete #%1</source>
+        <translation type="unfinished">删除 #%1</translation>
+    </message>
+    <message>
+        <source>Close chat</source>
+        <translation type="unfinished">关闭聊天</translation>
+    </message>
+    <message>
+        <source>Leave chat</source>
+        <translation type="unfinished">离开聊天</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete #%1 channel?</source>
+        <translation type="unfinished">您确定要删除 #%1 频道吗？</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to close this chat? This will remove the chat from the list. Your chat history will be retained and shown the next time you message each other.</source>
+        <translation type="unfinished">您确定要关闭此聊天吗？这将从列表中删除该聊天。您的聊天记录将被保留，并在下次您互相发送消息时显示。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to leave this chat?</source>
+        <translation type="unfinished">您确定要离开此聊天吗？</translation>
+    </message>
+</context>
+<context>
+    <name>ChatHeaderContentView</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished">更多</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 位成员</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>ChatMessagesView</name>
+    <message>
+        <source>Couldn&apos;t add reaction</source>
+        <translation type="unfinished">无法添加表情</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t remove reaction</source>
+        <translation type="unfinished">无法删除表情</translation>
+    </message>
+    <message>
+        <source>Please try again later</source>
+        <translation type="unfinished">请稍后再试</translation>
+    </message>
+    <message>
+        <source>Send Contact Request</source>
+        <translation type="unfinished">发送联系人请求</translation>
+    </message>
+    <message>
+        <source>Reject Contact Request</source>
+        <translation type="unfinished">拒绝联系人请求</translation>
+    </message>
+    <message>
+        <source>Accept Contact Request</source>
+        <translation type="unfinished">接受联系人请求</translation>
+    </message>
+    <message>
+        <source>Contact Request Pending...</source>
+        <translation type="unfinished">联系人请求待处理...</translation>
+    </message>
+</context>
+<context>
+    <name>ChatPermissionQualificationPanel</name>
+    <message>
+        <source>To post, hold</source>
+        <translation type="unfinished">要发布，请按住</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">或</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRequestMessagePanel</name>
+    <message>
+        <source>You need to be mutual contacts with this person for them to receive your messages</source>
+        <translation type="unfinished">您需要与此人互相关注，他们才能收到您的消息。</translation>
+    </message>
+    <message>
+        <source>Just click this button to add them as contact. They will receive a notification. Once they accept the request, you&apos;ll be able to chat</source>
+        <translation type="unfinished">只需点击此按钮将其添加到联系人中。他们将收到通知。一旦他们接受请求，您就可以开始聊天。</translation>
+    </message>
+    <message>
+        <source>Add to contacts</source>
+        <translation type="unfinished">添加为联系人</translation>
+    </message>
+</context>
+<context>
+    <name>ChatView</name>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+</context>
+<context>
+    <name>ChatsLoadingPanel</name>
+    <message>
+        <source>Loading chats...</source>
+        <translation type="unfinished">正在加载聊天记录...</translation>
+    </message>
+</context>
+<context>
+    <name>CollectibleDetailView</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>Minted by %1</source>
+        <translation type="unfinished">由%1铸造</translation>
+    </message>
+    <message>
+        <source>Properties</source>
+        <translation type="unfinished">属性</translation>
+    </message>
+    <message>
+        <source>Traits</source>
+        <translation type="unfinished">特征</translation>
+    </message>
+    <message>
+        <source>Links</source>
+        <translation type="unfinished">链接</translation>
+    </message>
+    <message>
+        <source>Activity will appear here</source>
+        <translation type="unfinished">活动将在此处显示</translation>
+    </message>
+    <message>
+        <source>Opensea</source>
+        <translation type="unfinished">Opensea</translation>
+    </message>
+    <message>
+        <source>Twitter</source>
+        <translation type="unfinished">推特</translation>
+    </message>
+</context>
+<context>
+    <name>CollectibleDetailsHeader</name>
+    <message>
+        <source>Community address copied</source>
+        <translation type="unfinished">社区地址已复制</translation>
+    </message>
+    <message>
+        <source>Community %1</source>
+        <translation type="unfinished">社区 %1</translation>
+    </message>
+    <message>
+        <source>Community name could not be fetched</source>
+        <translation type="unfinished">无法获取社区名称</translation>
+    </message>
+    <message>
+        <source>Unknown community</source>
+        <translation type="unfinished">未知社区</translation>
+    </message>
+</context>
+<context>
+    <name>CollectibleMedia</name>
+    <message>
+        <source>Unsupported
+file format</source>
+        <translation type="unfinished">不支持的文件格式</translation>
+    </message>
+</context>
+<context>
+    <name>CollectiblesHeader</name>
+    <message>
+        <source>Maximum number of collectibles to display reached</source>
+        <translation type="unfinished">已达到最大可显示收藏品数量</translation>
+    </message>
+</context>
+<context>
+    <name>CollectiblesNotSupportedTag</name>
+    <message>
+        <source>and</source>
+        <translation type="unfinished">和</translation>
+    </message>
+    <message>
+        <source>Displaying collectibles on %1 is not currently supported by Status.</source>
+        <translation type="unfinished">目前Status不支持在%1上显示收藏品。</translation>
+    </message>
+</context>
+<context>
+    <name>CollectiblesStore</name>
+    <message>
+        <source>%1 community collectibles successfully hidden</source>
+        <translation type="unfinished">已成功隐藏 %1 个社区收藏品</translation>
+    </message>
+    <message>
+        <source>%1 is now visible</source>
+        <translation type="unfinished">现在可以查看 %1 了</translation>
+    </message>
+    <message>
+        <source>%1 community collectibles are now visible</source>
+        <translation type="unfinished">现在可以查看 %1 个社区收藏品了</translation>
+    </message>
+</context>
+<context>
+    <name>CollectiblesView</name>
+    <message>
+        <source>Loading collectible...</source>
+        <translation type="unfinished">正在加载收藏品...</translation>
+    </message>
+    <message>
+        <source>Sort by:</source>
+        <translation type="unfinished">按以下方式排序:</translation>
+    </message>
+    <message>
+        <source>Date added</source>
+        <translation type="unfinished">添加日期</translation>
+    </message>
+    <message>
+        <source>Collectible name</source>
+        <translation type="unfinished">收藏品名称</translation>
+    </message>
+    <message>
+        <source>Collection/community name</source>
+        <translation type="unfinished">系列/社区名称</translation>
+    </message>
+    <message>
+        <source>Custom order</source>
+        <translation type="unfinished">自定义顺序</translation>
+    </message>
+    <message>
+        <source>Edit custom order →</source>
+        <translation type="unfinished">编辑自定义顺序 →</translation>
+    </message>
+    <message>
+        <source>Create custom order →</source>
+        <translation type="unfinished">创建自定义顺序 →</translation>
+    </message>
+    <message>
+        <source>Clear filter</source>
+        <translation type="unfinished">清除过滤器</translation>
+    </message>
+    <message>
+        <source>Collectibles will appear here</source>
+        <translation type="unfinished">收藏品将显示在此处</translation>
+    </message>
+    <message>
+        <source>Community minted</source>
+        <translation type="unfinished">社区铸造</translation>
+    </message>
+    <message>
+        <source>Others</source>
+        <translation type="unfinished">其他</translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+    <message>
+        <source>Receive</source>
+        <translation type="unfinished">接收</translation>
+    </message>
+    <message>
+        <source>Manage tokens</source>
+        <translation type="unfinished">管理代币</translation>
+    </message>
+    <message>
+        <source>Hide collectible</source>
+        <translation type="unfinished">隐藏收藏品</translation>
+    </message>
+    <message>
+        <source>Hide all collectibles from this community</source>
+        <translation type="unfinished">隐藏此社区的所有收藏品</translation>
+    </message>
+    <message>
+        <source>What are community collectibles?</source>
+        <translation type="unfinished">什么是社区收藏品？</translation>
+    </message>
+    <message>
+        <source>Community collectibles are collectibles that have been minted by a community. As these collectibles cannot be verified, always double check their origin and validity before interacting with them. If in doubt, ask a trusted member or admin of the relevant community.</source>
+        <translation type="unfinished">社区收藏品是由社区铸造的收藏品。由于这些收藏品无法验证，因此在与之交互之前，请务必仔细检查其来源和有效性。如有疑问，请咨询相关社区的可信成员或管理员。</translation>
+    </message>
+    <message>
+        <source>Hide &apos;%1&apos; collectibles</source>
+        <translation type="unfinished">隐藏“%1”收藏品</translation>
+    </message>
+    <message>
+        <source>Hide %1 community collectibles</source>
+        <translation type="unfinished">隐藏 %1 个社区收藏品</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to hide all community collectibles minted by %1? You will no longer see or be able to interact with these collectibles anywhere inside Status.</source>
+        <translation type="unfinished">您确定要隐藏由 %1 发行的所有社区收藏品吗？之后您将无法在 Status 内部的任何位置看到或与之交互。</translation>
+    </message>
+    <message>
+        <source>%1 community collectibles were successfully hidden. You can toggle collectible visibility via %2.</source>
+        <translation type="unfinished">已成功隐藏 %1 个社区收藏品。您可以通过 %2 切换收藏品的可见性。</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <comment>Go to Settings</comment>
+        <translation type="unfinished">设置</translation>
+    </message>
+</context>
+<context>
+    <name>ColorPanel</name>
+    <message>
+        <source>Community Colour</source>
+        <translation type="unfinished">社区颜色</translation>
+    </message>
+    <message>
+        <source>Select Community Colour</source>
+        <translation type="unfinished">选择社区颜色</translation>
+    </message>
+    <message>
+        <source>This is not a valid colour</source>
+        <translation type="unfinished">这不是一个有效的颜色</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">预览</translation>
+    </message>
+    <message>
+        <source>White text should be legible on top of this colour</source>
+        <translation type="unfinished">白色文本应该可以清晰地显示在这个颜色之上</translation>
+    </message>
+    <message>
+        <source>Standard colours</source>
+        <translation type="unfinished">标准颜色</translation>
+    </message>
+</context>
+<context>
+    <name>ColorPicker</name>
+    <message>
+        <source>Community colour</source>
+        <translation type="unfinished">社区颜色</translation>
+    </message>
+</context>
+<context>
+    <name>ColumnHeaderPanel</name>
+    <message numerus="yes">
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 个成员</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Invite contacts</source>
+        <translation type="unfinished">邀请联系人</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesGridView</name>
+    <message>
+        <source>Featured</source>
+        <extracomment>Featured communities</extracomment>
+        <translation type="unfinished">精选</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <extracomment>All communities</extracomment>
+        <translation type="unfinished">全部</translation>
+    </message>
+    <message>
+        <source>No communities found</source>
+        <translation type="unfinished">未找到社区</translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesListPanel</name>
+    <message numerus="yes">
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 位成员</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Membership Request Sent</source>
+        <translation type="unfinished">已发送入群申请</translation>
+    </message>
+    <message>
+        <source>View &amp; Join Community</source>
+        <translation type="unfinished">查看并加入社区</translation>
+    </message>
+    <message>
+        <source>Community Admin</source>
+        <translation type="unfinished">社区管理员</translation>
+    </message>
+    <message>
+        <source>Unmute Community</source>
+        <translation type="unfinished">解除社区静音</translation>
+    </message>
+    <message>
+        <source>Mute Community</source>
+        <translation type="unfinished">静音社区</translation>
+    </message>
+    <message>
+        <source>Invite People</source>
+        <translation type="unfinished">邀请成员</translation>
+    </message>
+    <message>
+        <source>Edit Shared Addresses</source>
+        <translation type="unfinished">编辑共享地址</translation>
+    </message>
+    <message>
+        <source>Cancel Membership Request</source>
+        <translation type="unfinished">取消入群申请</translation>
+    </message>
+    <message>
+        <source>Close Community</source>
+        <translation type="unfinished">关闭社区</translation>
+    </message>
+    <message>
+        <source>Leave Community</source>
+        <translation type="unfinished">退出社区</translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesPortalLayout</name>
+    <message>
+        <source>Discover Communities</source>
+        <translation type="unfinished">发现社区</translation>
+    </message>
+    <message>
+        <source>Join Community</source>
+        <translation type="unfinished">加入社区</translation>
+    </message>
+    <message>
+        <source>Create New Community</source>
+        <translation type="unfinished">创建新社区</translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesView</name>
+    <message>
+        <source>Import community</source>
+        <translation type="unfinished">导入社区</translation>
+    </message>
+    <message>
+        <source>Discover your Communities</source>
+        <translation type="unfinished">发现您的社区</translation>
+    </message>
+    <message>
+        <source>Explore and see what communities are trending</source>
+        <translation type="unfinished">探索并查看哪些社区正在流行</translation>
+    </message>
+    <message>
+        <source>Discover</source>
+        <translation type="unfinished">发现</translation>
+    </message>
+    <message>
+        <source>Owner</source>
+        <translation type="unfinished">所有者</translation>
+    </message>
+    <message>
+        <source>TokenMaster</source>
+        <translation type="unfinished">代币管理员</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <translation type="unfinished">管理员</translation>
+    </message>
+    <message>
+        <source>Member</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished">待处理</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityAssetsInfoPopup</name>
+    <message>
+        <source>What are community assets?</source>
+        <translation type="unfinished">什么是社区资产？</translation>
+    </message>
+    <message>
+        <source>Community assets are assets that have been minted by a community. As these assets cannot be verified, always double check their origin and validity before interacting with them. If in doubt, ask a trusted member or admin of the relevant community.</source>
+        <translation type="unfinished">社区资产是由某个社区发行的资产。由于这些资产无法验证，因此在与其交互之前，请务必仔细检查其来源和有效性。如有疑问，请咨询相关社区中值得信赖的成员或管理员。</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityBannedMemberCenterPanel</name>
+    <message>
+        <source>You&apos;ve been banned from &lt;b&gt;%1&lt;b&gt;</source>
+        <translation type="unfinished">您已被&lt;b&gt;%1&lt;b&gt;封禁</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityColumnView</name>
+    <message>
+        <source>Search channels...</source>
+        <translation type="unfinished">搜索频道...</translation>
+    </message>
+    <message>
+        <source>Create channel</source>
+        <translation type="unfinished">创建频道</translation>
+    </message>
+    <message>
+        <source>Create category</source>
+        <translation type="unfinished">创建分类</translation>
+    </message>
+    <message>
+        <source>Invite people</source>
+        <translation type="unfinished">邀请用户</translation>
+    </message>
+    <message>
+        <source>Mute category</source>
+        <translation type="unfinished">静音分类</translation>
+    </message>
+    <message>
+        <source>Unmute category</source>
+        <translation type="unfinished">取消静音分类</translation>
+    </message>
+    <message>
+        <source>Edit Category</source>
+        <translation type="unfinished">编辑分类</translation>
+    </message>
+    <message>
+        <source>Delete Category</source>
+        <translation type="unfinished">删除分类</translation>
+    </message>
+    <message>
+        <source>Delete &apos;%1&apos; category</source>
+        <translation type="unfinished">删除“%1”分类</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete &apos;%1&apos; category? Channels inside the category won&apos;t be deleted.</source>
+        <translation type="unfinished">您确定要删除“%1”分类吗？该分类中的频道不会被删除。</translation>
+    </message>
+    <message>
+        <source>Create channel or category</source>
+        <translation type="unfinished">创建频道或分类</translation>
+    </message>
+    <message>
+        <source>You were banned from community</source>
+        <translation type="unfinished">您已被社区封禁</translation>
+    </message>
+    <message>
+        <source>Membership request pending...</source>
+        <translation type="unfinished">成员资格请求待处理...</translation>
+    </message>
+    <message>
+        <source>Request to join</source>
+        <translation type="unfinished">请求加入</translation>
+    </message>
+    <message>
+        <source>Join Community</source>
+        <translation type="unfinished">加入社区</translation>
+    </message>
+    <message>
+        <source>Request to join failed</source>
+        <translation type="unfinished">请求加入失败</translation>
+    </message>
+    <message>
+        <source>Please try again later</source>
+        <translation type="unfinished">请稍后再试</translation>
+    </message>
+    <message>
+        <source>Finalise community ownership</source>
+        <translation type="unfinished">完成社区所有权确认</translation>
+    </message>
+    <message>
+        <source>To join, finalise community ownership</source>
+        <translation type="unfinished">要加入，请完成社区所有权确认</translation>
+    </message>
+    <message>
+        <source>Error deleting the category</source>
+        <translation type="unfinished">删除分类时出错</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityFetchPopup</name>
+    <message>
+        <source>Unable to fetch the community</source>
+        <translation type="unfinished">无法获取社区</translation>
+    </message>
+    <message>
+        <source>We&apos;re fetching community...</source>
+        <translation type="unfinished">我们正在获取社区...</translation>
+    </message>
+    <message>
+        <source>It may be offline, or Status couldn&apos;t reach it</source>
+        <translation type="unfinished">它可能已离线，或者Status无法访问</translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation type="unfinished">重试</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityInfoPanel</name>
+    <message>
+        <source>%1 Owner token</source>
+        <translation type="unfinished">%1 所有者代币</translation>
+    </message>
+    <message>
+        <source>%1 TokenMaster token</source>
+        <translation type="unfinished">%1 代币大师代币</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityMemberMessagesPopup</name>
+    <message>
+        <source>%1 messages</source>
+        <translation type="unfinished">%1 条消息</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n message(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 条消息</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>No messages</source>
+        <translation type="unfinished">没有消息</translation>
+    </message>
+    <message>
+        <source>Delete all messages by %1</source>
+        <translation type="unfinished">删除 %1 发送的所有消息</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityMembershipSetupDialog</name>
+    <message>
+        <source>Request to join %1</source>
+        <translation type="unfinished">请求加入%1</translation>
+    </message>
+    <message>
+        <source>Welcome to %1</source>
+        <translation type="unfinished">欢迎来到%1</translation>
+    </message>
+    <message>
+        <source>Requirements check pending</source>
+        <translation type="unfinished">正在检查要求</translation>
+    </message>
+    <message>
+        <source>Checking permissions to join failed</source>
+        <translation type="unfinished">检查加入权限失败</translation>
+    </message>
+    <message>
+        <source>Cancel Membership Request</source>
+        <translation type="unfinished">取消会员申请</translation>
+    </message>
+    <message>
+        <source>Share all addresses to join</source>
+        <translation type="unfinished">分享所有地址以加入</translation>
+    </message>
+    <message>
+        <source>Select addresses to share</source>
+        <translation type="unfinished">选择要分享的地址</translation>
+    </message>
+    <message>
+        <source>Community &lt;b&gt;%1&lt;/b&gt; has no intro message...</source>
+        <translation type="unfinished">社区&lt;b&gt;%1&lt;/b&gt;没有介绍信息...</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityProfilePopup</name>
+    <message>
+        <source>Public community</source>
+        <translation type="unfinished">公开社区</translation>
+    </message>
+    <message>
+        <source>Invitation only community</source>
+        <translation type="unfinished">仅限邀请的社区</translation>
+    </message>
+    <message>
+        <source>On request community</source>
+        <translation type="unfinished">按需加入的社区</translation>
+    </message>
+    <message>
+        <source>Unknown community</source>
+        <translation type="unfinished">未知社区</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityRulesPopup</name>
+    <message>
+        <source>%1 community rules</source>
+        <translation type="unfinished">%1 个社区规则</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+</context>
+<context>
+    <name>CommunitySettingsView</name>
+    <message numerus="yes">
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 位成员</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Back to community</source>
+        <translation type="unfinished">返回社区</translation>
+    </message>
+    <message>
+        <source>Overview</source>
+        <translation type="unfinished">概览</translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">权限</translation>
+    </message>
+    <message>
+        <source>Tokens</source>
+        <translation type="unfinished">代币</translation>
+    </message>
+    <message>
+        <source>Airdrops</source>
+        <translation type="unfinished">空投</translation>
+    </message>
+    <message>
+        <source>Error editing the community</source>
+        <translation type="unfinished">编辑社区时出错</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityTokenView</name>
+    <message>
+        <source>Mint asset on %1</source>
+        <translation type="unfinished">在%1上铸造资产</translation>
+    </message>
+    <message>
+        <source>Mint collectible on %1</source>
+        <translation type="unfinished">在%1上铸造收藏品</translation>
+    </message>
+    <message>
+        <source>Asset is being minted</source>
+        <translation type="unfinished">资产正在铸造中</translation>
+    </message>
+    <message>
+        <source>Collectible is being minted</source>
+        <translation type="unfinished">收藏品正在铸造中</translation>
+    </message>
+    <message>
+        <source>Asset minting failed</source>
+        <translation type="unfinished">资产铸造失败</translation>
+    </message>
+    <message>
+        <source>Collectible minting failed</source>
+        <translation type="unfinished">数字藏品铸造失败</translation>
+    </message>
+    <message>
+        <source>Review token details before minting it as they can&apos;t be edited later</source>
+        <translation type="unfinished">在铸造之前查看令牌详细信息，因为之后无法对其进行编辑</translation>
+    </message>
+    <message>
+        <source>Mint</source>
+        <translation type="unfinished">铸造</translation>
+    </message>
+    <message>
+        <source>Loading token holders...</source>
+        <translation type="unfinished">正在加载令牌持有者...</translation>
+    </message>
+</context>
+<context>
+    <name>CommunityTokensStore</name>
+    <message>
+        <source>Transaction failed</source>
+        <translation type="unfinished">交易失败</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmAddingNewMasterKey</name>
+    <message>
+        <source>Secure Your Assets and Funds</source>
+        <translation type="unfinished">保护您的资产和资金</translation>
+    </message>
+    <message>
+        <source>Your recovery phrase is a 12-word passcode to your funds.&lt;br/&gt;&lt;br/&gt;Your recovery phrase cannot be recovered if lost. Therefore, you &lt;b&gt;must&lt;/b&gt; back it up. The simplest way is to &lt;b&gt;write it down offline and store it somewhere secure.&lt;/b&gt;</source>
+        <translation type="unfinished">您的助记词是您资金的 12 个密码。&lt;br/&gt;&lt;br/&gt;如果丢失，您的助记词将无法恢复。因此，您&lt;b&gt;必须&lt;/b&gt;对其进行备份。最简单的方法是将它&lt;b&gt;写在纸上并存储在安全的地方。&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>I have a pen and paper</source>
+        <translation type="unfinished">我有一支笔和一张纸</translation>
+    </message>
+    <message>
+        <source>I am ready to write down my recovery phrase</source>
+        <translation type="unfinished">我已经准备好写下我的助记词</translation>
+    </message>
+    <message>
+        <source>I know where I’ll store it</source>
+        <translation type="unfinished">我知道我要把它存放在哪里</translation>
+    </message>
+    <message>
+        <source>You can only complete this process once. Status will not store your recovery phrase and can never help you recover it.</source>
+        <translation type="unfinished">您只能完成此过程一次。Status 不会存储您的助记词，并且永远无法帮助您恢复它。</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmAppRestartModal</name>
+    <message>
+        <source>Application Restart</source>
+        <translation type="unfinished">应用程序重启</translation>
+    </message>
+    <message>
+        <source>Please restart the application to apply the changes.</source>
+        <translation type="unfinished">请重新启动应用程序以应用更改。</translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished">重启</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmChangePasswordModal</name>
+    <message>
+        <source>Your data must now be re-encrypted with your new password. This process may take some time, during which you won’t be able to interact with the app. Do not quit the app or turn off your device. Doing so will lead to data corruption, loss of your Status profile and the inability to restart Status.</source>
+        <translation type="unfinished">您的数据现在必须使用新密码重新加密。此过程可能需要一些时间，在此期间您将无法与应用程序交互。请勿退出应用程序或关闭设备。否则会导致数据损坏、丢失您的状态资料以及无法重启状态。</translation>
+    </message>
+    <message>
+        <source>Re-encryption complete</source>
+        <translation type="unfinished">重新加密完成</translation>
+    </message>
+    <message>
+        <source>Re-encrypting your data with your new password...</source>
+        <translation type="unfinished">正在使用您的新密码重新加密您的数据...</translation>
+    </message>
+    <message>
+        <source>Restart Status and log in using your new password</source>
+        <translation type="unfinished">重启状态并使用您的新密码登录</translation>
+    </message>
+    <message>
+        <source>Do not quit the app or turn off your device</source>
+        <translation type="unfinished">请勿退出应用程序或关闭设备</translation>
+    </message>
+    <message>
+        <source>Change password</source>
+        <translation type="unfinished">更改密码</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Re-encrypt data using new password</source>
+        <translation type="unfinished">使用新密码重新加密数据</translation>
+    </message>
+    <message>
+        <source>Restart Status</source>
+        <translation type="unfinished">重启状态</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmExternalLinkPopup</name>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Opening external link</source>
+        <translation type="unfinished">正在打开外部链接</translation>
+    </message>
+    <message>
+        <source>Always trust links to &lt;b&gt;%1&lt;/b&gt;</source>
+        <translation type="unfinished">始终信任来自 &lt;b&gt;%1&lt;/b&gt; 的链接</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">打开</translation>
+    </message>
+    <message>
+        <source>For your privacy, Status asks before opening links, as websites may collect your IP or device information. Copy the link to open it elsewhere, or tap Open to use the browser set in Settings&gt;&gt;Browser&gt;&gt;Open links in</source>
+        <translation type="unfinished">为了保护您的隐私，Status 在打开链接之前会询问您，因为网站可能会收集您的 IP 或设备信息。复制链接并在其他地方打开它，或者点击“打开”以使用在“设置”&gt;&gt;“浏览器”&gt;&gt;“打开链接的方式”中设置的浏览器。</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmHideAssetPopup</name>
+    <message>
+        <source>Hide asset</source>
+        <translation type="unfinished">隐藏资产</translation>
+    </message>
+    <message>
+        <source>Hide %1 (%2)</source>
+        <translation type="unfinished">隐藏 %1 (%2)</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to hide %1 (%2)? You will no longer see or be able to interact with this asset anywhere inside Status.</source>
+        <translation type="unfinished">您确定要隐藏 %1 (%2) 吗？之后您将无法在 Status 中看到或与之交互。</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmHideCommunityAssetsPopup</name>
+    <message>
+        <source>Hide &apos;%1&apos; assets</source>
+        <translation type="unfinished">隐藏&apos;%1&apos;资产</translation>
+    </message>
+    <message>
+        <source>Hide %1 community assets</source>
+        <translation type="unfinished">隐藏%1社区资产</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to hide all community assets minted by %1? You will no longer see or be able to interact with these assets anywhere inside Status.</source>
+        <translation type="unfinished">您确定要隐藏由%1铸造的所有社区资产吗？之后您将无法在Status的任何地方看到或与之交互。</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmKeyPairForStopUsingState</name>
+    <message>
+        <source>I understand Keycard will no longer be used for signing, and Status password will be required</source>
+        <translation type="unfinished">我理解密钥卡将不再用于签名，并且需要状态密码</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmPasswordState</name>
+    <message>
+        <source>Have you written down your password?</source>
+        <translation type="unfinished">您是否已记录您的密码？</translation>
+    </message>
+    <message>
+        <source>You will never be able to recover your password if you loose it.</source>
+        <translation type="unfinished">如果您丢失了密码，将无法找回。</translation>
+    </message>
+    <message>
+        <source>If you need to, write it using pen and paper and keep in a safe place.</source>
+        <translation type="unfinished">如有需要，请用笔和纸写下来并保存在安全的地方。</translation>
+    </message>
+    <message>
+        <source>If you loose your password you will loose access to your Status profile.</source>
+        <translation type="unfinished">如果您丢失密码，您将无法访问您的 Status 个人资料。</translation>
+    </message>
+    <message>
+        <source>Confirm your password (again)</source>
+        <translation type="unfinished">再次确认您的密码</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmSeedPhraseBackup</name>
+    <message>
+        <source>Step 4 of 4</source>
+        <translation type="unfinished">第 4 步，共 4 步</translation>
+    </message>
+    <message>
+        <source>Complete back up</source>
+        <translation type="unfinished">完成备份</translation>
+    </message>
+    <message>
+        <source>Store Your Phrase Offline and Complete Your Back Up</source>
+        <translation type="unfinished">将您的助记词离线存储并完成备份</translation>
+    </message>
+    <message>
+        <source>By completing this process, you will remove your recovery phrase from this application’s storage. This makes your funds more secure.
+
+You will remain logged in, and your recovery phrase will be entirely in your hands.</source>
+        <translation type="unfinished">通过完成此过程，您将从本应用程序的存储中删除您的助记词。这会使您的资金更安全。
+
+您仍将保持登录状态，并且您的助记词完全由您掌握。</translation>
+    </message>
+    <message>
+        <source>I acknowledge that Status will not be able to show me my recovery phrase again.</source>
+        <translation type="unfinished">我确认 Status 将无法再次向我显示我的助记词。</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmationDialog</name>
+    <message>
+        <source>Confirm</source>
+        <translation type="unfinished">确认</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to do this?</source>
+        <translation type="unfinished">您确定要执行此操作吗？</translation>
+    </message>
+    <message>
+        <source>Confirm your action</source>
+        <translation type="unfinished">确认您的操作</translation>
+    </message>
+    <message>
+        <source>Do not show this again</source>
+        <translation type="unfinished">以后不要再显示</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmationPopup</name>
+    <message>
+        <source>Enable KLIPY GIFs?</source>
+        <translation type="unfinished">启用 KLIPY GIF？</translation>
+    </message>
+    <message>
+        <source>Once enabled, GIFs posted in the chat may share your metadata with KLIPY.</source>
+        <translation type="unfinished">启用后，在聊天中发布的 GIF 可能会将您的元数据与 KLIPY 共享。</translation>
+    </message>
+    <message>
+        <source>Enable</source>
+        <translation type="unfinished">启用</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectDAppModal</name>
+    <message>
+        <source>dApp connected</source>
+        <translation type="unfinished">已连接的 dApp</translation>
+    </message>
+    <message>
+        <source>Connection request</source>
+        <translation type="unfinished">连接请求</translation>
+    </message>
+    <message>
+        <source>Reject</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished">断开连接</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished">连接</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionStatusTag</name>
+    <message>
+        <source>Connected. You can now go back to the dApp.</source>
+        <translation type="unfinished">已连接。现在您可以返回到 dApp。</translation>
+    </message>
+    <message>
+        <source>Error connecting to dApp. Close and try again</source>
+        <translation type="unfinished">无法连接到 dApp。请关闭并重试。</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionWarnings</name>
+    <message>
+        <source>Retry now</source>
+        <translation type="unfinished">立即重试</translation>
+    </message>
+</context>
+<context>
+    <name>Constants</name>
+    <message>
+        <source>Key pair starting with whitespace are not allowed</source>
+        <translation type="unfinished">不允许以空格开头的密钥对</translation>
+    </message>
+    <message numerus="yes">
+        <source>Key pair must be at least %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>密钥对必须至少包含%n个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Only letters and numbers allowed</source>
+        <translation type="unfinished">仅允许字母和数字</translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, underscores, periods, whitespaces and hyphens allowed</source>
+        <translation type="unfinished">仅允许字母、数字、下划线、句点、空格和连字符</translation>
+    </message>
+    <message>
+        <source>Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished">无效字符（仅允许 A-Z 和 0-9，单个空格、连字符和下划线）</translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed</source>
+        <translation type="unfinished">仅允许字母、数字、下划线、句点、逗号、空格和连字符</translation>
+    </message>
+    <message>
+        <source>Special characters are not allowed</source>
+        <translation type="unfinished">不允许使用特殊字符</translation>
+    </message>
+    <message>
+        <source>Only letters, numbers and ASCII characters allowed</source>
+        <translation type="unfinished">仅允许字母、数字和 ASCII 字符</translation>
+    </message>
+    <message>
+        <source>Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished">名称太酷了（仅使用 A-Z 和 0-9，单个空格、连字符和下划线）</translation>
+    </message>
+    <message>
+        <source>Whole numbers only</source>
+        <translation type="unfinished">仅允许整数</translation>
+    </message>
+    <message>
+        <source>Positive real numbers only</source>
+        <translation type="unfinished">仅允许正实数</translation>
+    </message>
+    <message>
+        <source>How to display the QR code on your other device</source>
+        <translation type="unfinished">如何将二维码显示在您的其他设备上</translation>
+    </message>
+    <message>
+        <source>How to copy the encrypted key from your other device</source>
+        <translation type="unfinished">如何从您的其他设备复制加密密钥</translation>
+    </message>
+    <message>
+        <source>Limit of 20 accounts reached</source>
+        <translation type="unfinished">已达到 20 个帐户的限制</translation>
+    </message>
+    <message>
+        <source>Remove any account to add a new one.</source>
+        <translation type="unfinished">删除任何一个帐户以添加新的帐户。</translation>
+    </message>
+    <message>
+        <source>Limit of 5 key pairs reached</source>
+        <translation type="unfinished">已达到 5 个密钥对的限制</translation>
+    </message>
+    <message>
+        <source>Remove key pair to add a new one.</source>
+        <translation type="unfinished">删除密钥对以添加新的密钥对。</translation>
+    </message>
+    <message>
+        <source>Limit of 3 watched addresses reached</source>
+        <translation type="unfinished">已达到 3 个监视地址的限制</translation>
+    </message>
+    <message>
+        <source>Remove a watched address to add a new one.</source>
+        <translation type="unfinished">删除一个监视地址以添加新的地址。</translation>
+    </message>
+    <message>
+        <source>Limit of 20 saved addresses reached</source>
+        <translation type="unfinished">已达到 20 个保存地址的限制</translation>
+    </message>
+    <message>
+        <source>Remove a saved address to add a new one.</source>
+        <translation type="unfinished">删除一个保存地址以添加新的地址。</translation>
+    </message>
+    <message>
+        <source>Username already taken :(</source>
+        <translation type="unfinished">:用户名已被占用 :(</translation>
+    </message>
+    <message>
+        <source>Username doesn’t belong to you :(</source>
+        <translation type="unfinished">:此用户名不属于您 :(</translation>
+    </message>
+    <message>
+        <source>Continuing will connect this username with your chat key.</source>
+        <translation type="unfinished">继续操作会将此用户名与您的聊天密钥关联。</translation>
+    </message>
+    <message>
+        <source>✓ Username available!</source>
+        <translation type="unfinished">用户名可用！</translation>
+    </message>
+    <message>
+        <source>Username is already connected with your chat key and can be used inside Status.</source>
+        <translation type="unfinished">该用户名已与您的聊天密钥关联，并且可以在 Status 中使用。</translation>
+    </message>
+    <message>
+        <source>This user name is owned by you and connected with your chat key. Continue to set `Show my ENS username in chats`.</source>
+        <translation type="unfinished">此用户名归您所有，并与您的聊天密钥关联。继续设置“在聊天中显示我的 ENS 用户名”。</translation>
+    </message>
+    <message>
+        <source>Continuing will require a transaction to connect the username with your current chat key.</source>
+        <translation type="unfinished">继续操作需要进行交易才能将用户名与您当前的聊天密钥关联。</translation>
+    </message>
+    <message>
+        <source>Temporarily unavailable, will be available in the next release.</source>
+        <translation type="unfinished">暂时不可用，将在下一个版本中提供。</translation>
+    </message>
+</context>
+<context>
+    <name>ContactPanel</name>
+    <message>
+        <source>Send message</source>
+        <translation type="unfinished">发送消息</translation>
+    </message>
+    <message>
+        <source>Reject</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+    <message>
+        <source>Decline Request</source>
+        <translation type="unfinished">拒绝请求</translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished">接受</translation>
+    </message>
+    <message>
+        <source>Accept Request</source>
+        <translation type="unfinished">接受请求</translation>
+    </message>
+    <message>
+        <source>Remove Rejection</source>
+        <translation type="unfinished">移除拒绝</translation>
+    </message>
+</context>
+<context>
+    <name>ContactsColumnView</name>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">消息</translation>
+    </message>
+    <message>
+        <source>Start chat</source>
+        <translation type="unfinished">开始聊天</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+    <message>
+        <source>Search contacts and groups...</source>
+        <translation type="unfinished">搜索联系人和群组...</translation>
+    </message>
+    <message>
+        <source>Invite contacts</source>
+        <translation type="unfinished">邀请联系人</translation>
+    </message>
+</context>
+<context>
+    <name>ContactsListPanel</name>
+    <message>
+        <source>Contact Request Sent</source>
+        <translation type="unfinished">已发送联系请求</translation>
+    </message>
+</context>
+<context>
+    <name>ContactsStore</name>
+    <message>
+        <source>Nickname for %1 removed</source>
+        <translation type="unfinished">已删除 %1 的昵称</translation>
+    </message>
+    <message>
+        <source>Nickname for %1 changed</source>
+        <translation type="unfinished">已更改 %1 的昵称</translation>
+    </message>
+    <message>
+        <source>Nickname for %1 added</source>
+        <translation type="unfinished">已添加 %1 的昵称</translation>
+    </message>
+    <message>
+        <source>Contact request sent</source>
+        <translation type="unfinished">已发送联系人请求</translation>
+    </message>
+</context>
+<context>
+    <name>ContactsView</name>
+    <message>
+        <source>Send contact request to chat key</source>
+        <translation type="unfinished">发送联系人请求到聊天密钥</translation>
+    </message>
+    <message>
+        <source>Contacts</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>Pending Requests</source>
+        <translation type="unfinished">待处理的请求</translation>
+    </message>
+    <message>
+        <source>Dismissed Requests</source>
+        <translation type="unfinished">已拒绝的请求</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation type="unfinished">已阻止</translation>
+    </message>
+    <message>
+        <source>Search by name or chat key</source>
+        <translation type="unfinished">按姓名或聊天密钥搜索</translation>
+    </message>
+    <message>
+        <source>Trusted Contacts</source>
+        <translation type="unfinished">信任的联系人</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">已接收</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">已发送</translation>
+    </message>
+</context>
+<context>
+    <name>ContextCard</name>
+    <message>
+        <source>Connect with</source>
+        <translation type="unfinished">连接</translation>
+    </message>
+    <message>
+        <source>On</source>
+        <translation type="unfinished">开启</translation>
+    </message>
+</context>
+<context>
+    <name>ContractInfoButtonWithMenu</name>
+    <message>
+        <source>View %1 %2 contract address on %3</source>
+        <extracomment>e.g. &quot;View Optimism (DAI) contract address on Optimistic&quot;</extracomment>
+        <translation type="unfinished">在%3上查看%1的%2合约地址</translation>
+    </message>
+    <message>
+        <source>View %1 contract address on %2</source>
+        <translation type="unfinished">在%2上查看%1合约地址</translation>
+    </message>
+    <message>
+        <source>Copy contract address</source>
+        <translation type="unfinished">复制合约地址</translation>
+    </message>
+    <message>
+        <source>Copied</source>
+        <translation type="unfinished">已复制</translation>
+    </message>
+</context>
+<context>
+    <name>ControlNodeOfflineCenterPanel</name>
+    <message>
+        <source>%1 will be right back!</source>
+        <translation type="unfinished">您很快就能回来！</translation>
+    </message>
+    <message>
+        <source>You will automatically re-enter the community and be able to view and post as normal as soon as the community’s control node comes back online.</source>
+        <translation type="unfinished">一旦社区的控制节点恢复在线，您将自动重新加入社区，并可以像往常一样查看和发布内容。</translation>
+    </message>
+</context>
+<context>
+    <name>Controller</name>
+    <message>
+        <source>Please enter numbers only</source>
+        <translation type="unfinished">请输入数字</translation>
+    </message>
+    <message>
+        <source>Account number must be &lt;100</source>
+        <translation type="unfinished">账户号码必须小于100</translation>
+    </message>
+    <message>
+        <source>Non-Ethereum cointype</source>
+        <translation type="unfinished">非以太坊币类型</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertKeycardAccountAcksPage</name>
+    <message>
+        <source>Are you sure you want to migrate this profile keypair to Status?</source>
+        <translation type="unfinished">您确定要将此配置文件密钥对迁移到 Status 吗？</translation>
+    </message>
+    <message>
+        <source>This profile and its accounts will be less secure, as Keycard will no longer be required to transact or login.</source>
+        <translation type="unfinished">由于不再需要 Keycard 进行交易或登录，因此该配置文件及其帐户的安全性会降低。</translation>
+    </message>
+    <message>
+        <source>Your data will also be re-encrypted, restricting access to Status for up to 30 mins. Do you wish to continue?</source>
+        <translation type="unfinished">您的数据也将被重新加密，这将限制对 Status 的访问时间长达 30 分钟。您是否希望继续？</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertKeycardAccountPage</name>
+    <message>
+        <source>Re-encrypting your profile data</source>
+        <translation type="unfinished">正在重新加密您的个人资料数据</translation>
+    </message>
+    <message>
+        <source>Your data must be re-encrypted with your new password which may take some time.</source>
+        <translation type="unfinished">您的数据必须使用新密码进行重新加密，这可能需要一些时间。</translation>
+    </message>
+    <message>
+        <source>Re-encryption complete</source>
+        <translation type="unfinished">重新加密完成</translation>
+    </message>
+    <message>
+        <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
+        <translation type="unfinished">您的数据已成功使用新密码进行重新加密。现在您可以重启 Status 并使用您刚刚创建的密码登录到您的个人资料。</translation>
+    </message>
+    <message>
+        <source>Re-encryption failed</source>
+        <translation type="unfinished">重新加密失败</translation>
+    </message>
+    <message>
+        <source>Do not quit Status or turn off your device. Doing so will lead to loss of profile and inability to restart the app.</source>
+        <translation type="unfinished">请勿退出 Status 或关闭设备。否则会导致个人资料丢失，并且无法重启应用程序。</translation>
+    </message>
+    <message>
+        <source>Restart Status and log in with new password</source>
+        <translation type="unfinished">重启 Status 并使用新密码登录</translation>
+    </message>
+    <message>
+        <source>Back to login</source>
+        <translation type="unfinished">返回登录</translation>
+    </message>
+</context>
+<context>
+    <name>CopyToClipBoardButton</name>
+    <message>
+        <source>Copied!</source>
+        <translation type="unfinished">已复制！</translation>
+    </message>
+</context>
+<context>
+    <name>CountdownPill</name>
+    <message>
+        <source>Expired</source>
+        <translation type="unfinished">已过期</translation>
+    </message>
+    <message>
+        <source>%1d</source>
+        <comment>x days</comment>
+        <translation type="unfinished">%1天</translation>
+    </message>
+    <message>
+        <source>%1h</source>
+        <comment>x hours</comment>
+        <translation type="unfinished">%1小时</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n&#x2009;min(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 分钟</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1m</source>
+        <comment>x minutes</comment>
+        <translation type="unfinished">%1分钟</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n&#x2009;sec(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 秒</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Expired on: %1</source>
+        <translation type="unfinished">于 %1 过期</translation>
+    </message>
+    <message>
+        <source>Expires on: %1</source>
+        <translation type="unfinished">将于 %1 到期</translation>
+    </message>
+</context>
+<context>
+    <name>CountdownProgressIndicator</name>
+    <message>
+        <source>%1s</source>
+        <translation type="unfinished">%1秒</translation>
+    </message>
+</context>
+<context>
+    <name>CreateCategoryPopup</name>
+    <message>
+        <source>Edit category</source>
+        <translation type="unfinished">编辑类别</translation>
+    </message>
+    <message>
+        <source>New category</source>
+        <translation type="unfinished">新建类别</translation>
+    </message>
+    <message>
+        <source>Category title</source>
+        <translation type="unfinished">类别标题</translation>
+    </message>
+    <message>
+        <source>Name the category</source>
+        <translation type="unfinished">命名类别</translation>
+    </message>
+    <message>
+        <source>category name</source>
+        <translation type="unfinished">类别名称</translation>
+    </message>
+    <message>
+        <source>Channels</source>
+        <translation type="unfinished">频道</translation>
+    </message>
+    <message>
+        <source>Delete Category</source>
+        <translation type="unfinished">删除类别</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">保存</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">创建</translation>
+    </message>
+    <message>
+        <source>Error editing the category</source>
+        <translation type="unfinished">编辑类别时出错</translation>
+    </message>
+    <message>
+        <source>Error creating the category</source>
+        <translation type="unfinished">创建类别时出错</translation>
+    </message>
+</context>
+<context>
+    <name>CreateChannelPopup</name>
+    <message>
+        <source>Save changes to #%1 channel?</source>
+        <translation type="unfinished">保存对#%1频道的更改？</translation>
+    </message>
+    <message>
+        <source>You have made changes to #%1 channel. If you close this dialog without saving these changes will be lost?</source>
+        <translation type="unfinished">您已对#%1频道进行了更改。如果您在不保存的情况下关闭此对话框，这些更改将会丢失吗？</translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished">保存更改</translation>
+    </message>
+    <message>
+        <source>Close without saving</source>
+        <translation type="unfinished">放弃保存并关闭</translation>
+    </message>
+    <message>
+        <source>New Channel With Imported Chat History</source>
+        <translation type="unfinished">导入聊天记录的新频道</translation>
+    </message>
+    <message>
+        <source>Edit #%1</source>
+        <translation type="unfinished">编辑#%1</translation>
+    </message>
+    <message>
+        <source>New channel</source>
+        <translation type="unfinished">新频道</translation>
+    </message>
+    <message>
+        <source>Set channel color</source>
+        <translation type="unfinished">设置频道颜色</translation>
+    </message>
+    <message>
+        <source>Import chat history</source>
+        <translation type="unfinished">导入聊天记录</translation>
+    </message>
+    <message>
+        <source>Create channel</source>
+        <translation type="unfinished">创建频道</translation>
+    </message>
+    <message>
+        <source>Clear all</source>
+        <translation type="unfinished">全部清除</translation>
+    </message>
+    <message>
+        <source>Delete channel</source>
+        <translation type="unfinished">删除频道</translation>
+    </message>
+    <message>
+        <source>Proceed with (%1/%2) files</source>
+        <translation type="unfinished">继续处理(%1/%2)个文件</translation>
+    </message>
+    <message numerus="yes">
+        <source>Validate %n file(s)</source>
+        <translation type="unfinished">
+            <numerusform>验证%n个文件</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Validate (%1/%2) files</source>
+        <translation type="unfinished">验证(%1/%2)个文件</translation>
+    </message>
+    <message>
+        <source>Start channel import</source>
+        <translation type="unfinished">开始频道导入</translation>
+    </message>
+    <message>
+        <source>Select Discord channel JSON files to import</source>
+        <translation type="unfinished">选择要导入的Discord频道JSON文件</translation>
+    </message>
+    <message>
+        <source>Some of your community files cannot be used</source>
+        <translation type="unfinished">您的一些社区文件无法使用</translation>
+    </message>
+    <message>
+        <source>Uncheck any files you would like to exclude from the import</source>
+        <translation type="unfinished">取消选中任何您希望从导入中排除的文件</translation>
+    </message>
+    <message>
+        <source>(JSON file format only)</source>
+        <translation type="unfinished">（仅限JSON文件格式）</translation>
+    </message>
+    <message>
+        <source>Browse files</source>
+        <translation type="unfinished">浏览文件</translation>
+    </message>
+    <message>
+        <source>Export the Discord channel’s chat history data using %1</source>
+        <translation type="unfinished">使用%1导出Discord频道的聊天记录数据</translation>
+    </message>
+    <message>
+        <source>Refer to this &lt;a href=&apos;https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Readme.md&apos;&gt;documentation&lt;/a&gt; if you have any queries</source>
+        <translation type="unfinished">如果您有任何疑问，请参考此&lt;a href=&apos;https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Readme.md&apos;&gt;文档&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>Choose files to import</source>
+        <translation type="unfinished">选择要导入的文件</translation>
+    </message>
+    <message>
+        <source>JSON files (%1)</source>
+        <translation type="unfinished">JSON 文件 (%1)</translation>
+    </message>
+    <message>
+        <source>Select the chat history you would like to import into #%1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import all history</source>
+        <translation type="unfinished">导入所有历史记录</translation>
+    </message>
+    <message>
+        <source>Start date</source>
+        <translation type="unfinished">开始日期</translation>
+    </message>
+    <message>
+        <source>Channel name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source># Name the channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>channel name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, underscores, periods and hyphens allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel colour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pick a colour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description</source>
+        <translation type="unfinished">描述</translation>
+    </message>
+    <message>
+        <source>Describe the channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>channel description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide channel from members who don&apos;t have permissions to view the channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">权限</translation>
+    </message>
+    <message>
+        <source>Add permission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel Colour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select Channel Colour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update permission</source>
+        <translation type="unfinished">更新权限</translation>
+    </message>
+    <message>
+        <source>Create permission</source>
+        <translation type="unfinished">创建权限</translation>
+    </message>
+    <message>
+        <source>Edit #%1 permission</source>
+        <translation type="unfinished">编辑#%1权限</translation>
+    </message>
+    <message>
+        <source>New #%1 permission</source>
+        <translation type="unfinished">新建#%1权限</translation>
+    </message>
+    <message>
+        <source>Revert changes</source>
+        <translation type="unfinished">撤销更改</translation>
+    </message>
+    <message>
+        <source>Error creating the channel</source>
+        <translation type="unfinished">创建频道时出错</translation>
+    </message>
+</context>
+<context>
+    <name>CreateChatView</name>
+    <message>
+        <source>Contacts</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>You can only send direct messages to your Contacts.
+
+Send a contact request to the person you would like to chat with, you will be able to chat with them once they have accepted your contact request.</source>
+        <translation type="unfinished">您只能向您的联系人发送直接消息。
+
+向您想要聊天的人发送联系请求，一旦他们接受了您的联系请求，您就可以与他们聊天。</translation>
+    </message>
+</context>
+<context>
+    <name>CreateCommunityPopup</name>
+    <message>
+        <source>Import a community from Discord into Status</source>
+        <translation type="unfinished">将社区从 Discord 导入到 Status</translation>
+    </message>
+    <message>
+        <source>Create New Community</source>
+        <translation type="unfinished">创建新社区</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished">下一步</translation>
+    </message>
+    <message>
+        <source>Start Discord import</source>
+        <translation type="unfinished">开始 Discord 导入</translation>
+    </message>
+    <message>
+        <source>Create Community</source>
+        <translation type="unfinished">创建社区</translation>
+    </message>
+    <message>
+        <source>Clear all</source>
+        <translation type="unfinished">全部清除</translation>
+    </message>
+    <message>
+        <source>Proceed with (%1/%2) files</source>
+        <translation type="unfinished">继续处理 (%1/%2) 个文件</translation>
+    </message>
+    <message>
+        <source>Validate (%1/%2) files</source>
+        <translation type="unfinished">验证 (%1/%2) 个文件</translation>
+    </message>
+    <message>
+        <source>Import files</source>
+        <translation type="unfinished">导入文件</translation>
+    </message>
+    <message>
+        <source>Select Discord JSON files to import</source>
+        <translation type="unfinished">选择要导入的 Discord JSON 文件</translation>
+    </message>
+    <message>
+        <source>Some of your community files cannot be used</source>
+        <translation type="unfinished">您的一些社区文件无法使用</translation>
+    </message>
+    <message>
+        <source>Uncheck any files you would like to exclude from the import</source>
+        <translation type="unfinished">取消选中任何您希望从导入中排除的文件</translation>
+    </message>
+    <message>
+        <source>(JSON file format only)</source>
+        <translation type="unfinished">（仅限 JSON 文件格式）</translation>
+    </message>
+    <message>
+        <source>Browse files</source>
+        <translation type="unfinished">浏览文件</translation>
+    </message>
+    <message>
+        <source>Export your Discord JSON data using %1</source>
+        <translation type="unfinished">使用 %1 导出您的 Discord JSON 数据</translation>
+    </message>
+    <message>
+        <source>Refer to this &lt;a href=&apos;https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Readme.md&apos;&gt;documentation&lt;/a&gt; if you have any queries</source>
+        <translation type="unfinished">如果您有任何疑问，请参考此&lt;a href=&apos;https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Readme.md&apos;&gt;文档&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>Choose files to import</source>
+        <translation type="unfinished">选择要导入的文件</translation>
+    </message>
+    <message>
+        <source>JSON files (%1)</source>
+        <translation type="unfinished">JSON 文件 (%1)</translation>
+    </message>
+    <message>
+        <source>Please select the categories and channels you would like to import</source>
+        <translation type="unfinished">请选择您想要导入的类别和频道</translation>
+    </message>
+    <message>
+        <source>Import all history</source>
+        <translation type="unfinished">导入所有历史记录</translation>
+    </message>
+    <message>
+        <source>Start date</source>
+        <translation type="unfinished">开始日期</translation>
+    </message>
+    <message>
+        <source>Name your community</source>
+        <translation type="unfinished">为您的社区命名</translation>
+    </message>
+    <message>
+        <source>Give it a short description</source>
+        <translation type="unfinished">简要描述一下</translation>
+    </message>
+    <message>
+        <source>Community introduction and rules (you can edit this later)</source>
+        <translation type="unfinished">社区介绍和规则（稍后可以编辑）</translation>
+    </message>
+    <message>
+        <source>Error creating the community</source>
+        <translation type="unfinished">创建社区时出错</translation>
+    </message>
+</context>
+<context>
+    <name>CreatePasswordPage</name>
+    <message>
+        <source>Create profile password</source>
+        <translation type="unfinished">创建资料密码</translation>
+    </message>
+    <message>
+        <source>This password can’t be recovered</source>
+        <translation type="unfinished">此密码无法恢复</translation>
+    </message>
+    <message>
+        <source>Confirm password</source>
+        <translation type="unfinished">确认密码</translation>
+    </message>
+    <message>
+        <source>Got it</source>
+        <translation type="unfinished">知道了</translation>
+    </message>
+    <message>
+        <source>Your Status keys are the foundation of your self-sovereign identity in Web3. You have complete control over these keys, which you can use to sign transactions, access your data, and interact with Web3 services.
+
+Your keys are always securely stored on your device and protected by your Status profile password. Status doesn&apos;t know your password and can&apos;t reset it for you. If you forget your password, you may lose access to your Status profile and wallet funds.
+
+Remember your password and don&apos;t share it with anyone.</source>
+        <translation type="unfinished">您的 Status 密钥是您在 Web3 中自主身份的基础。您可以完全控制这些密钥，并使用它们来签署交易、访问数据以及与 Web3 服务进行交互。
+
+您的密钥始终安全地存储在您的设备上，并受到您的 Status 资料密码的保护。Status 不知道您的密码，也无法为您重置。如果您忘记了密码，您可能会失去对 Status 资料和钱包资金的访问权限。
+
+请记住您的密码，不要与任何人分享。</translation>
+    </message>
+</context>
+<context>
+    <name>CreatePasswordState</name>
+    <message>
+        <source>Create a password</source>
+        <translation type="unfinished">创建密码</translation>
+    </message>
+    <message>
+        <source>Create a password to unlock Status on this device &amp; sign transactions. &lt;span style=&apos;color:%1;&apos;&gt;You won’t be able to recover password if lost.&lt;/span&gt;</source>
+        <translation type="unfinished">创建一个密码，用于解锁此设备上的状态并签署交易。&lt;span style=&apos;color:%1;&apos;&gt;如果丢失密码，您将无法恢复。&lt;/span&gt;</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished">新密码</translation>
+    </message>
+    <message>
+        <source>To strengthen your password consider including:</source>
+        <translation type="unfinished">为了加强您的密码，请考虑包含以下内容：</translation>
+    </message>
+    <message>
+        <source>Lower case</source>
+        <translation type="unfinished">小写字母</translation>
+    </message>
+    <message>
+        <source>Upper case</source>
+        <translation type="unfinished">大写字母</translation>
+    </message>
+    <message>
+        <source>Numbers</source>
+        <translation type="unfinished">数字</translation>
+    </message>
+    <message>
+        <source>Symbols</source>
+        <translation type="unfinished">符号</translation>
+    </message>
+    <message>
+        <source>Confirm password</source>
+        <translation type="unfinished">确认密码</translation>
+    </message>
+</context>
+<context>
+    <name>CreateProfilePage</name>
+    <message>
+        <source>Create profile</source>
+        <translation type="unfinished">创建个人资料</translation>
+    </message>
+    <message>
+        <source>How would you like to start using Status?</source>
+        <translation type="unfinished">您希望如何开始使用 Status？</translation>
+    </message>
+    <message>
+        <source>Start fresh</source>
+        <translation type="unfinished">全新开始</translation>
+    </message>
+    <message>
+        <source>Create a new profile from scratch</source>
+        <translation type="unfinished">从头创建一个新的个人资料</translation>
+    </message>
+    <message>
+        <source>Let’s go!</source>
+        <translation type="unfinished">让我们开始！</translation>
+    </message>
+    <message>
+        <source>Use a recovery phrase</source>
+        <translation type="unfinished">使用助记词</translation>
+    </message>
+    <message>
+        <source>If you already have an Ethereum wallet</source>
+        <translation type="unfinished">如果您已经拥有以太坊钱包</translation>
+    </message>
+    <message>
+        <source>Use Keycard</source>
+        <translation type="unfinished">使用 Keycard</translation>
+    </message>
+    <message>
+        <source>Reveal what you have on Keycard first</source>
+        <translation type="unfinished">首先显示您在 Keycard 上的内容</translation>
+    </message>
+</context>
+<context>
+    <name>CurrenciesModel</name>
+    <message>
+        <source>US Dollars</source>
+        <translation type="unfinished">美元</translation>
+    </message>
+    <message>
+        <source>British Pound</source>
+        <translation type="unfinished">英镑</translation>
+    </message>
+    <message>
+        <source>Euros</source>
+        <translation type="unfinished">欧元</translation>
+    </message>
+    <message>
+        <source>Russian ruble</source>
+        <translation type="unfinished">俄罗斯卢布</translation>
+    </message>
+    <message>
+        <source>South Korean won</source>
+        <translation type="unfinished">韩元</translation>
+    </message>
+    <message>
+        <source>Ethereum</source>
+        <translation type="unfinished">以太坊</translation>
+    </message>
+    <message>
+        <source>Tokens</source>
+        <translation type="unfinished">代币</translation>
+    </message>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">比特币</translation>
+    </message>
+    <message>
+        <source>Status Network Token</source>
+        <translation type="unfinished">状态网络代币</translation>
+    </message>
+    <message>
+        <source>Dai</source>
+        <translation type="unfinished">戴</translation>
+    </message>
+    <message>
+        <source>United Arab Emirates dirham</source>
+        <translation type="unfinished">阿联酋迪拉姆</translation>
+    </message>
+    <message>
+        <source>Other Fiat</source>
+        <translation type="unfinished">其他法定货币</translation>
+    </message>
+    <message>
+        <source>Afghan afghani</source>
+        <translation type="unfinished">阿富汗阿富汗尼</translation>
+    </message>
+    <message>
+        <source>Argentine peso</source>
+        <translation type="unfinished">阿根廷比索</translation>
+    </message>
+    <message>
+        <source>Australian dollar</source>
+        <translation type="unfinished">澳大利亚元</translation>
+    </message>
+    <message>
+        <source>Barbadian dollar</source>
+        <translation type="unfinished">巴巴多斯元</translation>
+    </message>
+    <message>
+        <source>Bangladeshi taka</source>
+        <translation type="unfinished">孟加拉塔卡</translation>
+    </message>
+    <message>
+        <source>Bulgarian lev</source>
+        <translation type="unfinished">保加利亚列弗</translation>
+    </message>
+    <message>
+        <source>Bahraini dinar</source>
+        <translation type="unfinished">巴林第纳尔</translation>
+    </message>
+    <message>
+        <source>Brunei dollar</source>
+        <translation type="unfinished">文莱元</translation>
+    </message>
+    <message>
+        <source>Bolivian boliviano</source>
+        <translation type="unfinished">玻利维亚玻利维亚诺</translation>
+    </message>
+    <message>
+        <source>Brazillian real</source>
+        <translation type="unfinished">巴西雷亚尔</translation>
+    </message>
+    <message>
+        <source>Bhutanese ngultrum</source>
+        <translation type="unfinished">不丹努尔特拉</translation>
+    </message>
+    <message>
+        <source>Canadian dollar</source>
+        <translation type="unfinished">加拿大元</translation>
+    </message>
+    <message>
+        <source>Swiss franc</source>
+        <translation type="unfinished">瑞士法郎</translation>
+    </message>
+    <message>
+        <source>Chilean peso</source>
+        <translation type="unfinished">智利比索</translation>
+    </message>
+    <message>
+        <source>Chinese yuan</source>
+        <translation type="unfinished">人民币</translation>
+    </message>
+    <message>
+        <source>Colombian peso</source>
+        <translation type="unfinished">哥伦比亚比索</translation>
+    </message>
+    <message>
+        <source>Costa Rican colón</source>
+        <translation type="unfinished">哥斯达黎加科朗</translation>
+    </message>
+    <message>
+        <source>Czech koruna</source>
+        <translation type="unfinished">捷克克罗纳</translation>
+    </message>
+    <message>
+        <source>Danish krone</source>
+        <translation type="unfinished">丹麦克朗</translation>
+    </message>
+    <message>
+        <source>Dominican peso</source>
+        <translation type="unfinished">多米尼加比索</translation>
+    </message>
+    <message>
+        <source>Egyptian pound</source>
+        <translation type="unfinished">埃及镑</translation>
+    </message>
+    <message>
+        <source>Ethiopian birr</source>
+        <translation type="unfinished">埃塞俄比亚比尔</translation>
+    </message>
+    <message>
+        <source>Georgian lari</source>
+        <translation type="unfinished">格鲁吉亚拉里</translation>
+    </message>
+    <message>
+        <source>Ghanaian cedi</source>
+        <translation type="unfinished">加纳塞迪</translation>
+    </message>
+    <message>
+        <source>Hong Kong dollar</source>
+        <translation type="unfinished">港币</translation>
+    </message>
+    <message>
+        <source>Croatian kuna</source>
+        <translation type="unfinished">克罗地亚库纳</translation>
+    </message>
+    <message>
+        <source>Hungarian forint</source>
+        <translation type="unfinished">匈牙利福林</translation>
+    </message>
+    <message>
+        <source>Indonesian rupiah</source>
+        <translation type="unfinished">印度尼西亚盾</translation>
+    </message>
+    <message>
+        <source>Israeli new shekel</source>
+        <translation type="unfinished">以色列新谢克尔</translation>
+    </message>
+    <message>
+        <source>Indian rupee</source>
+        <translation type="unfinished">印度卢比</translation>
+    </message>
+    <message>
+        <source>Icelandic króna</source>
+        <translation type="unfinished">冰岛克朗</translation>
+    </message>
+    <message>
+        <source>Jamaican dollar</source>
+        <translation type="unfinished">牙买加元</translation>
+    </message>
+    <message>
+        <source>Japanese yen</source>
+        <translation type="unfinished">日元</translation>
+    </message>
+    <message>
+        <source>Kenyan shilling</source>
+        <translation type="unfinished">肯尼亚先令</translation>
+    </message>
+    <message>
+        <source>Kuwaiti dinar</source>
+        <translation type="unfinished">科威特第纳尔</translation>
+    </message>
+    <message>
+        <source>Kazakhstani tenge</source>
+        <translation type="unfinished">哈萨克斯坦坚戈</translation>
+    </message>
+    <message>
+        <source>Sri Lankan rupee</source>
+        <translation type="unfinished">斯里兰卡卢比</translation>
+    </message>
+    <message>
+        <source>Moroccan dirham</source>
+        <translation type="unfinished">摩洛哥迪拉姆</translation>
+    </message>
+    <message>
+        <source>Moldovan leu</source>
+        <translation type="unfinished">摩尔多瓦列伊</translation>
+    </message>
+    <message>
+        <source>Mauritian rupee</source>
+        <translation type="unfinished">毛里求斯卢比</translation>
+    </message>
+    <message>
+        <source>Malawian kwacha</source>
+        <translation type="unfinished">马拉维克瓦查</translation>
+    </message>
+    <message>
+        <source>Mexican peso</source>
+        <translation type="unfinished">墨西哥比索</translation>
+    </message>
+    <message>
+        <source>Malaysian ringgit</source>
+        <translation type="unfinished">马来西亚林吉特</translation>
+    </message>
+    <message>
+        <source>Mozambican metical</source>
+        <translation type="unfinished">莫桑比克梅蒂卡尔</translation>
+    </message>
+    <message>
+        <source>Namibian dollar</source>
+        <translation type="unfinished">纳米比亚元</translation>
+    </message>
+    <message>
+        <source>Nigerian naira</source>
+        <translation type="unfinished">尼日利亚奈拉</translation>
+    </message>
+    <message>
+        <source>Norwegian krone</source>
+        <translation type="unfinished">挪威克朗</translation>
+    </message>
+    <message>
+        <source>Nepalese rupee</source>
+        <translation type="unfinished">尼泊尔卢比</translation>
+    </message>
+    <message>
+        <source>New Zealand dollar</source>
+        <translation type="unfinished">新西兰元</translation>
+    </message>
+    <message>
+        <source>Omani rial</source>
+        <translation type="unfinished">阿曼里亚尔</translation>
+    </message>
+    <message>
+        <source>Peruvian sol</source>
+        <translation type="unfinished">秘鲁索尔</translation>
+    </message>
+    <message>
+        <source>Papua New Guinean kina</source>
+        <translation type="unfinished">巴布亚新几内亚基那</translation>
+    </message>
+    <message>
+        <source>Philippine peso</source>
+        <translation type="unfinished">菲律宾比索</translation>
+    </message>
+    <message>
+        <source>Pakistani rupee</source>
+        <translation type="unfinished">巴基斯坦卢比</translation>
+    </message>
+    <message>
+        <source>Polish złoty</source>
+        <translation type="unfinished">波兰兹罗提</translation>
+    </message>
+    <message>
+        <source>Paraguayan guaraní</source>
+        <translation type="unfinished">巴拉圭瓜拉尼</translation>
+    </message>
+    <message>
+        <source>Qatari riyal</source>
+        <translation type="unfinished">卡塔尔里亚尔</translation>
+    </message>
+    <message>
+        <source>Romanian leu</source>
+        <translation type="unfinished">罗马尼亚列伊</translation>
+    </message>
+    <message>
+        <source>Serbian dinar</source>
+        <translation type="unfinished">塞尔维亚第纳尔</translation>
+    </message>
+    <message>
+        <source>Saudi riyal</source>
+        <translation type="unfinished">沙特里亚尔</translation>
+    </message>
+    <message>
+        <source>Swedish krona</source>
+        <translation type="unfinished">瑞典克朗</translation>
+    </message>
+    <message>
+        <source>Singapore dollar</source>
+        <translation type="unfinished">新加坡元</translation>
+    </message>
+    <message>
+        <source>Thai baht</source>
+        <translation type="unfinished">泰国铢</translation>
+    </message>
+    <message>
+        <source>Trinidad and Tobago dollar</source>
+        <translation type="unfinished">特立尼达和多巴哥元</translation>
+    </message>
+    <message>
+        <source>New Taiwan dollar</source>
+        <translation type="unfinished">新台币</translation>
+    </message>
+    <message>
+        <source>Tanzanian shilling</source>
+        <translation type="unfinished">坦桑尼亚先令</translation>
+    </message>
+    <message>
+        <source>Turkish lira</source>
+        <translation type="unfinished">土耳其里拉</translation>
+    </message>
+    <message>
+        <source>Ukrainian hryvnia</source>
+        <translation type="unfinished">乌克兰格里夫纳</translation>
+    </message>
+    <message>
+        <source>Ugandan shilling</source>
+        <translation type="unfinished">乌干达先令</translation>
+    </message>
+    <message>
+        <source>Uruguayan peso</source>
+        <translation type="unfinished">乌拉圭比索</translation>
+    </message>
+    <message>
+        <source>Venezuelan bolívar</source>
+        <translation type="unfinished">委内瑞拉玻利瓦尔</translation>
+    </message>
+    <message>
+        <source>Vietnamese đồng</source>
+        <translation type="unfinished">越南盾</translation>
+    </message>
+    <message>
+        <source>South African rand</source>
+        <translation type="unfinished">南非兰特</translation>
+    </message>
+</context>
+<context>
+    <name>CurrenciesStore</name>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">不可用</translation>
+    </message>
+</context>
+<context>
+    <name>DAppConfirmDisconnectPopup</name>
+    <message>
+        <source>Are you sure you want to disconnect %1 from all accounts?</source>
+        <translation type="unfinished">您确定要将%1从所有帐户中注销吗？</translation>
+    </message>
+    <message>
+        <source>Disconnect %1</source>
+        <translation type="unfinished">注销%1</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Disconnect dApp</source>
+        <translation type="unfinished">断开DApp连接</translation>
+    </message>
+</context>
+<context>
+    <name>DAppDelegate</name>
+    <message>
+        <source>Disconnect dApp</source>
+        <translation type="unfinished">断开与dApp的连接</translation>
+    </message>
+</context>
+<context>
+    <name>DAppSignRequestModal</name>
+    <message>
+        <source>Sign Request</source>
+        <translation type="unfinished">签名请求</translation>
+    </message>
+    <message>
+        <source>%1 wants you to sign this transaction with %2</source>
+        <translation type="unfinished">%1希望您使用%2对这笔交易进行签名</translation>
+    </message>
+    <message>
+        <source>%1 wants you to sign this message with %2</source>
+        <translation type="unfinished">%1希望您使用%2对这条消息进行签名</translation>
+    </message>
+    <message>
+        <source>Only sign if you trust the dApp</source>
+        <translation type="unfinished">仅在您信任该DApp时才签名</translation>
+    </message>
+    <message>
+        <source>Insufficient funds for transaction</source>
+        <translation type="unfinished">交易资金不足</translation>
+    </message>
+    <message>
+        <source>Max fees:</source>
+        <translation type="unfinished">最高费用：</translation>
+    </message>
+    <message>
+        <source>No fees</source>
+        <translation type="unfinished">无费用</translation>
+    </message>
+    <message>
+        <source>Est. time:</source>
+        <translation type="unfinished">预计时间：</translation>
+    </message>
+    <message>
+        <source>Sign with</source>
+        <translation type="unfinished">使用以下方式签名</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Fees</source>
+        <translation type="unfinished">费用</translation>
+    </message>
+    <message>
+        <source>Max. fees on %1</source>
+        <translation type="unfinished">%1的最高费用</translation>
+    </message>
+</context>
+<context>
+    <name>DAppsListPopup</name>
+    <message>
+        <source>Connected dApps will appear here</source>
+        <translation type="unfinished">已连接的 DApp 将在此处显示</translation>
+    </message>
+    <message>
+        <source>Connected dApps</source>
+        <translation type="unfinished">已连接的 DApp</translation>
+    </message>
+    <message>
+        <source>Connect a dApp</source>
+        <translation type="unfinished">连接一个 DApp</translation>
+    </message>
+</context>
+<context>
+    <name>DAppsService</name>
+    <message>
+        <source>Connected to %1 via %2</source>
+        <translation type="unfinished">已通过%2连接到%1</translation>
+    </message>
+    <message>
+        <source>Disconnected from %1</source>
+        <translation type="unfinished">已从%1断开连接</translation>
+    </message>
+    <message>
+        <source>Connection request for %1 was rejected</source>
+        <translation type="unfinished">针对%1的连接请求已被拒绝</translation>
+    </message>
+    <message>
+        <source>Failed to reject connection request for %1</source>
+        <translation type="unfinished">未能拒绝针对%1的连接请求</translation>
+    </message>
+    <message>
+        <source>Fail to %1 from %2</source>
+        <translation type="unfinished">无法从%2执行%1操作</translation>
+    </message>
+    <message>
+        <source>accepted</source>
+        <translation type="unfinished">接受</translation>
+    </message>
+    <message>
+        <source>rejected</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+</context>
+<context>
+    <name>DAppsUriCopyInstructionsPopup</name>
+    <message>
+        <source>How to copy the dApp URI</source>
+        <translation type="unfinished">如何复制 dApp URI</translation>
+    </message>
+    <message>
+        <source>Navigate to a dApp with WalletConnect support</source>
+        <translation type="unfinished">导航到支持 WalletConnect 的 dApp</translation>
+    </message>
+    <message>
+        <source>Click the</source>
+        <translation type="unfinished">点击</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished">连接</translation>
+    </message>
+    <message>
+        <source> or </source>
+        <translation type="unfinished">或</translation>
+    </message>
+    <message>
+        <source>Connect wallet</source>
+        <translation type="unfinished">连接钱包</translation>
+    </message>
+    <message>
+        <source>button</source>
+        <translation type="unfinished">按钮</translation>
+    </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished">选择</translation>
+    </message>
+    <message>
+        <source>WalletConnect</source>
+        <translation type="unfinished">WalletConnect</translation>
+    </message>
+    <message>
+        <source> from the menu</source>
+        <translation type="unfinished">从菜单中</translation>
+    </message>
+    <message>
+        <source>Head back to Status and paste the URI</source>
+        <translation type="unfinished">返回 Status 并粘贴 URI</translation>
+    </message>
+</context>
+<context>
+    <name>DAppsWorkflow</name>
+    <message>
+        <source>Connect a dApp</source>
+        <translation type="unfinished">连接一个dApp</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>How would you like to connect?</source>
+        <translation type="unfinished">您希望如何连接？</translation>
+    </message>
+</context>
+<context>
+    <name>DappsComboBox</name>
+    <message>
+        <source>dApp connections</source>
+        <translation type="unfinished">dApp连接</translation>
+    </message>
+</context>
+<context>
+    <name>DeactivateNetworkPopup</name>
+    <message>
+        <source>Disable %1 network</source>
+        <translation type="unfinished">禁用%1网络</translation>
+    </message>
+    <message>
+        <source>Balances stored on this network will not be visible in the Wallet. Your funds will be safe and you can always enable the network again.</source>
+        <translation type="unfinished">存储在此网络上的余额将不会在钱包中显示。您的资金是安全的，您可以随时再次启用该网络。</translation>
+    </message>
+    <message>
+        <source>Disable %1</source>
+        <translation type="unfinished">禁用%1</translation>
+    </message>
+</context>
+<context>
+    <name>DefaultDAppExplorerView</name>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <source>Blockchain explorer in the address bar</source>
+        <translation type="unfinished">地址栏中的区块链浏览器</translation>
+    </message>
+    <message>
+        <source>Choose a blockchain explorer to open Ethereum addresses or transaction hashes entered in the address bar</source>
+        <translation type="unfinished">选择一个区块链浏览器，以打开在地址栏中输入的以太坊地址或交易哈希</translation>
+    </message>
+</context>
+<context>
+    <name>DeleteMessageConfirmationPopup</name>
+    <message>
+        <source>Confirm deleting this message</source>
+        <translation type="unfinished">确认删除此消息</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</source>
+        <translation type="unfinished">您确定要删除此消息吗？请注意，其他客户端不一定会同时删除该消息。</translation>
+    </message>
+</context>
+<context>
+    <name>DerivationPath</name>
+    <message>
+        <source>Derivation Path</source>
+        <translation type="unfinished">助记词路径</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished">重置</translation>
+    </message>
+    <message>
+        <source>Account</source>
+        <translation type="unfinished">账户</translation>
+    </message>
+    <message>
+        <source>Select address</source>
+        <translation type="unfinished">选择地址</translation>
+    </message>
+    <message>
+        <source>I understand that this non-Ethereum derivation path is incompatible with Keycard</source>
+        <translation type="unfinished">我理解此非以太坊助记词路径与Keycard不兼容</translation>
+    </message>
+</context>
+<context>
+    <name>DerivationPathDisplay</name>
+    <message>
+        <source>Derivation Path</source>
+        <translation type="unfinished">助记词路径</translation>
+    </message>
+    <message>
+        <source>Account</source>
+        <translation type="unfinished">账户</translation>
+    </message>
+</context>
+<context>
+    <name>DerivationPathSection</name>
+    <message>
+        <source>Derivation path</source>
+        <translation type="unfinished">派生路径</translation>
+    </message>
+    <message>
+        <source>(advanced)</source>
+        <translation type="unfinished">(高级)</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">编辑</translation>
+    </message>
+</context>
+<context>
+    <name>DescriptionInput</name>
+    <message>
+        <source>Description</source>
+        <translation type="unfinished">描述</translation>
+    </message>
+    <message>
+        <source>What your community is about</source>
+        <translation type="unfinished">您的社区是关于什么的</translation>
+    </message>
+    <message>
+        <source>community description</source>
+        <translation type="unfinished">社区描述</translation>
+    </message>
+</context>
+<context>
+    <name>DetailsView</name>
+    <message>
+        <source>Change PIN</source>
+        <translation type="unfinished">更改密码</translation>
+    </message>
+    <message>
+        <source>Keycard is empty</source>
+        <translation type="unfinished">密钥卡为空</translation>
+    </message>
+    <message>
+        <source>Keycard is blocked</source>
+        <translation type="unfinished">密钥卡已锁定</translation>
+    </message>
+    <message>
+        <source>Keycard stores only PIN</source>
+        <translation type="unfinished">密钥卡仅存储 PIN 码</translation>
+    </message>
+    <message>
+        <source>Keycard stores Status profile key pair</source>
+        <translation type="unfinished">密钥卡存储状态配置文件密钥对</translation>
+    </message>
+    <message>
+        <source>Keycard stores key pair</source>
+        <translation type="unfinished">密钥卡存储密钥对</translation>
+    </message>
+    <message>
+        <source>Keycard</source>
+        <translation type="unfinished">密钥卡</translation>
+    </message>
+    <message>
+        <source>Keycard is blocked due to five failed PUK input attempts</source>
+        <translation type="unfinished">由于五次错误的PUK密码输入，密钥卡已被锁定</translation>
+    </message>
+    <message>
+        <source>Keycard is blocked due to three failed PIN input attempts</source>
+        <translation type="unfinished">由于三次错误的 PIN 码输入，密钥卡已被锁定</translation>
+    </message>
+    <message>
+        <source>You are using this Keycard to login to Status</source>
+        <translation type="unfinished">您正在使用此密钥卡登录到状态</translation>
+    </message>
+    <message>
+        <source>This key pair have been already added to Status wallet</source>
+        <translation type="unfinished">此密钥对已添加到状态钱包</translation>
+    </message>
+    <message>
+        <source>Key pair has not been added to Status wallet</source>
+        <translation type="unfinished">尚未将密钥对添加到状态钱包</translation>
+    </message>
+    <message>
+        <source>You can’t operate with Keycard content right now, because Keycard has no free pairing slots. But you can use it with previously paired installations.</source>
+        <translation type="unfinished">由于密钥卡没有可用的配对槽，您现在无法操作密钥卡内容。但您可以将其与先前已配对的应用程序一起使用。</translation>
+    </message>
+    <message>
+        <source>Status profile is not migrated to keycard.</source>
+        <translation type="unfinished">状态配置文件未迁移到密钥卡。</translation>
+    </message>
+    <message>
+        <source>, </source>
+        <translation type="unfinished">，</translation>
+    </message>
+    <message>
+        <source>UID: %1</source>
+        <translation type="unfinished">用户 ID：%1</translation>
+    </message>
+    <message>
+        <source>What you can do:</source>
+        <translation type="unfinished">您可以执行以下操作：</translation>
+    </message>
+    <message>
+        <source>Move profile key pair to Keycard</source>
+        <translation type="unfinished">将配置文件密钥对移动到密钥卡</translation>
+    </message>
+    <message>
+        <source>Move key pair from Status wallet to Keycard</source>
+        <translation type="unfinished">将密钥对从状态钱包移动到密钥卡</translation>
+    </message>
+    <message>
+        <source>Keycard will be required for signing</source>
+        <translation type="unfinished">签名时需要密钥卡</translation>
+    </message>
+    <message>
+        <source>Import a new key pair to Keycard</source>
+        <translation type="unfinished">将新的密钥对导入到密钥卡</translation>
+    </message>
+    <message>
+        <source>Unblock with recovery phrase</source>
+        <translation type="unfinished">使用恢复短语解锁</translation>
+    </message>
+    <message>
+        <source>Unblock with PUK</source>
+        <translation type="unfinished">使用 PUK 解锁</translation>
+    </message>
+    <message>
+        <source>If you set your PUK earlier for this Keycard</source>
+        <translation type="unfinished">如果您之前为该密钥卡设置了 PUK。</translation>
+    </message>
+    <message>
+        <source>Add key pair to Status wallet</source>
+        <translation type="unfinished">将密钥对添加到状态钱包</translation>
+    </message>
+    <message>
+        <source>You’ll be able to sign transactions in Status wallet with Keycard</source>
+        <translation type="unfinished">您可以使用密钥卡在状态钱包中签署交易</translation>
+    </message>
+    <message>
+        <source>New name will be visible in Status and in other apps</source>
+        <translation type="unfinished">新名称将在状态和其他应用程序中显示</translation>
+    </message>
+    <message>
+        <source>Set or change PUK</source>
+        <translation type="unfinished">设置或更改PUK</translation>
+    </message>
+    <message>
+        <source>Remove everything from Keycard</source>
+        <translation type="unfinished">从密钥卡中删除所有内容</translation>
+    </message>
+    <message>
+        <source>Keycard will be required for signing and logging in to Status</source>
+        <translation type="unfinished">使用密钥卡进行签名和登录 Status 应用程序是必需的。</translation>
+    </message>
+    <message>
+        <source>Import a key pair from recovery phrase</source>
+        <translation type="unfinished">从恢复短语中导入密钥对</translation>
+    </message>
+    <message>
+        <source>In case you lost Keycard, want to create a backup or import a
+key pair. Keycard will be required for signing</source>
+        <translation type="unfinished">如果丢失了密钥卡，想要创建备份或导入密钥对。签名时需要密钥卡</translation>
+    </message>
+    <message>
+        <source>If you want to have a different PIN</source>
+        <translation type="unfinished">如果您想使用不同的密码</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">重命名</translation>
+    </message>
+    <message>
+        <source>If you want an additional recovery option</source>
+        <translation type="unfinished">如果您想要其他恢复选项</translation>
+    </message>
+    <message>
+        <source>Requires providing the recovery phrase for the key pair stored on Keycard</source>
+        <translation type="unfinished">需要提供存储在密钥卡上的密钥对的恢复短语</translation>
+    </message>
+    <message>
+        <source>Factory reset Keycard</source>
+        <translation type="unfinished">恢复出厂设置的密钥卡</translation>
+    </message>
+    <message>
+        <source>No free pairing slots</source>
+        <translation type="unfinished">没有可用的配对槽</translation>
+    </message>
+</context>
+<context>
+    <name>DidYouKnowMessages</name>
+    <message>
+        <source>Status messenger is the most secure fully decentralised messenger in the world</source>
+        <translation type="unfinished">状态消息传递工具是世界上最安全、完全去中心化的消息传递工具</translation>
+    </message>
+    <message>
+        <source>Status is truly private - none of your personal details (or any other information) are sent to us</source>
+        <translation type="unfinished">状态真正注重隐私——您的任何个人信息（或任何其他信息）都不会发送给我们</translation>
+    </message>
+    <message>
+        <source>Messages sent using Status are end to end encrypted and can only be opened by the recipient</source>
+        <translation type="unfinished">使用状态发送的消息采用端到端加密，只有收件人才能打开</translation>
+    </message>
+    <message>
+        <source>Status removes intermediaries to keep your messages private and your assets secure</source>
+        <translation type="unfinished">状态通过消除中介来保护您的消息隐私和资产安全</translation>
+    </message>
+    <message>
+        <source>Status uses the latest encryption and security tools to secure your messages and transactions</source>
+        <translation type="unfinished">状态使用最新的加密和安全工具来保护您的消息和交易</translation>
+    </message>
+    <message>
+        <source>Status enables pseudo-anonymous interaction with Web3, DeFi, and society in general</source>
+        <translation type="unfinished">状态可以实现与 Web3、DeFi 和社会的一般互动，从而实现假名化</translation>
+    </message>
+    <message>
+        <source>The Status Network token (SNT) is a modular utility token that fuels the Status network</source>
+        <translation type="unfinished">状态网络代币（SNT）是一种模块化的实用型代币，可为状态网络提供支持</translation>
+    </message>
+    <message>
+        <source>Your non-custodial wallet gives you full control over your funds without the use of a server</source>
+        <translation type="unfinished">您的非托管钱包让您完全控制自己的资金，而无需使用服务器</translation>
+    </message>
+    <message>
+        <source>Status is decentralized and serverless - chat, transact, and browse without surveillance and censorship</source>
+        <translation type="unfinished">状态是去中心化的且无服务器——聊天、交易和浏览时不会受到监控和审查</translation>
+    </message>
+    <message>
+        <source>Full metadata privacy means it&apos;s impossible to tell who you are talking to by surveilling your internet traffic</source>
+        <translation type="unfinished">完全的元数据隐私意味着通过监视您的互联网流量，无法确定您在与谁交谈</translation>
+    </message>
+    <message>
+        <source>Status uses the Waku p2p gossip messaging protocol — an evolution of the EF&apos;s original Whisper protocol</source>
+        <translation type="unfinished">状态使用 Waku 点对点八卦消息传递协议——这是以太坊基金会最初的 Whisper 协议的演进版</translation>
+    </message>
+    <message>
+        <source>Status is home to crypto&apos;s leading multi-chain self-custodial wallet</source>
+        <translation type="unfinished">状态是加密领域领先的多链自托管钱包的所在地</translation>
+    </message>
+    <message>
+        <source>Your cryptographic key pairs encrypt all of your messages which can only be unlocked by the intended recipient</source>
+        <translation type="unfinished">您的密码密钥对会对所有消息进行加密，只有预期的收件人才能解锁这些消息</translation>
+    </message>
+    <message>
+        <source>Status&apos; Web3 browser requires all DApps to ask permission before connecting to your wallet</source>
+        <translation type="unfinished">状态的 Web3 浏览器要求所有 DApp 在连接到您的钱包之前请求权限</translation>
+    </message>
+    <message>
+        <source>Status is open source software that lets you interact with p2p networks. Status itself doesn&apos;t provide any services</source>
+        <translation type="unfinished">状态是一种开源软件，可让您与点对点网络进行交互。状态本身不提供任何服务</translation>
+    </message>
+    <message>
+        <source>Status is a way to access p2p networks that are permissionlessly created and run by individuals around the world</source>
+        <translation type="unfinished">状态是一种访问由世界各地的人们无许可创建和运行的点对点网络的方式</translation>
+    </message>
+    <message>
+        <source>Our 10 core principles include liberty, security, transparency, censorship resistance and inclusivity</source>
+        <translation type="unfinished">我们的 10 项核心原则包括自由、安全、透明度、抗审查性和包容性</translation>
+    </message>
+    <message>
+        <source>Status believes in freedom, and in maximizing the individual freedom of our users</source>
+        <translation type="unfinished">状态相信自由，并致力于最大限度地提高我们用户的个人自由</translation>
+    </message>
+    <message>
+        <source>Status is designed and built to protect the sovereignty of individuals</source>
+        <translation type="unfinished">状态的设计和构建旨在保护个人的主权</translation>
+    </message>
+    <message>
+        <source>Status aims to protect the right to private, secure conversations, and the freedom to associate and collaborate</source>
+        <translation type="unfinished">状态旨在保护私密、安全对话的权利以及结社和合作的自由</translation>
+    </message>
+    <message>
+        <source>One of our core aims is to maximize social, political, and economic freedoms</source>
+        <translation type="unfinished">我们最核心的目标之一是最大限度地提高社会、政治和经济自由</translation>
+    </message>
+    <message>
+        <source>Status abides by the cryptoeconomic design principle of censorship resistance</source>
+        <translation type="unfinished">Status 遵循密码经济设计的审查抵抗原则</translation>
+    </message>
+    <message>
+        <source>Status is a public good licensed under the MPL-2.0 open source license, for anyone to share, modify and benefit from</source>
+        <translation type="unfinished">Status 是一种公共产品，采用 MPL-2.0 开源许可协议，任何人都可以共享、修改和从中受益</translation>
+    </message>
+    <message>
+        <source>The only continent that doesn&apos;t (yet!) have any Status core contributors is Antarctica</source>
+        <translation type="unfinished">目前唯一没有 Status 核心贡献者的洲是南极洲</translation>
+    </message>
+    <message>
+        <source>We are the 5th most active crypto project on GitHub</source>
+        <translation type="unfinished">我们是 GitHub 上第五活跃的加密货币项目</translation>
+    </message>
+    <message>
+        <source>Many other messengers with e2e encryption don&apos;t have metadata privacy!</source>
+        <translation type="unfinished">许多其他具有端到端加密的消息应用程序没有元数据隐私！</translation>
+    </message>
+    <message>
+        <source>Help to translate Status into your native language. See https://status.app/translations for more info</source>
+        <translation type="unfinished">请帮助将 Status 翻译成您的母语。有关更多信息，请访问 https://status.app/translations</translation>
+    </message>
+    <message>
+        <source>Status has a multi-chain wallet which will allow quick and easy multi-chain txns.</source>
+        <translation type="unfinished">Status 具有多链钱包，可实现快速简便的多链交易。</translation>
+    </message>
+    <message>
+        <source>Status&apos; Nimbus team is collaborating with the Ethereum Foundation to create the Portal Network</source>
+        <translation type="unfinished">Status 的 Nimbus 团队正在与以太坊基金会合作创建 Portal 网络</translation>
+    </message>
+    <message>
+        <source>Status&apos; Portal Network client (Fluffy) will let Status users interact with Ethereum in a fully decentralised way</source>
+        <translation type="unfinished">Status 的 Portal 网络客户端（Fluffy）将允许 Status 用户以完全去中心化的方式与以太坊进行交互</translation>
+    </message>
+    <message>
+        <source>Status supports free communication without the approval or oversight of big tech</source>
+        <translation type="unfinished">Status 支持不受大型科技公司批准或监督的自由通信</translation>
+    </message>
+    <message>
+        <source>Status allows you to communicate freely without the threat of surveillance</source>
+        <translation type="unfinished">Status 允许您在没有受到监视威胁的情况下自由交流</translation>
+    </message>
+    <message>
+        <source>Status supports free speech. Using p2p networks prevents us, or anyone else, from censoring you</source>
+        <translation type="unfinished">Status 支持言论自由。使用 P2P 网络可以防止我们或其他人对您进行审查</translation>
+    </message>
+    <message>
+        <source>Status is entirely open source and made by contributors all over the world</source>
+        <translation type="unfinished">Status 完全是开源的，由来自世界各地的贡献者共同开发</translation>
+    </message>
+    <message>
+        <source>Our team of core contributors work remotely from over 50+ countries spread across 6 continents</source>
+        <translation type="unfinished">我们的核心贡献者团队远程工作，分布在六大洲的 50 多个国家/地区</translation>
+    </message>
+    <message>
+        <source>We are dedicated to transitioning our governance model to being decentralised and autonomous</source>
+        <translation type="unfinished">我们致力于将治理模式转变为去中心化和自治模式</translation>
+    </message>
+    <message>
+        <source>Status core-contributors use Status as their primary communication tool</source>
+        <translation type="unfinished">Status 的核心贡献者使用 Status 作为他们的主要通信工具</translation>
+    </message>
+    <message>
+        <source>Status was co-founded by Jarrad Hope and Carl Bennetts</source>
+        <translation type="unfinished">Status 由 Jarrad Hope 和 Carl Bennetts 共同创立</translation>
+    </message>
+    <message>
+        <source>Status was created to ease the transition to a more open mobile internet</source>
+        <translation type="unfinished">Status 的创建是为了促进向更开放的移动互联网过渡</translation>
+    </message>
+    <message>
+        <source>Status aims to help anyone, anywhere, interact with Ethereum, requiring no more than a phone</source>
+        <translation type="unfinished">Status 旨在帮助任何人、在任何地方与以太坊进行交互，只需一部手机即可</translation>
+    </message>
+    <message>
+        <source>Your mobile company, and government are able to see the contents of all your private SMS messages</source>
+        <translation type="unfinished">您的移动运营商和政府可以查看您所有私人短信的内容。</translation>
+    </message>
+    <message>
+        <source>By using Keycard, you can ensure your funds are safe even if your phone is stolen</source>
+        <translation type="unfinished">通过使用Keycard，即使您的手机被盗，您也可以确保您的资金安全。</translation>
+    </message>
+    <message>
+        <source>You can enhance security by using Keycard + PIN entry as two-factor authentication</source>
+        <translation type="unfinished">您可以通过使用Keycard + PIN密码作为双重身份验证来增强安全性。</translation>
+    </message>
+</context>
+<context>
+    <name>DidYouKnowSplashScreen</name>
+    <message>
+        <source>DID YOU KNOW?</source>
+        <translation type="unfinished">你知道吗？</translation>
+    </message>
+</context>
+<context>
+    <name>DiscordImportProgressContents</name>
+    <message>
+        <source>Delete channel &amp; restart import</source>
+        <translation type="unfinished">删除频道并重新开始导入</translation>
+    </message>
+    <message>
+        <source>Close &amp; restart import</source>
+        <translation type="unfinished">关闭并重新开始导入</translation>
+    </message>
+    <message>
+        <source>Cancel import</source>
+        <translation type="unfinished">取消导入</translation>
+    </message>
+    <message>
+        <source>Restart import</source>
+        <translation type="unfinished">重新开始导入</translation>
+    </message>
+    <message>
+        <source>Hide window</source>
+        <translation type="unfinished">隐藏窗口</translation>
+    </message>
+    <message>
+        <source>Visit your new channel</source>
+        <translation type="unfinished">访问您的新频道</translation>
+    </message>
+    <message>
+        <source>Visit your new community</source>
+        <translation type="unfinished">访问您的新社区</translation>
+    </message>
+    <message>
+        <source>Setting up your new channel</source>
+        <translation type="unfinished">正在设置您的新频道</translation>
+    </message>
+    <message>
+        <source>Setting up your community</source>
+        <translation type="unfinished">正在设置您的社区</translation>
+    </message>
+    <message>
+        <source>Importing Discord channel</source>
+        <translation type="unfinished">正在导入 Discord 频道</translation>
+    </message>
+    <message>
+        <source>Importing channels</source>
+        <translation type="unfinished">正在导入频道</translation>
+    </message>
+    <message>
+        <source>Importing messages</source>
+        <translation type="unfinished">正在导入消息</translation>
+    </message>
+    <message>
+        <source>Downloading assets</source>
+        <translation type="unfinished">正在下载资源</translation>
+    </message>
+    <message>
+        <source>Initializing channel</source>
+        <translation type="unfinished">正在初始化频道</translation>
+    </message>
+    <message>
+        <source>Initializing community</source>
+        <translation type="unfinished">正在初始化社区</translation>
+    </message>
+    <message>
+        <source>✓ Complete</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>Import stopped...</source>
+        <translation type="unfinished">导入已停止...</translation>
+    </message>
+    <message>
+        <source>Pending...</source>
+        <translation type="unfinished">等待中... </translation>
+    </message>
+    <message>
+        <source>Importing from file %1 of %2...</source>
+        <translation type="unfinished">正在从文件 %1 (共 %2 个) 导入... </translation>
+    </message>
+    <message>
+        <source>%1%</source>
+        <translation type="unfinished">%1%</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n more issue(s) downloading assets</source>
+        <translation type="unfinished">
+            <numerusform>&apos;%1&apos; was imported with %n issue(s).&apos;</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Importing ‘%1’ from Discord...</source>
+        <translation type="unfinished">正在从 Discord 导入“%1”...</translation>
+    </message>
+    <message>
+        <source>Importing ‘%1’ from Discord stopped...</source>
+        <translation type="unfinished">从 Discord 导入“%1”已停止...</translation>
+    </message>
+    <message>
+        <source>Importing ‘%1’ stopped due to a critical issue...</source>
+        <translation type="unfinished">由于严重问题，导入“%1”已停止...</translation>
+    </message>
+    <message numerus="yes">
+        <source>‘%1’ was imported with %n issue(s).</source>
+        <translation type="unfinished">
+            <numerusform>“%1”已导入，其中有%n个问题。</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>‘%1’ was successfully imported from Discord.</source>
+        <translation type="unfinished">“%1”已成功从 Discord 导入。</translation>
+    </message>
+    <message>
+        <source>Your Discord import is in progress...</source>
+        <translation type="unfinished">您的 Discord 导入正在进行中...</translation>
+    </message>
+    <message>
+        <source>This process can take a while. Feel free to hide this window and use Status normally in the meantime. We’ll notify you when the %1 is ready for you.</source>
+        <translation type="unfinished">此过程可能需要一段时间。您可以随意隐藏此窗口，在此期间正常使用 Status。当 %1 准备好时，我们会通知您。</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished">频道</translation>
+    </message>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>If there were any issues with your import you can upload new JSON files via the community page at any time.</source>
+        <translation type="unfinished">如果您的导入过程中出现任何问题，您可以随时通过社区页面上传新的 JSON 文件。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to cancel the import?</source>
+        <translation type="unfinished">您确定要取消导入吗？</translation>
+    </message>
+    <message>
+        <source>Your new Status %1 will be deleted and all information entered will be lost.</source>
+        <translation type="unfinished">您新的 Status %1 将被删除，并且所有输入的信息都将丢失。</translation>
+    </message>
+    <message>
+        <source>channel</source>
+        <translation type="unfinished">频道</translation>
+    </message>
+    <message>
+        <source>community</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>Delete channel &amp; cancel import</source>
+        <translation type="unfinished">删除频道并取消导入</translation>
+    </message>
+    <message>
+        <source>Delete community</source>
+        <translation type="unfinished">删除社区</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Continue importing</source>
+        <translation type="unfinished">继续导入</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete the channel?</source>
+        <translation type="unfinished">您确定要删除频道吗？</translation>
+    </message>
+    <message>
+        <source>Your new Status channel will be deleted and all information entered will be lost.</source>
+        <translation type="unfinished">您新的 Status 频道将被删除，并且所有输入的信息都将丢失。</translation>
+    </message>
+</context>
+<context>
+    <name>DiscordImportProgressDialog</name>
+    <message>
+        <source>Import a channel from Discord into Status</source>
+        <translation type="unfinished">将 Discord 中的频道导入到 Status 中</translation>
+    </message>
+    <message>
+        <source>Import a community from Discord into Status</source>
+        <translation type="unfinished">将 Discord 中的社区导入到 Status 中</translation>
+    </message>
+</context>
+<context>
+    <name>DisplayNameValidators</name>
+    <message>
+        <source>Display Names can’t start or end with a space</source>
+        <translation type="unfinished">显示名称不能以空格开头或结尾</translation>
+    </message>
+    <message>
+        <source>Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)</source>
+        <translation type="unfinished">无效字符（仅使用A-Z和0-9、连字符、下划线和空格）</translation>
+    </message>
+    <message numerus="yes">
+        <source>Display Names must be at least %n character(s) long</source>
+        <translation type="unfinished">
+            <numerusform>显示名称的长度必须至少为 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Display Names can’t be longer than %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>显示名称的长度不能超过 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Display Names can’t end in “.eth”, “_eth” or “-eth”</source>
+        <translation type="unfinished">显示名称不能以“.eth”、“_eth”或“-eth”结尾</translation>
+    </message>
+    <message>
+        <source>Adjective-animal Display Name formats are not allowed</source>
+        <translation type="unfinished">不允许使用形容词-动物的显示名称格式</translation>
+    </message>
+</context>
+<context>
+    <name>DisplaySeedPhrase</name>
+    <message>
+        <source>Step 1 of 4</source>
+        <translation type="unfinished">第 1 步，共 4 步</translation>
+    </message>
+    <message>
+        <source>Write down your 12-word recovery phrase to keep offline</source>
+        <translation type="unfinished">将您的 12 个单词的恢复短语写下来并离线保存</translation>
+    </message>
+    <message>
+        <source>The next screen contains your recovery phrase.&lt;br/&gt;&lt;b&gt;Anyone&lt;/b&gt; who sees it can use it to access to your funds.</source>
+        <translation type="unfinished">下一个屏幕将显示您的助记词。&lt;br/&gt;&lt;b&gt;任何&lt;/b&gt;看到它的人都可以使用它来访问您的资金。</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadBar</name>
+    <message>
+        <source>Cancelled</source>
+        <translation type="unfinished">已取消</translation>
+    </message>
+    <message>
+        <source>Paused</source>
+        <translation type="unfinished">暂停中</translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation type="unfinished">显示全部</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadMenu</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">打开</translation>
+    </message>
+    <message>
+        <source>Show in folder</source>
+        <translation type="unfinished">在文件夹中显示</translation>
+    </message>
+    <message>
+        <source>Pause</source>
+        <translation type="unfinished">暂停</translation>
+    </message>
+    <message>
+        <source>Resume</source>
+        <translation type="unfinished">恢复</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadPage</name>
+    <message>
+        <source>Thanks for using Status</source>
+        <translation type="unfinished">感谢您使用 Status</translation>
+    </message>
+    <message>
+        <source>You&apos;re curently using version %1 of Status.</source>
+        <translation type="unfinished">您当前使用的是 Status 的 %1 版本。</translation>
+    </message>
+    <message>
+        <source>There&apos;s new version available to download.</source>
+        <translation type="unfinished">有新版本可供下载。</translation>
+    </message>
+    <message>
+        <source>Get Status %1</source>
+        <translation type="unfinished">获取 Status %1</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadView</name>
+    <message>
+        <source>Cancelled</source>
+        <translation type="unfinished">已取消</translation>
+    </message>
+    <message>
+        <source>Paused</source>
+        <translation type="unfinished">暂停中</translation>
+    </message>
+    <message>
+        <source>Downloaded files will appear here.</source>
+        <translation type="unfinished">下载的文件将显示在此处。</translation>
+    </message>
+</context>
+<context>
+    <name>DropAndEditImagePanel</name>
+    <message>
+        <source>Drop It!</source>
+        <translation type="unfinished">拖放！</translation>
+    </message>
+</context>
+<context>
+    <name>ENSPopup</name>
+    <message>
+        <source>Primary username</source>
+        <translation type="unfinished">主要用户名</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished">应用</translation>
+    </message>
+    <message>
+        <source>Your messages are displayed to others with this username:</source>
+        <translation type="unfinished">您的消息将以此用户名显示给其他人：</translation>
+    </message>
+    <message>
+        <source>Once you select a username, you won’t be able to disable it afterwards. You will only be able choose a different username to display.</source>
+        <translation type="unfinished">选择用户名后，您将无法再禁用它。您只能选择不同的用户名来显示。</translation>
+    </message>
+</context>
+<context>
+    <name>EditAirdropView</name>
+    <message>
+        <source>Airdrop %1 on %2</source>
+        <translation type="unfinished">在%2上进行空投%1</translation>
+    </message>
+    <message>
+        <source>What</source>
+        <translation type="unfinished">内容</translation>
+    </message>
+    <message>
+        <source>Example: 1 SOCK</source>
+        <translation type="unfinished">示例：1 SOCK</translation>
+    </message>
+    <message>
+        <source>First you need to mint or import an asset before you can perform an airdrop</source>
+        <translation type="unfinished">首先，您需要铸造或导入资产，然后才能执行空投。</translation>
+    </message>
+    <message>
+        <source>First you need to mint or import a collectible before you can perform an airdrop</source>
+        <translation type="unfinished">首先，您需要铸造或导入收藏品，然后才能执行空投。</translation>
+    </message>
+    <message>
+        <source>No members found</source>
+        <translation type="unfinished">未找到成员</translation>
+    </message>
+    <message>
+        <source>Show fees (will be enabled once the form is filled)</source>
+        <translation type="unfinished">显示费用（填写完表单后将启用）</translation>
+    </message>
+    <message>
+        <source>Add valid “What” and “To” values to see fees</source>
+        <translation type="unfinished">添加有效的“内容”和“接收者”值以查看费用</translation>
+    </message>
+    <message>
+        <source>Not enough tokens to send to all recipients. Reduce the number of recipients or change the number of tokens sent to each recipient.</source>
+        <translation type="unfinished">没有足够的代币发送给所有接收者。减少接收者的数量或更改每个接收者收到的代币数量。</translation>
+    </message>
+    <message>
+        <source>Create airdrop</source>
+        <translation type="unfinished">创建空投</translation>
+    </message>
+    <message numerus="yes">
+        <source>Sign transaction - Airdrop %n token(s)</source>
+        <translation type="unfinished">
+            <numerusform>签署交易 - 空投 %n 个代币</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>to %n recipient(s)</source>
+        <translation type="unfinished">
+            <numerusform>发送给 %n 位接收者</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>EditCommunityTokenView</name>
+    <message>
+        <source>Mint asset on %1</source>
+        <translation type="unfinished">在%1上铸造资产</translation>
+    </message>
+    <message>
+        <source>Mint collectible on %1</source>
+        <translation type="unfinished">在%1上铸造收藏品</translation>
+    </message>
+    <message>
+        <source>Icon</source>
+        <translation type="unfinished">图标</translation>
+    </message>
+    <message>
+        <source>Artwork</source>
+        <translation type="unfinished">艺术作品</translation>
+    </message>
+    <message>
+        <source>Upload</source>
+        <translation type="unfinished">上传</translation>
+    </message>
+    <message>
+        <source>Drag and Drop or Upload Artwork</source>
+        <translation type="unfinished">拖放或上传艺术作品</translation>
+    </message>
+    <message>
+        <source>Images only</source>
+        <translation type="unfinished">仅限图像</translation>
+    </message>
+    <message>
+        <source>Asset icon</source>
+        <translation type="unfinished">资产图标</translation>
+    </message>
+    <message>
+        <source>Collectible artwork</source>
+        <translation type="unfinished">收藏品艺术作品</translation>
+    </message>
+    <message>
+        <source>Upload asset icon</source>
+        <translation type="unfinished">上传资产图标</translation>
+    </message>
+    <message>
+        <source>Upload collectible artwork</source>
+        <translation type="unfinished">上传收藏品艺术作品</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message>
+        <source>Please name your token name (use A-Z and 0-9, hyphens and underscores only)</source>
+        <translation type="unfinished">请命名您的代币名称（仅使用A-Z、0-9、连字符和下划线）</translation>
+    </message>
+    <message>
+        <source>Your token name is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
+        <translation type="unfinished">您的代币名称太酷了（仅使用A-Z、0-9、连字符和下划线）</translation>
+    </message>
+    <message>
+        <source>Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
+        <translation type="unfinished">您的代币名称包含无效字符（仅使用A-Z、0-9、连字符和下划线）</translation>
+    </message>
+    <message>
+        <source>Asset name already exists</source>
+        <translation type="unfinished">资产名称已存在</translation>
+    </message>
+    <message>
+        <source>You have used this token name before</source>
+        <translation type="unfinished">您之前已经使用过此代币名称</translation>
+    </message>
+    <message>
+        <source>Description</source>
+        <translation type="unfinished">描述</translation>
+    </message>
+    <message>
+        <source>Describe your asset (will be shown in hodler&apos;s wallets)</source>
+        <translation type="unfinished">描述您的资产（将在持有者的钱包中显示）</translation>
+    </message>
+    <message>
+        <source>Describe your collectible (will be shown in hodler&apos;s wallets)</source>
+        <translation type="unfinished">描述您的收藏品（将在持有者的钱包中显示）</translation>
+    </message>
+    <message>
+        <source>Please enter a token description</source>
+        <translation type="unfinished">请输入代币描述</translation>
+    </message>
+    <message>
+        <source>Only A-Z, 0-9 and standard punctuation allowed</source>
+        <translation type="unfinished">仅允许使用A-Z、0-9和标准标点符号</translation>
+    </message>
+    <message>
+        <source>Symbol</source>
+        <translation type="unfinished">符号</translation>
+    </message>
+    <message>
+        <source>e.g. ETH</source>
+        <translation type="unfinished">例如：ETH</translation>
+    </message>
+    <message>
+        <source>e.g. DOODLE</source>
+        <translation type="unfinished">例如：DOODLE</translation>
+    </message>
+    <message>
+        <source>Please enter your token symbol (use A-Z only)</source>
+        <translation type="unfinished">请输入您的代币符号（仅使用A-Z）</translation>
+    </message>
+    <message>
+        <source>Your token symbol is too cool (use A-Z only)</source>
+        <translation type="unfinished">您的代币符号太酷了（仅使用A-Z）</translation>
+    </message>
+    <message>
+        <source>Your token symbol contains invalid characters (use A-Z only)</source>
+        <translation type="unfinished">您的代币符号包含无效字符（仅使用A-Z）</translation>
+    </message>
+    <message>
+        <source>Symbol already exists</source>
+        <translation type="unfinished">该符号已存在</translation>
+    </message>
+    <message>
+        <source>You have used this token symbol before</source>
+        <translation type="unfinished">您之前已经使用过此代币符号</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Unlimited supply</source>
+        <translation type="unfinished">无限供应</translation>
+    </message>
+    <message>
+        <source>Enable to allow the minting of additional tokens in the future. Disable to specify a finite supply</source>
+        <translation type="unfinished">启用以允许将来铸造更多代币。禁用以指定有限的供应量</translation>
+    </message>
+    <message>
+        <source>Total finite supply</source>
+        <translation type="unfinished">总有限供应量</translation>
+    </message>
+    <message>
+        <source>e.g. 300</source>
+        <translation type="unfinished">例如：300</translation>
+    </message>
+    <message>
+        <source>Please enter a total finite supply</source>
+        <translation type="unfinished">请输入总有限供应量</translation>
+    </message>
+    <message>
+        <source>Your total finite supply is too cool (use 0-9 only)</source>
+        <translation type="unfinished">您的总有限供应量太酷了（仅使用0-9）</translation>
+    </message>
+    <message>
+        <source>Your total finite supply contains invalid characters (use 0-9 only)</source>
+        <translation type="unfinished">您的总有限供应量包含无效字符（仅使用0-9）</translation>
+    </message>
+    <message>
+        <source>Enter a number between 1 and 999,999,999</source>
+        <translation type="unfinished">输入一个介于1和999,999,999之间的数字</translation>
+    </message>
+    <message>
+        <source>Not transferable (Soulbound)</source>
+        <translation type="unfinished">不可转让（灵魂绑定）</translation>
+    </message>
+    <message>
+        <source>Transferable</source>
+        <translation type="unfinished">可转让</translation>
+    </message>
+    <message>
+        <source>If enabled, the token is locked to the first address it is sent to and can never be transferred to another address. Useful for tokens that represent Admin permissions</source>
+        <translation type="unfinished">如果启用，该代币将锁定到它发送到的第一个地址，并且永远无法转移到另一个地址。适用于代表管理员权限的代币</translation>
+    </message>
+    <message>
+        <source>Remotely destructible</source>
+        <translation type="unfinished">可远程销毁</translation>
+    </message>
+    <message>
+        <source>Enable to allow you to destroy tokens remotely. Useful for revoking permissions from individuals</source>
+        <translation type="unfinished">启用以允许您远程销毁代币。适用于撤销个人的权限</translation>
+    </message>
+    <message>
+        <source>Show fees</source>
+        <translation type="unfinished">显示费用</translation>
+    </message>
+    <message>
+        <source>Fees will be enabled once the form is filled</source>
+        <translation type="unfinished">填写完表格后，将启用费用</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">预览</translation>
+    </message>
+</context>
+<context>
+    <name>EditCroppedImagePanel</name>
+    <message>
+        <source>Select different image</source>
+        <translation type="unfinished">选择不同的图像</translation>
+    </message>
+    <message>
+        <source>Remove image</source>
+        <translation type="unfinished">删除图像</translation>
+    </message>
+</context>
+<context>
+    <name>EditNetworkForm</name>
+    <message>
+        <source>Checking RPC...</source>
+        <translation type="unfinished">正在检查 RPC...</translation>
+    </message>
+    <message>
+        <source>What is %1? This isn’t a URL 😒</source>
+        <translation type="unfinished">这是什么？这不是一个 URL 😒</translation>
+    </message>
+    <message>
+        <source>RPC appears to be either offline or this is not a valid JSON RPC endpoint URL</source>
+        <translation type="unfinished">看起来 RPC 要么离线，要么不是有效的 JSON RPC 端点 URL。</translation>
+    </message>
+    <message>
+        <source>RPC successfully reached</source>
+        <translation type="unfinished">已成功连接到 RPC</translation>
+    </message>
+    <message>
+        <source>JSON RPC URLs are the same</source>
+        <translation type="unfinished">JSON RPC URL 相同</translation>
+    </message>
+    <message>
+        <source>Chain ID returned from JSON RPC doesn’t match %1</source>
+        <translation type="unfinished">从 JSON RPC 返回的链 ID 与 %1 不匹配</translation>
+    </message>
+    <message>
+        <source>Restart required for changes to take effect</source>
+        <translation type="unfinished">需要重新启动才能使更改生效</translation>
+    </message>
+    <message>
+        <source>Network name</source>
+        <translation type="unfinished">网络名称</translation>
+    </message>
+    <message>
+        <source>Short name</source>
+        <translation type="unfinished">简称</translation>
+    </message>
+    <message>
+        <source>Chain ID</source>
+        <translation type="unfinished">链 ID</translation>
+    </message>
+    <message>
+        <source>Native Token Symbol</source>
+        <translation type="unfinished">原生代币符号</translation>
+    </message>
+    <message>
+        <source>User JSON RPC URL #1</source>
+        <translation type="unfinished">用户 JSON RPC URL #1</translation>
+    </message>
+    <message>
+        <source>User JSON RPC URL #2</source>
+        <translation type="unfinished">用户 JSON RPC URL #2</translation>
+    </message>
+    <message>
+        <source>Block Explorer</source>
+        <translation type="unfinished">区块浏览器</translation>
+    </message>
+    <message>
+        <source>I understand that changing network settings can cause unforeseen issues, errors, security risks and potentially even loss of funds.</source>
+        <translation type="unfinished">我理解更改网络设置可能会导致无法预料的问题、错误、安全风险，甚至可能导致资金损失。</translation>
+    </message>
+    <message>
+        <source>Save Changes</source>
+        <translation type="unfinished">保存更改</translation>
+    </message>
+    <message>
+        <source>RPC URL change requires app restart</source>
+        <translation type="unfinished">RPC URL 更改需要重新启动应用程序</translation>
+    </message>
+    <message>
+        <source>For new JSON RPC URLs to take effect, Status must be restarted. Are you ready to do this now?</source>
+        <translation type="unfinished">为了使新的 JSON RPC URL 生效，必须重新启动 Status。您现在是否准备好执行此操作？</translation>
+    </message>
+    <message>
+        <source>Save and restart later</source>
+        <translation type="unfinished">稍后保存并重新启动</translation>
+    </message>
+    <message>
+        <source>Save and restart Status</source>
+        <translation type="unfinished">保存并重新启动 Status</translation>
+    </message>
+</context>
+<context>
+    <name>EditOwnerTokenView</name>
+    <message>
+        <source>This is the %1 Owner token. The hodler of this collectible has ultimate control over %1 Community token administration.</source>
+        <translation type="unfinished">这是%1所有者代币。持有此收藏品的人对%1社区代币管理拥有最终控制权。</translation>
+    </message>
+    <message>
+        <source>This is the %1 TokenMaster token. The hodler of this collectible has full admin rights for the %1 Community in Status and can mint and airdrop %1 Community tokens.</source>
+        <translation type="unfinished">这是%1 TokenMaster 代币。持有此收藏品的人在Status中对%1社区拥有完整的管理员权限，并且可以铸造和空投%1社区代币。</translation>
+    </message>
+    <message>
+        <source>Mint %1 Owner and TokenMaster tokens on %2</source>
+        <translation type="unfinished">在%2上铸造%1所有者和TokenMaster代币。</translation>
+    </message>
+    <message>
+        <source>Select account</source>
+        <translation type="unfinished">选择账户</translation>
+    </message>
+    <message>
+        <source>This account will be where you receive your Owner token and will also be the account that pays the token minting gas fees.</source>
+        <translation type="unfinished">您将在此处接收您的所有者代币，并且此帐户也将支付代币铸造的gas费用。</translation>
+    </message>
+    <message>
+        <source>Select network</source>
+        <translation type="unfinished">选择网络</translation>
+    </message>
+    <message>
+        <source>The network you select will be where all your community’s tokens reside. Once set, this setting can’t be changed and tokens can’t move to other networks.</source>
+        <translation type="unfinished">您选择的网络将是所有社区代币所在的网络。设置后，此设置无法更改，并且代币不能移动到其他网络。</translation>
+    </message>
+    <message>
+        <source>Mint</source>
+        <translation type="unfinished">铸造</translation>
+    </message>
+</context>
+<context>
+    <name>EditPermissionView</name>
+    <message>
+        <source>Anyone</source>
+        <translation type="unfinished">任何人</translation>
+    </message>
+    <message>
+        <source>Who holds</source>
+        <translation type="unfinished">拥有者</translation>
+    </message>
+    <message>
+        <source>Example: 10 SNT</source>
+        <translation type="unfinished">示例：10 SNT</translation>
+    </message>
+    <message>
+        <source>Is allowed to</source>
+        <translation type="unfinished">允许</translation>
+    </message>
+    <message>
+        <source>Example: View and post</source>
+        <translation type="unfinished">示例：查看和发布</translation>
+    </message>
+    <message>
+        <source>In</source>
+        <translation type="unfinished">在</translation>
+    </message>
+    <message>
+        <source>Example: `#general` channel</source>
+        <translation type="unfinished">示例：#general 频道</translation>
+    </message>
+    <message>
+        <source>Hide permission</source>
+        <translation type="unfinished">隐藏权限</translation>
+    </message>
+    <message>
+        <source>Make this permission hidden from members who don’t meet its requirements</source>
+        <translation type="unfinished">将此权限对不满足其要求的成员隐藏</translation>
+    </message>
+    <message>
+        <source>Permission with same properties is already active, edit properties to create a new permission.</source>
+        <translation type="unfinished">已存在具有相同属性的权限，请编辑属性以创建新权限。</translation>
+    </message>
+    <message>
+        <source>Any changes to community permissions will take effect after the control node receives and processes them</source>
+        <translation type="unfinished">社区权限的任何更改将在控制节点接收并处理后生效</translation>
+    </message>
+    <message>
+        <source>Create permission</source>
+        <translation type="unfinished">创建权限</translation>
+    </message>
+    <message>
+        <source>There was an error saving the permission: %1</source>
+        <translation type="unfinished">保存权限时发生错误：%1</translation>
+    </message>
+</context>
+<context>
+    <name>EditSlippagePanel</name>
+    <message>
+        <source>Slippage tolerance</source>
+        <translation type="unfinished">滑点容忍度</translation>
+    </message>
+    <message>
+        <source>Use default</source>
+        <translation type="unfinished">使用默认值</translation>
+    </message>
+    <message>
+        <source>Maximum deviation in price due to market volatility and liquidity allowed before the swap is cancelled. (%L1% default).</source>
+        <translation type="unfinished">在取消交易之前，允许因市场波动和流动性导致的最高价格偏差。（%L1% 默认）。</translation>
+    </message>
+    <message>
+        <source>Receive at least</source>
+        <translation type="unfinished">至少接收</translation>
+    </message>
+</context>
+<context>
+    <name>EmptyChatPanel</name>
+    <message>
+        <source>Share your profile</source>
+        <translation type="unfinished">分享您的个人资料</translation>
+    </message>
+    <message>
+        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.</source>
+        <translation type="unfinished">与朋友建立联系或邀请他们加入状态。</translation>
+    </message>
+</context>
+<context>
+    <name>EmptyPlaceholder</name>
+    <message>
+        <source>Loading gifs...</source>
+        <translation type="unfinished">正在加载 GIF...</translation>
+    </message>
+    <message>
+        <source>Favorite GIFs will appear here</source>
+        <translation type="unfinished">您喜欢的 GIF 将会显示在这里</translation>
+    </message>
+    <message>
+        <source>Recent GIFs will appear here</source>
+        <translation type="unfinished">最近使用的 GIF 将会显示在这里</translation>
+    </message>
+    <message>
+        <source>Error while contacting KLIPY API, please retry.</source>
+        <translation type="unfinished">联系 KLIPY API 时出错，请重试。</translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation type="unfinished">重试</translation>
+    </message>
+</context>
+<context>
+    <name>EnableBiometricsPage</name>
+    <message>
+        <source>Enable biometrics</source>
+        <translation type="unfinished">启用生物识别</translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished">稍后开启</translation>
+    </message>
+    <message>
+        <source>Use biometrics to fill in your password</source>
+        <translation type="unfinished">使用生物识别来填写您的密码</translation>
+    </message>
+    <message>
+        <source>Enable</source>
+        <translation type="unfinished">启用</translation>
+    </message>
+</context>
+<context>
+    <name>EnableBiometricsPopup</name>
+    <message>
+        <source>Enable biometrics</source>
+        <translation type="unfinished">启用生物识别</translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished">稍后开启</translation>
+    </message>
+    <message>
+        <source>Use biometrics to fill in your password</source>
+        <translation type="unfinished">使用生物识别来填写您的密码</translation>
+    </message>
+    <message>
+        <source>Enable</source>
+        <translation type="unfinished">启用</translation>
+    </message>
+</context>
+<context>
+    <name>EnableBiometricsPopupHandler</name>
+    <message>
+        <source>Biometric login and transaction authentication enabled for this device</source>
+        <translation type="unfinished">已为该设备启用生物识别登录和交易验证</translation>
+    </message>
+    <message>
+        <source>Biometric setup failed. Try again.</source>
+        <translation type="unfinished">生物识别设置失败。请重试。</translation>
+    </message>
+</context>
+<context>
+    <name>EnableFullMessageHistoryPopup</name>
+    <message>
+        <source>Enable full message history</source>
+        <translation type="unfinished">启用完整消息历史记录</translation>
+    </message>
+    <message>
+        <source>Enabling the Community History Service ensures every member can view the complete message history for all channels they have permission to view. Without this feature, message history will be limited to the last 30 days. Your computer, which is the control node for the community, must remain online for this to work.</source>
+        <translation type="unfinished">启用社区历史记录服务可确保每位成员都能查看他们有权访问的所有频道的完整消息历史记录。如果未启用此功能，消息历史记录将仅限于最近 30 天。作为社区控制节点的您的计算机必须保持在线状态才能使此功能正常工作。</translation>
+    </message>
+    <message>
+        <source>This service operates using the Archive Protocol, which will be automatically enabled using Logos Storage by default.</source>
+        <translation type="unfinished">该服务使用存档协议运行，默认情况下将自动启用 Logos 存储。</translation>
+    </message>
+    <message>
+        <source>Read more</source>
+        <translation type="unfinished">阅读更多</translation>
+    </message>
+    <message>
+        <source>Got it</source>
+        <translation type="unfinished">知道了</translation>
+    </message>
+</context>
+<context>
+    <name>EnableMessageBackupPopup</name>
+    <message>
+        <source>Skip</source>
+        <translation type="unfinished">跳过</translation>
+    </message>
+    <message>
+        <source>Enable</source>
+        <translation type="unfinished">启用</translation>
+    </message>
+    <message>
+        <source>Enable on-device message backup?</source>
+        <translation type="unfinished">启用设备端消息备份？</translation>
+    </message>
+    <message>
+        <source>Backups let you restore your 1-on-1, group, and community messages if you need to reinstall the app or switch devices. You can skip this step now and enable it anytime under: &lt;i&gt;Settings &gt; On-device backup &gt; Backup data&lt;/i&gt;</source>
+        <translation type="unfinished">如果需要重新安装应用程序或更换设备，备份可让您恢复一对一、群组和社区消息。您可以现在跳过此步骤，稍后在以下位置随时启用它：&lt;i&gt;设置 &gt; 设备端备份 &gt; 备份数据&lt;/i&gt;</translation>
+    </message>
+    <message>
+        <source>Enable on-device backup?</source>
+        <translation type="unfinished">启用设备端备份？</translation>
+    </message>
+    <message>
+        <source>On-device backups are:&lt;br&gt;&lt;b&gt;Automatic&lt;/b&gt; –  created every 30 minutes&lt;br&gt;&lt;b&gt;Secure&lt;/b&gt; – encrypted with your profile’s private key&lt;br&gt;&lt;b&gt;Private&lt;/b&gt; – stored only on your device</source>
+        <translation type="unfinished">设备端备份具有以下特点：&lt;br&gt;&lt;b&gt;自动&lt;/b&gt;——每 30 分钟创建一次&lt;br&gt;&lt;b&gt;安全&lt;/b&gt;——使用您的个人资料的私钥进行加密&lt;br&gt;&lt;b&gt;私密&lt;/b&gt;——仅存储在您的设备上</translation>
+    </message>
+    <message>
+        <source>To enable backups, choose a folder to store your backup files under the &lt;b&gt;Backup location&lt;/b&gt; setting.&lt;br&gt;&lt;br&gt;You can also &lt;b&gt;optionally&lt;/b&gt; back up your &lt;b&gt;1-on-1, group, and community messages&lt;/b&gt; by turning on the &lt;b&gt;Backup your messages&lt;/b&gt; toggle under the &lt;b&gt;Backup data&lt;/b&gt; setting.</source>
+        <translation type="unfinished">要启用备份，请在&lt;b&gt;备份位置&lt;/b&gt;设置下选择一个文件夹来存储您的备份文件。&lt;br&gt;&lt;br&gt;您还可以通过在&lt;b&gt;备份数据&lt;/b&gt;设置下打开&lt;b&gt;备份消息&lt;/b&gt;切换开关，&lt;b&gt;可选地&lt;/b&gt;备份您的&lt;b&gt;一对一、群组和社区消息&lt;/b&gt;。</translation>
+    </message>
+    <message>
+        <source>Go to settings</source>
+        <translation type="unfinished">转到设置</translation>
+    </message>
+</context>
+<context>
+    <name>EnablePushNotificationsPopup</name>
+    <message>
+        <source>Enable notifications</source>
+        <translation type="unfinished">启用通知</translation>
+    </message>
+    <message>
+        <source>Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished">接收您设备上的传入消息、提及和联系请求的通知提醒，以便您可以实时了解最新动态。随时在 &lt;b&gt;设置 → 通知&lt;/b&gt; 中自定义。&lt;br&gt;&lt;br&gt;Status 仅使用 APNs（Apple Push Notification 服务）来传递通知信号；您的端到端加密的消息内容不会通过该服务传输或存储。</translation>
+    </message>
+    <message>
+        <source>Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished">接收您设备上的传入消息、提及和联系请求的实时通知，以便您可以随时了解最新动态并回复或做出反应，而无需打开应用程序。随时在 &lt;b&gt;设置 → 通知&lt;/b&gt; 中自定义。&lt;br&gt;&lt;br&gt;Status 通过其设备上的后台服务传递通知，不涉及任何第三方、集中式服务器或中介。</translation>
+    </message>
+    <message>
+        <source>Don&apos;t ask me again</source>
+        <translation type="unfinished">不要再询问我</translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished">稍后开启</translation>
+    </message>
+    <message>
+        <source>Open settings</source>
+        <translation type="unfinished">打开设置</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+</context>
+<context>
+    <name>EnsAddedView</name>
+    <message>
+        <source>ENS usernames</source>
+        <translation type="unfinished">ENS用户名</translation>
+    </message>
+    <message>
+        <source>Username added</source>
+        <translation type="unfinished">已添加用户名</translation>
+    </message>
+    <message>
+        <source>%1 is now connected with your chat key and can be used in Status.</source>
+        <translation type="unfinished">现在，%1已与您的聊天密钥连接，并且可以在Status中使用。</translation>
+    </message>
+    <message>
+        <source>Ok, got it</source>
+        <translation type="unfinished">好的，明白了</translation>
+    </message>
+</context>
+<context>
+    <name>EnsConnectedView</name>
+    <message>
+        <source>ENS usernames</source>
+        <translation type="unfinished">ENS 用户名</translation>
+    </message>
+    <message>
+        <source>Username added</source>
+        <translation type="unfinished">用户名已添加</translation>
+    </message>
+    <message>
+        <source>%1 will be connected once the transaction is complete.</source>
+        <translation type="unfinished">交易完成后，系统将连接 %1。</translation>
+    </message>
+    <message>
+        <source>You can follow the progress in the Transaction History section of your wallet.</source>
+        <translation type="unfinished">您可以在钱包的“交易记录”部分中查看进度。</translation>
+    </message>
+    <message>
+        <source>Ok, got it</source>
+        <translation type="unfinished">好的，明白了</translation>
+    </message>
+</context>
+<context>
+    <name>EnsDetailsView</name>
+    <message>
+        <source>Wallet address</source>
+        <translation type="unfinished">钱包地址</translation>
+    </message>
+    <message>
+        <source>Copied to clipboard!</source>
+        <translation type="unfinished">已复制到剪贴板！</translation>
+    </message>
+    <message>
+        <source>Key</source>
+        <translation type="unfinished">密钥</translation>
+    </message>
+    <message>
+        <source>Remove username</source>
+        <translation type="unfinished">移除用户名</translation>
+    </message>
+    <message>
+        <source>Release username</source>
+        <translation type="unfinished">释放用户名</translation>
+    </message>
+    <message>
+        <source>Username locked. You won&apos;t be able to release it until %1</source>
+        <translation type="unfinished">用户名已被锁定。在%1之前，您将无法释放它。</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+</context>
+<context>
+    <name>EnsListView</name>
+    <message>
+        <source>ENS usernames</source>
+        <translation type="unfinished">ENS 用户名</translation>
+    </message>
+    <message>
+        <source>Add username</source>
+        <translation type="unfinished">添加用户名</translation>
+    </message>
+    <message>
+        <source>Your usernames</source>
+        <translation type="unfinished">您的用户名</translation>
+    </message>
+    <message>
+        <source>(pending)</source>
+        <translation type="unfinished">（待处理）</translation>
+    </message>
+    <message>
+        <source>Chat settings</source>
+        <translation type="unfinished">聊天设置</translation>
+    </message>
+    <message>
+        <source>Primary Username</source>
+        <translation type="unfinished">主要用户名</translation>
+    </message>
+    <message>
+        <source>None selected</source>
+        <translation type="unfinished">未选择</translation>
+    </message>
+    <message>
+        <source>Hey!</source>
+        <translation type="unfinished">嘿！</translation>
+    </message>
+    <message>
+        <source>You’re displaying your ENS username in chats</source>
+        <translation type="unfinished">您正在在聊天中显示您的 ENS 用户名</translation>
+    </message>
+</context>
+<context>
+    <name>EnsPanel</name>
+    <message>
+        <source>This condition has already been added</source>
+        <translation type="unfinished">此条件已添加</translation>
+    </message>
+    <message>
+        <source>This is not ENS name</source>
+        <translation type="unfinished">这不是 ENS 名称</translation>
+    </message>
+    <message>
+        <source>Put *. before ENS name to include all subdomains in permission</source>
+        <translation type="unfinished">在 ENS 名称前加上 *，以将所有子域包含在权限中</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">移除</translation>
+    </message>
+</context>
+<context>
+    <name>EnsRegisteredView</name>
+    <message>
+        <source>ENS usernames</source>
+        <translation type="unfinished">ENS 用户名</translation>
+    </message>
+    <message>
+        <source>Username added</source>
+        <translation type="unfinished">用户名已添加</translation>
+    </message>
+    <message>
+        <source>Nice! You own %1.stateofus.eth once the transaction is complete.</source>
+        <translation type="unfinished">太棒了！交易完成后，您将拥有 %1.stateofus.eth。</translation>
+    </message>
+    <message>
+        <source>You can follow the progress in the Transaction History section of your wallet.</source>
+        <translation type="unfinished">您可以在钱包的“交易记录”部分中查看进度。</translation>
+    </message>
+    <message>
+        <source>Ok, got it</source>
+        <translation type="unfinished">好的，明白了</translation>
+    </message>
+</context>
+<context>
+    <name>EnsReleasedView</name>
+    <message>
+        <source>ENS usernames</source>
+        <translation type="unfinished">ENS用户名</translation>
+    </message>
+    <message>
+        <source>Username removed</source>
+        <translation type="unfinished">已删除的用户名</translation>
+    </message>
+    <message>
+        <source>The username %1 will be removed and your deposit will be returned once the transaction is mined</source>
+        <translation type="unfinished">用户名%1将被删除，并且一旦交易被挖出，您的押金将退还</translation>
+    </message>
+    <message>
+        <source>You can follow the progress in the Transaction History section of your wallet.</source>
+        <translation type="unfinished">您可以在钱包的“交易记录”部分中查看进度。</translation>
+    </message>
+    <message>
+        <source>Ok, got it</source>
+        <translation type="unfinished">好的，明白了</translation>
+    </message>
+</context>
+<context>
+    <name>EnsSearchView</name>
+    <message>
+        <source>At least 4 characters. Latin letters, numbers, and lowercase only.</source>
+        <translation type="unfinished">至少 4 个字符。仅限拉丁字母、数字和小写字母。</translation>
+    </message>
+    <message>
+        <source>Letters and numbers only.</source>
+        <translation type="unfinished">仅限字母和数字。</translation>
+    </message>
+    <message>
+        <source>Type the entire username including the custom domain like username.domain.eth</source>
+        <translation type="unfinished">输入完整的用户名，包括自定义域名，例如 username.domain.eth</translation>
+    </message>
+    <message>
+        <source>Custom domain</source>
+        <translation type="unfinished">自定义域名</translation>
+    </message>
+    <message>
+        <source>I want a stateofus.eth domain</source>
+        <translation type="unfinished">我想要一个 stateofus.eth 域名</translation>
+    </message>
+    <message>
+        <source>I own a name on another domain</source>
+        <translation type="unfinished">我在其他域名上拥有一个名称</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+</context>
+<context>
+    <name>EnsTermsAndConditionsView</name>
+    <message>
+        <source>ENS usernames</source>
+        <translation type="unfinished">ENS 用户名</translation>
+    </message>
+    <message>
+        <source>Terms of name registration</source>
+        <translation type="unfinished">域名注册条款</translation>
+    </message>
+    <message>
+        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
+        <translation type="unfinished">资金将存入一年。您的 SNT 将被锁定，但不会被使用。</translation>
+    </message>
+    <message>
+        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
+        <translation type="unfinished">一年后，您可以释放域名并取回押金，或者不采取任何行动以保留该域名。</translation>
+    </message>
+    <message>
+        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
+        <translation type="unfinished">如果合同条款发生变化（例如，Status 进行合同升级），用户有权在任何时候释放用户名。</translation>
+    </message>
+    <message>
+        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
+        <translation type="unfinished">合约控制者无法访问您存入的资金。它们只能返回到发送它们的地址。</translation>
+    </message>
+    <message>
+        <source>Your address(es) will be publicly associated with your ENS name.</source>
+        <translation type="unfinished">您的地址将与您的 ENS 域名公开关联。</translation>
+    </message>
+    <message>
+        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
+        <translation type="unfinished">用户名作为 stateofus.eth 的子域节点创建，并受 ENS 智能合约条款约束。</translation>
+    </message>
+    <message>
+        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
+        <translation type="unfinished">您授权该合约代表您转移 SNT。这只能在您批准交易以授权转移时发生。</translation>
+    </message>
+    <message>
+        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
+        <translation type="unfinished">这些条款由以下地址的智能合约逻辑保证：</translation>
+    </message>
+    <message>
+        <source>%1 (Status UsernameRegistrar).</source>
+        <translation type="unfinished">%1（Status 用户名注册器）。</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
+        <translation type="unfinished">&lt;a href=&apos;%1/%2&apos;&gt;在 Etherscan 上查找&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>%1 (ENS Registry).</source>
+        <translation type="unfinished">%1（ENS 注册表）。</translation>
+    </message>
+    <message>
+        <source>Wallet address</source>
+        <translation type="unfinished">钱包地址</translation>
+    </message>
+    <message>
+        <source>Copied to clipboard!</source>
+        <translation type="unfinished">已复制到剪贴板！</translation>
+    </message>
+    <message>
+        <source>Key</source>
+        <translation type="unfinished">密钥</translation>
+    </message>
+    <message>
+        <source>Agree to &lt;a href=&quot;#&quot;&gt;Terms of name registration.&lt;/a&gt; I understand that my wallet address will be publicly connected to my username.</source>
+        <translation type="unfinished">同意 &lt;a href=&quot;#&quot;&gt;域名注册条款。&lt;/a&gt; 我理解我的钱包地址将与我的用户名公开关联。</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+    <message>
+        <source>10 SNT</source>
+        <translation type="unfinished">10 SNT</translation>
+    </message>
+    <message>
+        <source>Deposit</source>
+        <translation type="unfinished">存款</translation>
+    </message>
+    <message>
+        <source>Not enough SNT</source>
+        <translation type="unfinished">SNT 不足</translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation type="unfinished">注册</translation>
+    </message>
+</context>
+<context>
+    <name>EnsView</name>
+    <message>
+        <source>Release username</source>
+        <translation type="unfinished">释放用户名</translation>
+    </message>
+    <message>
+        <source>The account this username was bought with is no longer among active accounts.
+Please add it and try again.</source>
+        <translation type="unfinished">购买此用户名的帐户不再是活跃帐户。请添加它并重试。</translation>
+    </message>
+</context>
+<context>
+    <name>EnsWelcomeView</name>
+    <message>
+        <source>Get a universal username</source>
+        <translation type="unfinished">获取一个通用的用户名</translation>
+    </message>
+    <message>
+        <source>ENS names transform those crazy-long addresses into unique usernames.</source>
+        <translation type="unfinished">ENS 名称可以将那些冗长且复杂的地址转换为唯一的用户名。</translation>
+    </message>
+    <message>
+        <source>Customize your chat name</source>
+        <translation type="unfinished">自定义您的聊天名称</translation>
+    </message>
+    <message>
+        <source>An ENS name can replace your random 3-word name in chat. Be @yourname instead of %1.</source>
+        <translation type="unfinished">一个 ENS 名称可以替换您在聊天中的随机 3 个单词的名称。使用 @yourname，而不是 %1。</translation>
+    </message>
+    <message>
+        <source>Simplify your ETH address</source>
+        <translation type="unfinished">简化您的以太坊地址</translation>
+    </message>
+    <message>
+        <source>You can receive funds to your easy-to-share ENS name rather than your hexadecimal hash (0x...).</source>
+        <translation type="unfinished">您可以将资金发送到易于共享的 ENS 名称，而不是十六进制哈希值（0x...）。</translation>
+    </message>
+    <message>
+        <source>Receive transactions in chat</source>
+        <translation type="unfinished">在聊天中接收交易</translation>
+    </message>
+    <message>
+        <source>Others can send you funds via chat in one simple step.</source>
+        <translation type="unfinished">其他人可以通过简单的步骤通过聊天向您发送资金。</translation>
+    </message>
+    <message>
+        <source>10 SNT to register</source>
+        <translation type="unfinished">注册需要 10 SNT</translation>
+    </message>
+    <message>
+        <source>Register once to keep the name forever. After 1 year you can release the name and get your SNT back.</source>
+        <translation type="unfinished">只需注册一次即可永久保留该名称。一年后，您可以释放该名称并取回您的 SNT。</translation>
+    </message>
+    <message>
+        <source>Already own a username?</source>
+        <translation type="unfinished">您已经拥有用户名吗？</translation>
+    </message>
+    <message>
+        <source>You can verify and add any usernames you own in the next steps.</source>
+        <translation type="unfinished">您可以在接下来的步骤中验证和添加您拥有的任何用户名。</translation>
+    </message>
+    <message>
+        <source>Powered by Ethereum Name Services</source>
+        <translation type="unfinished">由以太坊域名服务提供支持</translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation type="unfinished">开始</translation>
+    </message>
+</context>
+<context>
+    <name>EnterKeyPairNameState</name>
+    <message>
+        <source>Name your key pair</source>
+        <translation type="unfinished">为您的密钥对命名</translation>
+    </message>
+    <message>
+        <source>What would you like this key pair to be called?</source>
+        <translation type="unfinished">您希望将此密钥对命名为什么？</translation>
+    </message>
+</context>
+<context>
+    <name>EnterKeypairName</name>
+    <message>
+        <source>Key name</source>
+        <translation type="unfinished">密钥名称</translation>
+    </message>
+    <message>
+        <source>Enter a name</source>
+        <translation type="unfinished">输入名称</translation>
+    </message>
+    <message numerus="yes">
+        <source>Key pair name must be at least %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>密钥对名称必须至少为 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>For your future reference. This is only visible to you.</source>
+        <translation type="unfinished">仅供您参考。此信息仅对您可见。</translation>
+    </message>
+</context>
+<context>
+    <name>EnterPairingPassword</name>
+    <message>
+        <source>Enter Keycard pairing password</source>
+        <translation type="unfinished">输入密钥卡配对密码</translation>
+    </message>
+    <message>
+        <source>This Keycard was set up with a custom pairing password. Enter it to continue.</source>
+        <translation type="unfinished">此密钥卡已设置为自定义配对密码。请输入以继续。</translation>
+    </message>
+    <message>
+        <source>Pairing password</source>
+        <translation type="unfinished">配对密码</translation>
+    </message>
+    <message>
+        <source>Pairing password incorrect</source>
+        <translation type="unfinished">配对密码不正确</translation>
+    </message>
+</context>
+<context>
+    <name>EnterPassword</name>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished">密码</translation>
+    </message>
+    <message>
+        <source>Enter your password</source>
+        <translation type="unfinished">输入您的密码</translation>
+    </message>
+    <message>
+        <source>Password incorrect</source>
+        <translation type="unfinished">密码不正确</translation>
+    </message>
+</context>
+<context>
+    <name>EnterPin</name>
+    <message>
+        <source>Authorization required</source>
+        <translation type="unfinished">需要授权</translation>
+    </message>
+    <message>
+        <source>This key pair is not stored on your Keycard. Authorize with your profile
+to sign using the keys stored on this device.</source>
+        <translation type="unfinished">此密钥对未存储在您的密钥卡上。使用您的个人资料进行授权，以便使用存储在此设备上的密钥进行签名。</translation>
+    </message>
+    <message>
+        <source>Authorize</source>
+        <translation type="unfinished">授权</translation>
+    </message>
+    <message>
+        <source>PIN incorrect</source>
+        <translation type="unfinished">密码错误</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n attempt(s) remaining</source>
+        <translation type="unfinished">
+            <numerusform>剩余 %n 次尝试</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Enter the Keycard PIN</source>
+        <translation type="unfinished">输入密钥卡密码</translation>
+    </message>
+</context>
+<context>
+    <name>EnterPinState</name>
+    <message>
+        <source>PIN incorrect</source>
+        <translation type="unfinished">密码错误</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n attempt(s) remaining</source>
+        <translation type="unfinished">
+            <numerusform>剩余 %n 次尝试</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>PIN doesn&apos;t match</source>
+        <translation type="unfinished">密码不匹配</translation>
+    </message>
+    <message>
+        <source>Enter new PIN</source>
+        <translation type="unfinished">输入新密码</translation>
+    </message>
+    <message>
+        <source>Repeat new PIN</source>
+        <translation type="unfinished">重复输入新密码</translation>
+    </message>
+    <message>
+        <source>Enter Keycard PIN</source>
+        <translation type="unfinished">输入密钥卡密码</translation>
+    </message>
+</context>
+<context>
+    <name>EnterPrivateKey</name>
+    <message>
+        <source>Private key</source>
+        <translation type="unfinished">私钥</translation>
+    </message>
+    <message>
+        <source>Enter recovery phrase for %1 key pair</source>
+        <translation type="unfinished">输入用于%1密钥对的助记词</translation>
+    </message>
+    <message>
+        <source>Type or paste your private key</source>
+        <translation type="unfinished">输入或粘贴您的私钥</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+    <message>
+        <source>Private key invalid</source>
+        <translation type="unfinished">私钥无效</translation>
+    </message>
+    <message>
+        <source>This is not the correct private key</source>
+        <translation type="unfinished">这不是正确的私钥</translation>
+    </message>
+    <message>
+        <source>New addresses cannot be derived from an account imported from a private key. Import using a recovery phrase if you wish to derive addresses.</source>
+        <translation type="unfinished">从导入的私钥帐户无法生成新的地址。如果您想生成地址，请使用助记词进行导入。</translation>
+    </message>
+    <message>
+        <source>Public address of private key</source>
+        <translation type="unfinished">私钥的公钥地址</translation>
+    </message>
+    <message>
+        <source>Key name</source>
+        <translation type="unfinished">密钥名称</translation>
+    </message>
+    <message>
+        <source>Enter a name</source>
+        <translation type="unfinished">输入名称</translation>
+    </message>
+    <message numerus="yes">
+        <source>Key pair name must be at least %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>密钥对名称必须至少为%n个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>For your future reference. This is only visible to you.</source>
+        <translation type="unfinished">仅供您参考。此信息仅对您可见。</translation>
+    </message>
+</context>
+<context>
+    <name>EnterPukState</name>
+    <message>
+        <source>Repeat your Keycard PUK</source>
+        <translation type="unfinished">请再次输入您的密钥卡 PUK</translation>
+    </message>
+    <message>
+        <source>Choose a Keycard PUK</source>
+        <translation type="unfinished">选择一个密钥卡 PUK</translation>
+    </message>
+    <message>
+        <source>Use numbers only</source>
+        <translation type="unfinished">仅使用数字</translation>
+    </message>
+    <message>
+        <source>PUK doesn&apos;t match</source>
+        <translation type="unfinished">PUK 不匹配</translation>
+    </message>
+    <message>
+        <source>Enter PUK</source>
+        <translation type="unfinished">输入 PUK</translation>
+    </message>
+</context>
+<context>
+    <name>EnterSeedPhrase</name>
+    <message>
+        <source>The phrase you’ve entered is invalid</source>
+        <translation type="unfinished">您输入的短语无效</translation>
+    </message>
+    <message>
+        <source>Enter recovery phrase</source>
+        <translation type="unfinished">输入助记词</translation>
+    </message>
+    <message>
+        <source>Enter private key for %1 key pair</source>
+        <translation type="unfinished">输入用于%1密钥对的私钥</translation>
+    </message>
+    <message>
+        <source>The entered recovery phrase is already added</source>
+        <translation type="unfinished">已添加的助记词不能重复使用</translation>
+    </message>
+    <message>
+        <source>This is not the correct recovery phrase for %1 key</source>
+        <translation type="unfinished">这不是适用于%1密钥的正确助记词</translation>
+    </message>
+    <message>
+        <source>Key name</source>
+        <translation type="unfinished">密钥名称</translation>
+    </message>
+    <message>
+        <source>Enter a name</source>
+        <translation type="unfinished">输入名称</translation>
+    </message>
+    <message numerus="yes">
+        <source>Key pair name must be at least %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>密钥对名称必须至少为%n个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>For your future reference. This is only visible to you.</source>
+        <translation type="unfinished">仅供您参考。此信息仅对您可见。</translation>
+    </message>
+</context>
+<context>
+    <name>EnterSeedPhraseState</name>
+    <message>
+        <source>Enter recovery phrase</source>
+        <translation type="unfinished">输入助记词</translation>
+    </message>
+    <message>
+        <source>Invalid recovery phrase</source>
+        <translation type="unfinished">无效的助记词</translation>
+    </message>
+</context>
+<context>
+    <name>EnterSeedPhraseWord</name>
+    <message>
+        <source>Step %1 of 4</source>
+        <translation type="unfinished">第 4 步中的第 %1 步</translation>
+    </message>
+    <message>
+        <source>Confirm word #%1 of your recovery phrase</source>
+        <translation type="unfinished">确认您的助记词中的第 %1 个单词</translation>
+    </message>
+    <message>
+        <source>Word #%1</source>
+        <translation type="unfinished">第 %1 个单词</translation>
+    </message>
+    <message>
+        <source>Enter word</source>
+        <translation type="unfinished">输入单词</translation>
+    </message>
+    <message>
+        <source>Incorrect word</source>
+        <translation type="unfinished">单词不正确</translation>
+    </message>
+</context>
+<context>
+    <name>ErrorDetails</name>
+    <message>
+        <source>Show error details</source>
+        <translation type="unfinished">显示错误详情</translation>
+    </message>
+</context>
+<context>
+    <name>ExemptionNotificationsModal</name>
+    <message>
+        <source>%1 exemption</source>
+        <translation type="unfinished">%1 次豁免</translation>
+    </message>
+    <message>
+        <source>Mute all messages</source>
+        <translation type="unfinished">静音所有消息</translation>
+    </message>
+    <message>
+        <source>Personal @ Mentions</source>
+        <translation type="unfinished">个人@提及</translation>
+    </message>
+    <message>
+        <source>Global @ Mentions</source>
+        <translation type="unfinished">全局@提及</translation>
+    </message>
+    <message>
+        <source>Other Messages</source>
+        <translation type="unfinished">其他消息</translation>
+    </message>
+    <message>
+        <source>Clear Exemptions</source>
+        <translation type="unfinished">清除豁免</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+</context>
+<context>
+    <name>ExemptionsView</name>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>1:1 Chat</source>
+        <translation type="unfinished">一对一聊天</translation>
+    </message>
+    <message>
+        <source>Group Chat</source>
+        <translation type="unfinished">群聊</translation>
+    </message>
+    <message>
+        <source>Muted</source>
+        <translation type="unfinished">已静音</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Quiet</source>
+        <translation type="unfinished">安静</translation>
+    </message>
+    <message>
+        <source>Personal @ Mentions %1</source>
+        <translation type="unfinished">个人@提及 %1</translation>
+    </message>
+    <message>
+        <source>Global @ Mentions %1</source>
+        <translation type="unfinished">全局@提及 %1</translation>
+    </message>
+    <message>
+        <source>Alerts</source>
+        <translation type="unfinished">提醒</translation>
+    </message>
+    <message>
+        <source>Other Messages %1</source>
+        <translation type="unfinished">其他消息 %1</translation>
+    </message>
+    <message>
+        <source>Multiple Exemptions</source>
+        <translation type="unfinished">多个免除</translation>
+    </message>
+</context>
+<context>
+    <name>ExportControlNodePopup</name>
+    <message>
+        <source>How to move the %1 control node to another device</source>
+        <translation type="unfinished">如何将%1控制节点移动到另一台设备</translation>
+    </message>
+    <message>
+        <source>Any of your synced &lt;b&gt;desktop&lt;/b&gt; devices can be the control node for this Community:</source>
+        <translation type="unfinished">您同步的任何&lt;b&gt;桌面&lt;/b&gt;设备都可以成为此社区的控制节点：</translation>
+    </message>
+    <message>
+        <source>You don’t currently have any &lt;b&gt;synced desktop devices&lt;/b&gt;. You will need to sync another desktop device before you can move the %1 control node to it. Does the device you want to use as the control node currently have Status installed?</source>
+        <translation type="unfinished">您当前没有&lt;b&gt;同步的桌面设备&lt;/b&gt;。在将%1控制节点移动到该设备之前，您需要同步另一台桌面设备。您想要用作控制节点的设备是否已安装Status？</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Control node (this device)</source>
+        <translation type="unfinished">控制节点（此设备）</translation>
+    </message>
+    <message>
+        <source>Not eligible (desktop only)</source>
+        <translation type="unfinished">不符合条件（仅限桌面）</translation>
+    </message>
+    <message>
+        <source>1. On the device you want to make the control node &lt;font color=&apos;%1&apos;&gt;login using this profile&lt;/font&gt;</source>
+        <translation type="unfinished">1. 在您想要设为控制节点的设备上&lt;font color=&apos;%1&apos;&gt;使用此配置文件登录&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <source>2. Go to</source>
+        <translation type="unfinished">2. 转到</translation>
+    </message>
+    <message>
+        <source>%1 Admin Overview</source>
+        <translation type="unfinished">%1管理员概览</translation>
+    </message>
+    <message>
+        <source>3. Click &lt;font color=&apos;%1&apos;&gt;Make this device the control node&lt;/font&gt;</source>
+        <translation type="unfinished">3. 点击&lt;font color=&apos;%1&apos;&gt;将此设备设为控制节点&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <source>Status installed on other device</source>
+        <translation type="unfinished">其他设备已安装Status</translation>
+    </message>
+    <message>
+        <source>Status not installed on other device</source>
+        <translation type="unfinished">其他设备未安装Status</translation>
+    </message>
+    <message>
+        <source>On this device...</source>
+        <translation type="unfinished">在此设备上...</translation>
+    </message>
+    <message>
+        <source>1. Go to</source>
+        <translation type="unfinished">1. 转到</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message>
+        <source>Syncing</source>
+        <translation type="unfinished">同步中</translation>
+    </message>
+    <message>
+        <source>3. Click &lt;font color=&apos;%1&apos;&gt;Setup Syncing&lt;/font&gt; and sync your other devices</source>
+        <translation type="unfinished">3. 点击&lt;font color=&apos;%1&apos;&gt;设置同步&lt;/font&gt;并同步您的其他设备</translation>
+    </message>
+    <message>
+        <source>4. Click &lt;font color=&apos;%1&apos;&gt;How to move control node&lt;/font&gt; again for next instructions</source>
+        <translation type="unfinished">4. 再次点击&lt;font color=&apos;%1&apos;&gt;如何移动控制节点&lt;/font&gt;以获取后续说明</translation>
+    </message>
+    <message>
+        <source>1. Install and launch Status on the device you want to use as the control node</source>
+        <translation type="unfinished">1. 在您想要用作控制节点的设备上安装并启动Status</translation>
+    </message>
+    <message>
+        <source>2. On that device, click &lt;font color=&apos;%1&apos;&gt;I already use Status&lt;/font&gt;</source>
+        <translation type="unfinished">2. 在该设备上，点击&lt;font color=&apos;%1&apos;&gt;我已使用Status&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <source>3. Click &lt;font color=&apos;%1&apos;&gt;Scan or enter sync code&lt;/font&gt; and sync your new device</source>
+        <translation type="unfinished">3. 点击&lt;font color=&apos;%1&apos;&gt;扫描或输入同步代码&lt;/font&gt;并同步您的新设备</translation>
+    </message>
+</context>
+<context>
+    <name>ExportKeypair</name>
+    <message>
+        <source>Authenticate to create a QR code</source>
+        <translation type="unfinished">验证以创建二维码</translation>
+    </message>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished">验证</translation>
+    </message>
+    <message>
+        <source>Encrypted key pairs code</source>
+        <translation type="unfinished">加密密钥对代码</translation>
+    </message>
+    <message>
+        <source>On your other device, navigate to the Wallet screen&lt;br&gt;and select ‘Import missing key pairs’. For security reasons,&lt;br&gt;do not save this code anywhere.</source>
+        <translation type="unfinished">在您的其他设备上，导航到“钱包”屏幕并选择“导入缺失的密钥对”。出于安全原因，请不要将此代码保存在任何地方。</translation>
+    </message>
+    <message>
+        <source>Your QR and encrypted key pairs code have expired.</source>
+        <translation type="unfinished">您的二维码和加密密钥对代码已过期。</translation>
+    </message>
+    <message>
+        <source>Failed to generate sync code</source>
+        <translation type="unfinished">同步码生成失败</translation>
+    </message>
+    <message>
+        <source>Failed to start pairing server</source>
+        <translation type="unfinished">配对服务器启动失败</translation>
+    </message>
+</context>
+<context>
+    <name>ExtendedDropdownContent</name>
+    <message>
+        <source>No data found</source>
+        <translation type="unfinished">未找到数据</translation>
+    </message>
+    <message>
+        <source>Most viewed</source>
+        <translation type="unfinished">最多浏览</translation>
+    </message>
+    <message>
+        <source>Newest first</source>
+        <translation type="unfinished">最新优先</translation>
+    </message>
+    <message>
+        <source>Oldest first</source>
+        <translation type="unfinished">最旧优先</translation>
+    </message>
+    <message>
+        <source>List</source>
+        <translation type="unfinished">列表</translation>
+    </message>
+    <message>
+        <source>Thumbnails</source>
+        <translation type="unfinished">缩略图</translation>
+    </message>
+    <message>
+        <source>Search all listed assets</source>
+        <translation type="unfinished">搜索所有已列出的资产</translation>
+    </message>
+    <message>
+        <source>Search assets</source>
+        <translation type="unfinished">搜索资产</translation>
+    </message>
+    <message>
+        <source>Search all collectibles</source>
+        <translation type="unfinished">搜索所有收藏品</translation>
+    </message>
+    <message>
+        <source>Search collectibles</source>
+        <translation type="unfinished">搜索收藏品</translation>
+    </message>
+    <message>
+        <source>Search %1</source>
+        <translation type="unfinished">搜索 %1</translation>
+    </message>
+    <message>
+        <source>Any %1</source>
+        <translation type="unfinished">任意 %1</translation>
+    </message>
+    <message>
+        <source>Mint asset</source>
+        <translation type="unfinished">铸造资产</translation>
+    </message>
+    <message>
+        <source>Mint collectible</source>
+        <translation type="unfinished">铸造收藏品</translation>
+    </message>
+</context>
+<context>
+    <name>FactoryResetConfirmationState</name>
+    <message>
+        <source>A factory reset will delete the key on this Keycard.
+Are you sure you want to do this?</source>
+        <translation type="unfinished">恢复出厂设置将删除此密钥卡上的密钥。
+您确定要执行此操作吗？</translation>
+    </message>
+    <message>
+        <source>I understand the key pair on this Keycard will be deleted</source>
+        <translation type="unfinished">我理解此密钥卡上的密钥对将被删除</translation>
+    </message>
+</context>
+<context>
+    <name>FavoriteMenu</name>
+    <message>
+        <source>Open in new Tab</source>
+        <translation type="unfinished">在新标签页中打开</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">编辑</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">移除</translation>
+    </message>
+</context>
+<context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished">最大</translation>
+    </message>
+</context>
+<context>
+    <name>FeesBox</name>
+    <message>
+        <source>Fees</source>
+        <translation type="unfinished">费用</translation>
+    </message>
+    <message>
+        <source>Select account to pay gas fees from</source>
+        <translation type="unfinished">选择用于支付 Gas 费用的账户</translation>
+    </message>
+</context>
+<context>
+    <name>FeesBoxFooter</name>
+    <message>
+        <source>Total</source>
+        <translation type="unfinished">总计</translation>
+    </message>
+</context>
+<context>
+    <name>FeesSummaryFooter</name>
+    <message>
+        <source>via %1</source>
+        <translation type="unfinished">通过 %1</translation>
+    </message>
+    <message>
+        <source>Total</source>
+        <translation type="unfinished">总计</translation>
+    </message>
+</context>
+<context>
+    <name>FilterComboBox</name>
+    <message>
+        <source>Collection</source>
+        <translation type="unfinished">收藏</translation>
+    </message>
+    <message>
+        <source>Collection, community, name or #</source>
+        <translation type="unfinished">收藏、社区、名称或#</translation>
+    </message>
+    <message>
+        <source>Community minted</source>
+        <translation type="unfinished">社区铸造</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">其他</translation>
+    </message>
+    <message>
+        <source>Collections</source>
+        <translation type="unfinished">收藏集</translation>
+    </message>
+    <message>
+        <source>No collection</source>
+        <translation type="unfinished">没有收藏</translation>
+    </message>
+</context>
+<context>
+    <name>FinaliseOwnershipDeclinePopup</name>
+    <message>
+        <source>Are you sure you don’t want to be the owner?</source>
+        <translation type="unfinished">您确定不想成为所有者吗？</translation>
+    </message>
+    <message>
+        <source>If you don’t want to be the owner of the %1 Community it is important that you let the previous owner know so they can organise another owner to take over. You will have to send the Owner token back to them or on to the next designated owner.</source>
+        <translation type="unfinished">如果您不想成为%1社区的所有者，重要的是您要告知之前的拥有者，以便他们可以安排另一位所有者接管。您需要将所有者令牌返还给他们或发送给下一位指定的拥有者。</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>I don&apos;t want to be the owner</source>
+        <translation type="unfinished">我不想成为所有者</translation>
+    </message>
+</context>
+<context>
+    <name>FinaliseOwnershipPopup</name>
+    <message>
+        <source>Update %1 Community smart contract on %2</source>
+        <translation type="unfinished">在%2上更新%1社区智能合约</translation>
+    </message>
+    <message>
+        <source>Finalise %1 ownership</source>
+        <translation type="unfinished">完成%1的所有权</translation>
+    </message>
+    <message>
+        <source>Make this device the control node and update smart contract</source>
+        <translation type="unfinished">将此设备设为控制节点并更新智能合约</translation>
+    </message>
+    <message>
+        <source>I don&apos;t want to be the owner</source>
+        <translation type="unfinished">我不想成为所有者</translation>
+    </message>
+    <message>
+        <source>Congratulations! You have been sent the %1 Community Owner token.</source>
+        <translation type="unfinished">恭喜！您已收到%1社区所有者代币。</translation>
+    </message>
+    <message>
+        <source>To finalise your ownership and assume ultimate admin rights for the %1 Community, you need to make your device the Community&apos;s &lt;a style=&quot;color:%3;&quot; href=&quot;%2&quot;&gt;control node&lt;/a&gt;&lt;a style=&quot;color:%3;text-decoration: none&quot; href=&quot;%2&quot;&gt;↗&lt;/a&gt;. You will also need to sign a small transaction to update the %1 Community smart contract to make you the official signatory for all Community changes.</source>
+        <translation type="unfinished">要最终确定您的所有权并获得%1社区的最高管理员权限，您需要将您的设备设为该社区的&lt;a style=&quot;color:%3;&quot; href=&quot;%2&quot;&gt;控制节点&lt;/a&gt;&lt;a style=&quot;color:%3;text-decoration: none&quot; href=&quot;%2&quot;&gt;↗&lt;/a&gt;。您还需要签署一小笔交易，以更新%1社区智能合约，使您成为所有社区更改的正式签名人。</translation>
+    </message>
+    <message>
+        <source>Symbol</source>
+        <translation type="unfinished">符号</translation>
+    </message>
+    <message>
+        <source>Visit Community</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>Finalising your ownership of the %1 Community requires you to:</source>
+        <translation type="unfinished">最终确定您对%1社区的所有权需要您执行以下操作：</translation>
+    </message>
+    <message>
+        <source>1. Make this device the control node for the Community</source>
+        <translation type="unfinished">1. 将此设备设为该社区的控制节点</translation>
+    </message>
+    <message>
+        <source>It is vital to keep your device online and running Status in order for the Community to operate effectively. Login with this account via another synced desktop device if you think it might be better suited for this purpose.</source>
+        <translation type="unfinished">为了使社区有效运行，必须保持您的设备在线并运行Status。如果您认为其他同步的桌面设备可能更适合此目的，请使用此帐户通过该设备登录。</translation>
+    </message>
+    <message>
+        <source>2. Update the %1 Community smart contract</source>
+        <translation type="unfinished">2. 更新%1社区智能合约</translation>
+    </message>
+    <message>
+        <source>This transaction updates the %1 Community smart contract, making you the %1 Community owner.</source>
+        <translation type="unfinished">此交易将更新%1社区智能合约，使您成为%1社区的所有者。</translation>
+    </message>
+    <message>
+        <source>Show fees (will be enabled once acknowledge confirmed)</source>
+        <translation type="unfinished">显示费用（在确认同意后启用）</translation>
+    </message>
+    <message>
+        <source>Gas fees will be paid from</source>
+        <translation type="unfinished">燃气费将从以下账户支付</translation>
+    </message>
+    <message>
+        <source>I acknowledge that I must keep this device online and running Status as much of the time as possible for the %1 Community to operate effectively</source>
+        <translation type="unfinished">我确认，为了使%1社区有效运行，我必须尽可能长时间地保持此设备在线并运行Status。</translation>
+    </message>
+</context>
+<context>
+    <name>FirstTokenReceivedPopup</name>
+    <message>
+        <source>Congratulations on receiving your first community asset: &lt;br&gt;&lt;b&gt;%1 %2 (%3) minted by %4&lt;/b&gt;. Community assets are assets that have been minted by a community. As these assets cannot be verified, always double check their origin and validity before interacting with them. If in doubt, ask a trusted member or admin of the relevant community.</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>Congratulations on receiving your first community collectible: &lt;br&gt;&lt;b&gt;%1 %2 minted by %3&lt;/b&gt;. Community collectibles are collectibles that have been minted by a community. As these collectibles cannot be verified, always double check their origin and validity before interacting with them. If in doubt, ask a trusted member or admin of the relevant community.</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>Visit Community</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>You received your first community asset</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>You received your first community collectible</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>Hide this asset</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>Hide this collectible</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>Got it!</source>
+        <translation type="unfinished">知道了！</translation>
+    </message>
+</context>
+<context>
+    <name>FleetRadioSelector</name>
+    <message>
+        <source>Warning!</source>
+        <translation type="unfinished">警告！</translation>
+    </message>
+    <message>
+        <source>Change fleet to %1</source>
+        <translation type="unfinished">更改舰队为 %1</translation>
+    </message>
+</context>
+<context>
+    <name>FleetsModal</name>
+    <message>
+        <source>Fleet</source>
+        <translation type="unfinished">舰队</translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddressMenu</name>
+    <message>
+        <source>Address copied</source>
+        <translation type="unfinished">地址已复制</translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished">复制地址</translation>
+    </message>
+    <message>
+        <source>Show address QR</source>
+        <translation type="unfinished">显示地址二维码</translation>
+    </message>
+    <message>
+        <source>Add to saved addresses</source>
+        <translation type="unfinished">添加到已保存的地址</translation>
+    </message>
+    <message>
+        <source>Remove from saved addresses</source>
+        <translation type="unfinished">从已保存的地址中移除</translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddresses</name>
+    <message>
+        <source>Search for name, ENS or address</source>
+        <translation type="unfinished">搜索名称、ENS 或地址</translation>
+    </message>
+    <message>
+        <source>No following addresses found. Check spelling or whether the address is correct.</source>
+        <translation type="unfinished">未找到任何关注的地址。请检查拼写或地址是否正确。</translation>
+    </message>
+    <message>
+        <source>No onchain follows yet. Find and follow Ethereum accounts on %1 to see them here.</source>
+        <translation type="unfinished">目前还没有链上关注。在 %1 上查找并关注以太坊帐户，以便在此处查看它们。</translation>
+    </message>
+    <message>
+        <source>Ethereum Follow Protocol</source>
+        <translation type="unfinished">以太坊关注协议</translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddressesDelegate</name>
+    <message>
+        <source>Remove from saved addresses</source>
+        <translation type="unfinished">从已保存的地址中移除</translation>
+    </message>
+    <message>
+        <source>Add to saved addresses</source>
+        <translation type="unfinished">添加到已保存的地址</translation>
+    </message>
+</context>
+<context>
+    <name>GapComponent</name>
+    <message>
+        <source>Fetch messages</source>
+        <translation type="unfinished">获取消息</translation>
+    </message>
+    <message>
+        <source>Between %1 and %2</source>
+        <translation type="unfinished">在%1和%2之间</translation>
+    </message>
+</context>
+<context>
+    <name>GetSyncCodeDesktopInstructions</name>
+    <message>
+        <source>Ensure both devices are on the same network</source>
+        <translation type="unfinished">请确保两台设备连接到同一网络</translation>
+    </message>
+    <message>
+        <source>Open Status on the device you want to import from</source>
+        <translation type="unfinished">在您要从中导入数据的设备上打开 Status</translation>
+    </message>
+    <message>
+        <source>Open Status App on your desktop device</source>
+        <translation type="unfinished">在您的桌面设备上打开状态应用程序</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">打开</translation>
+    </message>
+    <message>
+        <source>Settings / Wallet</source>
+        <translation type="unfinished">设置/钱包</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message>
+        <source>Click</source>
+        <translation type="unfinished">点击</translation>
+    </message>
+    <message>
+        <source>Navigate to the</source>
+        <translation type="unfinished">导航到</translation>
+    </message>
+    <message>
+        <source>Show encrypted QR of key pairs on this device</source>
+        <translation type="unfinished">在此设备上显示加密的密钥对二维码</translation>
+    </message>
+    <message>
+        <source>Syncing tab</source>
+        <translation type="unfinished">同步选项卡</translation>
+    </message>
+    <message>
+        <source>Copy the</source>
+        <translation type="unfinished">复制</translation>
+    </message>
+    <message>
+        <source>encrypted key pairs code</source>
+        <translation type="unfinished">加密密钥对代码</translation>
+    </message>
+    <message>
+        <source>on this device</source>
+        <translation type="unfinished">到此设备上</translation>
+    </message>
+    <message>
+        <source>Setup Syncing</source>
+        <translation type="unfinished">设置同步</translation>
+    </message>
+    <message>
+        <source>Paste the</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+    <message>
+        <source>Scan or enter the encrypted QR with this device</source>
+        <translation type="unfinished">使用此设备扫描或输入加密二维码</translation>
+    </message>
+    <message>
+        <source>to this device</source>
+        <translation type="unfinished">到此设备</translation>
+    </message>
+    <message>
+        <source>For security, delete the code as soon as you are done</source>
+        <translation type="unfinished">为了安全起见，完成操作后请立即删除代码</translation>
+    </message>
+    <message>
+        <source>Scan or enter the code</source>
+        <translation type="unfinished">扫描或输入代码</translation>
+    </message>
+    <message>
+        <source>Scan QR</source>
+        <translation type="unfinished">扫描二维码</translation>
+    </message>
+    <message>
+        <source>%1 %2</source>
+        <translation type="unfinished">%1 %2</translation>
+    </message>
+    <message>
+        <source>%1 %2 %3</source>
+        <translation type="unfinished">%1 %2 %3</translation>
+    </message>
+</context>
+<context>
+    <name>GetSyncCodeInstructionsPopup</name>
+    <message>
+        <source>How to get a pairing code on...</source>
+        <translation type="unfinished">如何在…上获取配对码</translation>
+    </message>
+</context>
+<context>
+    <name>GetSyncCodeMobileInstructions</name>
+    <message>
+        <source>Ensure both devices are on the same network</source>
+        <translation type="unfinished">请确保两台设备连接到同一网络</translation>
+    </message>
+    <message>
+        <source>Open Status on the device you want to import from</source>
+        <translation type="unfinished">在您要从中导入数据的设备上打开 Status</translation>
+    </message>
+    <message>
+        <source>Open Status App on your mobile device</source>
+        <translation type="unfinished">在您的移动设备上打开 Status 应用</translation>
+    </message>
+    <message>
+        <source>Open your</source>
+        <translation type="unfinished">打开您的</translation>
+    </message>
+    <message>
+        <source>Settings / Wallet</source>
+        <translation type="unfinished">设置/钱包</translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished">个人资料</translation>
+    </message>
+    <message>
+        <source>Tap</source>
+        <translation type="unfinished">点击</translation>
+    </message>
+    <message>
+        <source>Go to</source>
+        <translation type="unfinished">前往</translation>
+    </message>
+    <message>
+        <source>Show encrypted key pairs code</source>
+        <translation type="unfinished">显示加密密钥对代码</translation>
+    </message>
+    <message>
+        <source>Syncing</source>
+        <translation type="unfinished">同步中</translation>
+    </message>
+    <message>
+        <source>Copy the</source>
+        <translation type="unfinished">复制</translation>
+    </message>
+    <message>
+        <source>encrypted key pairs code</source>
+        <translation type="unfinished">加密密钥对代码</translation>
+    </message>
+    <message>
+        <source>on this device</source>
+        <translation type="unfinished">到此设备上</translation>
+    </message>
+    <message>
+        <source>Sync new device</source>
+        <translation type="unfinished">同步新设备</translation>
+    </message>
+    <message>
+        <source>Paste the</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+    <message>
+        <source>Scan or enter the encrypted QR with this device</source>
+        <translation type="unfinished">使用此设备扫描或输入加密二维码</translation>
+    </message>
+    <message>
+        <source>to this device</source>
+        <translation type="unfinished">到此设备</translation>
+    </message>
+    <message>
+        <source>For security, delete the code as soon as you are done</source>
+        <translation type="unfinished">为了安全起见，完成操作后请立即删除代码</translation>
+    </message>
+    <message>
+        <source>Scan or enter the code</source>
+        <translation type="unfinished">扫描或输入代码</translation>
+    </message>
+    <message>
+        <source>Scan QR</source>
+        <translation type="unfinished">扫描二维码</translation>
+    </message>
+    <message>
+        <source>%1 %2</source>
+        <translation type="unfinished">%1 %2</translation>
+    </message>
+    <message>
+        <source>%1 %2 %3</source>
+        <translation type="unfinished">%1 %2 %3</translation>
+    </message>
+</context>
+<context>
+    <name>GlobalBanner</name>
+    <message>
+        <source>You are back online</source>
+        <translation type="unfinished">您已重新连接到网络</translation>
+    </message>
+    <message>
+        <source>Internet connection lost. Reconnect to ensure everything is up to date.</source>
+        <translation type="unfinished">互联网连接中断。请重新连接，以确保所有内容都是最新的。</translation>
+    </message>
+    <message>
+        <source>Testnet mode enabled. All balances, transactions and dApp interactions will be on testnets.</source>
+        <translation type="unfinished">已启用测试网模式。所有余额、交易和与 dApp 的交互都将在测试网上进行。</translation>
+    </message>
+    <message>
+        <source>Turn off</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Secure your recovery phrase</source>
+        <translation type="unfinished">保护您的助记词</translation>
+    </message>
+    <message>
+        <source>Back up now</source>
+        <translation type="unfinished">立即备份</translation>
+    </message>
+</context>
+<context>
+    <name>GroupsModel</name>
+    <message>
+        <source>Popular assets on %1</source>
+        <translation type="unfinished">%1上的热门资产</translation>
+    </message>
+</context>
+<context>
+    <name>HandlersManager</name>
+    <message>
+        <source>Info</source>
+        <translation type="unfinished">信息</translation>
+    </message>
+    <message>
+        <source>Swap is not available in the testnet mode.</source>
+        <translation type="unfinished">在测试网络模式下，不支持兑换。</translation>
+    </message>
+    <message>
+        <source>Push notifications enabled</source>
+        <translation type="unfinished">已启用推送通知</translation>
+    </message>
+</context>
+<context>
+    <name>Helpers</name>
+    <message>
+        <source>Community minted</source>
+        <translation type="unfinished">社区铸造</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">其他</translation>
+    </message>
+</context>
+<context>
+    <name>HistoryView</name>
+    <message>
+        <source>Status Desktop is connected to a non-archival node. Transaction history may be incomplete.</source>
+        <translation type="unfinished">状态桌面已连接到非存档节点。交易历史记录可能不完整。</translation>
+    </message>
+    <message>
+        <source>Activity for this account will appear here</source>
+        <translation type="unfinished">此帐户的活动将在此处显示</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation type="unfinished">今天</translation>
+    </message>
+    <message>
+        <source>Yesterday</source>
+        <translation type="unfinished">昨天</translation>
+    </message>
+    <message>
+        <source>Earlier this week</source>
+        <translation type="unfinished">本周早些时候</translation>
+    </message>
+    <message>
+        <source>Last week</source>
+        <translation type="unfinished">上周</translation>
+    </message>
+    <message>
+        <source>Earlier this month</source>
+        <translation type="unfinished">本月早些时候</translation>
+    </message>
+    <message>
+        <source>Last month</source>
+        <translation type="unfinished">上个月</translation>
+    </message>
+    <message>
+        <source>New transactions</source>
+        <translation type="unfinished">新交易</translation>
+    </message>
+    <message>
+        <source>You have reached the beginning of the activity for this account</source>
+        <translation type="unfinished">您已到达此帐户活动的最开始处</translation>
+    </message>
+    <message>
+        <source>Back to most recent transaction</source>
+        <translation type="unfinished">返回到最新的交易</translation>
+    </message>
+</context>
+<context>
+    <name>HoldingsDropdown</name>
+    <message>
+        <source>No data found</source>
+        <translation type="unfinished">未找到数据</translation>
+    </message>
+    <message>
+        <source>No assets found</source>
+        <translation type="unfinished">未找到资产</translation>
+    </message>
+    <message>
+        <source>No collectibles found</source>
+        <translation type="unfinished">未找到收藏品</translation>
+    </message>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>ENS</source>
+        <translation type="unfinished">ENS</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+    <message>
+        <source>Asset</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>Collectible</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+</context>
+<context>
+    <name>HoldingsListPanel</name>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">或</translation>
+    </message>
+</context>
+<context>
+    <name>HomePage</name>
+    <message>
+        <source>Jump to a community, chat, account or a dApp...</source>
+        <translation type="unfinished">跳转到社区、聊天、账户或去中心化应用...</translation>
+    </message>
+</context>
+<context>
+    <name>HomePageDockButton</name>
+    <message>
+        <source>Unpin</source>
+        <translation type="unfinished">取消固定</translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished">断开连接</translation>
+    </message>
+</context>
+<context>
+    <name>HomePageGridChatItem</name>
+    <message>
+        <source>Group Chat</source>
+        <translation type="unfinished">群聊</translation>
+    </message>
+    <message>
+        <source>%1 Community</source>
+        <translation type="unfinished">%1社区</translation>
+    </message>
+    <message>
+        <source>Chat</source>
+        <translation type="unfinished">聊天</translation>
+    </message>
+</context>
+<context>
+    <name>HomePageGridCommunityItem</name>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished">待处理</translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <translation type="unfinished">已禁止</translation>
+    </message>
+</context>
+<context>
+    <name>HomePageGridDAppItem</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished">断开连接</translation>
+    </message>
+</context>
+<context>
+    <name>HomePageView</name>
+    <message>
+        <source>Homepage</source>
+        <translation type="unfinished">主页</translation>
+    </message>
+    <message>
+        <source>Example: duckduckgo.com</source>
+        <translation type="unfinished">示例：duckduckgo.com</translation>
+    </message>
+    <message>
+        <source>Choose the default start page for the Status browser</source>
+        <translation type="unfinished">选择 Status 浏览器的默认起始页面</translation>
+    </message>
+    <message>
+        <source>Status default</source>
+        <translation type="unfinished">Status 默认</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished">自定义</translation>
+    </message>
+</context>
+<context>
+    <name>HttpStatsModal</name>
+    <message>
+        <source>network %1 in %2 req · cache %3 in %4 req</source>
+        <translation type="unfinished">网络：%1/总请求数；缓存：%2/总请求数</translation>
+    </message>
+    <message>
+        <source>Total: %1</source>
+        <translation type="unfinished">总计：%1</translation>
+    </message>
+    <message>
+        <source>Disk cache: %1 of %2</source>
+        <translation type="unfinished">磁盘缓存：占总数的%1/%2</translation>
+    </message>
+    <message>
+        <source>Not counted here: status-go, messaging, the webviews, and requests made outside the QML network access manager.</source>
+        <translation type="unfinished">此处未统计：状态更新、消息传递、WebView 以及通过 QML 网络访问管理器之外发起的请求。</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation type="unfinished">刷新</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished">重置</translation>
+    </message>
+    <message>
+        <source>Clear cache</source>
+        <translation type="unfinished">清除缓存</translation>
+    </message>
+    <message>
+        <source>Total</source>
+        <translation type="unfinished">总计</translation>
+    </message>
+</context>
+<context>
+    <name>ImageContextMenu</name>
+    <message>
+        <source>Copy GIF</source>
+        <translation type="unfinished">复制 GIF</translation>
+    </message>
+    <message>
+        <source>Copy image</source>
+        <translation type="unfinished">复制图像</translation>
+    </message>
+    <message>
+        <source>Download GIF</source>
+        <translation type="unfinished">下载 GIF</translation>
+    </message>
+    <message>
+        <source>Download video</source>
+        <translation type="unfinished">下载视频</translation>
+    </message>
+    <message>
+        <source>Download image</source>
+        <translation type="unfinished">下载图像</translation>
+    </message>
+    <message>
+        <source>Copy link</source>
+        <translation type="unfinished">复制链接</translation>
+    </message>
+    <message>
+        <source>Open link</source>
+        <translation type="unfinished">打开链接</translation>
+    </message>
+</context>
+<context>
+    <name>ImageCropWorkflow</name>
+    <message>
+        <source>Supported image formats (%1)</source>
+        <translation type="unfinished">支持的图像格式 (%1)</translation>
+    </message>
+    <message>
+        <source>Image format not supported</source>
+        <translation type="unfinished">不支持的图像格式</translation>
+    </message>
+    <message>
+        <source>Format of the image you chose is not supported. Most probably you picked a file that is invalid, corrupted or has a wrong file extension. The requested file was: %1</source>
+        <translation type="unfinished">您选择的图像格式不受支持。最有可能的原因是，您选择的文件无效、已损坏或文件扩展名不正确。请求的文件为：%1</translation>
+    </message>
+    <message>
+        <source>Supported image extensions: %1</source>
+        <translation type="unfinished">支持的图像扩展名：%1</translation>
+    </message>
+</context>
+<context>
+    <name>ImportCommunityPopup</name>
+    <message>
+        <source>Join Community</source>
+        <translation type="unfinished">加入社区</translation>
+    </message>
+    <message>
+        <source>Invalid key</source>
+        <translation type="unfinished">无效密钥</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t find community</source>
+        <translation type="unfinished">找不到社区</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation type="unfinished">加入</translation>
+    </message>
+    <message>
+        <source>Enter the public key of, or a link to the community you wish to access</source>
+        <translation type="unfinished">输入您想要访问的社区的公钥或链接。</translation>
+    </message>
+    <message>
+        <source>Community key</source>
+        <translation type="unfinished">社区密钥</translation>
+    </message>
+    <message>
+        <source>Link or (compressed) public key...</source>
+        <translation type="unfinished">链接或（压缩）公钥...</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 位成员</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Public key detected</source>
+        <translation type="unfinished">检测到公钥</translation>
+    </message>
+</context>
+<context>
+    <name>ImportControlNodePopup</name>
+    <message>
+        <source>Make this device the control node for %1</source>
+        <translation type="unfinished">将此设备设为%1的控制节点</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to make this device the control node for %1? This device should be one that you are able to keep online and running Status at all times to enable the Community to function correctly.</source>
+        <translation type="unfinished">您确定要将此设备设置为%1的控制节点吗？此设备应始终保持在线并运行状态，以便社区能够正常工作。</translation>
+    </message>
+    <message>
+        <source>I acknowledge that...</source>
+        <translation type="unfinished">我确认...</translation>
+    </message>
+    <message>
+        <source>I must keep this device online and running Status</source>
+        <translation type="unfinished">我必须保持此设备处于在线和运行状态</translation>
+    </message>
+    <message>
+        <source>My other synced device will cease to be the control node for this Community</source>
+        <translation type="unfinished">我的其他同步设备将不再是此社区的控制节点</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>ImportKeypairInfo</name>
+    <message>
+        <source>Import key pair to use this account</source>
+        <translation type="unfinished">导入密钥对以使用此帐户</translation>
+    </message>
+    <message>
+        <source>This account was added to one of your synced devices. To use this account you will first need import the associated key pair to this device.</source>
+        <translation type="unfinished">此帐户已添加到您的一个同步设备中。要使用此帐户，您首先需要将关联的密钥对导入到此设备。</translation>
+    </message>
+    <message>
+        <source>Import missing key pair</source>
+        <translation type="unfinished">导入缺少的密钥对</translation>
+    </message>
+</context>
+<context>
+    <name>ImportLocalBackupPage</name>
+    <message>
+        <source>Import local backup</source>
+        <translation type="unfinished">导入本地备份</translation>
+    </message>
+    <message>
+        <source>Skip</source>
+        <translation type="unfinished">跳过</translation>
+    </message>
+    <message>
+        <source>Backup files (%1)</source>
+        <translation type="unfinished">备份文件（%1）</translation>
+    </message>
+    <message>
+        <source>Import the backup file for your Status profile, or skip this step and import it later from Settings &gt; On-device backups</source>
+        <translation type="unfinished">导入您的 Status 配置文件的备份文件，或者跳过此步骤，稍后从“设置”&gt;“设备上的备份”中导入。</translation>
+    </message>
+    <message>
+        <source>Import backup file</source>
+        <translation type="unfinished">导入备份文件</translation>
+    </message>
+</context>
+<context>
+    <name>InDropdown</name>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>Add channel</source>
+        <translation type="unfinished">添加频道</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <source>Add community</source>
+        <translation type="unfinished">添加社区</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n channel(s)</source>
+        <translation type="unfinished">
+            <numerusform>添加%n个频道</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>InlineSelectorPanel</name>
+    <message>
+        <source>No results found</source>
+        <translation type="unfinished">未找到结果</translation>
+    </message>
+    <message>
+        <source>Group Members</source>
+        <translation type="unfinished">群组成员</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Save Changes</source>
+        <translation type="unfinished">保存更改</translation>
+    </message>
+</context>
+<context>
+    <name>Input</name>
+    <message>
+        <source>Copied</source>
+        <translation type="unfinished">已复制</translation>
+    </message>
+    <message>
+        <source>Pasted</source>
+        <translation type="unfinished">已粘贴</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">复制</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+</context>
+<context>
+    <name>InsertEmptyKeycardState</name>
+    <message>
+        <source>Insert an empty Keycard</source>
+        <translation type="unfinished">请插入一张空的密钥卡</translation>
+    </message>
+    <message>
+        <source>Insert an empty Keycard you want to migrate your key pair to.</source>
+        <translation type="unfinished">请插入您要迁移密钥对的空密钥卡。</translation>
+    </message>
+</context>
+<context>
+    <name>IntroMessageInput</name>
+    <message>
+        <source>Dialog for new members</source>
+        <translation type="unfinished">新成员对话框</translation>
+    </message>
+    <message>
+        <source>What new members will read before joining (eg. community rules, welcome message, etc.). Members will need to tick a check box agreeing to these rules before they are allowed to join your community.</source>
+        <translation type="unfinished">新成员加入前将阅读的内容（例如，社区规则、欢迎信息等）。成员需要勾选复选框以同意这些规则，然后才能允许他们加入您的社区。</translation>
+    </message>
+    <message>
+        <source>community intro message</source>
+        <translation type="unfinished">社区介绍消息</translation>
+    </message>
+</context>
+<context>
+    <name>IntroduceYourselfPopup</name>
+    <message>
+        <source>Introduce yourself</source>
+        <translation type="unfinished">自我介绍</translation>
+    </message>
+    <message>
+        <source>Your Name</source>
+        <translation type="unfinished">您的姓名</translation>
+    </message>
+    <message>
+        <source>Add an optional display name and profile picture so others can easily recognise you.</source>
+        <translation type="unfinished">添加可选的显示名称和个人资料图片，以便其他人可以轻松识别您。</translation>
+    </message>
+    <message>
+        <source>Skip</source>
+        <translation type="unfinished">跳过</translation>
+    </message>
+    <message>
+        <source>Edit Profile in Settings</source>
+        <translation type="unfinished">在设置中编辑个人资料</translation>
+    </message>
+</context>
+<context>
+    <name>InvitationBubbleView</name>
+    <message>
+        <source>Verified community invitation</source>
+        <translation type="unfinished">已验证的社区邀请</translation>
+    </message>
+    <message>
+        <source>Community invitation</source>
+        <translation type="unfinished">社区邀请</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 位成员</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Go to Community</source>
+        <translation type="unfinished">前往社区</translation>
+    </message>
+</context>
+<context>
+    <name>InviteFriendsPopup</name>
+    <message>
+        <source>Download Status link</source>
+        <translation type="unfinished">下载状态链接</translation>
+    </message>
+    <message>
+        <source>Get Status at %1</source>
+        <translation type="unfinished">在%1获取状态</translation>
+    </message>
+</context>
+<context>
+    <name>InviteFriendsToCommunityPopup</name>
+    <message>
+        <source>Invite successfully sent</source>
+        <translation type="unfinished">邀请已成功发送</translation>
+    </message>
+    <message>
+        <source>Invite Contacts to %1</source>
+        <translation type="unfinished">邀请通讯录中的联系人到%1</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished">下一步</translation>
+    </message>
+    <message numerus="yes">
+        <source>Send %n invite(s)</source>
+        <translation type="unfinished">
+            <numerusform>发送%n个邀请</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>IssuePill</name>
+    <message numerus="yes">
+        <source>%n warning(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 个警告</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n error(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 个错误</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n message(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 条消息</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>JSDialogWindow</name>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished">确定</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>JoinCommunityCenterPanel</name>
+    <message>
+        <source>joined the channel</source>
+        <translation type="unfinished">加入了频道</translation>
+    </message>
+</context>
+<context>
+    <name>JoinPermissionsOverlayPanel</name>
+    <message>
+        <source>Membership requirements not met</source>
+        <translation type="unfinished">未满足会员资格要求</translation>
+    </message>
+    <message>
+        <source>Request to join Community</source>
+        <translation type="unfinished">请求加入社区</translation>
+    </message>
+    <message>
+        <source>Membership Request Pending...</source>
+        <translation type="unfinished">会员申请正在处理中...</translation>
+    </message>
+    <message>
+        <source>Channel requirements not met</source>
+        <translation type="unfinished">频道要求不符合</translation>
+    </message>
+    <message>
+        <source>Channel Membership Request Pending...</source>
+        <translation type="unfinished">频道会员申请正在处理中...</translation>
+    </message>
+    <message>
+        <source>Membership Request Rejected</source>
+        <translation type="unfinished">会员申请被拒绝</translation>
+    </message>
+    <message>
+        <source>Sorry, you don&apos;t hold the necessary tokens to view or post in any of &lt;b&gt;%1&lt;/b&gt; channels</source>
+        <translation type="unfinished">抱歉，您没有足够的代币来查看或发布任何&lt;b&gt;%1&lt;/b&gt;频道的帖子</translation>
+    </message>
+    <message>
+        <source>Requirements check pending...</source>
+        <translation type="unfinished">要求检查正在进行中...</translation>
+    </message>
+    <message>
+        <source>Encryption key has not arrived yet...</source>
+        <translation type="unfinished">加密密钥尚未到达...</translation>
+    </message>
+    <message>
+        <source>To join &lt;b&gt;%1&lt;/b&gt; you need to prove that you hold</source>
+        <translation type="unfinished">要加入&lt;b&gt;%1&lt;/b&gt;，您需要证明您持有</translation>
+    </message>
+    <message>
+        <source>Sorry, you can&apos;t join &lt;b&gt;%1&lt;/b&gt; because it&apos;s a private, closed community</source>
+        <translation type="unfinished">抱歉，您无法加入&lt;b&gt;%1&lt;/b&gt;，因为它是一个私密的封闭社区</translation>
+    </message>
+    <message>
+        <source>To view the &lt;b&gt;#%1&lt;/b&gt; channel you need to join &lt;b&gt;%2&lt;/b&gt; and prove that you hold</source>
+        <translation type="unfinished">要查看&lt;b&gt;#%1&lt;/b&gt;频道，您需要加入&lt;b&gt;%2&lt;/b&gt;并证明您持有</translation>
+    </message>
+    <message>
+        <source>To view the &lt;b&gt;#%1&lt;/b&gt; channel you need to hold</source>
+        <translation type="unfinished">要查看&lt;b&gt;#%1&lt;/b&gt;频道，您需要持有</translation>
+    </message>
+    <message>
+        <source>To view and post in the &lt;b&gt;#%1&lt;/b&gt; channel you need to join &lt;b&gt;%2&lt;/b&gt; and prove that you hold</source>
+        <translation type="unfinished">要查看和发布到&lt;b&gt;#%1&lt;/b&gt;频道，您需要加入&lt;b&gt;%2&lt;/b&gt;并证明您持有</translation>
+    </message>
+    <message>
+        <source>To view and post in the &lt;b&gt;#%1&lt;/b&gt; channel you need to hold</source>
+        <translation type="unfinished">要查看和发布到&lt;b&gt;#%1&lt;/b&gt;频道，您需要持有</translation>
+    </message>
+    <message>
+        <source>To moderate in the &lt;b&gt;#%1&lt;/b&gt; channel you need to hold</source>
+        <translation type="unfinished">要在&lt;b&gt;#%1&lt;/b&gt;频道中进行管理，您需要持有</translation>
+    </message>
+</context>
+<context>
+    <name>KeyPairCompactItem</name>
+    <message>
+        <source>Moving this key pair will require you to use your Keycard to login</source>
+        <translation type="unfinished">移动此密钥对需要您使用您的密钥卡登录</translation>
+    </message>
+    <message>
+        <source>Keycard Locked</source>
+        <translation type="unfinished">密钥卡已锁定</translation>
+    </message>
+    <message numerus="yes">
+        <source>Contains %n account(s) with Keycard incompatible derivation paths</source>
+        <translation type="unfinished">
+            <numerusform>包含%n个密钥卡不兼容的派生路径帐户</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>KeyPairItem</name>
+    <message>
+        <source>Moving this key pair will require you to use your Keycard to login</source>
+        <translation type="unfinished">移动此密钥对需要您使用您的密钥卡登录</translation>
+    </message>
+    <message>
+        <source>Keycard Locked</source>
+        <translation type="unfinished">密钥卡已锁定</translation>
+    </message>
+    <message numerus="yes">
+        <source>Contains %n account(s) with Keycard incompatible derivation paths</source>
+        <translation type="unfinished">
+            <numerusform>包含%n个密钥卡不兼容的派生路径帐户</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Active Accounts</source>
+        <translation type="unfinished">活跃账户</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardAuth</name>
+    <message>
+        <source>Plug in Keycard reader...</source>
+        <translation type="unfinished">请插入密钥卡读取器...</translation>
+    </message>
+    <message>
+        <source>Tap or insert Keycard...</source>
+        <translation type="unfinished">轻触或插入密钥卡...</translation>
+    </message>
+    <message>
+        <source>Reading Keycard...</source>
+        <translation type="unfinished">正在读取密钥卡...</translation>
+    </message>
+    <message>
+        <source>Keycard is empty</source>
+        <translation type="unfinished">密钥卡为空</translation>
+    </message>
+    <message>
+        <source>There is no key pair on this Keycard</source>
+        <translation type="unfinished">此密钥卡上没有密钥对</translation>
+    </message>
+    <message>
+        <source>This is not a Keycard</source>
+        <translation type="unfinished">这不是密钥卡</translation>
+    </message>
+    <message>
+        <source>Connection error</source>
+        <translation type="unfinished">连接错误</translation>
+    </message>
+    <message>
+        <source>Something went wrong, please try again</source>
+        <translation type="unfinished">出现问题，请重试</translation>
+    </message>
+    <message>
+        <source>Keycard locked</source>
+        <translation type="unfinished">密钥卡已锁定</translation>
+    </message>
+    <message>
+        <source>PIN entered incorrectly too many times</source>
+        <translation type="unfinished">密码输入错误次数过多</translation>
+    </message>
+    <message>
+        <source>PUK entered incorrectly too many times</source>
+        <translation type="unfinished">PUK 输入错误次数过多</translation>
+    </message>
+    <message>
+        <source>Keycard pairing error</source>
+        <translation type="unfinished">密钥卡配对错误</translation>
+    </message>
+    <message>
+        <source>Max pairing slots reached for this Keycard</source>
+        <translation type="unfinished">此密钥卡的配对插槽已达到最大值</translation>
+    </message>
+    <message>
+        <source>This Keycard was set up with a custom pairing password</source>
+        <translation type="unfinished">此密钥卡已设置为自定义配对密码</translation>
+    </message>
+    <message>
+        <source>Wrong Keycard inserted</source>
+        <translation type="unfinished">插入了错误的密钥卡</translation>
+    </message>
+    <message>
+        <source>Inserted Keycard does not match the expected key</source>
+        <translation type="unfinished">插入的密钥卡与预期的密钥不匹配</translation>
+    </message>
+    <message>
+        <source>Success</source>
+        <translation type="unfinished">成功</translation>
+    </message>
+    <message>
+        <source>The card is not a Keycard, try again with Keycard.</source>
+        <translation type="unfinished">该卡不是密钥卡，请使用密钥卡重试。</translation>
+    </message>
+    <message>
+        <source>Something went wrong</source>
+        <translation type="unfinished">出现问题</translation>
+    </message>
+    <message>
+        <source>Try again</source>
+        <translation type="unfinished">重试</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardChannelDrawer</name>
+    <message>
+        <source>Ready to scan</source>
+        <translation type="unfinished">准备好扫描</translation>
+    </message>
+    <message>
+        <source>Please tap your Keycard to the back of your device</source>
+        <translation type="unfinished">请将您的密钥卡贴在设备的背面</translation>
+    </message>
+    <message>
+        <source>Reading Keycard</source>
+        <translation type="unfinished">正在读取密钥卡</translation>
+    </message>
+    <message>
+        <source>Please keep your Keycard in place</source>
+        <translation type="unfinished">请保持密钥卡的位置不变</translation>
+    </message>
+    <message>
+        <source>Success</source>
+        <translation type="unfinished">成功</translation>
+    </message>
+    <message>
+        <source>Keycard operation completed successfully</source>
+        <translation type="unfinished">密钥卡操作已成功完成</translation>
+    </message>
+    <message>
+        <source>Keycard Not Supported</source>
+        <translation type="unfinished">不支持的密钥卡</translation>
+    </message>
+    <message>
+        <source>Your device does not support keycard operations. Please try again with a different device.</source>
+        <translation type="unfinished">您的设备不支持密钥卡操作。请尝试使用其他设备。</translation>
+    </message>
+    <message>
+        <source>Keycard Not Available</source>
+        <translation type="unfinished">密钥卡不可用</translation>
+    </message>
+    <message>
+        <source>Please enable NFC on your device to use the Keycard.</source>
+        <translation type="unfinished">请在您的设备上启用 NFC 以使用密钥卡。</translation>
+    </message>
+    <message>
+        <source>Dismiss</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Try to keep your Keycard in place</source>
+        <translation type="unfinished">请尽量保持密钥卡的位置不变</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardDetailsPage</name>
+    <message>
+        <source>No free pairing slots</source>
+        <translation type="unfinished">没有可用的配对槽</translation>
+    </message>
+    <message>
+        <source>Keycard is empty</source>
+        <translation type="unfinished">密钥卡为空</translation>
+    </message>
+    <message>
+        <source>Keycard is blocked</source>
+        <translation type="unfinished">密钥卡已锁定</translation>
+    </message>
+    <message>
+        <source>Keycard stores only PIN</source>
+        <translation type="unfinished">密钥卡仅存储 PIN 码</translation>
+    </message>
+    <message>
+        <source>Profile already exists</source>
+        <translation type="unfinished">配置文件已存在</translation>
+    </message>
+    <message>
+        <source>Keycard stores key pair</source>
+        <translation type="unfinished">密钥卡存储密钥对</translation>
+    </message>
+    <message>
+        <source>Keycard</source>
+        <translation type="unfinished">密钥卡</translation>
+    </message>
+    <message>
+        <source>, </source>
+        <translation type="unfinished">，</translation>
+    </message>
+    <message>
+        <source>UID: %1</source>
+        <translation type="unfinished">用户 ID：%1</translation>
+    </message>
+    <message>
+        <source>You can’t operate with Keycard content right now, because Keycard has no free pairing slots. But you can use it with previously paired installations.</source>
+        <translation type="unfinished">由于密钥卡没有可用的配对槽，您现在无法操作密钥卡内容。但您可以将其与先前已配对的应用程序一起使用。</translation>
+    </message>
+    <message>
+        <source>Profile for key pair stored on Keycard already added to this device.</source>
+        <translation type="unfinished">存储在密钥卡上的密钥对的配置文件已添加到此设备。</translation>
+    </message>
+    <message>
+        <source>Keycard stores information about your accounts</source>
+        <translation type="unfinished">密钥卡存储有关您的帐户的信息</translation>
+    </message>
+    <message>
+        <source>What you can do:</source>
+        <translation type="unfinished">您可以执行以下操作：</translation>
+    </message>
+    <message>
+        <source>Import a new key pair to Keycard and create new profile</source>
+        <translation type="unfinished">将新的密钥对导入到密钥卡并创建新的配置文件</translation>
+    </message>
+    <message>
+        <source>Keycard will be required for signing and logging in to Status</source>
+        <translation type="unfinished">使用密钥卡进行签名和登录 Status 应用程序是必需的。</translation>
+    </message>
+    <message>
+        <source>Import a key pair from recovery phrase</source>
+        <translation type="unfinished">从恢复短语中导入密钥对</translation>
+    </message>
+    <message>
+        <source>You’ll create a new profile or login if key pair already associated with existing Status profile. Keycard will be required for signing and logging in to Status</source>
+        <translation type="unfinished">如果您创建新的配置文件或登录，则密钥对已与现有的 Status 配置文件关联。使用密钥卡进行签名和登录 Status 应用程序是必需的。</translation>
+    </message>
+    <message>
+        <source>Unblock with recovery phrase</source>
+        <translation type="unfinished">使用恢复短语解锁</translation>
+    </message>
+    <message>
+        <source>Requires providing the recovery phrase for the key pair stored on Keycard</source>
+        <translation type="unfinished">需要提供存储在密钥卡上的密钥对的恢复短语</translation>
+    </message>
+    <message>
+        <source>Unblock with PUK</source>
+        <translation type="unfinished">使用 PUK 解锁</translation>
+    </message>
+    <message>
+        <source>If you set your PUK earlier for this Keycard</source>
+        <translation type="unfinished">如果您之前为该密钥卡设置了 PUK。</translation>
+    </message>
+    <message>
+        <source>Login with this Keycard</source>
+        <translation type="unfinished">使用此密钥卡登录</translation>
+    </message>
+    <message>
+        <source>Go back to login screen</source>
+        <translation type="unfinished">返回登录界面</translation>
+    </message>
+    <message>
+        <source>You can login with password and move your profile to Keycard, from the settings/Keycard section</source>
+        <translation type="unfinished">您可以输入密码进行登录，然后从“设置/密钥卡”部分将您的个人资料转移到密钥卡。</translation>
+    </message>
+    <message>
+        <source>Factory reset</source>
+        <translation type="unfinished">恢复出厂设置</translation>
+    </message>
+    <message>
+        <source>Remove everything from Keycard</source>
+        <translation type="unfinished">从密钥卡中删除所有内容</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardLostPage</name>
+    <message>
+        <source>Lost Keycard</source>
+        <translation type="unfinished">丢失的密钥卡</translation>
+    </message>
+    <message>
+        <source>If you don&apos;t have any other spare Keycard</source>
+        <translation type="unfinished">如果您没有其他备用密钥卡</translation>
+    </message>
+    <message>
+        <source>Buy new</source>
+        <translation type="unfinished">购买新的</translation>
+    </message>
+    <message>
+        <source>Go to Keycard.tech and order Keycard</source>
+        <translation type="unfinished">访问 Keycard.tech 并订购密钥卡</translation>
+    </message>
+    <message>
+        <source>If you have a spare Keycard</source>
+        <translation type="unfinished">如果您有备用密钥卡</translation>
+    </message>
+    <message>
+        <source>Read your spare Keycard</source>
+        <translation type="unfinished">读取您的备用密钥卡</translation>
+    </message>
+    <message>
+        <source>You may need to factory reset it first and then import key pair</source>
+        <translation type="unfinished">您可能需要先将其恢复出厂设置，然后导入密钥对</translation>
+    </message>
+    <message>
+        <source>Start using profile without Keycard</source>
+        <translation type="unfinished">开始使用没有密钥卡的配置文件</translation>
+    </message>
+    <message>
+        <source>Enter recovery phrase for your profile and login to status.</source>
+        <translation type="unfinished">输入您配置文件的恢复短语并登录到状态。</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardManagementPopup</name>
+    <message>
+        <source>Read Keycard</source>
+        <translation type="unfinished">读取密钥卡</translation>
+    </message>
+    <message>
+        <source>Keycard Flow</source>
+        <translation type="unfinished">密钥卡流程</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>I don&apos;t have or don&apos;t know PIN</source>
+        <translation type="unfinished">我没有或不知道密码</translation>
+    </message>
+    <message>
+        <source>Factory reset</source>
+        <translation type="unfinished">恢复出厂设置</translation>
+    </message>
+    <message>
+        <source>Start using profile without Keycard</source>
+        <translation type="unfinished">开始使用不带密钥卡的配置</translation>
+    </message>
+    <message>
+        <source>Log in with this Keycard</source>
+        <translation type="unfinished">使用此密钥卡登录</translation>
+    </message>
+    <message>
+        <source>Import a key pair from recovery phrase</source>
+        <translation type="unfinished">从恢复短语中导入密钥对</translation>
+    </message>
+    <message>
+        <source>Factory reset this Keycard</source>
+        <translation type="unfinished">恢复此密钥卡的出厂设置</translation>
+    </message>
+    <message>
+        <source>Resetting Keycard...</source>
+        <translation type="unfinished">正在重置密钥卡...</translation>
+    </message>
+    <message>
+        <source>Logging in with Keycard...</source>
+        <translation type="unfinished">正在使用密钥卡登录...</translation>
+    </message>
+    <message>
+        <source>Reading...</source>
+        <translation type="unfinished">读取中...</translation>
+    </message>
+    <message>
+        <source>Keycard has been reset</source>
+        <translation type="unfinished">密钥卡已重置</translation>
+    </message>
+    <message>
+        <source>Ready to recover your profile</source>
+        <translation type="unfinished">准备好恢复您的配置</translation>
+    </message>
+    <message>
+        <source>Success</source>
+        <translation type="unfinished">成功</translation>
+    </message>
+    <message>
+        <source>Keycard is now empty.</source>
+        <translation type="unfinished">密钥卡现在为空。</translation>
+    </message>
+    <message>
+        <source>Continue to log in and convert your profile to use a Status password.</source>
+        <translation type="unfinished">继续登录并将您的配置转换为使用状态密码。</translation>
+    </message>
+    <message>
+        <source>Continue to finish logging in.</source>
+        <translation type="unfinished">继续完成登录。</translation>
+    </message>
+    <message>
+        <source>Continue to finish setting up your profile.</source>
+        <translation type="unfinished">继续完成配置设置。</translation>
+    </message>
+    <message>
+        <source>Something went wrong</source>
+        <translation type="unfinished">出现问题</translation>
+    </message>
+    <message>
+        <source>Try again</source>
+        <translation type="unfinished">重试</translation>
+    </message>
+    <message>
+        <source>Import key pair from recovery phrase</source>
+        <translation type="unfinished">从恢复短语导入密钥对</translation>
+    </message>
+    <message>
+        <source>Try setting the PIN again</source>
+        <translation type="unfinished">再次尝试设置密码</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished">下一步</translation>
+    </message>
+    <message>
+        <source>Importing key pair to Keycard...</source>
+        <translation type="unfinished">正在将密钥对导入到密钥卡...</translation>
+    </message>
+    <message>
+        <source>Add another account</source>
+        <translation type="unfinished">添加另一个帐户</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+    <message>
+        <source>Key pair has been imported to Keycard</source>
+        <translation type="unfinished">密钥对已导入到密钥卡</translation>
+    </message>
+    <message>
+        <source>Keycard is now required to sign with this key pair.</source>
+        <translation type="unfinished">现在需要使用密钥卡才能使用此密钥对进行签名。</translation>
+    </message>
+    <message>
+        <source>Import a new key pair to Keycard</source>
+        <translation type="unfinished">将新的密钥对导入到密钥卡。</translation>
+    </message>
+    <message>
+        <source>Move key pair to Keycard</source>
+        <translation type="unfinished">将密钥对移动到密钥卡。</translation>
+    </message>
+    <message>
+        <source>Moving key pair to Keycard...</source>
+        <translation type="unfinished">正在将密钥对移动到密钥卡...</translation>
+    </message>
+    <message>
+        <source>Key pair has been moved to Keycard</source>
+        <translation type="unfinished">密钥对已移动到密钥卡。</translation>
+    </message>
+    <message>
+        <source>Move profile key pair to Keycard</source>
+        <translation type="unfinished">将配置文件密钥对移动到密钥卡。</translation>
+    </message>
+    <message>
+        <source>Moving profile key pair to Keycard...</source>
+        <translation type="unfinished">正在将配置文件密钥对移动到密钥卡...</translation>
+    </message>
+    <message>
+        <source>Profile key pair has been moved to Keycard</source>
+        <translation type="unfinished">配置文件密钥对已移动到密钥卡。</translation>
+    </message>
+    <message>
+        <source>Quit and restart Status</source>
+        <translation type="unfinished">退出并重新启动 Status。</translation>
+    </message>
+    <message>
+        <source>Re-encrypting data may take some time</source>
+        <translation type="unfinished">重新加密数据可能需要一些时间。</translation>
+    </message>
+    <message>
+        <source>Do not quit the application or turn off your device. Doing so will lead to data
+corruption, loss of your Status profile and the inability to restart Status.</source>
+        <translation type="unfinished">请勿退出应用程序或关闭设备。否则会导致数据损坏、丢失您的 Status 配置文件，并且无法重新启动 Status。</translation>
+    </message>
+    <message>
+        <source>Keycard is now required to log in and sign.</source>
+        <translation type="unfinished">现在需要使用密钥卡才能登录和签名。</translation>
+    </message>
+    <message>
+        <source>Add key pair to Status</source>
+        <translation type="unfinished">将密钥对添加到 Status。</translation>
+    </message>
+    <message>
+        <source>Adding key pair to Status...</source>
+        <translation type="unfinished">正在将密钥对添加到 Status...</translation>
+    </message>
+    <message>
+        <source>Key pair has been added to Status</source>
+        <translation type="unfinished">密钥对已添加到 Status。</translation>
+    </message>
+    <message>
+        <source>Now you can sign with this key pair using Keycard.</source>
+        <translation type="unfinished">现在您可以使用密钥卡使用此密钥对进行签名。</translation>
+    </message>
+    <message>
+        <source>Stop using Keycard for key pair</source>
+        <translation type="unfinished">停止为密钥对使用密钥卡。</translation>
+    </message>
+    <message>
+        <source>Create password</source>
+        <translation type="unfinished">创建密码。</translation>
+    </message>
+    <message>
+        <source>Finalize Status Password Creation</source>
+        <translation type="unfinished">完成 Status 密码创建。</translation>
+    </message>
+    <message>
+        <source>Moving key pair to Status...</source>
+        <translation type="unfinished">正在将密钥对移动到 Status...</translation>
+    </message>
+    <message>
+        <source>Key pair has been moved to Status</source>
+        <translation type="unfinished">密钥对已移动到“状态”</translation>
+    </message>
+    <message>
+        <source>Keycard read completed</source>
+        <translation type="unfinished">读卡完成</translation>
+    </message>
+    <message>
+        <source>Status password is now required to sign.</source>
+        <translation type="unfinished">现在需要状态密码才能进行签名。</translation>
+    </message>
+    <message>
+        <source>Stop using Keycard for profile key pair</source>
+        <translation type="unfinished">停止将密钥对用于配置文件</translation>
+    </message>
+    <message>
+        <source>Moving profile key pair to Status...</source>
+        <translation type="unfinished">正在将配置文件密钥对移动到“状态”...</translation>
+    </message>
+    <message>
+        <source>Profile key pair has been moved to Status</source>
+        <translation type="unfinished">配置文件密钥对已移动到“状态”</translation>
+    </message>
+    <message>
+        <source>Status password is now required to log in and sign.</source>
+        <translation type="unfinished">现在需要状态密码才能登录和签名。</translation>
+    </message>
+    <message>
+        <source>Change Keycard PIN</source>
+        <translation type="unfinished">更改密钥卡 PIN 码</translation>
+    </message>
+    <message>
+        <source>Changing Keycard PIN...</source>
+        <translation type="unfinished">正在更改密钥卡 PIN 码...</translation>
+    </message>
+    <message>
+        <source>Keycard PIN has been changed</source>
+        <translation type="unfinished">密钥卡 PIN 码已更改</translation>
+    </message>
+    <message>
+        <source>New PIN is required to interact with Keycard.</source>
+        <translation type="unfinished">与密钥卡交互需要新的 PIN 码。</translation>
+    </message>
+    <message>
+        <source>Set or change PUK</source>
+        <translation type="unfinished">设置或更改 PUK 码</translation>
+    </message>
+    <message>
+        <source>Setting your Keycard PUK...</source>
+        <translation type="unfinished">正在设置您的密钥卡 PUK 码...</translation>
+    </message>
+    <message>
+        <source>Keycard’s PUK successfully set</source>
+        <translation type="unfinished">密钥卡的 PUK 码已成功设置</translation>
+    </message>
+    <message>
+        <source>Rename Keycard</source>
+        <translation type="unfinished">重命名密钥卡</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished">重命名</translation>
+    </message>
+    <message>
+        <source>Renaming Keycard...</source>
+        <translation type="unfinished">正在重命名密钥卡...</translation>
+    </message>
+    <message>
+        <source>Keycard has been renamed</source>
+        <translation type="unfinished">密钥卡已重命名</translation>
+    </message>
+    <message>
+        <source>New name: %1</source>
+        <translation type="unfinished">新名称：%1</translation>
+    </message>
+    <message>
+        <source>Unblock with PUK</source>
+        <translation type="unfinished">使用 PUK 解锁</translation>
+    </message>
+    <message>
+        <source>Unblocking Keycard...</source>
+        <translation type="unfinished">正在解除密钥卡的锁定...</translation>
+    </message>
+    <message>
+        <source>Keycard has been unblocked</source>
+        <translation type="unfinished">密钥卡已解锁</translation>
+    </message>
+    <message>
+        <source>You can now use your Keycard again</source>
+        <translation type="unfinished">您现在可以再次使用您的密钥卡</translation>
+    </message>
+    <message>
+        <source>Unblock with recovery phrase</source>
+        <translation type="unfinished">使用恢复短语解锁</translation>
+    </message>
+    <message>
+        <source>It is now ready to use.</source>
+        <translation type="unfinished">它现在可以使用了。</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardProgressState</name>
+    <message>
+        <source>Reading...</source>
+        <translation type="unfinished">读取中...</translation>
+    </message>
+    <message>
+        <source>Success</source>
+        <translation type="unfinished">成功</translation>
+    </message>
+    <message>
+        <source>Something went wrong</source>
+        <translation type="unfinished">发生错误</translation>
+    </message>
+    <message>
+        <source>Try again</source>
+        <translation type="unfinished">重试</translation>
+    </message>
+    <message>
+        <source>Plug in Keycard reader...</source>
+        <translation type="unfinished">插入读卡器...</translation>
+    </message>
+    <message>
+        <source>Tap or insert Keycard...</source>
+        <translation type="unfinished">轻触或插入密钥卡...</translation>
+    </message>
+    <message>
+        <source>Reading Keycard...</source>
+        <translation type="unfinished">正在读取密钥卡...</translation>
+    </message>
+    <message>
+        <source>This is not a Keycard</source>
+        <translation type="unfinished">这不是密钥卡</translation>
+    </message>
+    <message>
+        <source>Connection error</source>
+        <translation type="unfinished">连接错误</translation>
+    </message>
+    <message>
+        <source>Something went wrong, please try again</source>
+        <translation type="unfinished">发生错误，请重试</translation>
+    </message>
+    <message>
+        <source>Wrong Keycard inserted</source>
+        <translation type="unfinished">插入了错误的密钥卡</translation>
+    </message>
+    <message>
+        <source>Inserted Keycard does not match the expected key</source>
+        <translation type="unfinished">插入的密钥卡与预期的密钥不匹配</translation>
+    </message>
+    <message>
+        <source>It&apos;s a different Keycard</source>
+        <translation type="unfinished">这是另一张密钥卡</translation>
+    </message>
+    <message>
+        <source>Keycard is not empty</source>
+        <translation type="unfinished">密钥卡非空</translation>
+    </message>
+    <message>
+        <source>Try again with an empty keycard</source>
+        <translation type="unfinished">请使用空的密钥卡重试</translation>
+    </message>
+    <message>
+        <source>The card is not a Keycard, try again with Keycard</source>
+        <translation type="unfinished">该卡不是密钥卡，请使用密钥卡重试</translation>
+    </message>
+    <message>
+        <source>Please try again with Keycard you read before</source>
+        <translation type="unfinished">请再次尝试您之前读取过的密钥卡</translation>
+    </message>
+    <message>
+        <source>PIN incorrect</source>
+        <translation type="unfinished">密码错误</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n attempt(s) remaining</source>
+        <translation type="unfinished">
+            <numerusform>剩余 %n 次尝试</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Keycard is blocked</source>
+        <translation type="unfinished">密钥卡已锁定</translation>
+    </message>
+    <message>
+        <source>Keycard is blocked due to three failed PIN input attempts</source>
+        <translation type="unfinished">由于三次错误的 PIN 码输入，密钥卡已被锁定</translation>
+    </message>
+    <message>
+        <source>PUK incorrect</source>
+        <translation type="unfinished">PUK密码错误</translation>
+    </message>
+    <message>
+        <source>Keycard is blocked due to five failed PUK input attempts</source>
+        <translation type="unfinished">由于五次错误的PUK密码输入，密钥卡已被锁定</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardSimulatorController</name>
+    <message>
+        <source>Keycard Simulator Controller</source>
+        <translation type="unfinished">密钥卡模拟器控制器</translation>
+    </message>
+    <message>
+        <source>Keycard &quot;%1&quot; not created: %2</source>
+        <translation type="unfinished">未创建密钥卡“%1”：%2</translation>
+    </message>
+    <message>
+        <source>Keycard &quot;%1&quot; created</source>
+        <translation type="unfinished">已创建密钥卡“%1”</translation>
+    </message>
+    <message>
+        <source>Applet version</source>
+        <translation type="unfinished">小程序版本</translation>
+    </message>
+    <message>
+        <source>Use applet tag 4.0 (SecureChannel V2)</source>
+        <translation type="unfinished">使用小程序标签 4.0（安全通道 V2）</translation>
+    </message>
+    <message>
+        <source>Tag 4.0 needs keycard-qt SecureChannel V2 support — not driveable by the app yet and refers to status-keycard after #72e9574 commit.</source>
+        <translation type="unfinished">标签 4.0 需要 keycard-qt 安全通道 V2 支持——该小程序尚未支持，并且指向提交 #72e9574 之后的 status-keycard。</translation>
+    </message>
+    <message>
+        <source>Default: tag 3.2 (classic password pairing), matches the current keycard-qt and refers to status-keycard #72e9574 commit.</source>
+        <translation type="unfinished">默认值：标签 3.2（经典密码配对），与当前的 keycard-qt 匹配，并指向提交 #72e9574 之后的 status-keycard。</translation>
+    </message>
+    <message>
+        <source>1. Simulator</source>
+        <translation type="unfinished">1. 模拟器</translation>
+    </message>
+    <message>
+        <source>Restart Keycard Simulator</source>
+        <translation type="unfinished">重新启动密钥卡模拟器</translation>
+    </message>
+    <message>
+        <source>Start Keycard Simulator</source>
+        <translation type="unfinished">启动密钥卡模拟器</translation>
+    </message>
+    <message>
+        <source>2. Create keycard</source>
+        <translation type="unfinished">2. 创建密钥卡</translation>
+    </message>
+    <message>
+        <source>Card id:</source>
+        <translation type="unfinished">卡 ID：</translation>
+    </message>
+    <message>
+        <source>Create Empty Keycard</source>
+        <translation type="unfinished">创建空白密钥卡</translation>
+    </message>
+    <message>
+        <source>— or create one with a seed —</source>
+        <translation type="unfinished">——或者使用种子创建一个——</translation>
+    </message>
+    <message>
+        <source>Seed phrase (mandatory)</source>
+        <translation type="unfinished">种子短语（必需）</translation>
+    </message>
+    <message>
+        <source>PIN:</source>
+        <translation type="unfinished">密码：</translation>
+    </message>
+    <message>
+        <source>PUK:</source>
+        <translation type="unfinished">PUK：</translation>
+    </message>
+    <message>
+        <source>Keycard name (optional)</source>
+        <translation type="unfinished">密钥卡名称（可选）</translation>
+    </message>
+    <message>
+        <source>Paths, comma-separated (optional)</source>
+        <translation type="unfinished">路径，逗号分隔（可选）</translation>
+    </message>
+    <message>
+        <source>Pairing password (optional, default if empty)</source>
+        <translation type="unfinished">配对密码（可选，如果为空则使用默认值）</translation>
+    </message>
+    <message>
+        <source>Create Keycard</source>
+        <translation type="unfinished">创建密钥卡</translation>
+    </message>
+    <message>
+        <source>Creating Keycard...</source>
+        <translation type="unfinished">正在创建密钥卡...</translation>
+    </message>
+    <message>
+        <source>Clear local pairings</source>
+        <translation type="unfinished">清除本地配对</translation>
+    </message>
+    <message>
+        <source>3. Select keycard (does not insert it)</source>
+        <translation type="unfinished">3. 选择密钥卡（无需插入）</translation>
+    </message>
+    <message>
+        <source>&lt;no keycard selected&gt;</source>
+        <translation type="unfinished">未选择密钥卡</translation>
+    </message>
+    <message>
+        <source>4. Reader &amp; card</source>
+        <translation type="unfinished">4. 阅读器和密钥卡</translation>
+    </message>
+    <message>
+        <source>Insert keycard</source>
+        <translation type="unfinished">插入密钥卡</translation>
+    </message>
+    <message>
+        <source>Inserts the selected keycard</source>
+        <translation type="unfinished">插入所选密钥卡</translation>
+    </message>
+    <message>
+        <source>Remove keycard</source>
+        <translation type="unfinished">移除密钥卡</translation>
+    </message>
+    <message>
+        <source>Removes the selected keycard</source>
+        <translation type="unfinished">移除所选密钥卡</translation>
+    </message>
+    <message>
+        <source>Plug reader</source>
+        <translation type="unfinished">连接阅读器</translation>
+    </message>
+    <message>
+        <source>Unplug reader</source>
+        <translation type="unfinished">断开阅读器</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardViewNew</name>
+    <message>
+        <source>Read Keycard</source>
+        <translation type="unfinished">读取密钥卡</translation>
+    </message>
+</context>
+<context>
+    <name>Keychain</name>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished">身份验证</translation>
+    </message>
+    <message>
+        <source>Login to Status</source>
+        <translation type="unfinished">登录状态</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Save password</source>
+        <translation type="unfinished">保存密码</translation>
+    </message>
+    <message>
+        <source>Confirm to enable biometric login</source>
+        <translation type="unfinished">确认启用生物识别登录</translation>
+    </message>
+</context>
+<context>
+    <name>KeypairImportPopup</name>
+    <message>
+        <source>Import missing key pairs</source>
+        <translation type="unfinished">导入缺失的密钥对</translation>
+    </message>
+    <message>
+        <source>Encrypted QR for %1 key pair</source>
+        <translation type="unfinished">%1 密钥对的加密二维码</translation>
+    </message>
+    <message>
+        <source>Encrypted QR for key pairs on this device</source>
+        <translation type="unfinished">此设备上密钥对的加密二维码</translation>
+    </message>
+    <message>
+        <source>Scan encrypted key pair QR code</source>
+        <translation type="unfinished">扫描加密密钥对二维码</translation>
+    </message>
+    <message>
+        <source>Import %1 key pair</source>
+        <translation type="unfinished">导入 %1 密钥对</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>Import key pair</source>
+        <translation type="unfinished">导入密钥对</translation>
+    </message>
+</context>
+<context>
+    <name>KickBanPopup</name>
+    <message>
+        <source>Kick %1</source>
+        <translation type="unfinished">踢出 %1</translation>
+    </message>
+    <message>
+        <source>Ban %1</source>
+        <translation type="unfinished">封禁 %1</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to kick &lt;b&gt;%1&lt;/b&gt; from %2?</source>
+        <translation type="unfinished">您确定要将 &lt;b&gt;%1&lt;/b&gt; 从 %2 中移除吗？</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to ban &lt;b&gt;%1&lt;/b&gt; from %2? This means that they will be kicked from this community and banned from re-joining.</source>
+        <translation type="unfinished">您确定要封禁 &lt;b&gt;%1&lt;/b&gt;，使其从 %2 中被移除并禁止重新加入吗？</translation>
+    </message>
+    <message>
+        <source>Delete all messages posted by the user</source>
+        <translation type="unfinished">删除用户发布的所有消息</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>LanguageView</name>
+    <message>
+        <source>Set Display Currency</source>
+        <translation type="unfinished">设置显示货币</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">语言</translation>
+    </message>
+    <message>
+        <source>We need your help to translate Status, so that together we can bring privacy and free speech to the people everywhere, including those who need it most.</source>
+        <translation type="unfinished">我们需要您的帮助来翻译 Status，以便我们共同为世界各地的人们带来隐私和言论自由，包括那些最需要它的人。</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished">了解更多</translation>
+    </message>
+    <message>
+        <source>Time Format</source>
+        <translation type="unfinished">时间格式</translation>
+    </message>
+    <message>
+        <source>Use System Settings</source>
+        <translation type="unfinished">使用系统设置</translation>
+    </message>
+    <message>
+        <source>Use 24-Hour Time</source>
+        <translation type="unfinished">使用 24 小时制</translation>
+    </message>
+    <message>
+        <source>Change language</source>
+        <translation type="unfinished">更改语言</translation>
+    </message>
+    <message>
+        <source>Display language has been changed. You must restart the application for changes to take effect.</source>
+        <translation type="unfinished">显示语言已更改。您必须重新启动应用程序才能使更改生效。</translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished">重启</translation>
+    </message>
+</context>
+<context>
+    <name>LeftTabView</name>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">钱包</translation>
+    </message>
+    <message>
+        <source>All accounts</source>
+        <translation type="unfinished">所有账户</translation>
+    </message>
+    <message>
+        <source>Saved addresses</source>
+        <translation type="unfinished">已保存的地址</translation>
+    </message>
+    <message>
+        <source>Add account</source>
+        <translation type="unfinished">添加账户</translation>
+    </message>
+    <message>
+        <source>Onchain friends</source>
+        <translation type="unfinished">链上好友</translation>
+    </message>
+</context>
+<context>
+    <name>LinkPreviewCard</name>
+    <message>
+        <source>Channel in</source>
+        <translation type="unfinished">频道内</translation>
+    </message>
+</context>
+<context>
+    <name>LinkPreviewMiniCard</name>
+    <message>
+        <source>Generating preview...</source>
+        <translation type="unfinished">正在生成预览...</translation>
+    </message>
+    <message>
+        <source>Failed to generate preview</source>
+        <translation type="unfinished">未能生成预览</translation>
+    </message>
+</context>
+<context>
+    <name>LinkPreviewSettingsCard</name>
+    <message>
+        <source>Show link previews?</source>
+        <translation type="unfinished">显示链接预览？</translation>
+    </message>
+    <message>
+        <source>A preview of your link will be shown here before you send it</source>
+        <translation type="unfinished">在您发送链接之前，此处将显示您的链接的预览。</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished">选项</translation>
+    </message>
+</context>
+<context>
+    <name>LinkPreviewSettingsCardMenu</name>
+    <message>
+        <source>Link previews</source>
+        <translation type="unfinished">链接预览</translation>
+    </message>
+    <message>
+        <source>Show for this message</source>
+        <translation type="unfinished">为此消息显示</translation>
+    </message>
+    <message>
+        <source>Always show previews</source>
+        <translation type="unfinished">始终显示预览</translation>
+    </message>
+    <message>
+        <source>Never show previews</source>
+        <translation type="unfinished">永不显示预览</translation>
+    </message>
+</context>
+<context>
+    <name>LinksMessageView</name>
+    <message>
+        <source>Enable automatic GIF unfurling</source>
+        <translation type="unfinished">启用自动 GIF 展开</translation>
+    </message>
+    <message>
+        <source>Once enabled, links posted in the chat may share your metadata with their owners</source>
+        <translation type="unfinished">启用后，聊天中发布的链接可能会与其所有者共享您的元数据。</translation>
+    </message>
+    <message>
+        <source>Always Enable</source>
+        <translation type="unfinished">始终启用</translation>
+    </message>
+    <message>
+        <source>Don&apos;t ask me again</source>
+        <translation type="unfinished">不再询问</translation>
+    </message>
+</context>
+<context>
+    <name>ListDropdownContent</name>
+    <message>
+        <source>No data found</source>
+        <translation type="unfinished">未找到数据</translation>
+    </message>
+    <message>
+        <source>Max. 1</source>
+        <translation type="unfinished">最多 1</translation>
+    </message>
+    <message>
+        <source>Search results</source>
+        <translation type="unfinished">搜索结果</translation>
+    </message>
+    <message>
+        <source>No results</source>
+        <translation type="unfinished">没有结果</translation>
+    </message>
+</context>
+<context>
+    <name>LoadingErrorComponent</name>
+    <message>
+        <source>Failed
+to load</source>
+        <translation type="unfinished">加载失败</translation>
+    </message>
+</context>
+<context>
+    <name>LocaleUtils</name>
+    <message>
+        <source>%1K</source>
+        <comment>Thousand</comment>
+        <translation type="unfinished">%1千</translation>
+    </message>
+    <message>
+        <source>%1M</source>
+        <comment>Million</comment>
+        <translation type="unfinished">%1百万</translation>
+    </message>
+    <message>
+        <source>%1B</source>
+        <comment>Billion</comment>
+        <translation type="unfinished">%1十亿</translation>
+    </message>
+    <message>
+        <source>%1T</source>
+        <comment>Trillion</comment>
+        <translation type="unfinished">%1万亿</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">不可用</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <comment>Billion</comment>
+        <translation type="unfinished">十亿</translation>
+    </message>
+    <message>
+        <source>Today %1</source>
+        <translation type="unfinished">今天 %1</translation>
+    </message>
+    <message>
+        <source>Yesterday %1</source>
+        <translation type="unfinished">昨天 %1</translation>
+    </message>
+    <message>
+        <source>%1 %2</source>
+        <translation type="unfinished">%1 %2</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n年前</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n month(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n个月前</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n周前</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n天前</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n小时前</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n min(s) ago</source>
+        <comment>x minute(s) ago</comment>
+        <translation type="unfinished">
+            <numerusform>%n分钟前</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n sec(s) ago</source>
+        <comment>x second(s) ago</comment>
+        <translation type="unfinished">
+            <numerusform>%n秒前</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>now</source>
+        <translation type="unfinished">现在</translation>
+    </message>
+</context>
+<context>
+    <name>LoginBySyncingPage</name>
+    <message>
+        <source>Pair devices to sync</source>
+        <translation type="unfinished">配对设备以同步</translation>
+    </message>
+    <message>
+        <source>If you have Status on another device</source>
+        <translation type="unfinished">如果您在其他设备上安装了 Status</translation>
+    </message>
+</context>
+<context>
+    <name>LoginKeycardBox</name>
+    <message>
+        <source>Plug in Keycard reader...</source>
+        <translation type="unfinished">请插入读卡器...</translation>
+    </message>
+    <message>
+        <source>Tap or insert your Keycard...</source>
+        <translation type="unfinished">轻触或插入您的密钥卡...</translation>
+    </message>
+    <message>
+        <source>Reading Keycard...</source>
+        <translation type="unfinished">正在读取密钥卡...</translation>
+    </message>
+    <message>
+        <source>Wrong Keycard for this profile</source>
+        <translation type="unfinished">此配置文件使用的密钥卡不正确。</translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
+        <translation type="unfinished">密钥卡已锁定。</translation>
+    </message>
+    <message>
+        <source>Unblock</source>
+        <translation type="unfinished">解除锁定。</translation>
+    </message>
+    <message>
+        <source>Pairing password</source>
+        <translation type="unfinished">配对密码。</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+    <message>
+        <source>This isn&apos;t a Keycard.&lt;br&gt;Remove card and insert a Keycard.</source>
+        <translation type="unfinished">这不是密钥卡。&lt;br&gt;请取出卡并插入密钥卡。</translation>
+    </message>
+    <message>
+        <source>Issue detecting Keycard.&lt;br&gt;Re-scan Keycard.</source>
+        <translation type="unfinished">检测密钥卡时出现问题。&lt;br&gt;请重新扫描密钥卡。</translation>
+    </message>
+    <message>
+        <source>This Keycard was set up with a custom pairing password. Enter it to continue.</source>
+        <translation type="unfinished">此密钥卡已设置为使用自定义配对密码。请输入以继续。</translation>
+    </message>
+    <message>
+        <source>No free pairing slots on this Keycard.&lt;br&gt;You can use it with previously paired installations.</source>
+        <translation type="unfinished">此密钥卡上没有可用的配对插槽。&lt;br&gt;您可以使用它与先前配对的安装程序一起使用。</translation>
+    </message>
+    <message>
+        <source>The scanned Keycard is empty.&lt;br&gt;Scan the correct Keycard for this profile.</source>
+        <translation type="unfinished">扫描到的密钥卡为空。&lt;br&gt;请扫描适用于此配置文件的正确密钥卡。</translation>
+    </message>
+    <message numerus="yes">
+        <source>PIN incorrect. %n attempt(s) remaining.</source>
+        <translation type="unfinished">
+            <numerusform>密码错误。您还有%n次尝试机会。</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Login failed. %1</source>
+        <translation type="unfinished">登录失败：%1。</translation>
+    </message>
+    <message>
+        <source>Show details.</source>
+        <translation type="unfinished">显示详细信息。</translation>
+    </message>
+    <message>
+        <source>Enter Keycard PIN</source>
+        <translation type="unfinished">输入密钥卡密码</translation>
+    </message>
+</context>
+<context>
+    <name>LoginPasswordBox</name>
+    <message>
+        <source>Log In</source>
+        <translation type="unfinished">登录</translation>
+    </message>
+    <message>
+        <source>Forgot your password?</source>
+        <translation type="unfinished">忘记密码？</translation>
+    </message>
+    <message>
+        <source>2. Reinstall the Status app</source>
+        <translation type="unfinished">2. 重新安装 Status 应用</translation>
+    </message>
+    <message>
+        <source>Re-download the app from %1 %2</source>
+        <translation type="unfinished">从 %1 %2 重新下载该应用</translation>
+    </message>
+    <message>
+        <source>Copy instructions</source>
+        <translation type="unfinished">复制说明</translation>
+    </message>
+    <message>
+        <source>To recover your profile and data follow these steps:</source>
+        <translation type="unfinished">要恢复您的个人资料和数据，请执行以下步骤：</translation>
+    </message>
+    <message>
+        <source>1. Copy backup file</source>
+        <translation type="unfinished">1. 复制备份文件</translation>
+    </message>
+    <message>
+        <source>3. Restore your Status profile(s)</source>
+        <translation type="unfinished">3. 还原您的 Status 个人资料</translation>
+    </message>
+    <message>
+        <source>If you have multiple profiles, repeat for each one:&lt;ul&gt;&lt;li&gt;On the Welcome screen, open the profile menu → Log in.&lt;li&gt;Select Log in with Recovery Phrase.&lt;li&gt;Enter your recovery phrase.&lt;li&gt;Create a new password.&lt;li&gt;Import the backup file from Step 1, or skip and import later from &lt;i&gt;Settings &gt; On-device backup&lt;/i&gt;.</source>
+        <translation type="unfinished">如果您有多个个人资料，请对每个个人资料重复执行以下操作：&lt;ul&gt;&lt;li&gt;在欢迎界面上，打开个人资料菜单 → 登录。&lt;li&gt;选择使用恢复短语登录。&lt;li&gt;输入您的恢复短语。&lt;li&gt;创建一个新密码。&lt;li&gt;导入步骤 1 中的备份文件，或者跳过并在稍后从 &lt;i&gt;设置 &gt; 设备上的备份&lt;/i&gt; 中导入。</translation>
+    </message>
+    <message>
+        <source>Save your Status profile backup file to a different folder, as it will be erased when you reinstall Status. If you have multiple profiles, save all their backup files.</source>
+        <translation type="unfinished">将您的 Status 个人资料备份文件保存到不同的文件夹中，因为在重新安装 Status 时它将被删除。如果您有多个个人资料，请保存所有这些个人资料的备份文件。</translation>
+    </message>
+</context>
+<context>
+    <name>LoginPasswordInput</name>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished">密码</translation>
+    </message>
+    <message>
+        <source>Hide password</source>
+        <translation type="unfinished">隐藏密码</translation>
+    </message>
+    <message>
+        <source>Reveal password</source>
+        <translation type="unfinished">显示密码</translation>
+    </message>
+</context>
+<context>
+    <name>LoginScreen</name>
+    <message>
+        <source>Password incorrect. %1</source>
+        <translation type="unfinished">密码不正确。%1</translation>
+    </message>
+    <message>
+        <source>Forgot password?</source>
+        <translation type="unfinished">忘记密码？</translation>
+    </message>
+    <message>
+        <source>Login failed. %1</source>
+        <translation type="unfinished">登录失败。%1</translation>
+    </message>
+    <message>
+        <source>Show details.</source>
+        <translation type="unfinished">显示详细信息。</translation>
+    </message>
+    <message>
+        <source>Welcome back</source>
+        <translation type="unfinished">欢迎回来</translation>
+    </message>
+    <message>
+        <source>Lost Keycard?</source>
+        <translation type="unfinished">丢失密钥卡？</translation>
+    </message>
+    <message>
+        <source>Login failed</source>
+        <translation type="unfinished">登录失败</translation>
+    </message>
+    <message>
+        <source>Copy error message</source>
+        <translation type="unfinished">复制错误消息</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+</context>
+<context>
+    <name>LoginTouchIdIndicator</name>
+    <message>
+        <source>Biometrics successful</source>
+        <translation type="unfinished">生物识别成功</translation>
+    </message>
+    <message>
+        <source>Biometrics failed</source>
+        <translation type="unfinished">生物识别失败</translation>
+    </message>
+    <message>
+        <source>Request biometrics prompt again</source>
+        <translation type="unfinished">再次请求生物识别提示</translation>
+    </message>
+</context>
+<context>
+    <name>LoginUserSelector</name>
+    <message>
+        <source>Create profile</source>
+        <translation type="unfinished">创建个人资料</translation>
+    </message>
+    <message>
+        <source>Log in</source>
+        <translation type="unfinished">登录</translation>
+    </message>
+    <message>
+        <source>Manage profiles</source>
+        <translation type="unfinished">管理资料</translation>
+    </message>
+</context>
+<context>
+    <name>LoginUserSelectorDelegate</name>
+    <message>
+        <source>Keycard is not yet supported</source>
+        <translation type="unfinished">目前尚不支持密钥卡</translation>
+    </message>
+</context>
+<context>
+    <name>LogoPicker</name>
+    <message>
+        <source>Community logo</source>
+        <translation type="unfinished">社区徽标</translation>
+    </message>
+    <message>
+        <source>Choose an image as logo</source>
+        <translation type="unfinished">选择一张图片作为徽标</translation>
+    </message>
+    <message>
+        <source>Make this my Community logo</source>
+        <translation type="unfinished">将此设置为我的社区徽标</translation>
+    </message>
+    <message>
+        <source>Upload a community logo</source>
+        <translation type="unfinished">上传社区徽标</translation>
+    </message>
+</context>
+<context>
+    <name>LogosNetworkView</name>
+    <message>
+        <source>Messages are sent via the Logos Messaging Network, a peer-to-peer network powered collectively by users running Status Desktop, making Status decentralized, resilient, and censorship-resistant. %1</source>
+        <translation type="unfinished">消息通过 Logos 消息网络发送，这是一个由运行 Status Desktop 的用户共同支持的对等网络，这使得 Status 去中心化、具有弹性且能够抵抗审查。%1</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished">了解更多</translation>
+    </message>
+    <message>
+        <source>Connected Logos network peers</source>
+        <translation type="unfinished">已连接的 Logos 网络节点</translation>
+    </message>
+    <message>
+        <source>Peers</source>
+        <translation type="unfinished">节点</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <translation type="unfinished">节点</translation>
+    </message>
+    <message>
+        <source>Checking peer connection...</source>
+        <translation type="unfinished">正在检查节点连接...</translation>
+    </message>
+    <message>
+        <source>Connected</source>
+        <translation type="unfinished">已连接</translation>
+    </message>
+    <message>
+        <source>Refresh Logos network peers</source>
+        <translation type="unfinished">刷新 Logos 网络节点</translation>
+    </message>
+    <message>
+        <source>Unable to refresh Logos network peers: %1</source>
+        <translation type="unfinished">无法刷新 Logos 网络节点：%1</translation>
+    </message>
+    <message>
+        <source>If Status has no connected Logos peers, check:</source>
+        <translation type="unfinished">如果 Status 没有连接的 Logos 节点，请检查：</translation>
+    </message>
+    <message>
+        <source>Some networks may block access to the Logos network. %1</source>
+        <translation type="unfinished">某些网络可能会阻止访问 Logos 网络。%1</translation>
+    </message>
+    <message>
+        <source>Try using a VPN</source>
+        <translation type="unfinished">尝试使用 VPN</translation>
+    </message>
+    <message>
+        <source>Current internet connection may be unstable. %1</source>
+        <translation type="unfinished">当前互联网连接可能不稳定。%1</translation>
+    </message>
+    <message>
+        <source>Try another network or disconnect your VPN</source>
+        <translation type="unfinished">尝试使用其他网络或断开 VPN 连接</translation>
+    </message>
+    <message>
+        <source>How to fix Logos network connection</source>
+        <translation type="unfinished">如何修复 Logos 网络连接</translation>
+    </message>
+</context>
+<context>
+    <name>Main</name>
+    <message>
+        <source>Account name</source>
+        <translation type="unfinished">帐户名</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message numerus="yes">
+        <source>Account name must be at least %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>帐户名必须至少为%n个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Colour</source>
+        <translation type="unfinished">颜色</translation>
+    </message>
+    <message>
+        <source>Account</source>
+        <translation type="unfinished">账户</translation>
+    </message>
+    <message>
+        <source>Public address of private key</source>
+        <translation type="unfinished">私钥的公共地址</translation>
+    </message>
+</context>
+<context>
+    <name>MainView</name>
+    <message>
+        <source>Secure your funds. Keep your profile safe.</source>
+        <translation type="unfinished">保护您的资金。确保您的个人资料安全。</translation>
+    </message>
+    <message>
+        <source>Networks</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Account order</source>
+        <translation type="unfinished">账户顺序</translation>
+    </message>
+    <message>
+        <source>Manage Tokens</source>
+        <translation type="unfinished">管理令牌</translation>
+    </message>
+    <message>
+        <source>Saved Addresses</source>
+        <translation type="unfinished">已保存的地址</translation>
+    </message>
+    <message>
+        <source>Import key pairs from this device to your other synced devices</source>
+        <translation type="unfinished">将此设备上的密钥对导入到您其他同步的设备上</translation>
+    </message>
+    <message>
+        <source>Show encrypted QR of key pairs on device</source>
+        <translation type="unfinished">显示设备上密钥对的加密二维码</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n key pair(s) require import to use on this device</source>
+        <translation type="unfinished">
+            <numerusform>需要导入 %n 个密钥对才能在此设备上使用</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import missing key pairs</source>
+        <translation type="unfinished">导入缺失的密钥对</translation>
+    </message>
+    <message>
+        <source>Automatically apply key pair migrations from paired devices</source>
+        <translation type="unfinished">自动应用来自配对设备的密钥对迁移</translation>
+    </message>
+    <message>
+        <source>When off, moving a key pair to or from a Keycard on a paired device won&apos;t change how this device logs in or signs. Turning it back on doesn&apos;t apply past changes.</source>
+        <translation type="unfinished">当关闭时，将密钥对移动到配对设备上的Keycard或从Keycard移出不会改变此设备的登录或签名方式。重新打开它不会应用之前的更改。</translation>
+    </message>
+    <message>
+        <source>Get Keycard</source>
+        <translation type="unfinished">获取Keycard</translation>
+    </message>
+</context>
+<context>
+    <name>ManageAssetsPanel</name>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>Your assets will appear here</source>
+        <translation type="unfinished">您的资产将显示在此处</translation>
+    </message>
+    <message>
+        <source>Community minted</source>
+        <translation type="unfinished">社区铸造</translation>
+    </message>
+    <message>
+        <source>Arrange by community</source>
+        <translation type="unfinished">按社区排列</translation>
+    </message>
+    <message>
+        <source>Your community minted assets will appear here</source>
+        <translation type="unfinished">您的社区铸造的资产将显示在此处</translation>
+    </message>
+</context>
+<context>
+    <name>ManageCollectiblesPanel</name>
+    <message>
+        <source>Community minted</source>
+        <translation type="unfinished">社区铸造</translation>
+    </message>
+    <message>
+        <source>Arrange by community</source>
+        <translation type="unfinished">按社区排列</translation>
+    </message>
+    <message>
+        <source>Your community minted collectibles will appear here</source>
+        <translation type="unfinished">您社区铸造的收藏品将显示在此处</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">其他</translation>
+    </message>
+    <message>
+        <source>Arrange by collection</source>
+        <translation type="unfinished">按系列排列</translation>
+    </message>
+    <message>
+        <source>Your other collectibles will appear here</source>
+        <translation type="unfinished">您的其他收藏品将显示在此处</translation>
+    </message>
+</context>
+<context>
+    <name>ManageHiddenPanel</name>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>Your hidden collectibles will appear here</source>
+        <translation type="unfinished">您的隐藏收藏品将在此处显示</translation>
+    </message>
+    <message>
+        <source>Your hidden assets will appear here</source>
+        <translation type="unfinished">您的隐藏资产将在此处显示</translation>
+    </message>
+</context>
+<context>
+    <name>ManageKeyPairAccountsState</name>
+    <message>
+        <source>Name your accounts</source>
+        <translation type="unfinished">为您的帐户命名</translation>
+    </message>
+    <message>
+        <source>Colour</source>
+        <translation type="unfinished">颜色</translation>
+    </message>
+    <message>
+        <source>Remove account</source>
+        <translation type="unfinished">移除账户</translation>
+    </message>
+    <message>
+        <source>Do you want to delete the &quot;%1&quot; account?</source>
+        <translation type="unfinished">您是否要删除“%1”帐户？</translation>
+    </message>
+    <message>
+        <source>Do you want to delete this account?</source>
+        <translation type="unfinished">您是否要删除此帐户？</translation>
+    </message>
+    <message>
+        <source>Yes, delete this account</source>
+        <translation type="unfinished">是，删除此帐户</translation>
+    </message>
+    <message>
+        <source>What would you like this account to be called?</source>
+        <translation type="unfinished">您希望将此帐户命名为哪个名称？</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">预览</translation>
+    </message>
+</context>
+<context>
+    <name>ManageTokenMenuButton</name>
+    <message>
+        <source>Move to top</source>
+        <translation type="unfinished">移到顶部</translation>
+    </message>
+    <message>
+        <source>Move up</source>
+        <translation type="unfinished">向上移动</translation>
+    </message>
+    <message>
+        <source>Move down</source>
+        <translation type="unfinished">向下移动</translation>
+    </message>
+    <message>
+        <source>Move to bottom</source>
+        <translation type="unfinished">移到底部</translation>
+    </message>
+    <message>
+        <source>Hide collectible</source>
+        <translation type="unfinished">隐藏收藏品</translation>
+    </message>
+    <message>
+        <source>Hide asset</source>
+        <translation type="unfinished">隐藏资产</translation>
+    </message>
+    <message>
+        <source>Show collectible</source>
+        <translation type="unfinished">显示收藏品</translation>
+    </message>
+    <message>
+        <source>Show asset</source>
+        <translation type="unfinished">显示资产</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">隐藏</translation>
+    </message>
+    <message>
+        <source>This collectible</source>
+        <translation type="unfinished">此收藏品</translation>
+    </message>
+    <message>
+        <source>This asset</source>
+        <translation type="unfinished">此资产</translation>
+    </message>
+    <message>
+        <source>All collectibles from this community</source>
+        <translation type="unfinished">来自此社区的所有收藏品</translation>
+    </message>
+    <message>
+        <source>All assets from this community</source>
+        <translation type="unfinished">来自此社区的所有资产</translation>
+    </message>
+    <message>
+        <source>All collectibles from this collection</source>
+        <translation type="unfinished">来自此系列的全部收藏品</translation>
+    </message>
+    <message>
+        <source>Hide all collectibles from this collection</source>
+        <translation type="unfinished">隐藏此系列中的所有收藏品</translation>
+    </message>
+    <message>
+        <source>Hide all collectibles from this community</source>
+        <translation type="unfinished">隐藏此社区的所有收藏品</translation>
+    </message>
+    <message>
+        <source>Hide all assets from this community</source>
+        <translation type="unfinished">隐藏此社区的所有资产</translation>
+    </message>
+    <message>
+        <source>Show all collectibles from this collection</source>
+        <translation type="unfinished">显示此系列中的所有收藏品</translation>
+    </message>
+    <message>
+        <source>Show all collectibles from this community</source>
+        <translation type="unfinished">显示来自此社区的所有收藏品</translation>
+    </message>
+    <message>
+        <source>Show all assets from this community</source>
+        <translation type="unfinished">显示来自此社区的所有资产</translation>
+    </message>
+</context>
+<context>
+    <name>ManageTokensCommunityTag</name>
+    <message>
+        <source>Community %1</source>
+        <translation type="unfinished">社区 %1</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>Unknown community</source>
+        <translation type="unfinished">未知社区</translation>
+    </message>
+    <message>
+        <source>Community name could not be fetched</source>
+        <translation type="unfinished">无法获取社区名称</translation>
+    </message>
+</context>
+<context>
+    <name>ManageTokensDelegate</name>
+    <message>
+        <source>Community minted</source>
+        <translation type="unfinished">社区铸造</translation>
+    </message>
+    <message>
+        <source>%1 was successfully hidden</source>
+        <translation type="unfinished">%1 已成功隐藏</translation>
+    </message>
+    <message>
+        <source>%1 (%2) was successfully hidden</source>
+        <translation type="unfinished">%1 (%2) 已成功隐藏</translation>
+    </message>
+</context>
+<context>
+    <name>ManageTokensGroupDelegate</name>
+    <message>
+        <source>Community %1</source>
+        <translation type="unfinished">社区 %1</translation>
+    </message>
+    <message>
+        <source>Unknown community</source>
+        <translation type="unfinished">未知社区</translation>
+    </message>
+    <message>
+        <source>Community name could not be fetched</source>
+        <translation type="unfinished">无法获取社区名称</translation>
+    </message>
+</context>
+<context>
+    <name>ManageTokensView</name>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished">隐藏</translation>
+    </message>
+    <message>
+        <source>Advanced</source>
+        <translation type="unfinished">高级</translation>
+    </message>
+    <message>
+        <source>Show community assets when sending tokens</source>
+        <translation type="unfinished">发送代币时显示社区资产</translation>
+    </message>
+    <message>
+        <source>Don’t display assets with balance lower than</source>
+        <translation type="unfinished">不显示余额低于的资产</translation>
+    </message>
+    <message>
+        <source>Auto-refresh tokens lists</source>
+        <translation type="unfinished">自动刷新代币列表</translation>
+    </message>
+    <message>
+        <source>Token lists</source>
+        <translation type="unfinished">代币列表</translation>
+    </message>
+    <message>
+        <source>Last check %1</source>
+        <translation type="unfinished">上次检查：%1</translation>
+    </message>
+    <message>
+        <source>Available if third-party services enabled</source>
+        <translation type="unfinished">如果启用了第三方服务，则可用</translation>
+    </message>
+</context>
+<context>
+    <name>MarkAsIDVerifiedDialog</name>
+    <message>
+        <source>Mark as trusted</source>
+        <translation type="unfinished">标记为信任联系人</translation>
+    </message>
+    <message>
+        <source>Mark users as trusted only if you&apos;re 100% sure who they are.</source>
+        <translation type="unfinished">只有在您 100% 确定用户身份时，才将他们标记为受信任用户。</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>MarkAsUntrustedPopup</name>
+    <message>
+        <source>Mark as untrusted</source>
+        <translation type="unfinished">标记为不受信任</translation>
+    </message>
+    <message>
+        <source>%1 will be marked as untrusted. This mark will only be visible to you.</source>
+        <translation type="unfinished">%1将被标记为不受信任。此标记仅对您可见。</translation>
+    </message>
+    <message>
+        <source>Remove trust mark</source>
+        <translation type="unfinished">移除信任标记</translation>
+    </message>
+    <message>
+        <source>Remove contact</source>
+        <translation type="unfinished">删除联系人</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>MarketFooter</name>
+    <message numerus="yes">
+        <source>Showing %L1 to %L2 of %n result(s)</source>
+        <translation type="unfinished">
+            <numerusform>显示第 %L1 到 %L2 个结果，共 %n 个结果</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>MarketLayout</name>
+    <message>
+        <source>Market</source>
+        <translation type="unfinished">市场</translation>
+    </message>
+    <message>
+        <source>Swap</source>
+        <translation type="unfinished">兑换</translation>
+    </message>
+    <message>
+        <source>%1 %2%</source>
+        <comment>[up/down/none character depending on value sign] [localized percentage value]%</comment>
+        <translation type="unfinished">%1 %2%</translation>
+    </message>
+</context>
+<context>
+    <name>MarketPrivacyWall</name>
+    <message>
+        <source>Enable third-party services for market features to work.</source>
+        <translation type="unfinished">启用第三方服务，以使市场功能正常运行。</translation>
+    </message>
+    <message>
+        <source>Real-time token data</source>
+        <translation type="unfinished">实时代币数据</translation>
+    </message>
+    <message>
+        <source>Stay updated with live prices and trading volumes.</source>
+        <translation type="unfinished">随时了解实时价格和交易量。</translation>
+    </message>
+    <message>
+        <source>Swap straight from the market</source>
+        <translation type="unfinished">直接从市场上进行兑换</translation>
+    </message>
+    <message>
+        <source>Easy swaps to any token from leaderboard</source>
+        <translation type="unfinished">轻松兑换排行榜中的任何代币</translation>
+    </message>
+</context>
+<context>
+    <name>MarketTokenHeader</name>
+    <message>
+        <source>#</source>
+        <translation type="unfinished">#</translation>
+    </message>
+    <message>
+        <source>Token</source>
+        <translation type="unfinished">代币</translation>
+    </message>
+    <message>
+        <source>Price</source>
+        <translation type="unfinished">价格</translation>
+    </message>
+    <message>
+        <source>24hr</source>
+        <translation type="unfinished">24小时</translation>
+    </message>
+    <message>
+        <source>24hr Volume</source>
+        <translation type="unfinished">24小时交易量</translation>
+    </message>
+    <message>
+        <source>Market Cap</source>
+        <translation type="unfinished">市值</translation>
+    </message>
+</context>
+<context>
+    <name>MaxSendButton</name>
+    <message>
+        <source>Max. %1</source>
+        <translation type="unfinished">最大值：%1</translation>
+    </message>
+</context>
+<context>
+    <name>MembersDropdown</name>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+    <message>
+        <source>Search members</source>
+        <translation type="unfinished">搜索成员</translation>
+    </message>
+    <message>
+        <source>No contacts found</source>
+        <translation type="unfinished">未找到联系人</translation>
+    </message>
+    <message>
+        <source>Select all</source>
+        <translation type="unfinished">全选</translation>
+    </message>
+    <message>
+        <source>Update members</source>
+        <translation type="unfinished">更新成员</translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n member(s)</source>
+        <translation type="unfinished">
+            <numerusform>添加%n个成员</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+</context>
+<context>
+    <name>MembersSelectorBase</name>
+    <message>
+        <source>To:</source>
+        <translation type="unfinished">到:</translation>
+    </message>
+    <message>
+        <source>%1 USER LIMIT REACHED</source>
+        <translation type="unfinished">已达到 %1 用户限制</translation>
+    </message>
+</context>
+<context>
+    <name>MembersSelectorPanel</name>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 位成员</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>MembersSettingsPanel</name>
+    <message>
+        <source>Members</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+    <message>
+        <source>Invite people</source>
+        <translation type="unfinished">邀请用户</translation>
+    </message>
+    <message>
+        <source>All Members</source>
+        <translation type="unfinished">所有成员</translation>
+    </message>
+    <message>
+        <source>Pending Requests</source>
+        <translation type="unfinished">待处理的请求</translation>
+    </message>
+    <message>
+        <source>Rejected</source>
+        <translation type="unfinished">已拒绝</translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <translation type="unfinished">已禁止</translation>
+    </message>
+    <message>
+        <source>Search by name or chat key</source>
+        <translation type="unfinished">按姓名或聊天密钥搜索</translation>
+    </message>
+</context>
+<context>
+    <name>MembersTabPanel</name>
+    <message>
+        <source>Waiting for owner node to come online</source>
+        <translation type="unfinished">等待所有者节点上线</translation>
+    </message>
+    <message>
+        <source>Messages deleted</source>
+        <translation type="unfinished">消息已删除</translation>
+    </message>
+    <message>
+        <source>Accept pending</source>
+        <translation type="unfinished">接受待处理请求</translation>
+    </message>
+    <message>
+        <source>Reject pending</source>
+        <translation type="unfinished">拒绝待处理请求</translation>
+    </message>
+    <message>
+        <source>Ban pending</source>
+        <translation type="unfinished">待处理的封禁</translation>
+    </message>
+    <message>
+        <source>Unban pending</source>
+        <translation type="unfinished">待处理的解封</translation>
+    </message>
+    <message>
+        <source>Kick pending</source>
+        <translation type="unfinished">待处理的踢出</translation>
+    </message>
+    <message>
+        <source>View messages</source>
+        <translation type="unfinished">查看消息</translation>
+    </message>
+    <message>
+        <source>Kick</source>
+        <translation type="unfinished">踢出</translation>
+    </message>
+    <message>
+        <source>Ban</source>
+        <translation type="unfinished">封禁</translation>
+    </message>
+    <message>
+        <source>Unban</source>
+        <translation type="unfinished">解封</translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished">接受</translation>
+    </message>
+    <message>
+        <source>Reject</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+</context>
+<context>
+    <name>MenuBackButton</name>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+</context>
+<context>
+    <name>MessageContextMenuView</name>
+    <message>
+        <source>Reply to</source>
+        <translation type="unfinished">回复</translation>
+    </message>
+    <message>
+        <source>Edit message</source>
+        <translation type="unfinished">编辑消息</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">复制</translation>
+    </message>
+    <message>
+        <source>Copy message</source>
+        <translation type="unfinished">复制消息</translation>
+    </message>
+    <message>
+        <source>Copy Message Id</source>
+        <translation type="unfinished">复制消息 ID</translation>
+    </message>
+    <message>
+        <source>Copy link to message</source>
+        <translation type="unfinished">复制消息链接</translation>
+    </message>
+    <message>
+        <source>Unpin</source>
+        <translation type="unfinished">取消置顶</translation>
+    </message>
+    <message>
+        <source>Pin</source>
+        <translation type="unfinished">置顶</translation>
+    </message>
+    <message>
+        <source>Mark as unread</source>
+        <translation type="unfinished">标记为未读</translation>
+    </message>
+    <message>
+        <source>Delete message</source>
+        <translation type="unfinished">删除消息</translation>
+    </message>
+</context>
+<context>
+    <name>MessageReactionsRow</name>
+    <message>
+        <source>Add reaction</source>
+        <translation type="unfinished">添加表情</translation>
+    </message>
+</context>
+<context>
+    <name>MessageView</name>
+    <message>
+        <source>You sent a contact request to %1</source>
+        <translation type="unfinished">您已向%1发送联系请求</translation>
+    </message>
+    <message>
+        <source>%1 sent you a contact request</source>
+        <translation type="unfinished">%1向您发送了联系请求</translation>
+    </message>
+    <message>
+        <source>You accepted %1&apos;s contact request</source>
+        <translation type="unfinished">您接受了%1的联系请求</translation>
+    </message>
+    <message>
+        <source>%1 accepted your contact request</source>
+        <translation type="unfinished">%1接受了您的联系请求</translation>
+    </message>
+    <message>
+        <source>You removed %1 as a contact</source>
+        <translation type="unfinished">您将%1从联系人列表中删除了。</translation>
+    </message>
+    <message>
+        <source>%1 removed you as a contact</source>
+        <translation type="unfinished">%1将您从其联系人列表中删除了。</translation>
+    </message>
+    <message>
+        <source>%1 pinned a message</source>
+        <translation type="unfinished">%1固定了一条消息</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; deleted this message</source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;删除了此消息</translation>
+    </message>
+    <message>
+        <source>Pinned</source>
+        <translation type="unfinished">已固定</translation>
+    </message>
+    <message>
+        <source>Pinned by</source>
+        <translation type="unfinished">由...固定</translation>
+    </message>
+    <message>
+        <source>Imported from discord</source>
+        <translation type="unfinished">从Discord导入</translation>
+    </message>
+    <message>
+        <source>Bridged from %1</source>
+        <translation type="unfinished">从%1桥接</translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">消息已删除</translation>
+    </message>
+    <message>
+        <source>Reply</source>
+        <translation type="unfinished">回复</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">编辑</translation>
+    </message>
+    <message>
+        <source>Unpin</source>
+        <translation type="unfinished">取消固定</translation>
+    </message>
+    <message>
+        <source>Pin</source>
+        <translation type="unfinished">固定</translation>
+    </message>
+    <message>
+        <source>Mark as unread</source>
+        <translation type="unfinished">标记为未读</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Unknown message. Trying to recover it</source>
+        <translation type="unfinished">未知消息。正在尝试恢复。</translation>
+    </message>
+</context>
+<context>
+    <name>MessagingView</name>
+    <message>
+        <source>Contacts, Requests, and Blocked Users</source>
+        <translation type="unfinished">联系人、请求和已阻止的用户</translation>
+    </message>
+    <message>
+        <source>GIF link previews</source>
+        <translation type="unfinished">GIF链接预览</translation>
+    </message>
+    <message>
+        <source>Allow show GIF previews</source>
+        <translation type="unfinished">允许显示GIF预览</translation>
+    </message>
+    <message>
+        <source>Website link previews</source>
+        <translation type="unfinished">网站链接预览</translation>
+    </message>
+    <message>
+        <source>Always ask</source>
+        <translation type="unfinished">始终询问</translation>
+    </message>
+    <message>
+        <source>Always show previews</source>
+        <translation type="unfinished">始终显示预览</translation>
+    </message>
+    <message>
+        <source>Never show previews</source>
+        <translation type="unfinished">从不显示预览</translation>
+    </message>
+    <message>
+        <source>Receive community messages &amp; requests from non-contacts</source>
+        <translation type="unfinished">接收来自非联系人的社区消息和请求</translation>
+    </message>
+    <message>
+        <source>Mobile data and Wi-Fi</source>
+        <translation type="unfinished">移动数据和Wi-Fi</translation>
+    </message>
+    <message>
+        <source>Wi-Fi only</source>
+        <translation type="unfinished">仅限Wi-Fi</translation>
+    </message>
+    <message>
+        <source>Sync messages on mobile data?</source>
+        <translation type="unfinished">是否通过移动数据同步消息？</translation>
+    </message>
+    <message>
+        <source>If you choose to sync over Wi-Fi only, messages sent to you while you are offline will be delivered once you connect to Wi-Fi.</source>
+        <translation type="unfinished">如果您选择仅通过Wi-Fi同步，在您离线期间发送给您的消息将在您连接到Wi-Fi时送达。</translation>
+    </message>
+    <message>
+        <source>The Status App uses a lot of data when fetching missed messages. If you have a limited data plan, consider syncing over Wi-Fi only.</source>
+        <translation type="unfinished">Status应用程序在获取未读消息时会消耗大量数据。如果您有有限的数据计划，请考虑仅通过Wi-Fi同步。</translation>
+    </message>
+    <message>
+        <source>Message syncing</source>
+        <translation type="unfinished">消息同步</translation>
+    </message>
+</context>
+<context>
+    <name>MintTokensFooterPanel</name>
+    <message>
+        <source>Send Owner token to transfer %1 Community ownership</source>
+        <translation type="unfinished">将所有者代币发送以转移%1社区的所有权</translation>
+    </message>
+    <message>
+        <source>Airdrop</source>
+        <translation type="unfinished">空投</translation>
+    </message>
+    <message>
+        <source>Retail</source>
+        <translation type="unfinished">零售</translation>
+    </message>
+    <message>
+        <source>Remotely destruct</source>
+        <translation type="unfinished">远程销毁</translation>
+    </message>
+    <message>
+        <source>Burn</source>
+        <translation type="unfinished">燃烧</translation>
+    </message>
+</context>
+<context>
+    <name>MintTokensSettingsPanel</name>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+    <message>
+        <source>Tokens</source>
+        <translation type="unfinished">代币</translation>
+    </message>
+    <message>
+        <source>Mint token</source>
+        <translation type="unfinished">铸造代币</translation>
+    </message>
+    <message>
+        <source>Loading tokens...</source>
+        <translation type="unfinished">正在加载代币...</translation>
+    </message>
+    <message>
+        <source>In order to mint, you must hodl the TokenMaster token for %1</source>
+        <translation type="unfinished">为了铸造，您必须持有TokenMaster代币%1个</translation>
+    </message>
+    <message>
+        <source>Mint Owner token</source>
+        <translation type="unfinished">铸造所有者代币</translation>
+    </message>
+    <message>
+        <source>Sign transaction - Mint %1 tokens</source>
+        <translation type="unfinished">签署交易 - 铸造%1个代币</translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>Sign transaction - Mint %1 token</source>
+        <translation type="unfinished">签署交易 - 铸造%1个代币</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Retry mint</source>
+        <translation type="unfinished">重试铸造</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation type="unfinished">刷新</translation>
+    </message>
+    <message>
+        <source>Restart token&apos;s transaction listening if the token got stuck in minting state</source>
+        <translation type="unfinished">如果代币卡在铸造状态，请重新启动其事务监听</translation>
+    </message>
+    <message>
+        <source>Sign transaction - Remotely-destruct TokenMaster token</source>
+        <translation type="unfinished">签署交易 - 远程销毁TokenMaster代币</translation>
+    </message>
+    <message numerus="yes">
+        <source>Remotely destruct %n token(s)</source>
+        <translation type="unfinished">
+            <numerusform>远程销毁 %n 个令牌</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remotely destruct</source>
+        <translation type="unfinished">远程销毁</translation>
+    </message>
+    <message>
+        <source>Continuing will destroy tokens held by members and revoke any permissions they are given. To undo you will have to issue them new tokens.</source>
+        <translation type="unfinished">继续操作将销毁成员持有的代币并撤销他们所拥有的任何权限。要撤消，您必须向他们发行新的代币。</translation>
+    </message>
+    <message>
+        <source>Sign transaction - Remotely destruct %1 token</source>
+        <translation type="unfinished">签署交易 - 远程销毁%1个代币</translation>
+    </message>
+    <message>
+        <source>Sign transaction - Burn %1 tokens</source>
+        <translation type="unfinished">签署交易 - 销毁%1个代币</translation>
+    </message>
+    <message numerus="yes">
+        <source>Remotely destruct %Ln %1 token(s) on %2</source>
+        <translation type="unfinished">
+            <numerusform>在 %2 上远程销毁 %1 个令牌</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Delete %1</source>
+        <translation type="unfinished">删除%1</translation>
+    </message>
+    <message>
+        <source>Delete %1 token</source>
+        <translation type="unfinished">删除%1个代币</translation>
+    </message>
+    <message>
+        <source>%1 is not yet minted, are you sure you want to delete it? All data associated with this token including its icon and description will be permanently deleted.</source>
+        <translation type="unfinished">%1尚未铸造，您确定要删除它吗？与此代币相关的所有数据（包括其图标和描述）都将被永久删除。</translation>
+    </message>
+</context>
+<context>
+    <name>MintedTokensView</name>
+    <message>
+        <source>Minting failed</source>
+        <translation type="unfinished">铸造失败</translation>
+    </message>
+    <message>
+        <source>Minting...</source>
+        <translation type="unfinished">正在铸造...</translation>
+    </message>
+    <message>
+        <source>1 of 1 (you hodl)</source>
+        <translation type="unfinished">1/1（您持有）</translation>
+    </message>
+    <message>
+        <source>1 of 1</source>
+        <translation type="unfinished">1/1</translation>
+    </message>
+    <message>
+        <source>∞ remaining</source>
+        <translation type="unfinished">剩余 ∞ 个</translation>
+    </message>
+    <message>
+        <source>%L1 / %L2 remaining</source>
+        <translation type="unfinished">剩余 %L1/%L2 个</translation>
+    </message>
+    <message>
+        <source>Community tokens</source>
+        <translation type="unfinished">社区代币</translation>
+    </message>
+    <message>
+        <source>You can mint custom tokens and import tokens for your community</source>
+        <translation type="unfinished">您可以为您的社区铸造自定义代币并导入代币</translation>
+    </message>
+    <message>
+        <source>Create remotely destructible soulbound tokens for admin permissions</source>
+        <translation type="unfinished">创建可远程销毁的灵魂绑定代币，用于管理员权限</translation>
+    </message>
+    <message>
+        <source>Reward individual members with custom tokens for their contribution</source>
+        <translation type="unfinished">使用自定义代币奖励个人成员以表彰他们的贡献</translation>
+    </message>
+    <message>
+        <source>Mint tokens for use with community and channel permissions</source>
+        <translation type="unfinished">铸造代币以用于社区和频道权限</translation>
+    </message>
+    <message>
+        <source>Get started</source>
+        <translation type="unfinished">开始使用</translation>
+    </message>
+    <message>
+        <source>Token minting can only be performed by admins that hodl the Community’s TokenMaster token. If you would like this permission, contact the Community founder (they will need to mint the Community Owner token before they can airdrop this to you).</source>
+        <translation type="unfinished">代币铸造只能由持有社区的 TokenMaster 代币的管理员执行。如果您需要此权限，请联系社区创始人（他们需要在向您空投之前先铸造社区所有者代币）。</translation>
+    </message>
+    <message>
+        <source>In order to Mint, Import and Airdrop community tokens, you first need to mint your Owner token which will give you permissions to access the token management features for your community.</source>
+        <translation type="unfinished">为了铸造、导入和空投社区代币，您首先需要铸造您的所有者代币，这将授予您访问社区的代币管理功能的权限。</translation>
+    </message>
+    <message>
+        <source>Mint Owner token</source>
+        <translation type="unfinished">铸造所有者代币</translation>
+    </message>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>You currently have no minted assets</source>
+        <translation type="unfinished">您当前没有已铸造的资产</translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>You currently have no minted collectibles</source>
+        <translation type="unfinished">您当前没有已铸造的收藏品</translation>
+    </message>
+    <message>
+        <source>Retry mint</source>
+        <translation type="unfinished">重试铸造</translation>
+    </message>
+</context>
+<context>
+    <name>MobileAddressBar</name>
+    <message>
+        <source>Stop</source>
+        <translation type="unfinished">停止</translation>
+    </message>
+    <message>
+        <source>Reload</source>
+        <translation type="unfinished">重新加载</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">钱包</translation>
+    </message>
+</context>
+<context>
+    <name>MobileSettingsMenu</name>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">浏览器</translation>
+    </message>
+    <message>
+        <source>Incognito</source>
+        <translation type="unfinished">无痕浏览</translation>
+    </message>
+    <message>
+        <source>Find in page</source>
+        <translation type="unfinished">在页面中查找</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">缩放</translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished">缩小</translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished">放大</translation>
+    </message>
+    <message>
+        <source>Zoom Fit</source>
+        <translation type="unfinished">最佳适配</translation>
+    </message>
+    <message>
+        <source>Compatibility mode</source>
+        <translation type="unfinished">兼容模式</translation>
+    </message>
+    <message>
+        <source>Force reload</source>
+        <translation type="unfinished">强制刷新</translation>
+    </message>
+    <message>
+        <source>Clear site data</source>
+        <translation type="unfinished">清除网站数据</translation>
+    </message>
+    <message>
+        <source>Clearing browsing data...</source>
+        <translation type="unfinished">正在清除浏览数据...</translation>
+    </message>
+    <message>
+        <source>Clear browsing data</source>
+        <translation type="unfinished">清除浏览数据</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+</context>
+<context>
+    <name>ModifySocialLinkModal</name>
+    <message>
+        <source>Edit %1 link</source>
+        <translation type="unfinished">编辑%1链接</translation>
+    </message>
+    <message>
+        <source>Edit custom Link</source>
+        <translation type="unfinished">编辑自定义链接</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <source>Change title</source>
+        <translation type="unfinished">更改标题</translation>
+    </message>
+    <message>
+        <source>Invalid title</source>
+        <translation type="unfinished">无效的标题</translation>
+    </message>
+    <message>
+        <source>Title and link combination already added</source>
+        <translation type="unfinished">标题和链接组合已添加</translation>
+    </message>
+    <message>
+        <source>Username already added</source>
+        <translation type="unfinished">用户名已添加</translation>
+    </message>
+    <message>
+        <source>Edit your link</source>
+        <translation type="unfinished">编辑您的链接</translation>
+    </message>
+    <message>
+        <source>Invalid %1</source>
+        <translation type="unfinished">无效的%1</translation>
+    </message>
+    <message>
+        <source>link</source>
+        <translation type="unfinished">链接</translation>
+    </message>
+    <message>
+        <source>URL already added</source>
+        <translation type="unfinished">网址已添加</translation>
+    </message>
+</context>
+<context>
+    <name>ModuleWarning</name>
+    <message>
+        <source>%1%</source>
+        <translation type="unfinished">%1%</translation>
+    </message>
+</context>
+<context>
+    <name>MuteChatMenuItem</name>
+    <message>
+        <source>Mute Channel</source>
+        <translation type="unfinished">静音频道</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">静音聊天</translation>
+    </message>
+    <message>
+        <source>For 15 mins</source>
+        <translation type="unfinished">持续 15 分钟</translation>
+    </message>
+    <message>
+        <source>For 1 hour</source>
+        <translation type="unfinished">持续 1 小时</translation>
+    </message>
+    <message>
+        <source>For 8 hours</source>
+        <translation type="unfinished">持续 8 小时</translation>
+    </message>
+    <message>
+        <source>For 24 hours</source>
+        <translation type="unfinished">持续 24 小时</translation>
+    </message>
+    <message>
+        <source>For 7 days</source>
+        <translation type="unfinished">持续 7 天</translation>
+    </message>
+    <message>
+        <source>Until I turn it back on</source>
+        <translation type="unfinished">直到我手动恢复</translation>
+    </message>
+</context>
+<context>
+    <name>MyProfileView</name>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">预览</translation>
+    </message>
+    <message>
+        <source>Invalid changes made to Identity</source>
+        <translation type="unfinished">对身份信息的修改无效</translation>
+    </message>
+    <message>
+        <source>Changes could not be saved. Try again</source>
+        <translation type="unfinished">无法保存更改。请重试。</translation>
+    </message>
+    <message>
+        <source>Identity</source>
+        <translation type="unfinished">身份信息</translation>
+    </message>
+    <message>
+        <source>Communities</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>Accounts</source>
+        <translation type="unfinished">帐户</translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>Web</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>This Display Name is already in use in one of your joined communities</source>
+        <translation type="unfinished">此显示名称已在您加入的某个社区中使用</translation>
+    </message>
+</context>
+<context>
+    <name>NameInput</name>
+    <message>
+        <source>Community name</source>
+        <translation type="unfinished">社区名称</translation>
+    </message>
+    <message>
+        <source>A catchy name</source>
+        <translation type="unfinished">一个引人注目的名字</translation>
+    </message>
+    <message>
+        <source>community name</source>
+        <translation type="unfinished">社区名称</translation>
+    </message>
+</context>
+<context>
+    <name>NavigationEducationDialog</name>
+    <message>
+        <source>To open app menu</source>
+        <translation type="unfinished">打开应用菜单</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkChipFilter</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">全部</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkConnectionStore</name>
+    <message>
+        <source>Requires internet connection</source>
+        <translation type="unfinished">需要互联网连接</translation>
+    </message>
+    <message>
+        <source>Requires Pocket Network(POKT) or Infura, both of which are currently unavailable</source>
+        <translation type="unfinished">需要 Pocket Network (POKT) 或 Infura，两者目前均不可用</translation>
+    </message>
+    <message>
+        <source>Internet connection lost. Data could not be retrieved.</source>
+        <translation type="unfinished">已丢失互联网连接。无法检索数据。</translation>
+    </message>
+    <message>
+        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both currently unavailable</source>
+        <translation type="unfinished">代币余额从 Pocket Network (POKT) 和 Infura 获取，两者目前均不可用</translation>
+    </message>
+    <message>
+        <source>Market values are fetched from CoinGecko which is currently unavailable</source>
+        <translation type="unfinished">市场价值从 CoinGecko 获取，该服务目前不可用</translation>
+    </message>
+    <message>
+        <source>Market values and token balances use CoinGecko and POKT/Infura which are all currently unavailable.</source>
+        <translation type="unfinished">市场价值和代币余额使用 CoinGecko 和 POKT/Infura，所有这些都当前不可用。</translation>
+    </message>
+    <message>
+        <source>Requires POKT/Infura for %1, which is currently unavailable</source>
+        <translation type="unfinished">需要 POKT/Infura 才能进行 %1 操作，该服务目前不可用</translation>
+    </message>
+    <message>
+        <source>Pocket Network (POKT) &amp; Infura are currently both unavailable for %1. %1 balances are as of %2.</source>
+        <translation type="unfinished">Pocket Network (POKT) 和 Infura 目前都无法用于 %1。%1 的余额截至 %2。</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkFilter</name>
+    <message>
+        <source>Select networks</source>
+        <translation type="unfinished">选择网络</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkSelectItemDelegate</name>
+    <message>
+        <source>%1 chain integrated. You can now view and swap &lt;br&gt;%1 assets, as well as interact with %1 dApps.</source>
+        <translation type="unfinished">已集成%1链。现在您可以查看和交换&lt;br&gt;%1资产，以及与%1去中心化应用进行交互。</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkSelectPopup</name>
+    <message>
+        <source>Manage networks</source>
+        <translation type="unfinished">管理网络</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkWarningPanel</name>
+    <message>
+        <source>The owner token is minted on a network that isn&apos;t selected. Click here to enable it:</source>
+        <translation type="unfinished">所有者令牌是在未选择的网络上铸造的。点击此处启用它：</translation>
+    </message>
+    <message>
+        <source>Enable %1</source>
+        <translation type="unfinished">启用 %1</translation>
+    </message>
+</context>
+<context>
+    <name>NetworksView</name>
+    <message>
+        <source>Mainnet</source>
+        <translation type="unfinished">主网</translation>
+    </message>
+    <message>
+        <source>Testnet</source>
+        <translation type="unfinished">测试网</translation>
+    </message>
+</context>
+<context>
+    <name>NewAccountLoginPage</name>
+    <message>
+        <source>Log in</source>
+        <translation type="unfinished">登录</translation>
+    </message>
+    <message>
+        <source>How would you like to log in to Status?</source>
+        <translation type="unfinished">您想如何登录到 Status？</translation>
+    </message>
+    <message>
+        <source>Log in with recovery phrase</source>
+        <translation type="unfinished">使用助记词登录</translation>
+    </message>
+    <message>
+        <source>If you have your Status recovery phrase</source>
+        <translation type="unfinished">如果您有您的 Status 助记词</translation>
+    </message>
+    <message>
+        <source>Enter recovery phrase</source>
+        <translation type="unfinished">输入助记词</translation>
+    </message>
+    <message>
+        <source>Log in by syncing</source>
+        <translation type="unfinished">通过同步登录</translation>
+    </message>
+    <message>
+        <source>If you have Status on another device</source>
+        <translation type="unfinished">如果您的其他设备上安装了 Status</translation>
+    </message>
+    <message>
+        <source>Reveal what you have on Keycard first</source>
+        <translation type="unfinished">首先显示您在 Keycard 上的内容</translation>
+    </message>
+    <message>
+        <source>To pair your devices and sync your profile, make sure:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Both devices are on the same non-mobile network&lt;/li&gt;&lt;li&gt;You&apos;re logged in on the other device&lt;/li&gt;&lt;li&gt;No firewall or VPN is blocking local network access&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished">要配对您的设备并同步您的个人资料，请确保：&lt;br&gt;&lt;ul&gt;&lt;li&gt;两个设备都在同一个非移动网络上&lt;/li&gt;&lt;li&gt;您已在另一台设备上登录&lt;/li&gt;&lt;li&gt;没有防火墙或 VPN 阻止本地网络访问&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+    <message>
+        <source>Status does not have access to local network</source>
+        <translation type="unfinished">Status 没有访问本地网络的权限</translation>
+    </message>
+    <message>
+        <source>Status must be connected to the local network on this device for you to be able to log in via syncing. To rectify this...</source>
+        <translation type="unfinished">为了让您能够通过同步登录，此设备上的 Status 必须连接到本地网络。要解决此问题... </translation>
+    </message>
+    <message>
+        <source>1. Open System Settings</source>
+        <translation type="unfinished">1. 打开系统设置</translation>
+    </message>
+    <message>
+        <source>2. Click Privacy &amp; Security</source>
+        <translation type="unfinished">2. 点击“隐私与安全”</translation>
+    </message>
+    <message>
+        <source>3. Click Local Network</source>
+        <translation type="unfinished">3. 点击“本地网络”</translation>
+    </message>
+    <message>
+        <source>4. Find Status</source>
+        <translation type="unfinished">4. 找到 Status</translation>
+    </message>
+    <message>
+        <source>5. Toggle the switch to grant access</source>
+        <translation type="unfinished">5. 切换开关以授予访问权限</translation>
+    </message>
+    <message>
+        <source>6. Click %1 below</source>
+        <translation type="unfinished">6. 点击下面的按钮</translation>
+    </message>
+    <message>
+        <source>Verify local network access</source>
+        <translation type="unfinished">验证本地网络访问权限</translation>
+    </message>
+    <message>
+        <source>Verifying</source>
+        <translation type="unfinished">正在验证中</translation>
+    </message>
+    <message>
+        <source>Checking access...</source>
+        <translation type="unfinished">正在检查访问权限...</translation>
+    </message>
+    <message>
+        <source>Use Keycard</source>
+        <translation type="unfinished">使用密钥卡</translation>
+    </message>
+    <message>
+        <source>Enable local network access to sync devices</source>
+        <translation type="unfinished">启用本地网络访问以同步设备</translation>
+    </message>
+    <message>
+        <source>Turn on Local network access in your device settings under Settings &gt;&gt; Status &gt;&gt; Local Network.</source>
+        <translation type="unfinished">在您的设备设置中，进入“设置”&gt;&gt;“状态”&gt;&gt;“本地网络”，打开“启用本地网络访问”。</translation>
+    </message>
+    <message>
+        <source>Open Settings</source>
+        <translation type="unfinished">打开设置</translation>
+    </message>
+</context>
+<context>
+    <name>NewMessagesMarker</name>
+    <message>
+        <source>UNREAD</source>
+        <comment>unread message(s)</comment>
+        <translation type="unfinished">未读</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n unread message(s) since %1</source>
+        <translation type="unfinished">
+            <numerusform>自 %1 起有 %n 条未读消息</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>NewsMessagePopup</name>
+    <message>
+        <source>Visit the website</source>
+        <translation type="unfinished">访问网站</translation>
+    </message>
+</context>
+<context>
+    <name>NicknamePopup</name>
+    <message>
+        <source>Edit nickname</source>
+        <translation type="unfinished">编辑昵称</translation>
+    </message>
+    <message>
+        <source>Add nickname</source>
+        <translation type="unfinished">添加昵称</translation>
+    </message>
+    <message>
+        <source>Nickname</source>
+        <translation type="unfinished">昵称</translation>
+    </message>
+    <message>
+        <source>Invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
+        <translation type="unfinished">无效字符（仅使用 A-Z 和 0-9、连字符和下划线）</translation>
+    </message>
+    <message numerus="yes">
+        <source>Nicknames must be at least %n character(s) long</source>
+        <translation type="unfinished">
+            <numerusform>昵称必须至少为%n个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Nicknames can’t start or end with a space</source>
+        <translation type="unfinished">昵称不能以空格开头或结尾</translation>
+    </message>
+    <message>
+        <source>Nicknames can’t end in “.eth”, “_eth” or “-eth”</source>
+        <translation type="unfinished">昵称不能以“.eth”、“_eth”或“-eth”结尾</translation>
+    </message>
+    <message>
+        <source>Adjective-animal nickname formats are not allowed</source>
+        <translation type="unfinished">不允许使用形容词-动物的昵称格式</translation>
+    </message>
+    <message>
+        <source>Nicknames help you identify others and are only visible to you</source>
+        <translation type="unfinished">昵称可帮助您识别他人，并且仅对您可见</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Remove nickname</source>
+        <translation type="unfinished">删除昵称</translation>
+    </message>
+    <message>
+        <source>Change nickname</source>
+        <translation type="unfinished">更改昵称</translation>
+    </message>
+</context>
+<context>
+    <name>NoFriendsRectangle</name>
+    <message>
+        <source>You don’t have any contacts yet. Invite your friends to start chatting.</source>
+        <translation type="unfinished">您还没有任何联系人。邀请您的朋友开始聊天。</translation>
+    </message>
+    <message>
+        <source>No users match your search</source>
+        <translation type="unfinished">没有用户符合您的搜索条件</translation>
+    </message>
+    <message>
+        <source>Invite friends</source>
+        <translation type="unfinished">邀请好友</translation>
+    </message>
+</context>
+<context>
+    <name>NoImageUploadedPanel</name>
+    <message>
+        <source>Upload</source>
+        <translation type="unfinished">上传</translation>
+    </message>
+    <message>
+        <source>Wide aspect ratio is optimal</source>
+        <translation type="unfinished">最佳宽高比</translation>
+    </message>
+</context>
+<context>
+    <name>NoPermissionsToJoinPopup</name>
+    <message>
+        <source>Required assets not held</source>
+        <translation type="unfinished">所需的资产未持有</translation>
+    </message>
+    <message>
+        <source>Reject</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+    <message>
+        <source>%1 no longer holds the tokens required to join %2 in their wallet, so their request to join %2 must be rejected.</source>
+        <translation type="unfinished">%1不再拥有加入%2所需的代币，因此必须拒绝他们加入%2的请求。</translation>
+    </message>
+    <message>
+        <source>%1 can request to join %2 again in the future, when they have the tokens required to join %2 in their wallet.</source>
+        <translation type="unfinished">未来，当%1拥有加入%2所需的代币时，可以再次申请加入%2。</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationAdaptorContactRequest</name>
+    <message>
+        <source>New contact request</source>
+        <translation type="unfinished">新的联系人请求</translation>
+    </message>
+    <message>
+        <source>You’ve sent request to contact</source>
+        <translation type="unfinished">您已发送联系请求</translation>
+    </message>
+    <message>
+        <source>Accepted your contact request</source>
+        <translation type="unfinished">已接受您的联系请求</translation>
+    </message>
+    <message>
+        <source>Declined your contact request</source>
+        <translation type="unfinished">拒绝了您的联系请求</translation>
+    </message>
+    <message>
+        <source>Contact request accepted</source>
+        <translation type="unfinished">联系请求已接受</translation>
+    </message>
+    <message>
+        <source>Contact request declined</source>
+        <translation type="unfinished">联系请求已拒绝</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationCard</name>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished">接受</translation>
+    </message>
+    <message>
+        <source>Mark as read</source>
+        <translation type="unfinished">标记为已读</translation>
+    </message>
+    <message>
+        <source>Mark as unread</source>
+        <translation type="unfinished">标记为未读</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationSelect</name>
+    <message>
+        <source>Send Alerts</source>
+        <translation type="unfinished">发送提醒</translation>
+    </message>
+    <message>
+        <source>Deliver Quietly</source>
+        <translation type="unfinished">静默推送</translation>
+    </message>
+    <message>
+        <source>Turn Off</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationsView</name>
+    <message>
+        <source>Enable notifications</source>
+        <translation type="unfinished">启用通知</translation>
+    </message>
+    <message>
+        <source>Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished">接收您计算机上的新消息、提及和联系请求的通知，以便您可以实时了解最新动态。随时在&lt;b&gt;设置→通知&lt;/b&gt;中自定义。&lt;br&gt;&lt;br&gt;Status 直接通过您的操作系统传递通知，不涉及任何第三方、集中式服务器或中间商。</translation>
+    </message>
+    <message>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished">&lt;font color=&apos;%1&apos;&gt;在您的设备设置中启用通知&lt;/font&gt;&lt;br&gt;&lt;br&gt;在下方应用程序中启用通知之前，请先在&lt;font color=&apos;%1&apos;&gt;您的设备设置&lt;/font&gt;中启用它们。</translation>
+    </message>
+    <message>
+        <source>Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished">Status 仅使用 APNs（苹果推送通知服务）来向您的设备传递通知信号；您的端到端加密的消息内容不会通过它传输或存储。</translation>
+    </message>
+    <message>
+        <source>Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished">Status 通过其设备上的后台服务在您的设备上传递通知，不涉及任何第三方、集中式服务器或中间商。</translation>
+    </message>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">消息</translation>
+    </message>
+    <message>
+        <source>1:1 Chats</source>
+        <translation type="unfinished">一对一聊天</translation>
+    </message>
+    <message>
+        <source>Group Chats</source>
+        <translation type="unfinished">群组聊天</translation>
+    </message>
+    <message>
+        <source>Personal @ Mentions</source>
+        <translation type="unfinished">个人@提及</translation>
+    </message>
+    <message>
+        <source>Messages containing @%1</source>
+        <translation type="unfinished">包含 @%1 的消息</translation>
+    </message>
+    <message>
+        <source>Global @ Mentions</source>
+        <translation type="unfinished">全局@提及</translation>
+    </message>
+    <message>
+        <source>Messages containing @everyone</source>
+        <translation type="unfinished">包含 @everyone 的消息</translation>
+    </message>
+    <message>
+        <source>All Messages</source>
+        <translation type="unfinished">所有消息</translation>
+    </message>
+    <message>
+        <source>Others</source>
+        <translation type="unfinished">其他</translation>
+    </message>
+    <message>
+        <source>Contact Requests</source>
+        <translation type="unfinished">联系请求</translation>
+    </message>
+    <message>
+        <source>Status News</source>
+        <translation type="unfinished">Status 新闻</translation>
+    </message>
+    <message>
+        <source>Enable RSS</source>
+        <translation type="unfinished">启用 RSS</translation>
+    </message>
+    <message>
+        <source>Notification Content</source>
+        <translation type="unfinished">通知内容</translation>
+    </message>
+    <message>
+        <source>Show Name and Message</source>
+        <translation type="unfinished">显示姓名和消息</translation>
+    </message>
+    <message>
+        <source>Hi there! So EIP-1559 will defini...</source>
+        <translation type="unfinished">你好！因此，EIP-1559 将定义...</translation>
+    </message>
+    <message>
+        <source>Name Only</source>
+        <translation type="unfinished">仅显示姓名</translation>
+    </message>
+    <message>
+        <source>You have a new message</source>
+        <translation type="unfinished">您收到一条新消息</translation>
+    </message>
+    <message>
+        <source>Anonymous</source>
+        <translation type="unfinished">匿名</translation>
+    </message>
+    <message>
+        <source>Play a Sound When Receiving a Notification</source>
+        <translation type="unfinished">接收通知时播放声音</translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished">音量</translation>
+    </message>
+    <message>
+        <source>Send a Test Notification</source>
+        <translation type="unfinished">发送测试通知</translation>
+    </message>
+    <message>
+        <source>Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings</source>
+        <translation type="unfinished">Status 直接通过您的操作系统传递通知，没有集中的服务器或中间人。请确保在系统设置中为 Status 启用此功能。</translation>
+    </message>
+    <message>
+        <source>Exemptions</source>
+        <translation type="unfinished">例外情况</translation>
+    </message>
+    <message>
+        <source>Search Communities, Group Chats and 1:1 Chats</source>
+        <translation type="unfinished">搜索社区、群聊和一对一聊天</translation>
+    </message>
+    <message>
+        <source>Most recent</source>
+        <translation type="unfinished">最近</translation>
+    </message>
+    <message>
+        <source>Including:</source>
+        <translation type="unfinished">包括：</translation>
+    </message>
+    <message>
+        <source>Mentions and replies in communities</source>
+        <translation type="unfinished">社区中的提及和回复</translation>
+    </message>
+    <message>
+        <source>Contact requests and group messages</source>
+        <translation type="unfinished">联系请求和群组消息</translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingFlow</name>
+    <message>
+        <source>Status Software Privacy Policy</source>
+        <translation type="unfinished">状态软件隐私政策</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>Status Software Terms of Use</source>
+        <translation type="unfinished">状态软件使用条款</translation>
+    </message>
+    <message>
+        <source>Remove %1 profile</source>
+        <translation type="unfinished">删除%1资料</translation>
+    </message>
+    <message>
+        <source>If you remove %1, all data for this profile will be deleted from this device. To use this profile again, you&apos;ll need to reimport it to this device.</source>
+        <translation type="unfinished">如果您删除了%1，此资料的所有数据都将从该设备中删除。要再次使用此资料，您需要将其重新导入到此设备。</translation>
+    </message>
+    <message>
+        <source>Remove profile</source>
+        <translation type="unfinished">删除资料</translation>
+    </message>
+    <message>
+        <source>Manage profiles</source>
+        <translation type="unfinished">管理资料</translation>
+    </message>
+</context>
+<context>
+    <name>OnboardingLayout</name>
+    <message>
+        <source>fetch pin</source>
+        <translation type="unfinished">获取 PIN 码</translation>
+    </message>
+    <message>
+        <source>fetch password</source>
+        <translation type="unfinished">获取密码</translation>
+    </message>
+    <message>
+        <source>Credentials not found.</source>
+        <translation type="unfinished">未找到凭据。</translation>
+    </message>
+    <message>
+        <source>Fetching credentials failed.</source>
+        <translation type="unfinished">获取凭据失败。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenLinksInView</name>
+    <message>
+        <source>Open links in</source>
+        <translation type="unfinished">在以下位置打开链接</translation>
+    </message>
+    <message>
+        <source>Choose which browser to use for opening links in Status</source>
+        <translation type="unfinished">选择用于在状态栏中打开链接的浏览器</translation>
+    </message>
+    <message>
+        <source>Status browser</source>
+        <translation type="unfinished">状态栏浏览器</translation>
+    </message>
+    <message>
+        <source>User device default browser</source>
+        <translation type="unfinished">用户设备默认浏览器</translation>
+    </message>
+</context>
+<context>
+    <name>OperatorsUtils</name>
+    <message>
+        <source>and</source>
+        <translation type="unfinished">和</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">或</translation>
+    </message>
+</context>
+<context>
+    <name>Options</name>
+    <message>
+        <source>Request to join required</source>
+        <translation type="unfinished">需要加入的请求</translation>
+    </message>
+    <message>
+        <source>Warning: Only token gated communities (or token gated channels inside non-token gated community) are encrypted</source>
+        <translation type="unfinished">警告：只有基于代币的社区（或位于非基于代币的社区内的基于代币的频道）才会被加密。</translation>
+    </message>
+    <message>
+        <source>New members can see full message history</source>
+        <translation type="unfinished">新成员可以看到完整的消息历史记录。</translation>
+    </message>
+    <message>
+        <source>Any member can pin a message</source>
+        <translation type="unfinished">任何成员都可以固定一条消息。</translation>
+    </message>
+    <message>
+        <source>You can token-gate your community and channels anytime after creation using existing tokens or by minting new ones in the community admin area.</source>
+        <translation type="unfinished">您可以在创建后随时使用现有代币或在社区管理区域中铸造新代币来对您的社区和频道进行基于代币的访问控制。</translation>
+    </message>
+    <message>
+        <source>Learn more about token-gating</source>
+        <translation type="unfinished">了解更多关于基于代币的访问控制的信息。</translation>
+    </message>
+</context>
+<context>
+    <name>OutroMessageInput</name>
+    <message>
+        <source>Leaving community message (you can edit this later)</source>
+        <translation type="unfinished">离开社区消息（稍后可以编辑）</translation>
+    </message>
+    <message>
+        <source>The message a member will see when they leave your community</source>
+        <translation type="unfinished">成员离开您的社区时将看到的消息</translation>
+    </message>
+    <message>
+        <source>community outro message</source>
+        <translation type="unfinished">社区退出消息</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewSettingsChart</name>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">消息数</translation>
+    </message>
+    <message>
+        <source>1H</source>
+        <translation type="unfinished">1小时</translation>
+    </message>
+    <message>
+        <source>Time period</source>
+        <translation type="unfinished">时间段</translation>
+    </message>
+    <message>
+        <source>1D</source>
+        <translation type="unfinished">1天</translation>
+    </message>
+    <message>
+        <source>7D</source>
+        <translation type="unfinished">7天</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">日期</translation>
+    </message>
+    <message>
+        <source>1M</source>
+        <translation type="unfinished">1个月</translation>
+    </message>
+    <message>
+        <source>6M</source>
+        <translation type="unfinished">6个月</translation>
+    </message>
+    <message>
+        <source>Month</source>
+        <translation type="unfinished">月</translation>
+    </message>
+    <message>
+        <source>1Y</source>
+        <translation type="unfinished">1年</translation>
+    </message>
+    <message>
+        <source>ALL</source>
+        <translation type="unfinished">全部</translation>
+    </message>
+    <message>
+        <source>Year</source>
+        <translation type="unfinished">年</translation>
+    </message>
+    <message>
+        <source>No. of Messages</source>
+        <translation type="unfinished">消息数量</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewSettingsFooter</name>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished">了解更多</translation>
+    </message>
+    <message>
+        <source>Finalise your ownership of the %1 Community</source>
+        <translation type="unfinished">完成您对%1社区的所有权</translation>
+    </message>
+    <message>
+        <source>You currently hodl the Owner token for %1. Make your device the control node to finalise ownership.</source>
+        <translation type="unfinished">您目前持有%1的Owner代币。将您的设备设置为控制节点以完成所有权。</translation>
+    </message>
+    <message>
+        <source>Finalise %1 ownership</source>
+        <translation type="unfinished">完成%1的所有权</translation>
+    </message>
+    <message>
+        <source>This device is currently the control node for the %1 Community</source>
+        <translation type="unfinished">此设备当前是%1社区的控制节点</translation>
+    </message>
+    <message>
+        <source>For your Community to function correctly keep this device online with Status running as much as possible.</source>
+        <translation type="unfinished">为了使您的社区正常运行，请尽可能保持此设备在线并运行Status。</translation>
+    </message>
+    <message>
+        <source>How to move control node</source>
+        <translation type="unfinished">如何移动控制节点</translation>
+    </message>
+    <message>
+        <source>Make this device the control node for the %1 Community</source>
+        <translation type="unfinished">将此设备设置为%1社区的控制节点</translation>
+    </message>
+    <message>
+        <source>Ensure this is a device you can keep online with Status running.</source>
+        <translation type="unfinished">确保这是一个您可以保持在线并运行Status的设备。</translation>
+    </message>
+    <message>
+        <source>Make this device the control node</source>
+        <translation type="unfinished">将此设备设置为控制节点</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewSettingsPanel</name>
+    <message>
+        <source>Overview</source>
+        <translation type="unfinished">概览</translation>
+    </message>
+    <message>
+        <source>Transfer ownership</source>
+        <translation type="unfinished">转移所有权</translation>
+    </message>
+    <message>
+        <source>Edit Community</source>
+        <translation type="unfinished">编辑社区</translation>
+    </message>
+    <message>
+        <source>Community administration is disabled when in testnet mode</source>
+        <translation type="unfinished">在测试网络模式下，禁用社区管理功能。</translation>
+    </message>
+    <message>
+        <source>To access your %1 community admin area, you need to turn off testnet mode.</source>
+        <translation type="unfinished">要访问您的%1社区管理员区域，您需要关闭测试网络模式。</translation>
+    </message>
+    <message>
+        <source>Turn off testnet mode</source>
+        <translation type="unfinished">关闭测试网络模式</translation>
+    </message>
+</context>
+<context>
+    <name>OwnerTokenWelcomeView</name>
+    <message>
+        <source>Your &lt;b&gt;Owner token&lt;/b&gt; will give you permissions to access the token management features for your community. This token is very important - only one will ever exist, and if this token gets lost then access to the permissions it enables for your community will be lost forever as well.&lt;br&gt;&lt;br&gt;
+                        Minting your Owner token also automatically mints your community’s &lt;b&gt;TokenMaster token&lt;/b&gt;.  You can airdrop your community’s TokenMaster token to anybody you wish to grant both Admin permissions and permission to access your community’s token management functions to.&lt;br&gt;&lt;br&gt;
+                        Only the hodler of the Owner token can airdrop TokenMaster tokens. TokenMaster tokens are soulbound (meaning they can’t be transferred), and you (the hodler of the Owner token) can remotely destruct a TokenMaster token at any time, to revoke TokenMaster permissions from any individual.</source>
+        <translation type="unfinished">:</translation>
+    </message>
+    <message>
+        <source>Only 1 will ever exist</source>
+        <translation type="unfinished">只有一个</translation>
+    </message>
+    <message>
+        <source>Hodler is the owner of the Community</source>
+        <translation type="unfinished">持有者是社区的所有者</translation>
+    </message>
+    <message>
+        <source>Ability to airdrop / destroy TokenMaster token</source>
+        <translation type="unfinished">可以空投/销毁 TokenMaster 令牌</translation>
+    </message>
+    <message>
+        <source>Ability to mint and airdrop Community tokens</source>
+        <translation type="unfinished">可以铸造和空投社区代币</translation>
+    </message>
+    <message>
+        <source>Unlimited supply</source>
+        <translation type="unfinished">无限供应</translation>
+    </message>
+    <message>
+        <source>Grants full Community admin rights</source>
+        <translation type="unfinished">授予完整的社区管理员权限</translation>
+    </message>
+    <message>
+        <source>Non-transferrable</source>
+        <translation type="unfinished">不可转让</translation>
+    </message>
+    <message>
+        <source>Remotely destructible by the Owner token hodler</source>
+        <translation type="unfinished">Owner 令牌持有者可以远程销毁</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished">下一步</translation>
+    </message>
+</context>
+<context>
+    <name>PairWCModal</name>
+    <message>
+        <source>Connect a dApp via WalletConnect</source>
+        <translation type="unfinished">通过WalletConnect连接一个dApp</translation>
+    </message>
+    <message>
+        <source>How to copy the dApp URI</source>
+        <translation type="unfinished">如何复制 dApp URI</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+</context>
+<context>
+    <name>PasswordConfirmationView</name>
+    <message>
+        <source>Passwords don&apos;t match</source>
+        <translation type="unfinished">密码不匹配</translation>
+    </message>
+    <message>
+        <source>Have you written down your password?</source>
+        <translation type="unfinished">您是否已记录您的密码？</translation>
+    </message>
+    <message>
+        <source>You will never be able to recover your password if you lose it.</source>
+        <translation type="unfinished">如果您丢失了密码，将无法找回。</translation>
+    </message>
+    <message>
+        <source>If you need to, write it using pen and paper and keep in a safe place.</source>
+        <translation type="unfinished">如有需要，请用笔和纸写下来并保存在安全的地方。</translation>
+    </message>
+    <message>
+        <source>If you lose your password you will lose access to your Status profile.</source>
+        <translation type="unfinished">如果丢失密码，您将无法访问您的状态资料。</translation>
+    </message>
+    <message>
+        <source>Confirm your password (again)</source>
+        <translation type="unfinished">再次确认您的密码</translation>
+    </message>
+</context>
+<context>
+    <name>PasswordView</name>
+    <message>
+        <source>Create a password</source>
+        <translation type="unfinished">创建密码</translation>
+    </message>
+    <message>
+        <source>Change your password</source>
+        <translation type="unfinished">更改您的密码</translation>
+    </message>
+    <message>
+        <source>Create a password to unlock Status on this device &amp; sign transactions.</source>
+        <translation type="unfinished">在此设备上创建密码以解锁 Status 并签署交易。</translation>
+    </message>
+    <message>
+        <source>You will not be able to recover this password if it is lost.</source>
+        <translation type="unfinished">如果丢失，您将无法恢复此密码。</translation>
+    </message>
+    <message numerus="yes">
+        <source>Minimum %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>最少 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Passwords don&apos;t match</source>
+        <translation type="unfinished">密码不匹配</translation>
+    </message>
+    <message>
+        <source>Only ASCII letters, numbers, and symbols are allowed</source>
+        <translation type="unfinished">仅允许使用 ASCII 字母、数字和符号</translation>
+    </message>
+    <message numerus="yes">
+        <source>Maximum %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>最多 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Password pwned, shouldn&apos;t be used</source>
+        <translation type="unfinished">密码已泄露，不应使用</translation>
+    </message>
+    <message>
+        <source>Common password, shouldn&apos;t be used</source>
+        <translation type="unfinished">常用密码，不应使用</translation>
+    </message>
+    <message>
+        <source>Current password</source>
+        <translation type="unfinished">当前密码</translation>
+    </message>
+    <message>
+        <source>Enter current password</source>
+        <translation type="unfinished">输入当前密码</translation>
+    </message>
+    <message>
+        <source>Choose password</source>
+        <translation type="unfinished">选择密码</translation>
+    </message>
+    <message>
+        <source>Type password</source>
+        <translation type="unfinished">输入密码</translation>
+    </message>
+    <message>
+        <source>Repeat password</source>
+        <translation type="unfinished">重复密码</translation>
+    </message>
+    <message>
+        <source>Passwords match</source>
+        <translation type="unfinished">密码匹配</translation>
+    </message>
+    <message>
+        <source>Lower case</source>
+        <translation type="unfinished">小写</translation>
+    </message>
+    <message>
+        <source>Upper case</source>
+        <translation type="unfinished">大写</translation>
+    </message>
+    <message>
+        <source>Numbers</source>
+        <translation type="unfinished">数字</translation>
+    </message>
+    <message>
+        <source>Symbols</source>
+        <translation type="unfinished">符号</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentRequestCardDelegate</name>
+    <message>
+        <source>Send %1 %2 to %3</source>
+        <translation type="unfinished">向%3发送%1 %2</translation>
+    </message>
+    <message>
+        <source>Requested by %1</source>
+        <translation type="unfinished">由%1发起</translation>
+    </message>
+    <message>
+        <source>Not available in the testnet mode</source>
+        <translation type="unfinished">在测试网络模式下不可用</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentRequestMiniCardDelegate</name>
+    <message>
+        <source>Payment request</source>
+        <translation type="unfinished">支付请求</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentRequestModal</name>
+    <message>
+        <source>Payment request</source>
+        <translation type="unfinished">支付请求</translation>
+    </message>
+    <message>
+        <source>Add to message</source>
+        <translation type="unfinished">添加到消息</translation>
+    </message>
+    <message>
+        <source>Into</source>
+        <translation type="unfinished">进入</translation>
+    </message>
+    <message>
+        <source>On</source>
+        <translation type="unfinished">开启</translation>
+    </message>
+    <message>
+        <source>Only</source>
+        <translation type="unfinished">仅</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionConflictWarningPanel</name>
+    <message>
+        <source>Conflicts with existing permission:</source>
+        <translation type="unfinished">与现有权限冲突:</translation>
+    </message>
+    <message>
+        <source>&quot;Anyone who holds %1 can %2 in %3&quot;</source>
+        <translation type="unfinished">持有%1的人可以在%3中进行%2操作</translation>
+    </message>
+    <message>
+        <source>Edit permissions to resolve a conflict.</source>
+        <translation type="unfinished">编辑权限以解决冲突。</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionItem</name>
+    <message>
+        <source>Active</source>
+        <translation type="unfinished">活动</translation>
+    </message>
+    <message>
+        <source>Pending, will become active once owner node comes online</source>
+        <translation type="unfinished">待处理，当所有者节点在线时将变为活动状态</translation>
+    </message>
+    <message>
+        <source>Deletion pending, will be deleted once owner node comes online</source>
+        <translation type="unfinished">删除待处理，当所有者节点在线时将被删除</translation>
+    </message>
+    <message>
+        <source>Pending updates will be applied when owner node comes online</source>
+        <translation type="unfinished">待处理的更新将在所有者节点在线时应用</translation>
+    </message>
+    <message>
+        <source>Anyone who holds</source>
+        <translation type="unfinished">任何持有者</translation>
+    </message>
+    <message>
+        <source>Anyone</source>
+        <translation type="unfinished">任何人</translation>
+    </message>
+    <message>
+        <source>is allowed to</source>
+        <translation type="unfinished">允许</translation>
+    </message>
+    <message>
+        <source>and</source>
+        <translation type="unfinished">和</translation>
+    </message>
+    <message>
+        <source>in</source>
+        <translation type="unfinished">在</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">编辑</translation>
+    </message>
+    <message>
+        <source>Duplicate</source>
+        <translation type="unfinished">重复</translation>
+    </message>
+    <message>
+        <source>Undo delete</source>
+        <translation type="unfinished">撤销删除</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionQualificationPanel</name>
+    <message numerus="yes">
+        <source>%L1% of the %Ln community member(s) with known addresses will qualify for this permission.</source>
+        <translation type="unfinished">
+            <numerusform>The addresses of %Ln community member(s) are unknown.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>The addresses of %Ln community member(s) are unknown.</source>
+        <translation type="unfinished">
+            <numerusform>%Ln 位社区成员的地址未知。</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>PermissionTypes</name>
+    <message>
+        <source>Become an admin</source>
+        <translation type="unfinished">成为管理员</translation>
+    </message>
+    <message>
+        <source>Become member</source>
+        <translation type="unfinished">成为成员</translation>
+    </message>
+    <message>
+        <source>View only</source>
+        <translation type="unfinished">仅查看</translation>
+    </message>
+    <message>
+        <source>View and post</source>
+        <translation type="unfinished">查看和发布</translation>
+    </message>
+    <message>
+        <source>Manage community tokens</source>
+        <translation type="unfinished">管理社区代币</translation>
+    </message>
+    <message>
+        <source>Manage TokenMaster tokens</source>
+        <translation type="unfinished">管理TokenMaster代币</translation>
+    </message>
+    <message>
+        <source>You are eligible to join as</source>
+        <translation type="unfinished">您有资格以以下身份加入</translation>
+    </message>
+    <message>
+        <source>You&apos;ll be a</source>
+        <translation type="unfinished">您将是</translation>
+    </message>
+    <message>
+        <source>You&apos;re a</source>
+        <translation type="unfinished">您是</translation>
+    </message>
+    <message>
+        <source>TokenMaster</source>
+        <translation type="unfinished">代币管理员</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <translation type="unfinished">管理员</translation>
+    </message>
+    <message>
+        <source>Member</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+    <message>
+        <source>You&apos;ll no longer be a</source>
+        <translation type="unfinished">您不再是</translation>
+    </message>
+    <message>
+        <source>Not eligible to join with current address selections</source>
+        <translation type="unfinished">当前地址选择不符合加入条件</translation>
+    </message>
+    <message>
+        <source>Members who meet the requirements will be allowed to create and edit permissions, token sales, airdrops and subscriptions</source>
+        <translation type="unfinished">满足条件的成员将被允许创建和编辑权限、代币销售、空投和订阅</translation>
+    </message>
+    <message>
+        <source>Be careful with assigning this permission.</source>
+        <translation type="unfinished">请谨慎分配此权限。</translation>
+    </message>
+    <message>
+        <source>Only the community owner can modify admin permissions</source>
+        <translation type="unfinished">只有社区所有者可以修改管理员权限</translation>
+    </message>
+    <message>
+        <source>Anyone who meets the requirements will be allowed to join your community</source>
+        <translation type="unfinished">任何满足条件的人都可以加入您的社区</translation>
+    </message>
+    <message>
+        <source>Members who meet the requirements will be allowed to read and write in the selected channels</source>
+        <translation type="unfinished">满足条件的成员将被允许在选定的频道中读取和写入</translation>
+    </message>
+    <message>
+        <source>Members who meet the requirements will be allowed to read the selected channels</source>
+        <translation type="unfinished">满足条件的成员将被允许读取选定的频道</translation>
+    </message>
+    <message>
+        <source>Max of 5 ‘become member’ permissions for this Community has been reached. You will need to delete an existing ‘become member’ permission before you can add a new one.</source>
+        <translation type="unfinished">此社区最多可以有 5 个“成为成员”权限。您需要删除现有的“成为成员”权限，然后才能添加新的权限。</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionsCard</name>
+    <message>
+        <source>%1 will be able to:</source>
+        <translation type="unfinished">%1 将能够：</translation>
+    </message>
+    <message>
+        <source>Check your account balance and activity</source>
+        <translation type="unfinished">查看您的账户余额和活动记录</translation>
+    </message>
+    <message>
+        <source>Request transactions and message signing</source>
+        <translation type="unfinished">请求交易并进行消息签名</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionsDropdown</name>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>Channels</source>
+        <translation type="unfinished">频道</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionsHelpers</name>
+    <message>
+        <source>Any ENS username</source>
+        <translation type="unfinished">任何 ENS 用户名</translation>
+    </message>
+    <message>
+        <source>ENS username on &apos;%1&apos; domain</source>
+        <translation type="unfinished">在 &apos;%1&apos; 域上的 ENS 用户名</translation>
+    </message>
+    <message>
+        <source>ENS username &apos;%1&apos;</source>
+        <translation type="unfinished">ENS 用户名 &apos;%1&apos;</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionsRow</name>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">或</translation>
+    </message>
+    <message>
+        <source>Eligible to join</source>
+        <translation type="unfinished">有资格加入</translation>
+    </message>
+    <message>
+        <source>Not eligible to join</source>
+        <translation type="unfinished">没有资格加入</translation>
+    </message>
+    <message>
+        <source>+%1</source>
+        <translation type="unfinished">+%1</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionsSettingsPanel</name>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">权限</translation>
+    </message>
+    <message>
+        <source>Add new permission</source>
+        <translation type="unfinished">添加新权限</translation>
+    </message>
+    <message>
+        <source>Edit permission</source>
+        <translation type="unfinished">编辑权限</translation>
+    </message>
+    <message>
+        <source>New permission</source>
+        <translation type="unfinished">新权限</translation>
+    </message>
+    <message>
+        <source>Update permission</source>
+        <translation type="unfinished">更新权限</translation>
+    </message>
+    <message>
+        <source>Revert changes</source>
+        <translation type="unfinished">撤销更改</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionsView</name>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">权限</translation>
+    </message>
+    <message>
+        <source>You can manage your community by creating and issuing membership and access permissions</source>
+        <translation type="unfinished">您可以创建和发布会员资格和访问权限，从而管理您的社区。</translation>
+    </message>
+    <message>
+        <source>Give individual members access to private channels</source>
+        <translation type="unfinished">允许各个成员访问私有频道。</translation>
+    </message>
+    <message>
+        <source>Monetise your community with subscriptions and fees</source>
+        <translation type="unfinished">通过订阅费来盈利。</translation>
+    </message>
+    <message>
+        <source>Require holding a token or NFT to obtain exclusive membership rights</source>
+        <translation type="unfinished">要求持有代币或 NFT 以获得独家会员资格</translation>
+    </message>
+    <message>
+        <source>No channel permissions</source>
+        <translation type="unfinished">没有频道权限。</translation>
+    </message>
+    <message>
+        <source>Users with view only permissions can add reactions</source>
+        <translation type="unfinished">仅具有查看权限的用户可以添加表情。</translation>
+    </message>
+    <message>
+        <source>Sure you want to delete permission</source>
+        <translation type="unfinished">确定要删除权限吗？</translation>
+    </message>
+    <message>
+        <source>If you delete this permission, any of your community members who rely on this permission will lose the access this permission gives them.</source>
+        <translation type="unfinished">如果您删除此权限，任何依赖于此权限的社区成员都将失去该权限赋予他们的访问权限。</translation>
+    </message>
+</context>
+<context>
+    <name>PinnedMessagesPopup</name>
+    <message>
+        <source>Pin limit reached</source>
+        <translation type="unfinished">已达到置顶限制</translation>
+    </message>
+    <message>
+        <source>Pinned messages</source>
+        <translation type="unfinished">已置顶的消息</translation>
+    </message>
+    <message>
+        <source>Unpin a previous message first</source>
+        <translation type="unfinished">请先取消置顶之前的消息</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n message(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 条消息</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Pinned messages will appear here.</source>
+        <translation type="unfinished">已置顶的消息将显示在此处。</translation>
+    </message>
+    <message>
+        <source>Unpin</source>
+        <translation type="unfinished">取消置顶</translation>
+    </message>
+    <message>
+        <source>Jump to</source>
+        <translation type="unfinished">跳转到</translation>
+    </message>
+    <message>
+        <source>Unpin selected message and pin new message</source>
+        <translation type="unfinished">取消置顶所选消息并置顶新消息</translation>
+    </message>
+</context>
+<context>
+    <name>PopupBase</name>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished">身份验证</translation>
+    </message>
+    <message>
+        <source>Use biometrics</source>
+        <translation type="unfinished">使用生物识别</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+    <message>
+        <source>Failed to update stored credentials</source>
+        <translation type="unfinished">无法更新存储的凭据</translation>
+    </message>
+    <message>
+        <source>Credentials successfully obtained from biometrics</source>
+        <translation type="unfinished">已成功从生物识别中获取凭据</translation>
+    </message>
+    <message>
+        <source>Biometrics not supported</source>
+        <translation type="unfinished">不支持生物识别</translation>
+    </message>
+    <message>
+        <source>Generic error occurred</source>
+        <translation type="unfinished">发生通用错误</translation>
+    </message>
+    <message>
+        <source>Biometrics is unavailable</source>
+        <translation type="unfinished">生物识别不可用</translation>
+    </message>
+    <message>
+        <source>Biometrics cancelled</source>
+        <translation type="unfinished">生物识别已取消</translation>
+    </message>
+    <message>
+        <source>Biometrics not found</source>
+        <translation type="unfinished">未找到生物识别</translation>
+    </message>
+    <message>
+        <source>Biometrics fallback error</source>
+        <translation type="unfinished">生物识别回退错误</translation>
+    </message>
+    <message>
+        <source>Unknown biometrics error</source>
+        <translation type="unfinished">未知生物识别错误</translation>
+    </message>
+</context>
+<context>
+    <name>Popups</name>
+    <message>
+        <source>Share addresses with %1&apos;s owner</source>
+        <translation type="unfinished">与%1的所有者共享地址</translation>
+    </message>
+    <message>
+        <source>Share addresses to rejoin %1</source>
+        <translation type="unfinished">共享地址以重新加入%1</translation>
+    </message>
+    <message>
+        <source>Image saved to %1</source>
+        <translation type="unfinished">图片已保存到%1</translation>
+    </message>
+    <message>
+        <source>Image saved to system gallery</source>
+        <translation type="unfinished">图片已保存到系统相册</translation>
+    </message>
+    <message>
+        <source>Failed to save image</source>
+        <translation type="unfinished">无法保存图片</translation>
+    </message>
+    <message>
+        <source>%1 removed from contacts and marked as untrusted</source>
+        <translation type="unfinished">已从联系人中删除%1，并标记为不受信任</translation>
+    </message>
+    <message>
+        <source>%1 marked as trusted</source>
+        <translation type="unfinished">%1 已标记为受信任</translation>
+    </message>
+    <message>
+        <source>%1 trust mark removed, removed from contacts and marked as untrusted</source>
+        <translation type="unfinished">已移除%1的信任标记，从联系人中删除，并标记为不受信任</translation>
+    </message>
+    <message>
+        <source>%1 trust mark removed and marked as untrusted</source>
+        <translation type="unfinished">已移除%1的信任标记，并标记为不受信任</translation>
+    </message>
+    <message>
+        <source>%1 trust mark removed and removed from contacts</source>
+        <translation type="unfinished">已移除%1的信任标记，并从联系人中删除</translation>
+    </message>
+    <message>
+        <source>Contact request accepted</source>
+        <translation type="unfinished">已接受联系请求</translation>
+    </message>
+    <message>
+        <source>Contact request ignored</source>
+        <translation type="unfinished">已忽略联系请求</translation>
+    </message>
+    <message>
+        <source>Recovery phrase permanently removed from Status application storage</source>
+        <translation type="unfinished">恢复短语已永久从Status应用程序存储中删除</translation>
+    </message>
+    <message>
+        <source>You backed up your recovery phrase. Access it in Settings</source>
+        <translation type="unfinished">您已备份了您的恢复短语。请在设置中访问它</translation>
+    </message>
+    <message>
+        <source>Profile Picture</source>
+        <translation type="unfinished">个人资料图片</translation>
+    </message>
+    <message>
+        <source>Make this my Profile Pic</source>
+        <translation type="unfinished">将此设置为我的头像</translation>
+    </message>
+    <message>
+        <source>%1 marked as untrusted</source>
+        <translation type="unfinished">%1 已标记为不受信任</translation>
+    </message>
+    <message>
+        <source>%1 unblocked</source>
+        <translation type="unfinished">%1 已解除阻止</translation>
+    </message>
+    <message>
+        <source>%1 blocked</source>
+        <translation type="unfinished">%1 已阻止</translation>
+    </message>
+    <message>
+        <source>Please choose a directory</source>
+        <translation type="unfinished">请选择一个目录</translation>
+    </message>
+    <message>
+        <source>Are you sure want to leave &apos;%1&apos;?</source>
+        <translation type="unfinished">您确定要离开“%1”吗？</translation>
+    </message>
+    <message>
+        <source>You will need to request to join if you want to become a member again in the future. If you joined the Community via public key ensure you have a copy of it before you go.</source>
+        <translation type="unfinished">如果您将来想再次成为会员，则需要重新申请加入。如果您通过公钥加入了社区，请确保在离开之前备份一份。</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Leave %1</source>
+        <translation type="unfinished">离开%1</translation>
+    </message>
+    <message>
+        <source>Align with paired device</source>
+        <translation type="unfinished">与配对设备同步</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated to Keycard on paired device</source>
+        <translation type="unfinished">您的个人资料已迁移到配对设备上的Keycard</translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated from Keycard to Status</source>
+        <translation type="unfinished">您的个人资料已从Keycard迁移到Status</translation>
+    </message>
+    <message>
+        <source>In order to align on the login/signing method on this device, you need to complete the migration flow, clicking the &quot;Continue&quot; button below, or cancel this popup if you want to keep the current login/signing method.</source>
+        <translation type="unfinished">为了使此设备上的登录/签名方法保持一致，您需要完成迁移流程，点击下面的“继续”按钮，或者取消此弹出窗口以保留当前的登录/签名方法。</translation>
+    </message>
+    <message>
+        <source>If you don&apos;t want to see this message again, go to Settings/Wallet and toggle off &quot;Automatically apply key pair migrations from paired device&quot;.</source>
+        <translation type="unfinished">如果您不想再次看到此消息，请转到“设置/钱包”，然后关闭“自动应用来自配对设备的密钥对迁移”选项。</translation>
+    </message>
+    <message>
+        <source>Sign transaction - update %1 smart contract</source>
+        <translation type="unfinished">签署交易 - 更新%1智能合约</translation>
+    </message>
+    <message>
+        <source>%1 (%2) successfully hidden. You can toggle asset visibility via %3.</source>
+        <translation type="unfinished">%1（%2）已成功隐藏。您可以通过%3切换资产可见性。</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <comment>Go to Settings</comment>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message>
+        <source>Hide collectible</source>
+        <translation type="unfinished">隐藏收藏品</translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation type="unfinished">隐藏%1</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to hide %1? You will no longer see or be able to interact with this collectible anywhere inside Status.</source>
+        <translation type="unfinished">您确定要隐藏%1吗？之后您将不再能在Status的任何地方看到或与之交互。</translation>
+    </message>
+    <message>
+        <source>%1 successfully hidden. You can toggle collectible visibility via %2.</source>
+        <translation type="unfinished">%1已成功隐藏。您可以通过%2切换收藏品可见性。</translation>
+    </message>
+    <message>
+        <source>Status Software Privacy Policy</source>
+        <translation type="unfinished">状态软件隐私政策</translation>
+    </message>
+    <message>
+        <source>Status Software Terms of Use</source>
+        <translation type="unfinished">状态软件使用条款</translation>
+    </message>
+    <message>
+        <source>Sign out</source>
+        <translation type="unfinished">注销</translation>
+    </message>
+    <message>
+        <source>Make sure you have your account password and recovery phrase stored. Without them you can lock yourself out of your account and lose funds.</source>
+        <translation type="unfinished">请确保您已存储好您的帐户密码和恢复短语。否则，您可能会被锁定在帐户之外并丢失资金。</translation>
+    </message>
+    <message>
+        <source>Sign out &amp; Quit</source>
+        <translation type="unfinished">注销并退出</translation>
+    </message>
+</context>
+<context>
+    <name>PrimaryNavSidebar</name>
+    <message>
+        <source>Activity Center</source>
+        <translation type="unfinished">活动中心</translation>
+    </message>
+</context>
+<context>
+    <name>PrivacyAndSecurityView</name>
+    <message>
+        <source>Privacy policy</source>
+        <translation type="unfinished">隐私政策</translation>
+    </message>
+    <message>
+        <source>Receive Status News via RSS</source>
+        <translation type="unfinished">通过 RSS 接收状态新闻</translation>
+    </message>
+    <message>
+        <source>Your IP address will be exposed to https://status.app</source>
+        <translation type="unfinished">您的 IP 地址将被暴露给 https://status.app</translation>
+    </message>
+    <message>
+        <source>Third-party services</source>
+        <translation type="unfinished">第三方服务</translation>
+    </message>
+    <message>
+        <source>Enable/disable all third-party services</source>
+        <translation type="unfinished">启用/禁用所有第三方服务</translation>
+    </message>
+    <message>
+        <source>Share feedback or suggest improvements on our %1.</source>
+        <translation type="unfinished">在我们的%1上分享反馈或提出改进建议。</translation>
+    </message>
+    <message>
+        <source>Trusted sites</source>
+        <translation type="unfinished">可信任的网站</translation>
+    </message>
+    <message>
+        <source>Manage trusted sites. Their links open without confirmation.</source>
+        <translation type="unfinished">管理可信任的网站。它们的链接无需确认即可打开。</translation>
+    </message>
+</context>
+<context>
+    <name>PrivacyStore</name>
+    <message>
+        <source>Third-party services successfully enabled</source>
+        <translation type="unfinished">已成功启用第三方服务</translation>
+    </message>
+    <message>
+        <source>Third-party services successfully disabled</source>
+        <translation type="unfinished">已成功禁用第三方服务</translation>
+    </message>
+</context>
+<context>
+    <name>PrivacyWallCarousel</name>
+    <message>
+        <source>Enable third-party services</source>
+        <translation type="unfinished">启用第三方服务</translation>
+    </message>
+    <message>
+        <source>Share feedback or suggest improvements on our %1.</source>
+        <translation type="unfinished">在我们的%1上分享反馈或提出改进建议。</translation>
+    </message>
+</context>
+<context>
+    <name>PrivilegedTokenArtworkPanel</name>
+    <message>
+        <source>Included</source>
+        <translation type="unfinished">包含</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileContextMenu</name>
+    <message>
+        <source>Mark as trusted</source>
+        <translation type="unfinished">标记为信任联系人</translation>
+    </message>
+    <message>
+        <source>Review contact request</source>
+        <translation type="unfinished">审核联系请求</translation>
+    </message>
+    <message>
+        <source>Edit nickname</source>
+        <translation type="unfinished">编辑昵称</translation>
+    </message>
+    <message>
+        <source>Add nickname</source>
+        <translation type="unfinished">添加昵称</translation>
+    </message>
+    <message>
+        <source>Remove nickname</source>
+        <translation type="unfinished">删除昵称</translation>
+    </message>
+    <message>
+        <source>Remove trusted mark</source>
+        <translation type="unfinished">移除信任标记</translation>
+    </message>
+    <message>
+        <source>Unblock user</source>
+        <translation type="unfinished">解除用户屏蔽</translation>
+    </message>
+    <message>
+        <source>Remove from group</source>
+        <translation type="unfinished">从群组中移除</translation>
+    </message>
+    <message>
+        <source>Mark as untrusted</source>
+        <translation type="unfinished">标记为不信任联系人</translation>
+    </message>
+    <message>
+        <source>Remove untrusted mark</source>
+        <translation type="unfinished">移除不信任标记</translation>
+    </message>
+    <message>
+        <source>Remove contact</source>
+        <translation type="unfinished">删除联系人</translation>
+    </message>
+    <message>
+        <source>Block user</source>
+        <translation type="unfinished">屏蔽用户</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileDescriptionPanel</name>
+    <message>
+        <source>Display name</source>
+        <translation type="unfinished">显示名称</translation>
+    </message>
+    <message>
+        <source>Display Name</source>
+        <translation type="unfinished">显示名称</translation>
+    </message>
+    <message>
+        <source>Bio</source>
+        <translation type="unfinished">简介</translation>
+    </message>
+    <message>
+        <source>Tell us about yourself</source>
+        <translation type="unfinished">请介绍一下你自己</translation>
+    </message>
+    <message numerus="yes">
+        <source>Bio can&apos;t be longer than %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>简介不能超过%n个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Invalid characters. Standard keyboard characters and emojis only.</source>
+        <translation type="unfinished">无效字符。仅允许使用标准键盘字符和表情符号。</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileDialogView</name>
+    <message>
+        <source>Edit Profile</source>
+        <translation type="unfinished">编辑个人资料</translation>
+    </message>
+    <message>
+        <source>Not available in preview mode</source>
+        <translation type="unfinished">在预览模式下不可用</translation>
+    </message>
+    <message>
+        <source>Send Message</source>
+        <translation type="unfinished">发送消息</translation>
+    </message>
+    <message>
+        <source>Review contact request</source>
+        <translation type="unfinished">审核联系请求</translation>
+    </message>
+    <message>
+        <source>Send contact request</source>
+        <translation type="unfinished">发送联系请求</translation>
+    </message>
+    <message>
+        <source>Block user</source>
+        <translation type="unfinished">屏蔽用户</translation>
+    </message>
+    <message>
+        <source>Unblock user</source>
+        <translation type="unfinished">解除用户屏蔽</translation>
+    </message>
+    <message>
+        <source>Contact Request Pending</source>
+        <translation type="unfinished">联系请求待处理</translation>
+    </message>
+    <message>
+        <source>Share Profile</source>
+        <translation type="unfinished">分享个人资料</translation>
+    </message>
+    <message>
+        <source>Mark as trusted</source>
+        <translation type="unfinished">标记为信任联系人</translation>
+    </message>
+    <message>
+        <source>Edit nickname</source>
+        <translation type="unfinished">编辑昵称</translation>
+    </message>
+    <message>
+        <source>Add nickname</source>
+        <translation type="unfinished">添加昵称</translation>
+    </message>
+    <message>
+        <source>Show QR code</source>
+        <translation type="unfinished">显示二维码</translation>
+    </message>
+    <message>
+        <source>Copy link to profile</source>
+        <translation type="unfinished">复制个人资料链接</translation>
+    </message>
+    <message>
+        <source>Copied to clipboard</source>
+        <translation type="unfinished">已复制到剪贴板</translation>
+    </message>
+    <message>
+        <source>Remove trusted mark</source>
+        <translation type="unfinished">移除信任标记</translation>
+    </message>
+    <message>
+        <source>Remove nickname</source>
+        <translation type="unfinished">删除昵称</translation>
+    </message>
+    <message>
+        <source>Mark as untrusted</source>
+        <translation type="unfinished">标记为不受信任</translation>
+    </message>
+    <message>
+        <source>Remove untrusted mark</source>
+        <translation type="unfinished">移除不信任标记</translation>
+    </message>
+    <message>
+        <source>Remove contact</source>
+        <translation type="unfinished">删除联系人</translation>
+    </message>
+    <message>
+        <source>Copy Chat Key</source>
+        <translation type="unfinished">复制聊天密钥</translation>
+    </message>
+    <message>
+        <source>Communities</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>Accounts</source>
+        <translation type="unfinished">帐户</translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>Web</source>
+        <translation type="unfinished">网页</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileHeader</name>
+    <message>
+        <source>Bridged from Discord</source>
+        <translation type="unfinished">已从 Discord 导入</translation>
+    </message>
+    <message>
+        <source>Select different image</source>
+        <translation type="unfinished">选择不同的图片</translation>
+    </message>
+    <message>
+        <source>Select image</source>
+        <translation type="unfinished">选择图片</translation>
+    </message>
+    <message>
+        <source>Use a collectible</source>
+        <translation type="unfinished">使用收藏品</translation>
+    </message>
+    <message>
+        <source>Remove image</source>
+        <translation type="unfinished">移除图片</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileLayout</name>
+    <message>
+        <source>Contacts</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>Logos Network</source>
+        <translation type="unfinished">Logos 网络</translation>
+    </message>
+    <message>
+        <source>Status Keycard</source>
+        <translation type="unfinished">状态密钥卡</translation>
+    </message>
+    <message>
+        <source>The Keycard module is still busy, please try again</source>
+        <translation type="unfinished">密钥卡模块仍在忙碌中，请稍后再试</translation>
+    </message>
+</context>
+<context>
+    <name>ProfilePerspectiveSelector</name>
+    <message>
+        <source>Stranger</source>
+        <translation type="unfinished">陌生人</translation>
+    </message>
+    <message>
+        <source>Contact</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>Trusted contact</source>
+        <translation type="unfinished">信任的联系人</translation>
+    </message>
+    <message>
+        <source>Preview as %1</source>
+        <translation type="unfinished">以%1预览</translation>
+    </message>
+</context>
+<context>
+    <name>ProfilePopupInviteFriendsPanel</name>
+    <message>
+        <source>Contacts</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>Search contacts</source>
+        <translation type="unfinished">搜索联系人</translation>
+    </message>
+    <message>
+        <source>Share community</source>
+        <translation type="unfinished">分享社区</translation>
+    </message>
+    <message>
+        <source>Copied!</source>
+        <translation type="unfinished">已复制！</translation>
+    </message>
+</context>
+<context>
+    <name>ProfilePopupInviteMessagePanel</name>
+    <message>
+        <source>Invitation Message</source>
+        <translation type="unfinished">邀请消息</translation>
+    </message>
+    <message>
+        <source>The message a contact will get with community invitation</source>
+        <translation type="unfinished">联系人收到社区邀请时将看到的消息</translation>
+    </message>
+    <message>
+        <source>Invites will be sent to:</source>
+        <translation type="unfinished">邀请将被发送至：</translation>
+    </message>
+</context>
+<context>
+    <name>ProfilePopupOverviewPanel</name>
+    <message>
+        <source>Share community</source>
+        <translation type="unfinished">分享社区</translation>
+    </message>
+    <message>
+        <source>Copied!</source>
+        <translation type="unfinished">已复制！</translation>
+    </message>
+    <message>
+        <source>Close Community</source>
+        <translation type="unfinished">关闭社区</translation>
+    </message>
+    <message>
+        <source>Leave Community</source>
+        <translation type="unfinished">离开社区</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseAccountsPanel</name>
+    <message>
+        <source>Accounts here will show on your profile</source>
+        <translation type="unfinished">此处的帐户将在您的个人资料中显示</translation>
+    </message>
+    <message>
+        <source>Accounts here will be hidden from your profile</source>
+        <translation type="unfinished">此处的帐户将从您的个人资料中隐藏</translation>
+    </message>
+    <message>
+        <source>No accounts matching search</source>
+        <translation type="unfinished">没有匹配搜索的帐户</translation>
+    </message>
+    <message>
+        <source>Search account name or address</source>
+        <translation type="unfinished">搜索帐户名称或地址</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseAccountsView</name>
+    <message>
+        <source>%1 has not shared any accounts</source>
+        <translation type="unfinished">%1尚未分享任何账户</translation>
+    </message>
+    <message>
+        <source>Copied</source>
+        <translation type="unfinished">已复制</translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished">复制地址</translation>
+    </message>
+    <message>
+        <source>Show address QR</source>
+        <translation type="unfinished">显示地址二维码</translation>
+    </message>
+    <message>
+        <source>Save address</source>
+        <translation type="unfinished">保存地址</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseAssetsPanel</name>
+    <message>
+        <source>Assets here will show on your profile</source>
+        <translation type="unfinished">您在此处添加的资产将在您的个人资料中显示。</translation>
+    </message>
+    <message>
+        <source>Assets here will be hidden from your profile</source>
+        <translation type="unfinished">您在此处添加的资产将从您的个人资料中隐藏。</translation>
+    </message>
+    <message>
+        <source>No assets matching search</source>
+        <translation type="unfinished">没有找到匹配搜索结果的资产。</translation>
+    </message>
+    <message>
+        <source>Search asset name, symbol or community</source>
+        <translation type="unfinished">搜索资产名称、代码或社区。</translation>
+    </message>
+    <message>
+        <source>Don’t see some of your assets?</source>
+        <translation type="unfinished">看不到您的一些资产？</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseAssetsView</name>
+    <message>
+        <source>%1 has not shared any assets</source>
+        <translation type="unfinished">%1尚未分享任何资产</translation>
+    </message>
+    <message>
+        <source>Visit community</source>
+        <translation type="unfinished">访问社区</translation>
+    </message>
+    <message>
+        <source>View on CoinGecko</source>
+        <translation type="unfinished">在CoinGecko上查看</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseCollectiblesPanel</name>
+    <message>
+        <source>Collectibles here will show on your profile</source>
+        <translation type="unfinished">您在此处收集的物品将在您的个人资料中显示。</translation>
+    </message>
+    <message>
+        <source>Collectibles here will be hidden from your profile</source>
+        <translation type="unfinished">您在此处收集的物品将从您的个人资料中隐藏。</translation>
+    </message>
+    <message>
+        <source>No collectibles matching search</source>
+        <translation type="unfinished">没有匹配搜索结果的收藏品。</translation>
+    </message>
+    <message>
+        <source>Search collectible name, number, collection or community</source>
+        <translation type="unfinished">搜索收藏品的名称、编号、系列或社区。</translation>
+    </message>
+    <message>
+        <source>Don’t see some of your collectibles?</source>
+        <translation type="unfinished">您是否未看到部分收藏品？</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseCollectiblesView</name>
+    <message>
+        <source>%1 has not shared any collectibles</source>
+        <translation type="unfinished">%1尚未分享任何收藏品</translation>
+    </message>
+    <message>
+        <source>Visit community</source>
+        <translation type="unfinished">访问社区</translation>
+    </message>
+    <message>
+        <source>View on Opensea</source>
+        <translation type="unfinished">在Opensea上查看</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseCommunitiesPanel</name>
+    <message>
+        <source>Drag communities here to display in showcase</source>
+        <translation type="unfinished">将社区拖动到此处以在展示区中显示</translation>
+    </message>
+    <message>
+        <source>Communities here will be hidden from your Profile</source>
+        <translation type="unfinished">此处的社区将在您的个人资料中隐藏</translation>
+    </message>
+    <message>
+        <source>No communities matching search</source>
+        <translation type="unfinished">没有匹配的社区</translation>
+    </message>
+    <message>
+        <source>Search community name or role</source>
+        <translation type="unfinished">搜索社区名称或角色</translation>
+    </message>
+    <message>
+        <source>Member</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseCommunitiesView</name>
+    <message>
+        <source>%1 has not shared any communities</source>
+        <translation type="unfinished">%1尚未分享任何社区</translation>
+    </message>
+    <message>
+        <source>Owner</source>
+        <translation type="unfinished">所有者</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <translation type="unfinished">管理员</translation>
+    </message>
+    <message>
+        <source>Token Master</source>
+        <translation type="unfinished">代币大师</translation>
+    </message>
+    <message>
+        <source>Member</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+    <message>
+        <source>You&apos;re there too</source>
+        <translation type="unfinished">你也在其中</translation>
+    </message>
+    <message>
+        <source>Visit community</source>
+        <translation type="unfinished">访问社区</translation>
+    </message>
+    <message>
+        <source>Invite People</source>
+        <translation type="unfinished">邀请用户</translation>
+    </message>
+    <message>
+        <source>Copied</source>
+        <translation type="unfinished">已复制</translation>
+    </message>
+    <message>
+        <source>Copy link to community</source>
+        <translation type="unfinished">复制社区链接</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseInfoPopup</name>
+    <message>
+        <source>Build your profile showcase</source>
+        <translation type="unfinished">创建您的个人资料展示</translation>
+    </message>
+    <message>
+        <source>Show visitors to your profile...</source>
+        <translation type="unfinished">向访问您个人资料的用户展示……</translation>
+    </message>
+    <message>
+        <source>Communities you are a member of</source>
+        <translation type="unfinished">您参与的社区</translation>
+    </message>
+    <message>
+        <source>Assets and collectibles you hodl</source>
+        <translation type="unfinished">您拥有的资产和收藏品</translation>
+    </message>
+    <message>
+        <source>Accounts you own to make sending your funds easy</source>
+        <translation type="unfinished">您拥有的账户，以便轻松发送您的资金</translation>
+    </message>
+    <message>
+        <source>Choose your level of privacy with visibility controls</source>
+        <translation type="unfinished">选择您的隐私级别，并使用可见性控制</translation>
+    </message>
+    <message>
+        <source>Build your showcase</source>
+        <translation type="unfinished">创建您的展示</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcasePanel</name>
+    <message>
+        <source>In showcase</source>
+        <translation type="unfinished">正在展示中</translation>
+    </message>
+    <message>
+        <source>Showcase limit of %1 reached</source>
+        <translation type="unfinished">已达到%1的展示上限</translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished">隐藏</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">隐藏</translation>
+    </message>
+    <message>
+        <source>Everyone</source>
+        <translation type="unfinished">所有人</translation>
+    </message>
+    <message>
+        <source>Contacts</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>Showcase limit of %1 reached. &lt;br&gt;Remove item from showcase to add more.</source>
+        <translation type="unfinished">已达到%1的展示上限。从展示中移除项目以添加更多。</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseSocialLinksView</name>
+    <message>
+        <source>%1 has not shared any links</source>
+        <translation type="unfinished">%1尚未分享任何链接</translation>
+    </message>
+    <message>
+        <source>Social handles and links are unverified</source>
+        <translation type="unfinished">社交账号和链接未经验证</translation>
+    </message>
+    <message>
+        <source>Copied</source>
+        <translation type="unfinished">已复制</translation>
+    </message>
+    <message>
+        <source>Copy link</source>
+        <translation type="unfinished">复制链接</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileShowcaseView</name>
+    <message>
+        <source>%1 is a community minted asset. Would you like to visit the community that minted it?</source>
+        <translation type="unfinished">%1 是一个社区铸造的资产。您想访问铸造它的社区吗？</translation>
+    </message>
+    <message>
+        <source>%1 is a community minted collectible. Would you like to visit the community that minted it?</source>
+        <translation type="unfinished">%1 是一个社区铸造的收藏品。您想访问铸造它的社区吗？</translation>
+    </message>
+    <message>
+        <source>Minted by %1</source>
+        <translation type="unfinished">由 %1 铸造</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileSocialLinksPanel</name>
+    <message>
+        <source>In showcase</source>
+        <translation type="unfinished">正在展示中</translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished">%1 / %2</translation>
+    </message>
+    <message>
+        <source>Link limit of %1 reached</source>
+        <translation type="unfinished">已达到 %1 个链接限制</translation>
+    </message>
+    <message>
+        <source>＋ Add a link</source>
+        <translation type="unfinished">＋ 添加链接</translation>
+    </message>
+    <message>
+        <source>Edit link</source>
+        <translation type="unfinished">编辑链接</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileUtils</name>
+    <message>
+        <source>X (Twitter)</source>
+        <translation type="unfinished">推特</translation>
+    </message>
+    <message>
+        <source>Personal site</source>
+        <translation type="unfinished">个人网站</translation>
+    </message>
+    <message>
+        <source>Github</source>
+        <translation type="unfinished">GitHub</translation>
+    </message>
+    <message>
+        <source>YouTube channel</source>
+        <translation type="unfinished">YouTube频道</translation>
+    </message>
+    <message>
+        <source>Discord handle</source>
+        <translation type="unfinished">Discord用户名</translation>
+    </message>
+    <message>
+        <source>Telegram handle</source>
+        <translation type="unfinished">Telegram用户名</translation>
+    </message>
+    <message>
+        <source>Personal</source>
+        <translation type="unfinished">个人</translation>
+    </message>
+    <message>
+        <source>YouTube</source>
+        <translation type="unfinished">YouTube</translation>
+    </message>
+    <message>
+        <source>Discord</source>
+        <translation type="unfinished">Discord</translation>
+    </message>
+    <message>
+        <source>Telegram</source>
+        <translation type="unfinished">Telegram</translation>
+    </message>
+    <message>
+        <source>Twitter username</source>
+        <translation type="unfinished">推特用户名</translation>
+    </message>
+    <message>
+        <source>Owner</source>
+        <translation type="unfinished">所有者</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <translation type="unfinished">管理员</translation>
+    </message>
+    <message>
+        <source>TokenMaster</source>
+        <translation type="unfinished">代币管理员</translation>
+    </message>
+    <message>
+        <source>Member</source>
+        <translation type="unfinished">成员</translation>
+    </message>
+</context>
+<context>
+    <name>PromotionalCommunityCard</name>
+    <message>
+        <source>Want to see your community here?</source>
+        <translation type="unfinished">想在这里看到您的社区吗？</translation>
+    </message>
+    <message>
+        <source>Help more people discover your community - start or join the vote to get it on the board.</source>
+        <translation type="unfinished">帮助更多人发现您的社区——发起或参与投票，让它出现在推荐列表中。</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished">了解更多</translation>
+    </message>
+    <message>
+        <source>Initiate the vote</source>
+        <translation type="unfinished">发起投票</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Use Status profile password</source>
+        <translation type="unfinished">使用状态配置文件密码</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <source>Enable access to your camera</source>
+        <translation type="unfinished">启用对您相机的访问权限</translation>
+    </message>
+    <message>
+        <source>Align the QR code within the frame to scan</source>
+        <translation type="unfinished">将二维码对准框架以进行扫描</translation>
+    </message>
+    <message>
+        <source>Scanned successfully</source>
+        <translation type="unfinished">扫描成功</translation>
+    </message>
+    <message>
+        <source>To scan QR codes, add contacts, send funds to wallets, and sync apps.</source>
+        <translation type="unfinished">要扫描二维码、添加联系人、向钱包发送资金和同步应用程序。</translation>
+    </message>
+    <message>
+        <source>Open settings</source>
+        <translation type="unfinished">打开设置</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScannerDialog</name>
+    <message>
+        <source>QR Scanner</source>
+        <translation type="unfinished">二维码扫描器</translation>
+    </message>
+    <message>
+        <source>Contact request</source>
+        <translation type="unfinished">联系请求</translation>
+    </message>
+    <message>
+        <source>Join communities</source>
+        <translation type="unfinished">加入社区</translation>
+    </message>
+    <message>
+        <source>Send tokens</source>
+        <translation type="unfinished">发送代币</translation>
+    </message>
+    <message>
+        <source>Open WEB links</source>
+        <translation type="unfinished">打开网页链接</translation>
+    </message>
+    <message>
+        <source>We cannot read that QR code.</source>
+        <translation type="unfinished">我们无法读取该二维码。</translation>
+    </message>
+    <message>
+        <source>WalletConnect to connect to dApps</source>
+        <translation type="unfinished">使用 WalletConnect 连接到 dApp</translation>
+    </message>
+</context>
+<context>
+    <name>RPCStatsModal</name>
+    <message>
+        <source>Total</source>
+        <translation type="unfinished">总计</translation>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation type="unfinished">刷新</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished">重置</translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveModal</name>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished">复制地址</translation>
+    </message>
+    <message>
+        <source>QR code for wallet address</source>
+        <translation type="unfinished">钱包地址的二维码</translation>
+    </message>
+</context>
+<context>
+    <name>RecipientInfoButtonWithMenu</name>
+    <message>
+        <source>View receiver address on %1</source>
+        <extracomment>e.g. &quot;View receiver address on Etherscan&quot;</extracomment>
+        <translation type="unfinished">在%1上查看接收者地址</translation>
+    </message>
+    <message>
+        <source>Copy receiver address</source>
+        <translation type="unfinished">复制接收者地址</translation>
+    </message>
+    <message>
+        <source>Copied</source>
+        <translation type="unfinished">已复制</translation>
+    </message>
+</context>
+<context>
+    <name>RecipientSelectorPanel</name>
+    <message>
+        <source>Recent</source>
+        <translation type="unfinished">最近</translation>
+    </message>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished">已保存</translation>
+    </message>
+    <message>
+        <source>My Accounts</source>
+        <translation type="unfinished">我的账户</translation>
+    </message>
+    <message>
+        <source>Recently used addresses will appear here</source>
+        <translation type="unfinished">您最近使用的地址将显示在此处</translation>
+    </message>
+    <message>
+        <source>Your saved addresses will appear here</source>
+        <translation type="unfinished">您的已保存地址将显示在此处</translation>
+    </message>
+    <message>
+        <source>Add another account to send tokens between them</source>
+        <translation type="unfinished">添加另一个帐户以在它们之间发送代币</translation>
+    </message>
+    <message>
+        <source>Search for saved address</source>
+        <translation type="unfinished">搜索已保存的地址</translation>
+    </message>
+    <message>
+        <source>No Saved Address</source>
+        <translation type="unfinished">没有已保存的地址</translation>
+    </message>
+    <message>
+        <source>No Recents</source>
+        <translation type="unfinished">没有最近使用过的地址</translation>
+    </message>
+</context>
+<context>
+    <name>RecipientTypeSelectionDropdown</name>
+    <message>
+        <source>ETH adresses</source>
+        <translation type="unfinished">以太坊地址</translation>
+    </message>
+    <message>
+        <source>Community members</source>
+        <translation type="unfinished">社区成员</translation>
+    </message>
+</context>
+<context>
+    <name>RecipientView</name>
+    <message>
+        <source>Enter a valid Ethereum address or ENS name</source>
+        <translation type="unfinished">请输入有效的以太坊地址或ENS名称</translation>
+    </message>
+</context>
+<context>
+    <name>RemotelyDestructPopup</name>
+    <message>
+        <source>Remotely destruct %1 token on %2</source>
+        <translation type="unfinished">在%2上远程销毁%1代币</translation>
+    </message>
+    <message>
+        <source>Remotely destruct %1 token</source>
+        <translation type="unfinished">远程销毁%1代币</translation>
+    </message>
+    <message>
+        <source>Show fees (will be enabled once the form is filled)</source>
+        <translation type="unfinished">显示费用（填写完表单后将启用）</translation>
+    </message>
+    <message>
+        <source>Select a hodler to see remote destruction gas fees</source>
+        <translation type="unfinished">选择一个持有者以查看远程销毁手续费</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message numerus="yes">
+        <source>Remotely destruct %n token(s)</source>
+        <translation type="unfinished">
+            <numerusform>远程销毁 %n 个令牌</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>RemoveAccountConfirmationPopup</name>
+    <message>
+        <source>Remove %1</source>
+        <translation type="unfinished">删除 %1</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to remove %1? The account will be removed from all of your synced devices. Make sure you have a backup of your keys or recovery phrase before proceeding. %2 Copying the derivation path to this account now will enable you to import it again at a later date should you wish to do so:</source>
+        <translation type="unfinished">您确定要删除 %1 吗？该帐户将被从所有同步设备中删除。在继续操作之前，请确保您已备份密钥或恢复短语。%2 现在将此帐户的派生路径复制到剪贴板，以便以后可以再次导入：</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to remove %1? The address will be removed from all of your synced devices.</source>
+        <translation type="unfinished">您确定要删除 %1 吗？该地址将被从所有同步设备中删除。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to remove %1 and it&apos;s associated private key? The account and private key will be removed from all of your synced devices.</source>
+        <translation type="unfinished">您确定要删除 %1 及其关联的私钥吗？帐户和私钥将从所有同步设备中删除。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to remove %1? The account will be removed from all of your synced devices. Copying the derivation path to this account now will enable you to import it again at a later date should you with to do so:</source>
+        <translation type="unfinished">您确定要删除 %1 吗？该帐户将被从所有同步设备中删除。现在将此帐户的派生路径复制到剪贴板，以便以后可以再次导入：</translation>
+    </message>
+    <message>
+        <source>Derivation path for %1</source>
+        <translation type="unfinished">%1 的派生路径</translation>
+    </message>
+    <message>
+        <source>I have a copy of the private key</source>
+        <translation type="unfinished">我已备份私钥</translation>
+    </message>
+    <message>
+        <source>I have taken note of the derivation path</source>
+        <translation type="unfinished">我已经记下了派生路径</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>RemoveContactPopup</name>
+    <message>
+        <source>Remove contact</source>
+        <translation type="unfinished">删除联系人</translation>
+    </message>
+    <message>
+        <source>You and %1 will no longer be contacts</source>
+        <translation type="unfinished">您和%1将不再是联系人</translation>
+    </message>
+    <message>
+        <source>Remove trust mark</source>
+        <translation type="unfinished">移除信任标记</translation>
+    </message>
+    <message>
+        <source>Mark %1 as untrusted</source>
+        <translation type="unfinished">将%1标记为不受信任</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>RemoveIDVerificationDialog</name>
+    <message>
+        <source>Remove trust mark</source>
+        <translation type="unfinished">移除信任标记</translation>
+    </message>
+    <message>
+        <source>%1 will no longer be marked as trusted. This is only visible to you.</source>
+        <translation type="unfinished">Mark %1 as untrusted&apos;:&apos;将 %1 标记为不可信&apos;}]}&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Mark %1 as untrusted</source>
+        <translation type="unfinished">将%1标记为不受信任</translation>
+    </message>
+    <message>
+        <source>Remove contact</source>
+        <translation type="unfinished">删除联系人</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>RemoveKeypairPopup</name>
+    <message>
+        <source>Remove %1 key pair</source>
+        <translation type="unfinished">移除 %1 个密钥对</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to remove %1 key pair? The key pair will be removed from all of your synced devices. Make sure you have a backup of your keys or recovery phrase before proceeding.</source>
+        <translation type="unfinished">您确定要删除 %1 个密钥对吗？该密钥对将从所有同步设备中移除。请确保在继续操作之前备份您的密钥或助记词。</translation>
+    </message>
+    <message>
+        <source>Accounts related to this key pair will also be removed:</source>
+        <translation type="unfinished">与此密钥对关联的帐户也将被删除：</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Remove key pair and derived accounts</source>
+        <translation type="unfinished">删除密钥对和派生帐户</translation>
+    </message>
+</context>
+<context>
+    <name>RemoveSavedAddressPopup</name>
+    <message>
+        <source>Remove %1</source>
+        <translation type="unfinished">移除 %1</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Remove saved address</source>
+        <translation type="unfinished">移除已保存的地址</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to remove %1 from your saved addresses?</source>
+        <translation type="unfinished">您确定要从已保存的地址中删除 %1 吗？</translation>
+    </message>
+</context>
+<context>
+    <name>RenameAccountModal</name>
+    <message>
+        <source>Rename %1</source>
+        <translation type="unfinished">重命名 %1</translation>
+    </message>
+    <message>
+        <source>Enter an account name...</source>
+        <translation type="unfinished">输入账户名称...</translation>
+    </message>
+    <message numerus="yes">
+        <source>Account name must be at least %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>帐户名必须至少包含 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>This is not a valid account name</source>
+        <translation type="unfinished">这不是一个有效的账户名称</translation>
+    </message>
+    <message>
+        <source>COLOUR</source>
+        <translation type="unfinished">颜色</translation>
+    </message>
+    <message>
+        <source>Change Name</source>
+        <translation type="unfinished">更改名称</translation>
+    </message>
+    <message>
+        <source>Changing settings failed</source>
+        <translation type="unfinished">设置更改失败</translation>
+    </message>
+</context>
+<context>
+    <name>RenameGroupPopup</name>
+    <message>
+        <source>Edit group name and image</source>
+        <translation type="unfinished">编辑群组名称和图片</translation>
+    </message>
+    <message>
+        <source>Name the group</source>
+        <translation type="unfinished">为群组命名</translation>
+    </message>
+    <message>
+        <source>group name</source>
+        <translation type="unfinished">群组名称</translation>
+    </message>
+    <message>
+        <source>Group image</source>
+        <translation type="unfinished">群组图像</translation>
+    </message>
+    <message>
+        <source>Choose an image as logo</source>
+        <translation type="unfinished">选择一张图片作为徽标</translation>
+    </message>
+    <message>
+        <source>Use as an icon for this group chat</source>
+        <translation type="unfinished">将其用作此群聊的图标</translation>
+    </message>
+    <message>
+        <source>Standard colours</source>
+        <translation type="unfinished">标准颜色</translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished">保存更改</translation>
+    </message>
+</context>
+<context>
+    <name>RenameKeypairPopup</name>
+    <message>
+        <source>Rename key pair</source>
+        <translation type="unfinished">重命名密钥对</translation>
+    </message>
+    <message>
+        <source>Same name</source>
+        <translation type="unfinished">相同的名称</translation>
+    </message>
+    <message>
+        <source>Key pair name already in use</source>
+        <translation type="unfinished">密钥对名称已被使用</translation>
+    </message>
+    <message>
+        <source>Key pair name</source>
+        <translation type="unfinished">密钥对名称</translation>
+    </message>
+    <message>
+        <source>Accounts derived from this key pair</source>
+        <translation type="unfinished">从此密钥派生的帐户</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished">保存更改</translation>
+    </message>
+</context>
+<context>
+    <name>ReviewContactRequestPopup</name>
+    <message>
+        <source>Review contact request</source>
+        <translation type="unfinished">审核联系请求</translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation type="unfinished">忽略</translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished">接受</translation>
+    </message>
+</context>
+<context>
+    <name>RightTabView</name>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation type="unfinished">历史</translation>
+    </message>
+</context>
+<context>
+    <name>RootStore</name>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">您</translation>
+    </message>
+    <message>
+        <source>You need to be a member of this group to send messages</source>
+        <translation type="unfinished">您需要成为此群组的成员才能发送消息</translation>
+    </message>
+    <message>
+        <source>Add %1 as a contact to send a message</source>
+        <translation type="unfinished">将%1添加为联系人以发送消息</translation>
+    </message>
+    <message>
+        <source>Type something</source>
+        <translation type="unfinished">输入内容</translation>
+    </message>
+</context>
+<context>
+    <name>RouterErrorTag</name>
+    <message>
+        <source>- Hide details</source>
+        <translation type="unfinished">- 隐藏详细信息</translation>
+    </message>
+    <message>
+        <source>+ Show details</source>
+        <translation type="unfinished">+ 显示详细信息</translation>
+    </message>
+</context>
+<context>
+    <name>SavedAddressActivityPopup</name>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+</context>
+<context>
+    <name>SavedAddresses</name>
+    <message>
+        <source>Search for name, ENS or address</source>
+        <translation type="unfinished">搜索名称、ENS 或地址</translation>
+    </message>
+    <message>
+        <source>Your saved addresses will appear here</source>
+        <translation type="unfinished">您保存的地址将显示在此处</translation>
+    </message>
+    <message>
+        <source>No saved addresses found. Check spelling or address is correct.</source>
+        <translation type="unfinished">未找到已保存的地址。请检查拼写或地址是否正确。</translation>
+    </message>
+</context>
+<context>
+    <name>SavedAddressesDelegate</name>
+    <message>
+        <source>Edit saved address</source>
+        <translation type="unfinished">编辑已保存的地址</translation>
+    </message>
+    <message>
+        <source>Address copied</source>
+        <translation type="unfinished">地址已复制</translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished">复制地址</translation>
+    </message>
+    <message>
+        <source>Show address QR</source>
+        <translation type="unfinished">显示地址二维码</translation>
+    </message>
+    <message>
+        <source>Remove saved address</source>
+        <translation type="unfinished">移除已保存的地址</translation>
+    </message>
+    <message>
+        <source>Add to saved addresses</source>
+        <translation type="unfinished">添加到已保存的地址</translation>
+    </message>
+</context>
+<context>
+    <name>ScanOrEnterQrCode</name>
+    <message>
+        <source>Scan encrypted QR code</source>
+        <translation type="unfinished">扫描加密的二维码</translation>
+    </message>
+    <message>
+        <source>Enter encrypted key</source>
+        <translation type="unfinished">输入加密密钥</translation>
+    </message>
+    <message>
+        <source>This does not look like the correct key pair QR code</source>
+        <translation type="unfinished">这看起来不像正确的密钥对二维码</translation>
+    </message>
+    <message>
+        <source>This does not look like an encrypted key pair code</source>
+        <translation type="unfinished">这看起来不像一个加密的密钥对代码</translation>
+    </message>
+    <message>
+        <source>Paste encrypted key</source>
+        <translation type="unfinished">粘贴加密密钥</translation>
+    </message>
+</context>
+<context>
+    <name>ScrollingModal</name>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">系统</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished">自定义</translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <translation type="unfinished">速度</translation>
+    </message>
+    <message>
+        <source>Deceleration</source>
+        <translation type="unfinished">减速度</translation>
+    </message>
+    <message>
+        <source>Test scrolling</source>
+        <translation type="unfinished">测试滚动</translation>
+    </message>
+</context>
+<context>
+    <name>SearchBox</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+</context>
+<context>
+    <name>SearchBoxWithRightIcon</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+</context>
+<context>
+    <name>SearchEngineModal</name>
+    <message>
+        <source>Search engine</source>
+        <translation type="unfinished">搜索引擎</translation>
+    </message>
+    <message>
+        <source>https://example.com/search?q=</source>
+        <translation type="unfinished">https://example.com/search?q=</translation>
+    </message>
+    <message>
+        <source>Custom search engine URL prefix</source>
+        <translation type="unfinished">自定义搜索引擎网址前缀</translation>
+    </message>
+    <message>
+        <source>URL must start with http:// or https://</source>
+        <translation type="unfinished">网址必须以 http:// 或 https:// 开头</translation>
+    </message>
+</context>
+<context>
+    <name>SearchEnginesConfig</name>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <source>valid URLs open directly; non-addresses won&apos;t be searched.</source>
+        <translation type="unfinished">有效的网址将直接打开；非地址不会被搜索。</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished">自定义</translation>
+    </message>
+    <message>
+        <source>Plug in your own search engine that follows the OpenSearch URL format</source>
+        <translation type="unfinished">插入您自己的搜索引擎，该搜索引擎应遵循 OpenSearch URL 格式</translation>
+    </message>
+</context>
+<context>
+    <name>SearchableAssetsPanel</name>
+    <message>
+        <source>Your assets will appear here</source>
+        <translation type="unfinished">您的资产将显示在此处</translation>
+    </message>
+    <message>
+        <source>Search for token or enter token address</source>
+        <translation type="unfinished">搜索代币或输入代币地址</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+    <message>
+        <source>Loading more tokens...</source>
+        <translation type="unfinished">正在加载更多代币...</translation>
+    </message>
+</context>
+<context>
+    <name>SearchableCollectiblesPanel</name>
+    <message>
+        <source>Your collectibles will appear here</source>
+        <translation type="unfinished">您的收藏品将显示在此处</translation>
+    </message>
+    <message>
+        <source>Search collectibles</source>
+        <translation type="unfinished">搜索收藏品</translation>
+    </message>
+    <message>
+        <source>Community minted</source>
+        <translation type="unfinished">社区铸造</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">其他</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished">返回</translation>
+    </message>
+</context>
+<context>
+    <name>SeedPhrase</name>
+    <message>
+        <source>Reveal recovery phrase</source>
+        <translation type="unfinished">显示恢复短语</translation>
+    </message>
+</context>
+<context>
+    <name>SeedPhraseDisplayState</name>
+    <message>
+        <source>Write down your recovery phrase</source>
+        <translation type="unfinished">请记下您的助记词</translation>
+    </message>
+    <message>
+        <source>The next screen contains your recovery phrase.&lt;br/&gt;&lt;b&gt;Anyone&lt;/b&gt; who sees it can use it to access to your funds.</source>
+        <translation type="unfinished">下一个屏幕将显示您的助记词。&lt;br/&gt;&lt;b&gt;任何&lt;/b&gt;看到它的人都可以使用它来访问您的资金。</translation>
+    </message>
+</context>
+<context>
+    <name>SeedphrasePage</name>
+    <message>
+        <source>Create profile using a recovery phrase</source>
+        <translation type="unfinished">使用助记词创建资料</translation>
+    </message>
+    <message>
+        <source>Enter your 12, 18 or 24 word recovery phrase</source>
+        <translation type="unfinished">输入您的 12、18 或 24 个单词的助记词</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+</context>
+<context>
+    <name>SeedphraseVerifyInput</name>
+    <message>
+        <source>Enter word</source>
+        <translation type="unfinished">输入单词</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">清除</translation>
+    </message>
+</context>
+<context>
+    <name>SelectImportMethod</name>
+    <message>
+        <source>Import method</source>
+        <translation type="unfinished">导入方法</translation>
+    </message>
+    <message>
+        <source>Import via scanning encrypted QR</source>
+        <translation type="unfinished">通过扫描加密二维码导入</translation>
+    </message>
+    <message>
+        <source>Import via entering recovery phrase</source>
+        <translation type="unfinished">通过输入助记词导入</translation>
+    </message>
+    <message>
+        <source>Import via entering private key</source>
+        <translation type="unfinished">通过输入私钥导入</translation>
+    </message>
+</context>
+<context>
+    <name>SelectKeyPairState</name>
+    <message>
+        <source>Select key pair</source>
+        <translation type="unfinished">选择密钥对</translation>
+    </message>
+    <message>
+        <source>I understand that moving this key pair will require using Keycard to sign</source>
+        <translation type="unfinished">我理解，移动此密钥对需要使用Keycard进行签名</translation>
+    </message>
+    <message>
+        <source>Profile key pair</source>
+        <translation type="unfinished">配置文件密钥对</translation>
+    </message>
+    <message>
+        <source>Key pair</source>
+        <translation type="unfinished">密钥对</translation>
+    </message>
+    <message>
+        <source>I understand that moving this key pair will require using Keycard to log in and sign</source>
+        <translation type="unfinished">我理解，移动此密钥对需要使用Keycard登录并进行签名</translation>
+    </message>
+</context>
+<context>
+    <name>SelectKeypair</name>
+    <message>
+        <source>To use the associated accounts on this device, you need to import their key pairs.</source>
+        <translation type="unfinished">要在此设备上使用关联的帐户，您需要导入它们的密钥对。</translation>
+    </message>
+    <message>
+        <source>Import key pairs from your other device</source>
+        <translation type="unfinished">从您的其他设备导入密钥对</translation>
+    </message>
+    <message>
+        <source>Import via scanning encrypted QR</source>
+        <translation type="unfinished">通过扫描加密二维码进行导入</translation>
+    </message>
+    <message>
+        <source>Import individual keys</source>
+        <translation type="unfinished">导入单个密钥</translation>
+    </message>
+</context>
+<context>
+    <name>SelectMasterKey</name>
+    <message>
+        <source>Add new master key</source>
+        <translation type="unfinished">添加新的主密钥</translation>
+    </message>
+    <message>
+        <source>Import using recovery phrase</source>
+        <translation type="unfinished">使用助记词导入</translation>
+    </message>
+    <message>
+        <source>Import private key</source>
+        <translation type="unfinished">导入私钥</translation>
+    </message>
+    <message>
+        <source>Generate new master key</source>
+        <translation type="unfinished">生成新的主密钥</translation>
+    </message>
+    <message>
+        <source>Use Keycard</source>
+        <translation type="unfinished">使用Keycard</translation>
+    </message>
+    <message>
+        <source>Continue in Keycard settings</source>
+        <translation type="unfinished">在Keycard设置中继续</translation>
+    </message>
+</context>
+<context>
+    <name>SelectOrigin</name>
+    <message>
+        <source>Origin</source>
+        <translation type="unfinished">来源</translation>
+    </message>
+    <message>
+        <source>From Keycard, private key or recovery phrase</source>
+        <translation type="unfinished">从密钥卡、私钥或助记词导入</translation>
+    </message>
+    <message>
+        <source>Any ETH address</source>
+        <translation type="unfinished">任何以太坊地址</translation>
+    </message>
+    <message>
+        <source>key pair requires import to use on this device</source>
+        <translation type="unfinished">要在此设备上使用，需要导入密钥对</translation>
+    </message>
+</context>
+<context>
+    <name>SelectParamsForBuyCryptoPanel</name>
+    <message>
+        <source>Buy via %1</source>
+        <translation type="unfinished">通过 %1 购买</translation>
+    </message>
+    <message>
+        <source>Select which network and asset</source>
+        <translation type="unfinished">选择网络和资产</translation>
+    </message>
+    <message>
+        <source>Select network</source>
+        <translation type="unfinished">选择网络</translation>
+    </message>
+    <message>
+        <source>Select asset</source>
+        <translation type="unfinished">选择资产</translation>
+    </message>
+</context>
+<context>
+    <name>SendContactRequestMenuItem</name>
+    <message>
+        <source>Send contact request</source>
+        <translation type="unfinished">发送联系人请求</translation>
+    </message>
+</context>
+<context>
+    <name>SendContactRequestModal</name>
+    <message>
+        <source>Why should they accept your contact request?</source>
+        <translation type="unfinished">他们为什么要接受您的联系请求？</translation>
+    </message>
+    <message>
+        <source>Write a short message telling them who you are...</source>
+        <translation type="unfinished">写一段简短的文字，告诉他们你是谁......</translation>
+    </message>
+    <message>
+        <source>Send contact request</source>
+        <translation type="unfinished">发送联系请求</translation>
+    </message>
+    <message>
+        <source>who are you</source>
+        <translation type="unfinished">你是谁</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>SendContactRequestToChatKeyModal</name>
+    <message>
+        <source>Send Contact Request to chat key</source>
+        <translation type="unfinished">向聊天密钥发送联系请求</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+    <message>
+        <source>Enter chat key here</source>
+        <translation type="unfinished">在此处输入聊天密钥</translation>
+    </message>
+    <message>
+        <source>Cannot send a contact request to oneself</source>
+        <translation type="unfinished">无法向自己发送联系请求</translation>
+    </message>
+    <message>
+        <source>This user is blocked. Unblock to send a contact request.</source>
+        <translation type="unfinished">该用户已被阻止。取消阻止以发送联系请求。</translation>
+    </message>
+    <message>
+        <source>You already sent a contact request.</source>
+        <translation type="unfinished">您已经发送了联系请求。</translation>
+    </message>
+    <message>
+        <source>You are already contacts.</source>
+        <translation type="unfinished">你们已经是联系人了。</translation>
+    </message>
+    <message>
+        <source>Say who you are / why you want to become a contact...</source>
+        <translation type="unfinished">请说明您的身份/您希望成为联系人的原因... </translation>
+    </message>
+    <message>
+        <source>who are you</source>
+        <translation type="unfinished">你是谁？</translation>
+    </message>
+    <message>
+        <source>Send Contact Request</source>
+        <translation type="unfinished">发送联系请求</translation>
+    </message>
+</context>
+<context>
+    <name>SendMessageMenuItem</name>
+    <message>
+        <source>Send message</source>
+        <translation type="unfinished">发送消息</translation>
+    </message>
+</context>
+<context>
+    <name>SendModalFooter</name>
+    <message>
+        <source>Est time</source>
+        <translation type="unfinished">预计时间</translation>
+    </message>
+    <message>
+        <source>Est fees</source>
+        <translation type="unfinished">预计费用</translation>
+    </message>
+    <message>
+        <source>Review Send</source>
+        <translation type="unfinished">查看并发送</translation>
+    </message>
+</context>
+<context>
+    <name>SendModalHandler</name>
+    <message>
+        <source>Info</source>
+        <translation type="unfinished">信息</translation>
+    </message>
+    <message>
+        <source>Token that you&apos;re trying to send is not supported.</source>
+        <translation type="unfinished">您尝试发送的代币不受支持。</translation>
+    </message>
+    <message>
+        <source>Your assets on %1</source>
+        <translation type="unfinished">您在%1上的资产</translation>
+    </message>
+    <message>
+        <source>Popular assets</source>
+        <translation type="unfinished">热门资产</translation>
+    </message>
+</context>
+<context>
+    <name>SendModalHeader</name>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+    <message>
+        <source>On:</source>
+        <translation type="unfinished">时间：</translation>
+    </message>
+</context>
+<context>
+    <name>SendRecipientInput</name>
+    <message>
+        <source>Enter an ENS name or address</source>
+        <translation type="unfinished">输入一个 ENS 名称或地址</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+</context>
+<context>
+    <name>SendSignModal</name>
+    <message>
+        <source>Sign Send</source>
+        <translation type="unfinished">签署并发送</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <extracomment>e.g. (Send) 100 DAI to batista.eth</extracomment>
+        <translation type="unfinished">从 %1 到 %2</translation>
+    </message>
+    <message>
+        <source>Send %1 to %2 on %3</source>
+        <translation type="unfinished">在 %3 将 %1 发送给 %2</translation>
+    </message>
+    <message>
+        <source>Review all details before signing</source>
+        <translation type="unfinished">在签名之前，请查看所有详细信息</translation>
+    </message>
+    <message>
+        <source>Max fees</source>
+        <translation type="unfinished">最大费用</translation>
+    </message>
+    <message>
+        <source>Edit transaction settings</source>
+        <translation type="unfinished">编辑交易设置</translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">从</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">到</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Fees</source>
+        <translation type="unfinished">费用</translation>
+    </message>
+    <message>
+        <source>Max. fees on %1</source>
+        <translation type="unfinished">%1 上的最大费用</translation>
+    </message>
+</context>
+<context>
+    <name>SessionRequest</name>
+    <message>
+        <source>sign</source>
+        <translation type="unfinished">签名</translation>
+    </message>
+    <message>
+        <source>sign this message</source>
+        <translation type="unfinished">对这条消息进行签名</translation>
+    </message>
+    <message>
+        <source>sign typed data</source>
+        <translation type="unfinished">对输入的数据进行签名</translation>
+    </message>
+    <message>
+        <source>sign transaction</source>
+        <translation type="unfinished">对交易进行签名</translation>
+    </message>
+    <message>
+        <source>sign this transaction</source>
+        <translation type="unfinished">对这笔交易进行签名</translation>
+    </message>
+    <message>
+        <source>transaction</source>
+        <translation type="unfinished">交易</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDirtyToastMessage</name>
+    <message>
+        <source>Changes detected</source>
+        <translation type="unfinished">检测到更改</translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation type="unfinished">保存更改</translation>
+    </message>
+    <message>
+        <source>Save for later</source>
+        <translation type="unfinished">稍后保存</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsEntriesModel</name>
+    <message>
+        <source>Apps</source>
+        <translation type="unfinished">应用程序</translation>
+    </message>
+    <message>
+        <source>Preferences</source>
+        <translation type="unfinished">偏好设置</translation>
+    </message>
+    <message>
+        <source>About &amp; Help</source>
+        <translation type="unfinished">关于与帮助</translation>
+    </message>
+    <message>
+        <source>Back up recovery phrase</source>
+        <translation type="unfinished">备份恢复短语</translation>
+    </message>
+    <message>
+        <source>Recovery phrase</source>
+        <translation type="unfinished">恢复短语</translation>
+    </message>
+    <message>
+        <source>Profile</source>
+        <translation type="unfinished">个人资料</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished">密码</translation>
+    </message>
+    <message>
+        <source>Keycard</source>
+        <translation type="unfinished">密钥卡</translation>
+    </message>
+    <message>
+        <source>ENS usernames</source>
+        <translation type="unfinished">ENS 用户名</translation>
+    </message>
+    <message>
+        <source>This section is going through a redesign.</source>
+        <translation type="unfinished">此部分正在进行重新设计。</translation>
+    </message>
+    <message>
+        <source>Syncing</source>
+        <translation type="unfinished">同步中</translation>
+    </message>
+    <message>
+        <source>Connection problems can happen.&lt;br&gt;If they do, please use the Enter a Recovery Phrase feature instead.</source>
+        <translation type="unfinished">可能会出现连接问题。&lt;br&gt;如果发生，请改用“输入恢复短语”功能。</translation>
+    </message>
+    <message>
+        <source>Logos network</source>
+        <translation type="unfinished">Logos 网络</translation>
+    </message>
+    <message>
+        <source>Messaging</source>
+        <translation type="unfinished">消息传递</translation>
+    </message>
+    <message>
+        <source>Contacts</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">钱包</translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">浏览器</translation>
+    </message>
+    <message>
+        <source>Communities</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>Privacy and security</source>
+        <translation type="unfinished">隐私与安全</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">外观</translation>
+    </message>
+    <message>
+        <source>Notifications</source>
+        <translation type="unfinished">通知</translation>
+    </message>
+    <message>
+        <source>Language &amp; Currency</source>
+        <translation type="unfinished">语言和货币</translation>
+    </message>
+    <message>
+        <source>Advanced</source>
+        <translation type="unfinished">高级</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation type="unfinished">关于</translation>
+    </message>
+    <message>
+        <source>Sign out &amp; Quit</source>
+        <translation type="unfinished">注销并退出</translation>
+    </message>
+    <message>
+        <source>On-device backup</source>
+        <translation type="unfinished">设备内备份</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsLeftTabView</name>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+</context>
+<context>
+    <name>SetupSyncingPopup</name>
+    <message>
+        <source>Sync a New Device</source>
+        <translation type="unfinished">同步新设备</translation>
+    </message>
+    <message>
+        <source>Sync code</source>
+        <translation type="unfinished">同步代码</translation>
+    </message>
+    <message>
+        <source>On your other device, navigate to the Syncing&lt;br&gt;screen and select Enter Sync Code.</source>
+        <translation type="unfinished">在您的其他设备上，导航到“同步”屏幕并选择“输入同步代码”。</translation>
+    </message>
+    <message>
+        <source>Your QR and Sync Code have expired.</source>
+        <translation type="unfinished">您的二维码和同步代码已过期。</translation>
+    </message>
+    <message>
+        <source>Failed to generate sync code</source>
+        <translation type="unfinished">生成同步代码失败</translation>
+    </message>
+    <message>
+        <source>Failed to start pairing server</source>
+        <translation type="unfinished">启动配对服务器失败</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+</context>
+<context>
+    <name>ShareProfileDialog</name>
+    <message>
+        <source>Profile link</source>
+        <translation type="unfinished">个人资料链接</translation>
+    </message>
+    <message>
+        <source>Emoji hash</source>
+        <translation type="unfinished">表情符号哈希值</translation>
+    </message>
+    <message>
+        <source>Copy emoji hash</source>
+        <translation type="unfinished">复制表情符号哈希值</translation>
+    </message>
+    <message>
+        <source>Privacy first! Join me on Status for truly private and secure chats. Use my profile link to download Status and connect: %1</source>
+        <translation type="unfinished">首先注重隐私！在 Status 上与我一起进行真正私密且安全的聊天。使用我的个人资料链接下载 Status 并连接：%1</translation>
+    </message>
+    <message>
+        <source>Copy invitation &amp; link</source>
+        <translation type="unfinished">复制邀请和链接</translation>
+    </message>
+    <message>
+        <source>Copy link</source>
+        <translation type="unfinished">复制链接</translation>
+    </message>
+    <message>
+        <source>Connect with %1 on Status: %2</source>
+        <translation type="unfinished">在 Status 上与 %1 连接：%2</translation>
+    </message>
+    <message>
+        <source>%1&apos;s profile</source>
+        <translation type="unfinished">%1 的个人资料</translation>
+    </message>
+    <message>
+        <source>Share profile to invite contacts</source>
+        <translation type="unfinished">分享个人资料以邀请联系人</translation>
+    </message>
+</context>
+<context>
+    <name>ShareUtils</name>
+    <message>
+        <source>Share via</source>
+        <translation type="unfinished">通过分享</translation>
+    </message>
+</context>
+<context>
+    <name>SharedAddressesAccountSelector</name>
+    <message>
+        <source>No relevant tokens</source>
+        <translation type="unfinished">没有相关的代币</translation>
+    </message>
+    <message>
+        <source>Use this address for any Community airdrops</source>
+        <translation type="unfinished">将此地址用于任何社区空投</translation>
+    </message>
+</context>
+<context>
+    <name>SharedAddressesPanel</name>
+    <message>
+        <source>Edit which addresses you share with %1</source>
+        <translation type="unfinished">编辑您与%1共享的地址</translation>
+    </message>
+    <message>
+        <source>Select addresses to share with %1</source>
+        <translation type="unfinished">选择要与%1共享的地址</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Requirements check pending</source>
+        <translation type="unfinished">正在检查要求</translation>
+    </message>
+    <message>
+        <source>Checking permissions failed</source>
+        <translation type="unfinished">检查权限失败</translation>
+    </message>
+    <message>
+        <source>Save changes &amp; leave %1</source>
+        <translation type="unfinished">保存更改并离开%1</translation>
+    </message>
+    <message>
+        <source>Save changes &amp; update my permissions</source>
+        <translation type="unfinished">保存更改并更新我的权限</translation>
+    </message>
+    <message>
+        <source>Reveal all addresses</source>
+        <translation type="unfinished">显示所有地址</translation>
+    </message>
+    <message numerus="yes">
+        <source>Reveal %n address(s)</source>
+        <translation type="unfinished">
+            <numerusform>显示 %n 个地址</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Share all addresses to join</source>
+        <translation type="unfinished">共享所有地址以加入</translation>
+    </message>
+    <message numerus="yes">
+        <source>Share %n address(s) to join</source>
+        <translation type="unfinished">
+            <numerusform>分享 %n 个地址以加入</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Selected addresses have insufficient tokens to maintain %1 membership</source>
+        <translation type="unfinished">所选地址的代币不足以维持%1会员资格</translation>
+    </message>
+    <message>
+        <source>By deselecting these addresses, you will lose channel permissions</source>
+        <translation type="unfinished">取消选择这些地址后，您将失去频道权限</translation>
+    </message>
+</context>
+<context>
+    <name>SharedAddressesPermissionsPanel</name>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">权限</translation>
+    </message>
+    <message>
+        <source>Updating eligibility</source>
+        <translation type="unfinished">正在更新资格</translation>
+    </message>
+    <message>
+        <source>Become an admin</source>
+        <translation type="unfinished">成为管理员</translation>
+    </message>
+    <message>
+        <source>Join %1</source>
+        <translation type="unfinished">加入%1</translation>
+    </message>
+    <message>
+        <source>Become a TokenMaster</source>
+        <translation type="unfinished">成为TokenMaster</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <translation type="unfinished">管理员</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation type="unfinished">加入</translation>
+    </message>
+    <message>
+        <source>View only</source>
+        <translation type="unfinished">仅查看</translation>
+    </message>
+    <message>
+        <source>View &amp; post</source>
+        <translation type="unfinished">查看和发布</translation>
+    </message>
+    <message>
+        <source>TokenMaster</source>
+        <translation type="unfinished">代币管理员</translation>
+    </message>
+</context>
+<context>
+    <name>SharedAddressesSigningPanel</name>
+    <message>
+        <source>Save addresses you share with %1</source>
+        <translation type="unfinished">保存您与%1共享的地址</translation>
+    </message>
+    <message>
+        <source>Request to join %1</source>
+        <translation type="unfinished">请求加入%1</translation>
+    </message>
+    <message>
+        <source>Share all addresses to join</source>
+        <translation type="unfinished">分享所有地址以加入</translation>
+    </message>
+    <message numerus="yes">
+        <source>Share %n address(s) to join</source>
+        <translation type="unfinished">
+            <numerusform>分享 %n 个地址以加入</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Sign</source>
+        <translation type="unfinished">签名</translation>
+    </message>
+    <message>
+        <source>Signed</source>
+        <translation type="unfinished">已签名</translation>
+    </message>
+    <message numerus="yes">
+        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</source>
+        <translation type="unfinished">
+            <numerusform>要与 &lt;b&gt;%1&lt;/b&gt; 分享 %n 个地址，请使用关联的密钥对进行签名...</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Stored on device</source>
+        <translation type="unfinished">存储在设备上</translation>
+    </message>
+    <message>
+        <source>Stored on keycard</source>
+        <translation type="unfinished">存储在密钥卡上</translation>
+    </message>
+</context>
+<context>
+    <name>ShowcaseDelegate</name>
+    <message>
+        <source>Show to</source>
+        <translation type="unfinished">显示给</translation>
+    </message>
+    <message>
+        <source>Everyone</source>
+        <translation type="unfinished">所有人</translation>
+    </message>
+    <message>
+        <source>Everyone (set account to Everyone)</source>
+        <translation type="unfinished">所有人（将帐户设置为“所有人”）</translation>
+    </message>
+    <message>
+        <source>Contacts</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>Contacts (set account to Contacts)</source>
+        <translation type="unfinished">联系人（将帐户设置为“联系人”）</translation>
+    </message>
+    <message>
+        <source>No one</source>
+        <translation type="unfinished">没有人</translation>
+    </message>
+</context>
+<context>
+    <name>SignCollectibleInfoBox</name>
+    <message>
+        <source>View collectible on OpenSea</source>
+        <translation type="unfinished">在OpenSea上查看收藏品</translation>
+    </message>
+    <message>
+        <source>View collectible on %1</source>
+        <extracomment>e.g. &quot;View collectible on Etherscan&quot;</extracomment>
+        <translation type="unfinished">在%1上查看收藏品</translation>
+    </message>
+    <message>
+        <source>Copy %1 collectible address</source>
+        <translation type="unfinished">复制%1收藏品地址</translation>
+    </message>
+    <message>
+        <source>Copied</source>
+        <translation type="unfinished">已复制</translation>
+    </message>
+</context>
+<context>
+    <name>SignPopup</name>
+    <message>
+        <source>Sign community request with %1</source>
+        <translation type="unfinished">使用%1签署社区请求</translation>
+    </message>
+    <message>
+        <source>Sign Transaction</source>
+        <translation type="unfinished">签署交易</translation>
+    </message>
+    <message>
+        <source>Sign</source>
+        <translation type="unfinished">签名</translation>
+    </message>
+    <message>
+        <source>Update password &amp; sign</source>
+        <translation type="unfinished">更新密码并签名</translation>
+    </message>
+    <message>
+        <source>Update PIN &amp; sign</source>
+        <translation type="unfinished">更新PIN码并签名</translation>
+    </message>
+    <message>
+        <source>Failed to sign with the authorized credentials</source>
+        <translation type="unfinished">使用授权凭据进行签名失败</translation>
+    </message>
+</context>
+<context>
+    <name>SignTransactionModalBase</name>
+    <message>
+        <source>Sign</source>
+        <translation type="unfinished">签名</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Reject</source>
+        <translation type="unfinished">拒绝</translation>
+    </message>
+</context>
+<context>
+    <name>SignTransactionsPopup</name>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Sign transaction</source>
+        <translation type="unfinished">签署交易</translation>
+    </message>
+</context>
+<context>
+    <name>SimpleSendModal</name>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">到</translation>
+    </message>
+    <message>
+        <source>Fees</source>
+        <translation type="unfinished">费用</translation>
+    </message>
+    <message>
+        <source>Insufficient funds for send transaction</source>
+        <translation type="unfinished">发送交易的资金不足</translation>
+    </message>
+    <message>
+        <source>Add ETH</source>
+        <translation type="unfinished">添加以太坊</translation>
+    </message>
+    <message>
+        <source>Add BNB</source>
+        <translation type="unfinished">添加币安币</translation>
+    </message>
+    <message>
+        <source>Add assets</source>
+        <translation type="unfinished">添加资产</translation>
+    </message>
+    <message>
+        <source>Add %1</source>
+        <translation type="unfinished">添加 %1</translation>
+    </message>
+</context>
+<context>
+    <name>SimpleTransactionsFees</name>
+    <message>
+        <source>Est %1 transaction fee</source>
+        <translation type="unfinished">预计%1交易手续费</translation>
+    </message>
+</context>
+<context>
+    <name>SimplifiedMessageView</name>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">您</translation>
+    </message>
+</context>
+<context>
+    <name>SlippageSelector</name>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished">自定义</translation>
+    </message>
+    <message>
+        <source>Enter a slippage value</source>
+        <translation type="unfinished">输入滑点值</translation>
+    </message>
+    <message>
+        <source>Slippage should be more than 0</source>
+        <translation type="unfinished">滑点应大于 0</translation>
+    </message>
+    <message>
+        <source>Invalid value</source>
+        <translation type="unfinished">无效值</translation>
+    </message>
+    <message>
+        <source>Slippage may be higher than necessary</source>
+        <translation type="unfinished">滑点可能高于必要值</translation>
+    </message>
+</context>
+<context>
+    <name>SortOrderComboBox</name>
+    <message>
+        <source>Sort by</source>
+        <translation type="unfinished">按以下方式排序</translation>
+    </message>
+</context>
+<context>
+    <name>SortableTokenHoldersList</name>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished">用户名</translation>
+    </message>
+    <message>
+        <source>No. of messages</source>
+        <translation type="unfinished">消息数量</translation>
+    </message>
+    <message>
+        <source>Hodling</source>
+        <translation type="unfinished">持有</translation>
+    </message>
+</context>
+<context>
+    <name>SortableTokenHoldersPanel</name>
+    <message>
+        <source>%1 token hodlers</source>
+        <translation type="unfinished">%1 个代币持有者</translation>
+    </message>
+    <message>
+        <source>Search hodlers</source>
+        <translation type="unfinished">搜索持有者</translation>
+    </message>
+    <message>
+        <source>Search results</source>
+        <translation type="unfinished">搜索结果</translation>
+    </message>
+    <message>
+        <source>No hodlers found</source>
+        <translation type="unfinished">未找到持有者</translation>
+    </message>
+    <message>
+        <source>No hodlers just yet</source>
+        <translation type="unfinished">目前还没有持有者</translation>
+    </message>
+    <message>
+        <source>You can Airdrop tokens to deserving Community members or to give individuals token-based permissions.</source>
+        <translation type="unfinished">您可以向值得的社区成员空投代币，或授予个人基于代币的权限。</translation>
+    </message>
+    <message>
+        <source>Airdrop</source>
+        <translation type="unfinished">空投</translation>
+    </message>
+    <message>
+        <source>View Profile</source>
+        <translation type="unfinished">查看资料</translation>
+    </message>
+    <message>
+        <source>View Messages</source>
+        <translation type="unfinished">查看消息</translation>
+    </message>
+    <message>
+        <source>Remotely destruct</source>
+        <translation type="unfinished">远程销毁</translation>
+    </message>
+    <message>
+        <source>Kick</source>
+        <translation type="unfinished">踢出</translation>
+    </message>
+    <message>
+        <source>Ban</source>
+        <translation type="unfinished">封禁</translation>
+    </message>
+</context>
+<context>
+    <name>SplashScreen</name>
+    <message>
+        <source>Preparing Status for you</source>
+        <translation type="unfinished">正在为您准备状态</translation>
+    </message>
+    <message>
+        <source>Hang in there! Just a few more seconds!</source>
+        <translation type="unfinished">请稍等！还有几秒钟！</translation>
+    </message>
+</context>
+<context>
+    <name>StatusAddressOrEnsValidator</name>
+    <message>
+        <source>Please enter a valid address or ENS name.</source>
+        <translation type="unfinished">请输入有效的地址或 ENS 名称。</translation>
+    </message>
+</context>
+<context>
+    <name>StatusAddressValidator</name>
+    <message>
+        <source>Please enter a valid address.</source>
+        <translation type="unfinished">请输入有效的地址。</translation>
+    </message>
+</context>
+<context>
+    <name>StatusAsyncEnsValidator</name>
+    <message>
+        <source>ENS name could not be resolved in to an address</source>
+        <translation type="unfinished">无法将 ENS 名称解析为地址</translation>
+    </message>
+</context>
+<context>
+    <name>StatusAsyncValidator</name>
+    <message>
+        <source>invalid input</source>
+        <translation type="unfinished">无效输入</translation>
+    </message>
+</context>
+<context>
+    <name>StatusBadge</name>
+    <message>
+        <source>99+</source>
+        <translation type="unfinished">99+</translation>
+    </message>
+</context>
+<context>
+    <name>StatusChatImageExtensionValidator</name>
+    <message>
+        <source>Format not supported.</source>
+        <translation type="unfinished">不支持的格式。</translation>
+    </message>
+    <message>
+        <source>Format not supported. File: %1</source>
+        <translation type="unfinished">不支持的格式。文件：%1</translation>
+    </message>
+    <message>
+        <source>Upload %1 only</source>
+        <translation type="unfinished">仅上传%1</translation>
+    </message>
+</context>
+<context>
+    <name>StatusChatImageLoader</name>
+    <message>
+        <source>Error loading the image</source>
+        <translation type="unfinished">无法加载图像</translation>
+    </message>
+    <message>
+        <source>Loading image...</source>
+        <translation type="unfinished">正在加载图像...</translation>
+    </message>
+</context>
+<context>
+    <name>StatusChatImageQtyValidator</name>
+    <message numerus="yes">
+        <source>You can only upload %n image(s) at a time</source>
+        <translation type="unfinished">
+            <numerusform>您一次最多只能上传 %n 张图片</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>StatusChatImageSizeValidator</name>
+    <message>
+        <source>Max image size is %1 MB</source>
+        <translation type="unfinished">最大图片大小为%1 MB</translation>
+    </message>
+</context>
+<context>
+    <name>StatusChatInfoButton</name>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished">取消静音</translation>
+    </message>
+    <message numerus="yes">
+        <source>%Ln pinned message(s)</source>
+        <translation type="unfinished">
+            <numerusform>%Ln 条已钉帖消息</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>StatusChatInput</name>
+    <message>
+        <source>Type something</source>
+        <translation type="unfinished">输入内容</translation>
+    </message>
+    <message>
+        <source>Sticker</source>
+        <translation type="unfinished">贴纸</translation>
+    </message>
+    <message>
+        <source>Multiple payment requests</source>
+        <translation type="unfinished">多个支付请求</translation>
+    </message>
+    <message>
+        <source>Payment request %1 %2</source>
+        <translation type="unfinished">支付请求 %1 %2</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n Image(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 张图片</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Please choose an image</source>
+        <translation type="unfinished">请选择一张图片</translation>
+    </message>
+    <message>
+        <source>Image files (%1)</source>
+        <translation type="unfinished">图像文件 (%1)</translation>
+    </message>
+    <message>
+        <source>Please reduce the message length</source>
+        <translation type="unfinished">请减少消息长度</translation>
+    </message>
+    <message>
+        <source>Maximum message character count is %1</source>
+        <translation type="unfinished">最大消息字符数为 %1</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished">编辑</translation>
+    </message>
+</context>
+<context>
+    <name>StatusChatListCategoryItem</name>
+    <message>
+        <source>Add channel inside category</source>
+        <translation type="unfinished">在类别中添加频道</translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation type="unfinished">更多</translation>
+    </message>
+</context>
+<context>
+    <name>StatusChatListItem</name>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished">取消静音</translation>
+    </message>
+</context>
+<context>
+    <name>StatusClearButton</name>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">清除</translation>
+    </message>
+</context>
+<context>
+    <name>StatusColorDialog</name>
+    <message>
+        <source>This is not a valid colour</source>
+        <translation type="unfinished">这不是一个有效的颜色</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation type="unfinished">预览</translation>
+    </message>
+    <message>
+        <source>Standard colours</source>
+        <translation type="unfinished">标准颜色</translation>
+    </message>
+    <message>
+        <source>Select Colour</source>
+        <translation type="unfinished">选择颜色</translation>
+    </message>
+</context>
+<context>
+    <name>StatusContactVerificationIcons</name>
+    <message>
+        <source>Blocked</source>
+        <translation type="unfinished">已阻止</translation>
+    </message>
+    <message>
+        <source>Trusted contact</source>
+        <translation type="unfinished">可信联系人</translation>
+    </message>
+    <message>
+        <source>Untrusted contact</source>
+        <translation type="unfinished">不可信联系人</translation>
+    </message>
+    <message>
+        <source>Contact</source>
+        <translation type="unfinished">联系人</translation>
+    </message>
+    <message>
+        <source>Untrusted</source>
+        <translation type="unfinished">不可信</translation>
+    </message>
+</context>
+<context>
+    <name>StatusCurrencySelector</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+</context>
+<context>
+    <name>StatusDatePicker</name>
+    <message>
+        <source>Today</source>
+        <translation type="unfinished">今天</translation>
+    </message>
+    <message>
+        <source>Previous year</source>
+        <translation type="unfinished">上一年</translation>
+    </message>
+    <message>
+        <source>Previous month</source>
+        <translation type="unfinished">上个月</translation>
+    </message>
+    <message>
+        <source>Select year/month</source>
+        <translation type="unfinished">选择年份/月份</translation>
+    </message>
+    <message>
+        <source>Next year</source>
+        <translation type="unfinished">下一年</translation>
+    </message>
+    <message>
+        <source>Next month</source>
+        <translation type="unfinished">下一个月</translation>
+    </message>
+</context>
+<context>
+    <name>StatusDateRangePicker</name>
+    <message>
+        <source>Filter activity by period</source>
+        <translation type="unfinished">按时间段筛选活动</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">从</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">到</translation>
+    </message>
+    <message>
+        <source>Now</source>
+        <translation type="unfinished">现在</translation>
+    </message>
+    <message>
+        <source>&apos;From&apos; can&apos;t be later than &apos;To&apos;</source>
+        <translation type="unfinished">开始日期不能晚于结束日期</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set date to future</source>
+        <translation type="unfinished">无法设置未来日期</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished">重置</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished">应用</translation>
+    </message>
+</context>
+<context>
+    <name>StatusDialog</name>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished">确定</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Abort</source>
+        <translation type="unfinished">中止</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>No to all</source>
+        <translation type="unfinished">全部拒绝</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">否</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">打开</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">保存</translation>
+    </message>
+    <message>
+        <source>Save all</source>
+        <translation type="unfinished">全部保存</translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation type="unfinished">重试</translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation type="unfinished">忽略</translation>
+    </message>
+    <message>
+        <source>Yes to all</source>
+        <translation type="unfinished">全部同意</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished">应用</translation>
+    </message>
+</context>
+<context>
+    <name>StatusEmojiPopup</name>
+    <message>
+        <source>Search Results</source>
+        <translation type="unfinished">搜索结果</translation>
+    </message>
+    <message>
+        <source>No results found</source>
+        <translation type="unfinished">未找到结果</translation>
+    </message>
+</context>
+<context>
+    <name>StatusFloatValidator</name>
+    <message>
+        <source>Please enter a valid numeric value.</source>
+        <translation type="unfinished">请输入有效的数字。</translation>
+    </message>
+</context>
+<context>
+    <name>StatusGifColumn</name>
+    <message>
+        <source>Remove from favorites</source>
+        <translation type="unfinished">从收藏夹中移除</translation>
+    </message>
+    <message>
+        <source>Add to favorites</source>
+        <translation type="unfinished">添加到收藏夹</translation>
+    </message>
+</context>
+<context>
+    <name>StatusGifPopup</name>
+    <message>
+        <source>Search KLIPY</source>
+        <translation type="unfinished">搜索 KLIPY</translation>
+    </message>
+    <message>
+        <source>TRENDING</source>
+        <translation type="unfinished">热门</translation>
+    </message>
+    <message>
+        <source>FAVORITES</source>
+        <translation type="unfinished">收藏夹</translation>
+    </message>
+    <message>
+        <source>RECENT</source>
+        <translation type="unfinished">最近</translation>
+    </message>
+    <message>
+        <source>Enable third-party services for gifs feature to work.</source>
+        <translation type="unfinished">启用第三方服务以使 GIF 功能正常工作。</translation>
+    </message>
+    <message>
+        <source>Enable third-party services</source>
+        <translation type="unfinished">启用第三方服务</translation>
+    </message>
+</context>
+<context>
+    <name>StatusImageModal</name>
+    <message>
+        <source>Failed to load %1</source>
+        <translation type="unfinished">无法加载 %1</translation>
+    </message>
+    <message>
+        <source>empty image</source>
+        <translation type="unfinished">空图像</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+</context>
+<context>
+    <name>StatusIntValidator</name>
+    <message>
+        <source>Please enter a valid numeric value.</source>
+        <translation type="unfinished">请输入有效的数字。</translation>
+    </message>
+</context>
+<context>
+    <name>StatusLanguageSelector</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+</context>
+<context>
+    <name>StatusMacNotification</name>
+    <message>
+        <source>My latest message
+ with a return</source>
+        <translation type="unfinished">我的最新消息，已回复</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">打开</translation>
+    </message>
+</context>
+<context>
+    <name>StatusMessageDialog</name>
+    <message>
+        <source>Question</source>
+        <translation type="unfinished">问题</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">信息</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+</context>
+<context>
+    <name>StatusMessageEmojiReactions</name>
+    <message>
+        <source>%1 more</source>
+        <translation type="unfinished">还有 %1 个</translation>
+    </message>
+    <message>
+        <source>%1 reacted with %2</source>
+        <translation type="unfinished">%1 对 %2 进行了反应</translation>
+    </message>
+    <message>
+        <source>Add reaction</source>
+        <translation type="unfinished">添加表情</translation>
+    </message>
+    <message>
+        <source>Maximum number of different reactions reached</source>
+        <translation type="unfinished">已达到最大不同表情数量</translation>
+    </message>
+</context>
+<context>
+    <name>StatusMessageHeader</name>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">您</translation>
+    </message>
+    <message>
+        <source>Failed to resend: %1</source>
+        <translation type="unfinished">重发失败：%1</translation>
+    </message>
+    <message>
+        <source>Delivered</source>
+        <translation type="unfinished">已发送</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">已发送</translation>
+    </message>
+    <message>
+        <source>Sending</source>
+        <translation type="unfinished">发送中</translation>
+    </message>
+    <message>
+        <source>Sending failed</source>
+        <translation type="unfinished">发送失败</translation>
+    </message>
+    <message>
+        <source>Resend</source>
+        <translation type="unfinished">重发</translation>
+    </message>
+</context>
+<context>
+    <name>StatusMessageReply</name>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">您</translation>
+    </message>
+</context>
+<context>
+    <name>StatusMinLengthValidator</name>
+    <message>
+        <source>Please enter a value</source>
+        <translation type="unfinished">请输入一个值</translation>
+    </message>
+    <message numerus="yes">
+        <source>The value must be at least %n character(s).</source>
+        <translation type="unfinished">
+            <numerusform>该值必须至少为 %n 个字符。</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>StatusNewTag</name>
+    <message>
+        <source>NEW</source>
+        <translation type="unfinished">新</translation>
+    </message>
+</context>
+<context>
+    <name>StatusPasswordStrengthIndicator</name>
+    <message>
+        <source>Very weak</source>
+        <translation type="unfinished">非常弱</translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <translation type="unfinished">弱</translation>
+    </message>
+    <message>
+        <source>Okay</source>
+        <translation type="unfinished">还可以</translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <translation type="unfinished">好</translation>
+    </message>
+    <message>
+        <source>Very strong</source>
+        <translation type="unfinished">非常好</translation>
+    </message>
+</context>
+<context>
+    <name>StatusQrCodeScanner</name>
+    <message>
+        <source>Camera is not available</source>
+        <translation type="unfinished">相机不可用</translation>
+    </message>
+</context>
+<context>
+    <name>StatusSearchListPopup</name>
+    <message>
+        <source>Search...</source>
+        <translation type="unfinished">搜索...</translation>
+    </message>
+</context>
+<context>
+    <name>StatusSearchLocationMenu</name>
+    <message>
+        <source>Anywhere</source>
+        <translation type="unfinished">任何地方</translation>
+    </message>
+</context>
+<context>
+    <name>StatusSearchPopup</name>
+    <message>
+        <source>No results</source>
+        <translation type="unfinished">没有结果</translation>
+    </message>
+    <message>
+        <source>Anywhere</source>
+        <translation type="unfinished">任何地方</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+    <message>
+        <source>In: </source>
+        <translation type="unfinished">在：</translation>
+    </message>
+</context>
+<context>
+    <name>StatusSeedPhraseTabBar</name>
+    <message>
+        <source>12 word</source>
+        <translation type="unfinished">12 个词</translation>
+    </message>
+    <message>
+        <source>18 word</source>
+        <translation type="unfinished">18 个词</translation>
+    </message>
+    <message>
+        <source>24 word</source>
+        <translation type="unfinished">24 个词</translation>
+    </message>
+</context>
+<context>
+    <name>StatusStackModal</name>
+    <message>
+        <source>StackModal</source>
+        <translation type="unfinished">堆叠模式</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation type="unfinished">下一步</translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+</context>
+<context>
+    <name>StatusStickerButton</name>
+    <message>
+        <source>Buy for %L1 SNT</source>
+        <translation type="unfinished">购买，价格为%L1 SNT</translation>
+    </message>
+    <message>
+        <source>Uninstall</source>
+        <translation type="unfinished">卸载</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <source>Free</source>
+        <translation type="unfinished">免费</translation>
+    </message>
+    <message>
+        <source>Install</source>
+        <translation type="unfinished">安装</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Pending...</source>
+        <translation type="unfinished">等待中...</translation>
+    </message>
+    <message>
+        <source>%L1 SNT</source>
+        <translation type="unfinished">%L1 SNT</translation>
+    </message>
+</context>
+<context>
+    <name>StatusStickersPopup</name>
+    <message>
+        <source>Failed to load stickers</source>
+        <translation type="unfinished">未能加载贴纸</translation>
+    </message>
+    <message>
+        <source>Try again</source>
+        <translation type="unfinished">重试</translation>
+    </message>
+    <message>
+        <source>You don&apos;t have any stickers yet</source>
+        <translation type="unfinished">您目前还没有任何贴纸</translation>
+    </message>
+    <message>
+        <source>Recently used stickers will appear here</source>
+        <translation type="unfinished">最近使用的贴纸将显示在此处</translation>
+    </message>
+    <message>
+        <source>Get Stickers</source>
+        <translation type="unfinished">获取贴纸</translation>
+    </message>
+    <message>
+        <source>Enable third-party services</source>
+        <translation type="unfinished">启用第三方服务</translation>
+    </message>
+    <message>
+        <source>Enable third-party services for stickers feature to work.</source>
+        <translation type="unfinished">启用第三方服务以使贴纸功能正常工作。</translation>
+    </message>
+</context>
+<context>
+    <name>StatusSyncCodeInput</name>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">复制</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+</context>
+<context>
+    <name>StatusSyncDeviceDelegate</name>
+    <message>
+        <source>Unknown device</source>
+        <translation type="unfinished">未知设备</translation>
+    </message>
+    <message>
+        <source>This device</source>
+        <translation type="unfinished">此设备</translation>
+    </message>
+    <message>
+        <source>Never seen online</source>
+        <translation type="unfinished">从未在线</translation>
+    </message>
+    <message>
+        <source>Online now</source>
+        <translation type="unfinished">现在在线</translation>
+    </message>
+    <message numerus="yes">
+        <source>Online %n minute(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n 分钟前上线</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Last seen earlier today</source>
+        <translation type="unfinished">今天稍早最后一次出现</translation>
+    </message>
+    <message>
+        <source>Last online yesterday</source>
+        <translation type="unfinished">昨天最后一次在线</translation>
+    </message>
+    <message>
+        <source>Last online: %1</source>
+        <translation type="unfinished">上次在线：%1</translation>
+    </message>
+    <message>
+        <source>Pair</source>
+        <translation type="unfinished">配对</translation>
+    </message>
+    <message>
+        <source>Unpair</source>
+        <translation type="unfinished">取消配对</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTextField</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished">剪切</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">复制</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished">全选</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTextMessage</name>
+    <message>
+        <source>(edited)</source>
+        <translation type="unfinished">（已编辑）</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTokenInlineSelector</name>
+    <message>
+        <source>Hold</source>
+        <translation type="unfinished">保持</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">或</translation>
+    </message>
+    <message>
+        <source>to post</source>
+        <translation type="unfinished">发布</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTrayIcon</name>
+    <message>
+        <source>Open Status</source>
+        <translation type="unfinished">打开状态</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished">退出</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTxProgressBar</name>
+    <message>
+        <source>Failed on %1</source>
+        <translation type="unfinished">在 %1 上失败</translation>
+    </message>
+    <message>
+        <source>Confirmation in progress on %1...</source>
+        <translation type="unfinished">正在 %1 上进行确认...</translation>
+    </message>
+    <message>
+        <source>Finalised on %1</source>
+        <translation type="unfinished">已在 %1 上完成</translation>
+    </message>
+    <message>
+        <source>Confirmed on %1, finalisation in progress...</source>
+        <translation type="unfinished">已在 %1 上确认，正在进行最终处理...</translation>
+    </message>
+    <message>
+        <source>Pending on %1...</source>
+        <translation type="unfinished">等待 %1 处理中...</translation>
+    </message>
+    <message>
+        <source>In epoch %1</source>
+        <translation type="unfinished">在第 %1 个周期内</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) until finality</source>
+        <translation type="unfinished">
+            <numerusform>距离最终确定还有 %n 天</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1 / %2 confirmations</source>
+        <translation type="unfinished">%1 / %2 次确认</translation>
+    </message>
+</context>
+<context>
+    <name>StatusUrlValidator</name>
+    <message>
+        <source>Please enter a valid URL</source>
+        <translation type="unfinished">请输入有效的网址</translation>
+    </message>
+</context>
+<context>
+    <name>StatusValidator</name>
+    <message>
+        <source>invalid input</source>
+        <translation type="unfinished">无效输入</translation>
+    </message>
+</context>
+<context>
+    <name>StringUtils</name>
+    <message>
+        <source>(edited)</source>
+        <translation type="unfinished">(已编辑)</translation>
+    </message>
+</context>
+<context>
+    <name>SupportedTokenListsPanel</name>
+    <message numerus="yes">
+        <source>%n token(s) · Last updated %1</source>
+        <translation type="unfinished">
+            <numerusform>%n 个标记 · 上次更新于 %1</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished">查看</translation>
+    </message>
+</context>
+<context>
+    <name>SwapApproveCapModal</name>
+    <message>
+        <source>Approve spending cap</source>
+        <translation type="unfinished">批准支出上限</translation>
+    </message>
+    <message>
+        <source>Set %1 spending cap in %2 for %3 on %4</source>
+        <extracomment>e.g. &quot;Set 100 DAI spending cap in &lt;account name&gt; for &lt;service&gt; on &lt;network name&gt;&quot;</extracomment>
+        <translation type="unfinished">在%4为%3设置%2中的%1支出上限</translation>
+    </message>
+    <message>
+        <source>The smart contract specified will be able to spend up to %1 of your current or future balance.</source>
+        <translation type="unfinished">指定的智能合约将能够花费您当前或未来余额的最多%1。</translation>
+    </message>
+    <message>
+        <source>Review all details before signing</source>
+        <translation type="unfinished">签名前请查看所有详细信息</translation>
+    </message>
+    <message>
+        <source>Max fees:</source>
+        <translation type="unfinished">最大费用：</translation>
+    </message>
+    <message>
+        <source>Est. time:</source>
+        <translation type="unfinished">预计时间：</translation>
+    </message>
+    <message>
+        <source>Set spending cap</source>
+        <translation type="unfinished">设置支出上限</translation>
+    </message>
+    <message>
+        <source>Account</source>
+        <translation type="unfinished">账户</translation>
+    </message>
+    <message>
+        <source>Token</source>
+        <translation type="unfinished">代币</translation>
+    </message>
+    <message>
+        <source>Via smart contract</source>
+        <translation type="unfinished">通过智能合约</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Fees</source>
+        <translation type="unfinished">费用</translation>
+    </message>
+    <message>
+        <source>Max. fees on %1</source>
+        <translation type="unfinished">在%1上的最大费用</translation>
+    </message>
+</context>
+<context>
+    <name>SwapFromAccountPopup</name>
+    <message>
+        <source>From account</source>
+        <translation type="unfinished">来源账户</translation>
+    </message>
+</context>
+<context>
+    <name>SwapInputPanel</name>
+    <message>
+        <source>Your assets on %1</source>
+        <translation type="unfinished">您在%1上的资产</translation>
+    </message>
+    <message>
+        <source>Your assets</source>
+        <translation type="unfinished">您的资产</translation>
+    </message>
+    <message>
+        <source>Popular assets</source>
+        <translation type="unfinished">热门资产</translation>
+    </message>
+</context>
+<context>
+    <name>SwapModal</name>
+    <message>
+        <source>Swap</source>
+        <translation type="unfinished">兑换</translation>
+    </message>
+    <message>
+        <source>Add assets</source>
+        <translation type="unfinished">添加资产</translation>
+    </message>
+    <message>
+        <source>Add %1</source>
+        <translation type="unfinished">添加 %1</translation>
+    </message>
+    <message>
+        <source>%1 s</source>
+        <comment>short for seconds</comment>
+        <translation type="unfinished">%1 秒</translation>
+    </message>
+    <message>
+        <source>Best return</source>
+        <translation type="unfinished">最佳收益</translation>
+    </message>
+    <message>
+        <source>by %1</source>
+        <translation type="unfinished">由 %1 提供</translation>
+    </message>
+    <message>
+        <source>via %1</source>
+        <translation type="unfinished">通过 %1</translation>
+    </message>
+    <message>
+        <source>Approving %1</source>
+        <translation type="unfinished">正在批准 %1</translation>
+    </message>
+    <message>
+        <source>Approve %1</source>
+        <translation type="unfinished">批准 %1</translation>
+    </message>
+    <message>
+        <source>Confirm swap</source>
+        <translation type="unfinished">确认兑换</translation>
+    </message>
+    <message>
+        <source>Approving %1 spending cap to Swap</source>
+        <translation type="unfinished">正在批准向 Swap 授权 %1 的支出上限</translation>
+    </message>
+    <message>
+        <source>Approve %1 spending cap to Swap</source>
+        <translation type="unfinished">批准向 Swap 授权 %1 的支出上限</translation>
+    </message>
+    <message>
+        <source>Sign Swap</source>
+        <translation type="unfinished">签署兑换协议</translation>
+    </message>
+    <message>
+        <source>Sign</source>
+        <translation type="unfinished">签署</translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <translation type="unfinished">信息</translation>
+    </message>
+    <message>
+        <source>Swaps on %1 are coming soon.</source>
+        <translation type="unfinished">%1 上的兑换功能即将推出。</translation>
+    </message>
+</context>
+<context>
+    <name>SwapModalAdaptor</name>
+    <message>
+        <source>Insufficient funds for swap</source>
+        <translation type="unfinished">用于兑换的资金不足</translation>
+    </message>
+    <message>
+        <source>Not enough ETH to pay gas fees</source>
+        <translation type="unfinished">ETH 余额不足以支付 Gas 费用</translation>
+    </message>
+    <message>
+        <source>Fetching the price took longer than expected. Please, try again later.</source>
+        <translation type="unfinished">获取价格所需的时间比预期长。请稍后重试。</translation>
+    </message>
+    <message>
+        <source>Not enough liquidity. Lower token amount or try again later.</source>
+        <translation type="unfinished">流动性不足。减少代币数量或稍后重试。</translation>
+    </message>
+    <message>
+        <source>Price impact too high. Lower token amount or try again later.</source>
+        <translation type="unfinished">价格影响过大。减少代币数量或稍后重试。</translation>
+    </message>
+    <message>
+        <source>No routes found with enough liquidity</source>
+        <translation type="unfinished">未找到具有足够流动性的路径</translation>
+    </message>
+    <message>
+        <source>Something went wrong. Change amount, token or try again later.</source>
+        <translation type="unfinished">出现问题。更改金额、代币或稍后重试。</translation>
+    </message>
+</context>
+<context>
+    <name>SwapProvidersTermsAndConditionsText</name>
+    <message>
+        <source>Powered by</source>
+        <translation type="unfinished">由以下提供支持</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished">查看</translation>
+    </message>
+    <message>
+        <source>Terms &amp; Conditions</source>
+        <translation type="unfinished">条款与条件</translation>
+    </message>
+</context>
+<context>
+    <name>SwapSignModal</name>
+    <message>
+        <source>%1 to %2</source>
+        <extracomment>e.g. (swap) 100 DAI to 100 USDT</extracomment>
+        <translation type="unfinished">%1 到 %2</translation>
+    </message>
+    <message>
+        <source>Swap %1 to %2 in %3 on %4</source>
+        <extracomment>e.g. &quot;Swap 100 DAI to 100 USDT in &lt;account name&gt; on &lt;network chain name&gt;&quot;</extracomment>
+        <translation type="unfinished">在 %4 的 %3 中交换 %1 为 %2</translation>
+    </message>
+    <message>
+        <source>Review all details before signing</source>
+        <translation type="unfinished">在签名之前查看所有详细信息</translation>
+    </message>
+    <message>
+        <source>Max fees:</source>
+        <translation type="unfinished">最大费用：</translation>
+    </message>
+    <message>
+        <source>Max slippage:</source>
+        <translation type="unfinished">最大滑点：</translation>
+    </message>
+    <message>
+        <source>Pay</source>
+        <translation type="unfinished">支付</translation>
+    </message>
+    <message>
+        <source>Receive</source>
+        <translation type="unfinished">接收</translation>
+    </message>
+    <message>
+        <source>In account</source>
+        <translation type="unfinished">账户中</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Fees</source>
+        <translation type="unfinished">费用</translation>
+    </message>
+    <message>
+        <source>Max. fees on %1</source>
+        <translation type="unfinished">%1 上的最大费用</translation>
+    </message>
+</context>
+<context>
+    <name>SwapToAccountPopup</name>
+    <message>
+        <source>Send to</source>
+        <translation type="unfinished">发送至</translation>
+    </message>
+</context>
+<context>
+    <name>SyncDeviceCustomizationPopup</name>
+    <message>
+        <source>Personalize %1</source>
+        <translation type="unfinished">个性化设置 %1</translation>
+    </message>
+    <message>
+        <source>Device name</source>
+        <translation type="unfinished">设备名称</translation>
+    </message>
+    <message>
+        <source>Device name can not be empty</source>
+        <translation type="unfinished">设备名称不能为空</translation>
+    </message>
+    <message>
+        <source>Installation ID</source>
+        <translation type="unfinished">安装ID</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>Delete Device</source>
+        <translation type="unfinished">删除设备</translation>
+    </message>
+</context>
+<context>
+    <name>SyncProgressPage</name>
+    <message>
+        <source>Profile sync in progress...</source>
+        <translation type="unfinished">配置文件同步中...</translation>
+    </message>
+    <message>
+        <source>Your profile data is being synced to this device</source>
+        <translation type="unfinished">您的配置文件数据正在同步到此设备</translation>
+    </message>
+    <message>
+        <source>Please keep both devices switched on and connected to the same network until the sync is complete</source>
+        <translation type="unfinished">请在同步完成之前，保持两个设备都已打开并连接到同一网络。</translation>
+    </message>
+    <message>
+        <source>Profile synced</source>
+        <translation type="unfinished">配置文件已同步</translation>
+    </message>
+    <message>
+        <source>Your profile data has been synced to this device</source>
+        <translation type="unfinished">您的配置文件数据已同步到此设备</translation>
+    </message>
+    <message>
+        <source>Failed to pair devices</source>
+        <translation type="unfinished">配对设备失败</translation>
+    </message>
+    <message>
+        <source>Try again and double-check the instructions</source>
+        <translation type="unfinished">请重试并仔细检查说明</translation>
+    </message>
+    <message>
+        <source>Log in</source>
+        <translation type="unfinished">登录</translation>
+    </message>
+    <message>
+        <source>Try to pair again</source>
+        <translation type="unfinished">再次尝试配对</translation>
+    </message>
+    <message>
+        <source>Log in via recovery phrase</source>
+        <translation type="unfinished">通过恢复短语登录</translation>
+    </message>
+</context>
+<context>
+    <name>SyncingCodeInstructions</name>
+    <message>
+        <source>Mobile</source>
+        <translation type="unfinished">手机</translation>
+    </message>
+    <message>
+        <source>Desktop</source>
+        <translation type="unfinished">桌面</translation>
+    </message>
+</context>
+<context>
+    <name>SyncingDeviceView</name>
+    <message>
+        <source>Device found!</source>
+        <translation type="unfinished">已找到设备！</translation>
+    </message>
+    <message>
+        <source>Device synced!</source>
+        <translation type="unfinished">设备同步完成！</translation>
+    </message>
+    <message>
+        <source>Device failed to sync</source>
+        <translation type="unfinished">设备同步失败</translation>
+    </message>
+    <message>
+        <source>Syncing your profile and settings preferences</source>
+        <translation type="unfinished">正在同步您的个人资料和设置首选项</translation>
+    </message>
+    <message>
+        <source>Your devices are now in sync</source>
+        <translation type="unfinished">您的设备现在已同步</translation>
+    </message>
+    <message>
+        <source>Syncing with device</source>
+        <translation type="unfinished">正在与设备同步</translation>
+    </message>
+    <message>
+        <source>Synced device</source>
+        <translation type="unfinished">已同步的设备</translation>
+    </message>
+    <message>
+        <source>Failed to sync devices</source>
+        <translation type="unfinished">设备同步失败</translation>
+    </message>
+</context>
+<context>
+    <name>SyncingDisplayCode</name>
+    <message>
+        <source>Reveal QR</source>
+        <translation type="unfinished">显示二维码</translation>
+    </message>
+    <message>
+        <source>Regenerate</source>
+        <translation type="unfinished">重新生成</translation>
+    </message>
+    <message>
+        <source>Code valid for: </source>
+        <translation type="unfinished">有效期：</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">复制</translation>
+    </message>
+</context>
+<context>
+    <name>SyncingEnterCode</name>
+    <message>
+        <source>Scan QR code</source>
+        <translation type="unfinished">扫描二维码</translation>
+    </message>
+    <message>
+        <source>Enter code</source>
+        <translation type="unfinished">输入代码</translation>
+    </message>
+    <message>
+        <source>How to get a pairing code</source>
+        <translation type="unfinished">如何获取配对码</translation>
+    </message>
+    <message>
+        <source>This does not look like a pairing QR code</source>
+        <translation type="unfinished">这看起来不像是一个配对二维码</translation>
+    </message>
+    <message>
+        <source>This does not look like a pairing code</source>
+        <translation type="unfinished">这看起来不像是一个配对码</translation>
+    </message>
+    <message>
+        <source>Type or paste pairing code</source>
+        <translation type="unfinished">输入或粘贴配对码</translation>
+    </message>
+    <message>
+        <source>eg. %1</source>
+        <translation type="unfinished">例如：%1</translation>
+    </message>
+    <message>
+        <source>Ensure both devices are on the same local network</source>
+        <translation type="unfinished">确保两个设备都在同一个局域网中</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+</context>
+<context>
+    <name>SyncingView</name>
+    <message>
+        <source>Verify your login with password or Keycard</source>
+        <translation type="unfinished">使用密码或密钥卡验证您的登录</translation>
+    </message>
+    <message>
+        <source>Reveal a temporary QR and Sync Code</source>
+        <translation type="unfinished">显示临时二维码和同步代码</translation>
+    </message>
+    <message>
+        <source>Share that information with your new device</source>
+        <translation type="unfinished">与您的新设备共享此信息</translation>
+    </message>
+    <message>
+        <source>Devices</source>
+        <translation type="unfinished">设备</translation>
+    </message>
+    <message>
+        <source>Loading devices...</source>
+        <translation type="unfinished">正在加载设备...</translation>
+    </message>
+    <message>
+        <source>Error loading devices. Please try again later.</source>
+        <translation type="unfinished">加载设备时出错。请稍后重试。</translation>
+    </message>
+    <message>
+        <source>Sync a New Device</source>
+        <translation type="unfinished">同步新设备</translation>
+    </message>
+    <message>
+        <source>You own your data. Sync it among your devices.</source>
+        <translation type="unfinished">您拥有自己的数据。在您的设备之间进行同步。</translation>
+    </message>
+    <message>
+        <source>Setup Syncing</source>
+        <translation type="unfinished">设置同步</translation>
+    </message>
+    <message>
+        <source>This is best done in private. The code will grant access to your profile.</source>
+        <translation type="unfinished">最好在私下进行此操作。该代码将授予对您个人资料的访问权限。</translation>
+    </message>
+    <message>
+        <source>How to get a sync code</source>
+        <translation type="unfinished">如何获取同步码</translation>
+    </message>
+    <message>
+        <source>Pair Device</source>
+        <translation type="unfinished">配对设备</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to pair this device?</source>
+        <translation type="unfinished">您确定要配对此设备吗？</translation>
+    </message>
+    <message>
+        <source>Pair</source>
+        <translation type="unfinished">配对</translation>
+    </message>
+    <message>
+        <source>Error pairing device: %1</source>
+        <translation type="unfinished">配对设备时出错：%1</translation>
+    </message>
+    <message>
+        <source>Unpair Device</source>
+        <translation type="unfinished">取消配对设备</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to unpair this device?</source>
+        <translation type="unfinished">您确定要取消配对此设备吗？</translation>
+    </message>
+    <message>
+        <source>Unpair</source>
+        <translation type="unfinished">取消配对</translation>
+    </message>
+    <message>
+        <source>Error unpairing device: %1</source>
+        <translation type="unfinished">取消配对设备时出错：%1</translation>
+    </message>
+    <message>
+        <source>Restore my past messages to this device</source>
+        <translation type="unfinished">将我过去的聊天记录恢复到此设备</translation>
+    </message>
+    <message>
+        <source>Copies and sends your direct, group, and community messages to your new device using encrypted local pairing.</source>
+        <translation type="unfinished">使用加密的本地配对，将您的直接消息、群组消息和社区消息复制并发送到您的新设备。</translation>
+    </message>
+    <message>
+        <source>Delete Device</source>
+        <translation type="unfinished">删除设备</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Error deleting device: %1</source>
+        <translation type="unfinished">删除设备时出错：%1</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this device?
+This action cannot be undone.</source>
+        <translation type="unfinished">您确定要删除此设备吗？
+此操作无法撤消。</translation>
+    </message>
+</context>
+<context>
+    <name>TabsBookmarksOverviewModal</name>
+    <message>
+        <source>Open tabs</source>
+        <translation type="unfinished">打开的标签页</translation>
+    </message>
+    <message>
+        <source>Bookmarks</source>
+        <translation type="unfinished">书签</translation>
+    </message>
+    <message>
+        <source>Search in open tabs</source>
+        <translation type="unfinished">在已打开的标签页中搜索</translation>
+    </message>
+    <message>
+        <source>Search in bookmarks</source>
+        <translation type="unfinished">在书签中搜索</translation>
+    </message>
+    <message>
+        <source>Edit bookmark</source>
+        <translation type="unfinished">编辑书签</translation>
+    </message>
+    <message>
+        <source>Delete bookmark</source>
+        <translation type="unfinished">删除书签</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+</context>
+<context>
+    <name>TagsPanel</name>
+    <message>
+        <source>Community Tags</source>
+        <translation type="unfinished">社区标签</translation>
+    </message>
+    <message>
+        <source>Confirm Community Tags</source>
+        <translation type="unfinished">确认社区标签</translation>
+    </message>
+    <message>
+        <source>Select tags that will fit your Community</source>
+        <translation type="unfinished">选择适合您社区的标签</translation>
+    </message>
+    <message>
+        <source>Search tags</source>
+        <translation type="unfinished">搜索标签</translation>
+    </message>
+    <message>
+        <source>Selected tags</source>
+        <translation type="unfinished">已选标签</translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished">%1 / %2</translation>
+    </message>
+    <message>
+        <source>No tags selected yet</source>
+        <translation type="unfinished">尚未选择任何标签</translation>
+    </message>
+</context>
+<context>
+    <name>TagsPicker</name>
+    <message>
+        <source>Tags</source>
+        <translation type="unfinished">标签</translation>
+    </message>
+    <message>
+        <source>Choose tags describing the community</source>
+        <translation type="unfinished">选择描述社区的标签</translation>
+    </message>
+    <message>
+        <source>Add at least 1 tag</source>
+        <translation type="unfinished">至少添加一个标签</translation>
+    </message>
+</context>
+<context>
+    <name>TestnetModePopup</name>
+    <message>
+        <source>Turn off testnet mode</source>
+        <translation type="unfinished">关闭测试网络模式</translation>
+    </message>
+    <message>
+        <source>Turn on testnet mode</source>
+        <translation type="unfinished">开启测试网络模式</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to turn off %1? All future transactions will be performed on live networks with real funds</source>
+        <translation type="unfinished">您确定要关闭 %1 吗？所有未来的交易都将在实时网络上进行，并使用真实资金。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to turn on %1? In this mode, all blockchain data displayed will come from testnets and all blockchain interactions will be with testnets. Testnet mode switches the entire app to using testnets only. Please switch this mode on only if you know exactly why you need to use it.</source>
+        <translation type="unfinished">您确定要开启 %1 吗？在这种模式下，所有显示的区块链数据都将来自测试网络，并且所有区块链交互都将与测试网络进行。测试网络模式会将整个应用程序切换为仅使用测试网络。请仅在您确切知道需要使用它的原因时才启用此模式。</translation>
+    </message>
+    <message>
+        <source>Testnet mode turned on</source>
+        <translation type="unfinished">已开启测试网络模式</translation>
+    </message>
+    <message>
+        <source>Testnet mode turned off</source>
+        <translation type="unfinished">已关闭测试网络模式</translation>
+    </message>
+</context>
+<context>
+    <name>ThirdpartyServicesPopup</name>
+    <message>
+        <source>Third-party services</source>
+        <translation type="unfinished">第三方服务</translation>
+    </message>
+    <message>
+        <source>Status uses essential third-party services to make your experience more convenient, efficient, and engaging. While only necessary integrations are included, users who prefer to avoid any third-party services can disable them entirely – though this may limit functionality and affect usability</source>
+        <translation type="unfinished">Status 使用必要的第三方服务，以使您的体验更加便捷、高效和引人入胜。虽然仅包含必要的功能集成，但如果用户希望避免使用任何第三方服务，则可以完全禁用它们——但这可能会限制功能并影响可用性</translation>
+    </message>
+    <message>
+        <source>Features that will be unavailable:</source>
+        <translation type="unfinished">将不可用的功能：</translation>
+    </message>
+    <message>
+        <source>Wallet (Swap, Send, Token data, etc.)</source>
+        <translation type="unfinished">钱包（交换、发送、代币数据等）</translation>
+    </message>
+    <message>
+        <source>Market (Token data, prices, and news, etc.)</source>
+        <translation type="unfinished">市场（代币数据、价格和新闻等）</translation>
+    </message>
+    <message>
+        <source>Token-gated communities and admin tools</source>
+        <translation type="unfinished">基于代币的社区和管理员工具</translation>
+    </message>
+    <message>
+        <source>Status news, etc.</source>
+        <translation type="unfinished">Status 新闻等</translation>
+    </message>
+    <message>
+        <source>You may also experience:</source>
+        <translation type="unfinished">您也可能会遇到：</translation>
+    </message>
+    <message>
+        <source>Missing or invalid data</source>
+        <translation type="unfinished">缺少或无效的数据</translation>
+    </message>
+    <message>
+        <source>Errors and unexpected behavior</source>
+        <translation type="unfinished">错误和意外行为</translation>
+    </message>
+    <message>
+        <source>Only disable third-party services if you&apos;re aware of the trade-offs. Re-enable them anytime in Settings. Read more details about third-party services %1.</source>
+        <translation type="unfinished">仅在您了解权衡之后才禁用第三方服务。随时可以在设置中重新启用它们。阅读有关第三方服务的更多详细信息 %1。</translation>
+    </message>
+    <message>
+        <source>Share feedback or suggest improvements on our %1.</source>
+        <translation type="unfinished">在我们的%1上分享反馈或提出改进建议。</translation>
+    </message>
+    <message>
+        <source>Disable services and restart the app</source>
+        <translation type="unfinished">禁用服务并重启应用程序</translation>
+    </message>
+    <message>
+        <source>Enable services and restart the app</source>
+        <translation type="unfinished">启用服务并重启应用程序</translation>
+    </message>
+    <message>
+        <source>Disable third-party services</source>
+        <translation type="unfinished">禁用第三方服务</translation>
+    </message>
+    <message>
+        <source>Enable third-party services</source>
+        <translation type="unfinished">启用第三方服务</translation>
+    </message>
+    <message>
+        <source>Browser (browse web-pages, connect dApps)</source>
+        <translation type="unfinished">浏览器（浏览网页，连接 dApp）</translation>
+    </message>
+    <message>
+        <source>Sync with NTP (Network Time Protocol) servers</source>
+        <translation type="unfinished">与 NTP（网络时间协议）服务器同步</translation>
+    </message>
+    <message>
+        <source>Missed messages if your device time isn’t synced to network time</source>
+        <translation type="unfinished">如果您的设备时间未与网络时间同步，则可能会错过消息</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailsDropdownContent</name>
+    <message>
+        <source>No results</source>
+        <translation type="unfinished">没有结果</translation>
+    </message>
+</context>
+<context>
+    <name>ToastsManager</name>
+    <message>
+        <source>You received the Owner token for %1. To finalize ownership, make your device the control node.</source>
+        <translation type="unfinished">您收到了%1的Owner代币。要完成所有权确认，请将您的设备设置为控制节点。</translation>
+    </message>
+    <message>
+        <source>Finalise ownership</source>
+        <translation type="unfinished">完成所有权确认</translation>
+    </message>
+    <message>
+        <source>You declined ownership of %1.</source>
+        <translation type="unfinished">您拒绝了%1的所有权。</translation>
+    </message>
+    <message>
+        <source>Return owner token to sender</source>
+        <translation type="unfinished">将Owner代币返回给发送者</translation>
+    </message>
+    <message>
+        <source>Your device is no longer the control node for %1.
+                                             Your ownership and admin rights for %1 have been transferred to the new owner.</source>
+        <translation type="unfinished">您的设备不再是%1的控制节点。
+您对%1的所有权和管理员权限已转移到新所有者。</translation>
+    </message>
+    <message>
+        <source>You received your first community asset</source>
+        <translation type="unfinished">您收到了您的第一个社区资产</translation>
+    </message>
+    <message>
+        <source>You received your first community collectible</source>
+        <translation type="unfinished">您收到了您的第一个社区收藏品</translation>
+    </message>
+    <message>
+        <source>%1: %2 %3</source>
+        <translation type="unfinished">%1：%2 %3</translation>
+    </message>
+    <message>
+        <source>Learn more</source>
+        <translation type="unfinished">了解更多</translation>
+    </message>
+    <message>
+        <source>You were airdropped %1 %2 from %3 to %4</source>
+        <translation type="unfinished">您从%3空投了%1个%2到%4。</translation>
+    </message>
+    <message>
+        <source>View transaction details</source>
+        <translation type="unfinished">查看交易详情</translation>
+    </message>
+    <message>
+        <source>Read more</source>
+        <translation type="unfinished">阅读更多</translation>
+    </message>
+    <message>
+        <source>Profile changes saved</source>
+        <translation type="unfinished">个人资料更改已保存</translation>
+    </message>
+    <message>
+        <source>Profile changes could not be saved</source>
+        <translation type="unfinished">无法保存个人资料更改</translation>
+    </message>
+    <message>
+        <source>Trust mark removed for %1</source>
+        <translation type="unfinished">已为%1移除信任标记</translation>
+    </message>
+    <message>
+        <source>Contact removed</source>
+        <translation type="unfinished">联系人已删除</translation>
+    </message>
+    <message>
+        <source>%1 removed you as a contact</source>
+        <translation type="unfinished">%1将您从其联系人列表中删除了。</translation>
+    </message>
+    <message>
+        <source>You removed %1 as a contact</source>
+        <translation type="unfinished">您将%1从联系人列表中删除了。</translation>
+    </message>
+    <message>
+        <source>Backup failed</source>
+        <translation type="unfinished">备份失败</translation>
+    </message>
+    <message>
+        <source>Check Settings &gt; Backups to see the details and try again</source>
+        <translation type="unfinished">请查看“设置”&gt;“备份”，以了解详细信息并重试。</translation>
+    </message>
+    <message>
+        <source>Your data backup restored successfully</source>
+        <translation type="unfinished">您的数据备份已成功恢复</translation>
+    </message>
+    <message>
+        <source>Import failed. Make sure the backup file matches your profile name.</source>
+        <translation type="unfinished">导入失败。请确保备份文件与您的个人资料名称匹配。</translation>
+    </message>
+</context>
+<context>
+    <name>TokenCategories</name>
+    <message>
+        <source>Community assets</source>
+        <translation type="unfinished">社区资产</translation>
+    </message>
+    <message>
+        <source>Your assets</source>
+        <translation type="unfinished">您的资产</translation>
+    </message>
+    <message>
+        <source>All listed assets</source>
+        <translation type="unfinished">所有已列出的资产</translation>
+    </message>
+    <message>
+        <source>Community collectibles</source>
+        <translation type="unfinished">社区收藏品</translation>
+    </message>
+    <message>
+        <source>Your collectibles</source>
+        <translation type="unfinished">您的收藏品</translation>
+    </message>
+    <message>
+        <source>All collectibles</source>
+        <translation type="unfinished">所有收藏品</translation>
+    </message>
+</context>
+<context>
+    <name>TokenDelegate</name>
+    <message>
+        <source>%1 %2%</source>
+        <comment>[up/down/none character depending on value sign] [localized percentage value]%</comment>
+        <translation type="unfinished">%1 %2%</translation>
+    </message>
+</context>
+<context>
+    <name>TokenHoldersList</name>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished">用户名</translation>
+    </message>
+    <message>
+        <source>Hodling</source>
+        <translation type="unfinished">持有</translation>
+    </message>
+</context>
+<context>
+    <name>TokenHoldersPanel</name>
+    <message>
+        <source>%1 token hodlers</source>
+        <translation type="unfinished">%1 个代币持有者</translation>
+    </message>
+    <message>
+        <source>Search hodlers</source>
+        <translation type="unfinished">搜索持有者</translation>
+    </message>
+    <message>
+        <source>No hodlers found</source>
+        <translation type="unfinished">未找到持有者</translation>
+    </message>
+</context>
+<context>
+    <name>TokenInfoPanel</name>
+    <message>
+        <source>Symbol</source>
+        <translation type="unfinished">符号</translation>
+    </message>
+    <message>
+        <source>Total</source>
+        <translation type="unfinished">总计</translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished">剩余</translation>
+    </message>
+    <message>
+        <source>DP</source>
+        <translation type="unfinished">DP</translation>
+    </message>
+    <message>
+        <source>Transferable</source>
+        <translation type="unfinished">可转移的</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">否</translation>
+    </message>
+    <message>
+        <source>Destructible</source>
+        <translation type="unfinished">可销毁</translation>
+    </message>
+    <message>
+        <source>Account</source>
+        <translation type="unfinished">账户</translation>
+    </message>
+</context>
+<context>
+    <name>TokenListPopup</name>
+    <message numerus="yes">
+        <source>%n token(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 个代币</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">完成</translation>
+    </message>
+    <message>
+        <source>Source</source>
+        <translation type="unfinished">来源</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">版本</translation>
+    </message>
+    <message>
+        <source>%1 - last updated %2</source>
+        <translation type="unfinished">%1 - 上次更新于 %2</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message>
+        <source>Symbol</source>
+        <translation type="unfinished">符号</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">地址</translation>
+    </message>
+    <message>
+        <source>(Test)</source>
+        <translation type="unfinished">（测试）</translation>
+    </message>
+</context>
+<context>
+    <name>TokenMasterActionPopup</name>
+    <message>
+        <source>Ban %1</source>
+        <translation type="unfinished">封禁 %1</translation>
+    </message>
+    <message>
+        <source>Kick %1</source>
+        <translation type="unfinished">踢出 %1</translation>
+    </message>
+    <message>
+        <source>Remotely destruct TokenMaster token</source>
+        <translation type="unfinished">远程销毁 TokenMaster 代币</translation>
+    </message>
+    <message>
+        <source>Remotely destruct 1 TokenMaster token on %1</source>
+        <translation type="unfinished">在 %1 上远程销毁 1 个 TokenMaster 代币</translation>
+    </message>
+    <message>
+        <source>Continuing will destroy the TokenMaster token held by &lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; and revoke the permissions they have by virtue of holding this token.</source>
+        <translation type="unfinished">您确定要将 &lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; 从 %2 中禁止吗？&lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; 是 TokenMaster 代币持有者。为了将其移除，您还必须远程销毁他们的 TokenMaster 代币，以撤销他们因持有此代币而获得的权限。</translation>
+    </message>
+    <message>
+        <source>Are you sure you kick &lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; from %2? &lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; is a TokenMaster hodler. In order to kick them you must also remotely destruct their TokenMaster token to revoke the permissions they have by virtue of holding this token.</source>
+        <translation type="unfinished">您确定要禁止 &lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; 访问 %2 吗？&lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; 是一个 TokenMaster 持有者。为了将其移除，您还必须远程销毁他们的 TokenMaster 代币，以撤销他们因持有此代币而获得的权限。</translation>
+    </message>
+    <message>
+        <source>Are you sure you ban &lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; from %2? &lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; is a TokenMaster hodler. In order to kick them you must also remotely destruct their TokenMaster token to revoke the permissions they have by virtue of holding this token.</source>
+        <translation type="unfinished">您确定要禁止 &lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; 访问 %2 吗？&lt;span style=&quot;font-weight:600;&quot;&gt;%1&lt;/span&gt; 是一个 TokenMaster 持有者。为了将其踢出，您还必须远程销毁他们的 TokenMaster 代币，以撤销他们因持有此代币而获得的权限。</translation>
+    </message>
+    <message>
+        <source>Delete all messages posted by the user</source>
+        <translation type="unfinished">删除用户发布的所有消息</translation>
+    </message>
+    <message>
+        <source>Remotely destruct 1 TokenMaster token</source>
+        <translation type="unfinished">远程销毁 1 个 TokenMaster 代币</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Ban %1 and remotely destruct 1 token</source>
+        <translation type="unfinished">禁止 %1 并远程销毁 1 个代币</translation>
+    </message>
+    <message>
+        <source>Kick %1 and remotely destruct 1 token</source>
+        <translation type="unfinished">移除 %1 并远程销毁 1 个代币</translation>
+    </message>
+    <message>
+        <source>Remotely destruct 1 token</source>
+        <translation type="unfinished">远程销毁 1 个代币</translation>
+    </message>
+</context>
+<context>
+    <name>TokenPanel</name>
+    <message>
+        <source>Network for airdrop</source>
+        <translation type="unfinished">空投网络</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">添加</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">移除</translation>
+    </message>
+</context>
+<context>
+    <name>TokenPermissionsPopup</name>
+    <message>
+        <source>Token permissions for %1 channel</source>
+        <translation type="unfinished">%1频道的令牌权限</translation>
+    </message>
+</context>
+<context>
+    <name>TokenSelectorButton</name>
+    <message>
+        <source>Select token</source>
+        <translation type="unfinished">选择令牌</translation>
+    </message>
+</context>
+<context>
+    <name>TokenSelectorCompactButton</name>
+    <message>
+        <source>Select asset</source>
+        <translation type="unfinished">选择资产</translation>
+    </message>
+</context>
+<context>
+    <name>TokenSelectorPanel</name>
+    <message>
+        <source>Assets</source>
+        <translation type="unfinished">资产</translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">收藏品</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionContextMenu</name>
+    <message>
+        <source>View on %1</source>
+        <translation type="unfinished">在%1上查看</translation>
+    </message>
+    <message>
+        <source>Copy transaction hash</source>
+        <translation type="unfinished">复制交易哈希</translation>
+    </message>
+    <message>
+        <source>Copied</source>
+        <translation type="unfinished">已复制</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDelegate</name>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">不可用</translation>
+    </message>
+    <message>
+        <source>%1 (community asset) from %2 on %3</source>
+        <translation type="unfinished">来自 %2 的 %1（社区资产），时间为 %3</translation>
+    </message>
+    <message>
+        <source>%1 from %2 to %3 on %4 and %5</source>
+        <translation type="unfinished">%1 从 %2 到 %3，时间为 %4 和 %5</translation>
+    </message>
+    <message>
+        <source>%1 to %2 on %3 and %4</source>
+        <translation type="unfinished">%1 到 %2，时间为 %3 和 %4</translation>
+    </message>
+    <message>
+        <source>%1 from %2 to %3 on %4</source>
+        <translation type="unfinished">%1 从 %2 到 %3，时间为 %4</translation>
+    </message>
+    <message>
+        <source>%1 to %2 on %3</source>
+        <translation type="unfinished">%1 到 %2，时间为 %3</translation>
+    </message>
+    <message>
+        <source>%1 from %2 on %3 and %4</source>
+        <translation type="unfinished">来自 %2 的 %1，时间为 %3 和 %4</translation>
+    </message>
+    <message>
+        <source>%1 from %2 on %3</source>
+        <translation type="unfinished">来自 %2 的 %1，时间为 %3</translation>
+    </message>
+    <message>
+        <source>%1 at %2 on %3 in %4</source>
+        <translation type="unfinished">%1 在 %2 上，时间为 %3，地点为 %4</translation>
+    </message>
+    <message>
+        <source>%1 at %2 on %3</source>
+        <translation type="unfinished">%1 在 %2 上，时间为 %3</translation>
+    </message>
+    <message>
+        <source>%1 to %2 in %3 on %4</source>
+        <translation type="unfinished">%1 到 %2，地点为 %3，时间为 %4</translation>
+    </message>
+    <message>
+        <source>%1 from %2 to %3 in %4</source>
+        <translation type="unfinished">%1 从 %2 到 %3，地点为 %4</translation>
+    </message>
+    <message>
+        <source>%1 from %2 to %3</source>
+        <translation type="unfinished">%1 从 %2 到 %3</translation>
+    </message>
+    <message>
+        <source>Via %1 on %2</source>
+        <translation type="unfinished">通过 %1，时间为 %2</translation>
+    </message>
+    <message>
+        <source>%1 via %2 in %3</source>
+        <translation type="unfinished">%1 通过 %2，地点为 %3</translation>
+    </message>
+    <message>
+        <source>%1 via %2</source>
+        <translation type="unfinished">%1 通过 %2</translation>
+    </message>
+    <message>
+        <source>%1 in %2 for %3 on %4</source>
+        <translation type="unfinished">在 %2 中进行 %1，用于 %3，时间为 %4</translation>
+    </message>
+    <message>
+        <source>%1 for %2 on %3</source>
+        <translation type="unfinished">%1 用于 %2，时间为 %3</translation>
+    </message>
+    <message>
+        <source>Between %1 and %2 on %3</source>
+        <translation type="unfinished">在 %3 上，介于 %1 和 %2 之间</translation>
+    </message>
+    <message>
+        <source>With %1 on %2</source>
+        <translation type="unfinished">使用 %1，时间为 %2</translation>
+    </message>
+    <message>
+        <source>Send failed</source>
+        <translation type="unfinished">发送失败</translation>
+    </message>
+    <message>
+        <source>Sending</source>
+        <translation type="unfinished">发送中</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">已发送</translation>
+    </message>
+    <message>
+        <source>Receive failed</source>
+        <translation type="unfinished">接收失败</translation>
+    </message>
+    <message>
+        <source>Receiving</source>
+        <translation type="unfinished">接收中</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">已接收</translation>
+    </message>
+    <message>
+        <source>Destroy failed</source>
+        <translation type="unfinished">销毁失败</translation>
+    </message>
+    <message>
+        <source>Destroying</source>
+        <translation type="unfinished">销毁中</translation>
+    </message>
+    <message>
+        <source>Destroyed</source>
+        <translation type="unfinished">已销毁</translation>
+    </message>
+    <message>
+        <source>Swap failed</source>
+        <translation type="unfinished">兑换失败</translation>
+    </message>
+    <message>
+        <source>Swapping</source>
+        <translation type="unfinished">兑换中</translation>
+    </message>
+    <message>
+        <source>Swapped</source>
+        <translation type="unfinished">已兑换</translation>
+    </message>
+    <message>
+        <source>Bridge failed</source>
+        <translation type="unfinished">桥接失败</translation>
+    </message>
+    <message>
+        <source>Bridging</source>
+        <translation type="unfinished">桥接中</translation>
+    </message>
+    <message>
+        <source>Bridged</source>
+        <translation type="unfinished">已桥接</translation>
+    </message>
+    <message>
+        <source>Contract deployment failed</source>
+        <translation type="unfinished">合约部署失败</translation>
+    </message>
+    <message>
+        <source>Deploying contract</source>
+        <translation type="unfinished">正在部署合约</translation>
+    </message>
+    <message>
+        <source>Contract deployed</source>
+        <translation type="unfinished">合约已部署</translation>
+    </message>
+    <message>
+        <source>Collectible minting failed</source>
+        <translation type="unfinished">数字藏品铸造失败</translation>
+    </message>
+    <message>
+        <source>Minting collectible</source>
+        <translation type="unfinished">正在铸造数字藏品</translation>
+    </message>
+    <message>
+        <source>Collectible minted</source>
+        <translation type="unfinished">已铸造的收藏品</translation>
+    </message>
+    <message>
+        <source>Token minting failed</source>
+        <translation type="unfinished">代币铸造失败</translation>
+    </message>
+    <message>
+        <source>Minting token</source>
+        <translation type="unfinished">正在铸造代币</translation>
+    </message>
+    <message>
+        <source>Token minted</source>
+        <translation type="unfinished">代币已铸造</translation>
+    </message>
+    <message>
+        <source>Failed to set spending cap</source>
+        <translation type="unfinished">设置消费上限失败</translation>
+    </message>
+    <message>
+        <source>Setting spending cap</source>
+        <translation type="unfinished">正在设置消费上限</translation>
+    </message>
+    <message>
+        <source>Spending cap set</source>
+        <translation type="unfinished">消费上限已设置</translation>
+    </message>
+    <message>
+        <source>Interaction</source>
+        <translation type="unfinished">交互</translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation type="unfinished">重试</translation>
+    </message>
+    <message>
+        <source>Unknown NFT</source>
+        <translation type="unfinished">未知的 NFT</translation>
+    </message>
+    <message>
+        <source>%1 from %2 in %3</source>
+        <translation type="unfinished">来自 %2 的 %1，在 %3 中</translation>
+    </message>
+    <message>
+        <source>%1 from %2</source>
+        <translation type="unfinished">来自 %2 的 %1</translation>
+    </message>
+    <message>
+        <source>Unknown token</source>
+        <translation type="unfinished">未知代币</translation>
+    </message>
+    <message>
+        <source>Unknown token (%1)</source>
+        <translation type="unfinished">未知代币 (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionSettings</name>
+    <message>
+        <source>Got it</source>
+        <translation type="unfinished">知道了</translation>
+    </message>
+    <message>
+        <source>Read more</source>
+        <translation type="unfinished">阅读更多</translation>
+    </message>
+    <message>
+        <source>Transaction settings</source>
+        <translation type="unfinished">交易设置</translation>
+    </message>
+    <message>
+        <source>Set your own fees &amp; nonce</source>
+        <translation type="unfinished">自定义费用和随机数</translation>
+    </message>
+    <message>
+        <source>Set your own base fee, priority fee, gas amount and nonce</source>
+        <translation type="unfinished">自定义基本费用、优先级费用、燃气量和随机数</translation>
+    </message>
+    <message>
+        <source>Regular cost option using suggested gas price</source>
+        <translation type="unfinished">使用建议的燃气价格的常规成本选项</translation>
+    </message>
+    <message>
+        <source>Increased gas price, incentivising miners to confirm more quickly</source>
+        <translation type="unfinished">提高燃气价格，激励矿工更快地确认交易</translation>
+    </message>
+    <message>
+        <source>Highest base and priority fee, ensuring the fastest possible confirmation</source>
+        <translation type="unfinished">最高的基准费用和优先级费用，确保最快的确认速度</translation>
+    </message>
+    <message>
+        <source>Low cost option using current network base fee and a low priority fee</source>
+        <translation type="unfinished">使用当前网络基本费用和较低的优先级费用的低成本选项</translation>
+    </message>
+    <message>
+        <source>Gas price</source>
+        <translation type="unfinished">燃气价格</translation>
+    </message>
+    <message>
+        <source>Max base fee</source>
+        <translation type="unfinished">最大基本费用</translation>
+    </message>
+    <message>
+        <source>Lower than necessary (current %1)</source>
+        <translation type="unfinished">低于必要值（当前 %1）</translation>
+    </message>
+    <message>
+        <source>Higher than necessary (current %1)</source>
+        <translation type="unfinished">高于必要值（当前 %1）</translation>
+    </message>
+    <message>
+        <source>Current: %1</source>
+        <translation type="unfinished">当前：%1</translation>
+    </message>
+    <message>
+        <source>The gas price you set is the exact amount you’ll pay per unit of gas used. If you set a gas price higher than what’s required for inclusion, the difference will not be refunded. Choose your gas price carefully to avoid overpaying.
+</source>
+        <translation type="unfinished">您设置的燃气价格是每单位使用的燃气的确切金额。如果您设置的燃气价格高于包含所需的费用，则不会退还差额。请仔细选择您的燃气价格，以避免支付过多。</translation>
+    </message>
+    <message>
+        <source>When your transaction gets included in the block, any difference between your max base fee and the actual base fee will be refunded.
+</source>
+        <translation type="unfinished">当您的交易包含在区块中时，您的最大基本费用与实际基本费用之间的任何差异都将退还。</translation>
+    </message>
+    <message>
+        <source>Note: the %1 amount shown for this value is calculated:
+Gas price (in GWEI) * gas amount</source>
+        <translation type="unfinished">注意：此处显示的 %1 金额的计算方式为：燃气价格（以 GWEI 为单位）* 燃气量</translation>
+    </message>
+    <message>
+        <source>Note: the %1 amount shown for this value is calculated:
+Max base fee (in GWEI) * Max gas amount</source>
+        <translation type="unfinished">注意：此处显示的 %1 金额的计算方式为：最大基本费用（以 GWEI 为单位）* 最大燃气量</translation>
+    </message>
+    <message>
+        <source>Priority fee</source>
+        <translation type="unfinished">优先级费用</translation>
+    </message>
+    <message>
+        <source>Higher than max base fee: %1</source>
+        <translation type="unfinished">高于最大基本费用：%1</translation>
+    </message>
+    <message>
+        <source>Higher than necessary (current %1 - %2)</source>
+        <translation type="unfinished">高于必要值（当前 %1 - %2）</translation>
+    </message>
+    <message>
+        <source>Current: %1 - %2</source>
+        <translation type="unfinished">当前：%1 - %2</translation>
+    </message>
+    <message>
+        <source>AKA miner tip. A voluntary fee you can add to incentivise miners or validators to prioritise your transaction.
+
+The higher the tip, the faster your transaction is likely to be processed, especially curing periods of higher network congestion.
+</source>
+        <translation type="unfinished">AKA 矿工小费。您可以添加此项，以激励矿工或验证者优先处理您的交易。
+
+小费越高，您的交易可能处理得越快，尤其是在网络拥塞期间。</translation>
+    </message>
+    <message>
+        <source>Note: the %1 amount shown for this value is calculated: Priority fee (in GWEI) * Max gas amount</source>
+        <translation type="unfinished">请注意：此处显示的 %1 金额是根据以下公式计算得出：优先级费用（以 GWEI 为单位）* 最大燃气量。</translation>
+    </message>
+    <message>
+        <source>Max gas amount</source>
+        <translation type="unfinished">最大燃气量</translation>
+    </message>
+    <message>
+        <source>Too low (should be between %1 and %2)</source>
+        <translation type="unfinished">太低（应在 %1 和 %2 之间）</translation>
+    </message>
+    <message>
+        <source>Too high (should be between %1 and %2)</source>
+        <translation type="unfinished">太高（应在 %1 和 %2 之间）</translation>
+    </message>
+    <message>
+        <source>UNITS</source>
+        <translation type="unfinished">单位</translation>
+    </message>
+    <message>
+        <source>Gas amount</source>
+        <translation type="unfinished">燃气量</translation>
+    </message>
+    <message>
+        <source>AKA gas limit. Refers to the maximum number of computational steps (or units of gas) that a transaction can consume. It represents the complexity or amount of work required to execute a transaction or smart contract.
+
+The gas limit is a cap on how much work the transaction can do on the blockchain. If the gas limit is set too low, the transaction may fail due to insufficient gas.</source>
+        <translation type="unfinished">AKA 燃气限制。指的是交易可以消耗的最大计算步骤数（或燃气单位）。它代表执行交易或智能合约所需的复杂程度或工作量。
+
+燃气限制是对区块链上交易可以执行的工作量的上限。如果燃气限制设置得太低，由于燃气不足，交易可能会失败。</translation>
+    </message>
+    <message>
+        <source>Nonce</source>
+        <translation type="unfinished">随机数</translation>
+    </message>
+    <message>
+        <source>Higher than suggested nonce of %1</source>
+        <translation type="unfinished">高于建议的随机数 %1</translation>
+    </message>
+    <message>
+        <source>Last transaction: %1</source>
+        <translation type="unfinished">上次交易：%1</translation>
+    </message>
+    <message>
+        <source>Transaction counter ensuring transactions from your account are processed in the correct order and can’t be replayed. Each new transaction increments the nonce by 1, ensuring uniqueness and preventing double-spending.
+
+If a transaction with a lower nonce is pending, higher nonce transactions will remain in the queue until the earlier one is confirmed.</source>
+        <translation type="unfinished">交易计数器可确保从您的帐户发起的交易按正确的顺序处理，并且无法重复播放。每次新的交易都会将随机数增加 1，从而确保唯一性并防止双重支付。
+
+如果存在具有较低随机数的待处理交易，则具有较高随机数的交易将保留在队列中，直到确认较早的交易为止。</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation type="unfinished">确认</translation>
+    </message>
+</context>
+<context>
+    <name>TransferOwnershipAlertPopup</name>
+    <message>
+        <source>Transfer ownership of %1</source>
+        <translation type="unfinished">转移%1的所有权</translation>
+    </message>
+    <message>
+        <source>How to move the %1 control node to another device</source>
+        <translation type="unfinished">如何将%1控制节点移动到另一台设备</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;It looks like you haven’t minted the %1 Owner token yet.&lt;/b&gt; Once you have minted this token, you can transfer ownership of %1 by sending the Owner token to the account of the person you want to be the new Community owner.</source>
+        <translation type="unfinished">&lt;b&gt;看来您尚未铸造%1所有者代币。&lt;/b&gt; 铸造此代币后，您可以将所有者代币发送到您希望成为新社区所有者的用户的帐户，从而转移%1的所有权。</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;It looks like you haven’t minted the %1 Owner token yet.&lt;/b&gt; Once you have minted this token, you can make one of your other synced desktop devices the control node for the %1 Community.</source>
+        <translation type="unfinished">&lt;b&gt;看来您尚未铸造%1所有者代币。&lt;/b&gt; 铸造此代币后，您可以将其他同步的桌面设备之一设置为%1社区的控制节点。</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Mint %1 Owner token</source>
+        <translation type="unfinished">铸造%1所有者代币</translation>
+    </message>
+</context>
+<context>
+    <name>TransferOwnershipPopup</name>
+    <message>
+        <source>Are you sure you want to transfer ownership of %1? All ownership rights you currently hold for %1 will be transferred to the new owner.</source>
+        <translation type="unfinished">您确定要转移%1的所有权吗？您目前对%1拥有的一切所有权都将被转移给新所有者。</translation>
+    </message>
+    <message>
+        <source>To transfer ownership of %1:</source>
+        <translation type="unfinished">要转移%1的所有权：</translation>
+    </message>
+    <message>
+        <source>1. Send the %1 Owner token (%2) to the new owner’s address</source>
+        <translation type="unfinished">1. 将%1的Owner代币（%2）发送到新所有者的地址</translation>
+    </message>
+    <message>
+        <source>2. Ask the new owner to setup the control node for %1 on their desktop device</source>
+        <translation type="unfinished">2. 告知新所有者在其桌面设备上设置%1的控制节点。</translation>
+    </message>
+    <message>
+        <source>I acknowledge that...</source>
+        <translation type="unfinished">我确认...</translation>
+    </message>
+    <message>
+        <source>My ownership rights will be removed and transferred to the recipient</source>
+        <translation type="unfinished">我的所有权将被删除并转移给接收方。</translation>
+    </message>
+    <message>
+        <source>Transfer ownership of %1</source>
+        <translation type="unfinished">转移%1的所有权</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Send %1 owner token</source>
+        <translation type="unfinished">发送%1 Owner代币</translation>
+    </message>
+</context>
+<context>
+    <name>UnblockContactConfirmationDialog</name>
+    <message>
+        <source>Unblock user</source>
+        <translation type="unfinished">解除用户屏蔽</translation>
+    </message>
+    <message>
+        <source>Unblocking %1 will allow new messages you receive from %1 to reach you.</source>
+        <translation type="unfinished">解除对 %1 的屏蔽后，您将可以收到来自 %1 的新消息。</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Unblock</source>
+        <translation type="unfinished">解除屏蔽</translation>
+    </message>
+</context>
+<context>
+    <name>UrlUtils</name>
+    <message>
+        <source>Internal storage</source>
+        <translation type="unfinished">内部存储</translation>
+    </message>
+    <message>
+        <source>SD card</source>
+        <translation type="unfinished">SD卡</translation>
+    </message>
+    <message>
+        <source>Storage</source>
+        <translation type="unfinished">存储</translation>
+    </message>
+</context>
+<context>
+    <name>UseRecoveryPhraseFlow</name>
+    <message>
+        <source>Create profile using a recovery phrase</source>
+        <translation type="unfinished">使用助记词创建资料</translation>
+    </message>
+    <message>
+        <source>Enter recovery phrase of lost Keycard</source>
+        <translation type="unfinished">输入丢失的Keycard的助记词</translation>
+    </message>
+    <message>
+        <source>Log in with your Status recovery phrase</source>
+        <translation type="unfinished">使用您的Status助记词登录</translation>
+    </message>
+    <message>
+        <source>Recovery phrase doesn’t match the profile of an existing Keycard user on this device</source>
+        <translation type="unfinished">助记词与此设备上现有Keycard用户的资料不匹配</translation>
+    </message>
+    <message>
+        <source>The entered recovery phrase is already added</source>
+        <translation type="unfinished">输入的助记词已添加</translation>
+    </message>
+    <message>
+        <source>Invalid recovery phrase</source>
+        <translation type="unfinished">无效的助记词</translation>
+    </message>
+</context>
+<context>
+    <name>UserListPanel</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished">搜索</translation>
+    </message>
+    <message>
+        <source>Search members...</source>
+        <translation type="unfinished">搜索成员...</translation>
+    </message>
+    <message>
+        <source>Member re-evaluation in progress...</source>
+        <translation type="unfinished">成员重新评估中...</translation>
+    </message>
+    <message>
+        <source>Saving community edits might take longer than usual</source>
+        <translation type="unfinished">保存社区编辑可能需要比平时更长的时间</translation>
+    </message>
+    <message>
+        <source>Online</source>
+        <translation type="unfinished">在线</translation>
+    </message>
+    <message>
+        <source>Inactive</source>
+        <translation type="unfinished">不活跃</translation>
+    </message>
+</context>
+<context>
+    <name>UserStatusContextMenu</name>
+    <message>
+        <source>Copy Chat Key</source>
+        <translation type="unfinished">复制聊天密钥</translation>
+    </message>
+    <message>
+        <source>Copy link to profile</source>
+        <translation type="unfinished">复制个人资料链接</translation>
+    </message>
+    <message>
+        <source>Always online</source>
+        <translation type="unfinished">始终在线</translation>
+    </message>
+    <message>
+        <source>Inactive</source>
+        <translation type="unfinished">不活跃</translation>
+    </message>
+    <message>
+        <source>Set status automatically</source>
+        <translation type="unfinished">自动设置状态</translation>
+    </message>
+    <message>
+        <source>Invite contacts</source>
+        <translation type="unfinished">邀请联系人</translation>
+    </message>
+</context>
+<context>
+    <name>Utils</name>
+    <message numerus="yes">
+        <source>%n word(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n 个字</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>You need to enter a password</source>
+        <translation type="unfinished">您需要输入密码</translation>
+    </message>
+    <message numerus="yes">
+        <source>Password needs to be %n character(s) or more</source>
+        <translation type="unfinished">
+            <numerusform>密码必须至少为 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>You need to repeat your password</source>
+        <translation type="unfinished">您需要重复输入密码</translation>
+    </message>
+    <message>
+        <source>Passwords don&apos;t match</source>
+        <translation type="unfinished">密码不匹配</translation>
+    </message>
+    <message>
+        <source>You need to enter a PIN</source>
+        <translation type="unfinished">您需要输入PIN码</translation>
+    </message>
+    <message>
+        <source>The PIN must contain only digits</source>
+        <translation type="unfinished">PIN码必须只包含数字</translation>
+    </message>
+    <message numerus="yes">
+        <source>The PIN must be exactly %n digit(s)</source>
+        <translation type="unfinished">
+            <numerusform>PIN 必须正好是 %n 位数字</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>You need to repeat your PIN</source>
+        <translation type="unfinished">您需要重复输入PIN码</translation>
+    </message>
+    <message>
+        <source>PINs don&apos;t match</source>
+        <translation type="unfinished">PIN码不匹配</translation>
+    </message>
+    <message>
+        <source>You need to enter a %1</source>
+        <translation type="unfinished">您需要输入%1</translation>
+    </message>
+    <message numerus="yes">
+        <source>The %1 cannot exceed %n character(s)</source>
+        <translation type="unfinished">
+            <numerusform>%1 不能超过 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Must be an hexadecimal color (eg: #4360DF)</source>
+        <translation type="unfinished">必须是十六进制颜色（例如：#4360DF）</translation>
+    </message>
+    <message>
+        <source>Use only lowercase letters (a to z), numbers &amp; dashes (-). Do not use chat keys.</source>
+        <translation type="unfinished">只能使用小写字母（a到z）、数字和破折号（-）。请勿使用聊天按键。</translation>
+    </message>
+    <message numerus="yes">
+        <source>Value has to be at least %n character(s) long</source>
+        <translation type="unfinished">
+            <numerusform>值必须至少为 %n 个字符</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">消息</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">钱包</translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation type="unfinished">浏览器</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message>
+        <source>Discover Communities</source>
+        <translation type="unfinished">发现社区</translation>
+    </message>
+    <message>
+        <source>Swap</source>
+        <translation type="unfinished">兑换</translation>
+    </message>
+    <message>
+        <source>Market</source>
+        <translation type="unfinished">市场</translation>
+    </message>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished">社区</translation>
+    </message>
+    <message>
+        <source>dApp</source>
+        <translation type="unfinished">dApp</translation>
+    </message>
+    <message>
+        <source>Home Page</source>
+        <translation type="unfinished">主页</translation>
+    </message>
+    <message>
+        <source>QR Scanner</source>
+        <translation type="unfinished">二维码扫描器</translation>
+    </message>
+    <message>
+        <source>Add new user</source>
+        <translation type="unfinished">添加新用户</translation>
+    </message>
+    <message>
+        <source>Add existing Status user</source>
+        <translation type="unfinished">添加现有的Status用户</translation>
+    </message>
+    <message>
+        <source>Lost Keycard</source>
+        <translation type="unfinished">丢失的密钥卡</translation>
+    </message>
+    <message>
+        <source>New watched address</source>
+        <translation type="unfinished">新的已监控地址</translation>
+    </message>
+    <message>
+        <source>Watched address</source>
+        <translation type="unfinished">已添加的地址</translation>
+    </message>
+    <message>
+        <source>Existing</source>
+        <translation type="unfinished">现有</translation>
+    </message>
+    <message>
+        <source>Import new</source>
+        <translation type="unfinished">导入新项</translation>
+    </message>
+    <message>
+        <source>Add new master key</source>
+        <translation type="unfinished">添加新的主密钥</translation>
+    </message>
+    <message>
+        <source>Add watched address</source>
+        <translation type="unfinished">添加监控地址</translation>
+    </message>
+    <message>
+        <source>Failed to start the transaction</source>
+        <translation type="unfinished">启动交易失败</translation>
+    </message>
+    <message>
+        <source>No account selected to send the transaction from</source>
+        <translation type="unfinished">未选择用于发送交易的账户</translation>
+    </message>
+    <message>
+        <source>Failed to prepare the transaction</source>
+        <translation type="unfinished">准备交易失败</translation>
+    </message>
+    <message>
+        <source>Failed to send the transaction</source>
+        <translation type="unfinished">发送交易失败</translation>
+    </message>
+    <message>
+        <source>Transaction signing was not completed</source>
+        <translation type="unfinished">交易签名未完成</translation>
+    </message>
+    <message>
+        <source>Failed to prepare the transaction for signing</source>
+        <translation type="unfinished">准备签名交易失败</translation>
+    </message>
+    <message>
+        <source>acc</source>
+        <comment>short for account</comment>
+        <translation type="unfinished">帐户</translation>
+    </message>
+    <message>
+        <source>Arbiscan</source>
+        <translation type="unfinished">Arbiscan</translation>
+    </message>
+    <message>
+        <source>Optimistic</source>
+        <translation type="unfinished">乐观</translation>
+    </message>
+    <message>
+        <source>BaseScan</source>
+        <translation type="unfinished">BaseScan</translation>
+    </message>
+    <message>
+        <source>BscScan</source>
+        <translation type="unfinished">BscScan</translation>
+    </message>
+    <message>
+        <source>Etherscan</source>
+        <translation type="unfinished">Etherscan</translation>
+    </message>
+    <message>
+        <source>On Keycard</source>
+        <translation type="unfinished">在密钥卡上</translation>
+    </message>
+    <message>
+        <source>On device</source>
+        <translation type="unfinished">在设备上</translation>
+    </message>
+    <message>
+        <source>Requires import</source>
+        <translation type="unfinished">需要导入</translation>
+    </message>
+    <message>
+        <source>Restored from backup. Import key pair to use derived accounts.</source>
+        <translation type="unfinished">已从备份中恢复。导入密钥对以使用派生帐户。</translation>
+    </message>
+    <message>
+        <source>Import key pair to use derived accounts</source>
+        <translation type="unfinished">导入密钥对以使用派生帐户</translation>
+    </message>
+    <message>
+        <source>LineaScan</source>
+        <translation type="unfinished">LineaScan</translation>
+    </message>
+    <message>
+        <source>Messages are loading...</source>
+        <translation type="unfinished">消息加载中...</translation>
+    </message>
+    <message>
+        <source>Unichain Explorer</source>
+        <translation type="unfinished">Unichain 浏览器</translation>
+    </message>
+    <message>
+        <source>Katana Explorer</source>
+        <translation type="unfinished">Katana 浏览器</translation>
+    </message>
+    <message>
+        <source>Ink Explorer</source>
+        <translation type="unfinished">Ink 浏览器</translation>
+    </message>
+    <message>
+        <source>Abstract Explorer</source>
+        <translation type="unfinished">抽象浏览器</translation>
+    </message>
+    <message>
+        <source>ZkSync Era Explorer</source>
+        <translation type="unfinished">ZkSync Era 浏览器</translation>
+    </message>
+    <message>
+        <source>Soneium Explorer</source>
+        <translation type="unfinished">Soneium 浏览器</translation>
+    </message>
+    <message>
+        <source>ScrollScan</source>
+        <translation type="unfinished">ScrollScan</translation>
+    </message>
+    <message>
+        <source>BlastScan</source>
+        <translation type="unfinished">BlastScan</translation>
+    </message>
+    <message>
+        <source>Robinhood Explorer</source>
+        <translation type="unfinished">Robinhood 浏览器</translation>
+    </message>
+</context>
+<context>
+    <name>ViewProfileMenuItem</name>
+    <message>
+        <source>View Profile</source>
+        <translation type="unfinished">查看个人资料</translation>
+    </message>
+</context>
+<context>
+    <name>WCUriInput</name>
+    <message>
+        <source>Paste URI</source>
+        <translation type="unfinished">粘贴URI</translation>
+    </message>
+    <message>
+        <source>WalletConnect URI too cool</source>
+        <translation type="unfinished">WalletConnect URI 太棒了</translation>
+    </message>
+    <message>
+        <source>WalletConnect URI invalid</source>
+        <translation type="unfinished">WalletConnect URI 无效</translation>
+    </message>
+    <message>
+        <source>WalletConnect URI already used</source>
+        <translation type="unfinished">WalletConnect URI 已被使用</translation>
+    </message>
+    <message>
+        <source>WalletConnect URI has expired</source>
+        <translation type="unfinished">WalletConnect URI 已过期</translation>
+    </message>
+    <message>
+        <source>dApp is requesting to connect on an unsupported network</source>
+        <translation type="unfinished">dApp 正在请求连接到不受支持的网络</translation>
+    </message>
+    <message>
+        <source>Unexpected error occurred. Try again.</source>
+        <translation type="unfinished">发生意外错误。请重试。</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+</context>
+<context>
+    <name>WalletAccountDetailsKeypairItem</name>
+    <message>
+        <source>Watched address</source>
+        <translation type="unfinished">已添加的地址</translation>
+    </message>
+</context>
+<context>
+    <name>WalletAccountHeader</name>
+    <message>
+        <source>All accounts</source>
+        <translation type="unfinished">所有账户</translation>
+    </message>
+    <message>
+        <source>Last refreshed %1</source>
+        <translation type="unfinished">上次刷新于 %1</translation>
+    </message>
+</context>
+<context>
+    <name>WalletAddressMenu</name>
+    <message>
+        <source>Address copied</source>
+        <translation type="unfinished">地址已复制</translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished">复制地址</translation>
+    </message>
+    <message>
+        <source>Show address QR</source>
+        <translation type="unfinished">显示地址二维码</translation>
+    </message>
+</context>
+<context>
+    <name>WalletAssetsStore</name>
+    <message>
+        <source>%1 community assets successfully hidden</source>
+        <translation type="unfinished">已成功隐藏 %1 个社区资产</translation>
+    </message>
+    <message>
+        <source>%1 is now visible</source>
+        <translation type="unfinished">现在可以查看 %1 了</translation>
+    </message>
+    <message>
+        <source>%1 community assets are now visible</source>
+        <translation type="unfinished">现在可以查看 %1 个社区资产</translation>
+    </message>
+</context>
+<context>
+    <name>WalletFollowingAddressesHeader</name>
+    <message>
+        <source>Last refreshed %1</source>
+        <translation type="unfinished">上次刷新于 %1</translation>
+    </message>
+    <message>
+        <source>Find a friend</source>
+        <translation type="unfinished">查找好友</translation>
+    </message>
+    <message>
+        <source>Onchain friends</source>
+        <translation type="unfinished">链上好友</translation>
+    </message>
+</context>
+<context>
+    <name>WalletFooter</name>
+    <message>
+        <source>Send Owner token to transfer %1 Community ownership</source>
+        <translation type="unfinished">将所有者代币发送以转移%1社区的所有权</translation>
+    </message>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+    <message>
+        <source>Soulbound collectibles cannot be sent to another wallet</source>
+        <translation type="unfinished">无法将 Soulbound 收藏品发送到其他钱包</translation>
+    </message>
+    <message>
+        <source>Receive</source>
+        <translation type="unfinished">接收</translation>
+    </message>
+    <message>
+        <source>Buy</source>
+        <translation type="unfinished">购买</translation>
+    </message>
+    <message>
+        <source>Swap</source>
+        <translation type="unfinished">兑换</translation>
+    </message>
+</context>
+<context>
+    <name>WalletKeyPairDelegate</name>
+    <message>
+        <source>Watched addresses</source>
+        <translation type="unfinished">已添加的地址</translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">排除</translation>
+    </message>
+    <message>
+        <source>Included</source>
+        <translation type="unfinished">包含</translation>
+    </message>
+</context>
+<context>
+    <name>WalletKeypairAccountMenu</name>
+    <message>
+        <source>Show encrypted QR on device</source>
+        <translation type="unfinished">在设备上显示加密的二维码</translation>
+    </message>
+    <message>
+        <source>Stop using Keycard</source>
+        <translation type="unfinished">停止使用密钥卡</translation>
+    </message>
+    <message>
+        <source>Move key pair to a Keycard</source>
+        <translation type="unfinished">将密钥对移动到密钥卡</translation>
+    </message>
+    <message>
+        <source>Import key pair from device via encrypted QR</source>
+        <translation type="unfinished">通过加密的二维码从设备导入密钥对</translation>
+    </message>
+    <message>
+        <source>Import via entering private key</source>
+        <translation type="unfinished">通过输入私钥进行导入</translation>
+    </message>
+    <message>
+        <source>Import via entering recovery phrase</source>
+        <translation type="unfinished">通过输入恢复短语进行导入</translation>
+    </message>
+    <message>
+        <source>Rename key pair</source>
+        <translation type="unfinished">重命名密钥对</translation>
+    </message>
+    <message>
+        <source>Remove key pair and derived accounts</source>
+        <translation type="unfinished">删除密钥对和派生帐户</translation>
+    </message>
+</context>
+<context>
+    <name>WalletNetworkDelegate</name>
+    <message>
+        <source>%1 chain integrated. You can now view and swap &lt;br&gt;%1 assets, as well as interact with %1 dApps.</source>
+        <translation type="unfinished">已集成%1链。现在您可以查看和交换&lt;br&gt;%1资产，以及与%1去中心化应用进行交互。</translation>
+    </message>
+    <message>
+        <source>Required for some Status features</source>
+        <translation type="unfinished">某些Status功能需要</translation>
+    </message>
+</context>
+<context>
+    <name>WalletPrivacyWall</name>
+    <message>
+        <source>Enable third-party services for wallet features to work.</source>
+        <translation type="unfinished">启用第三方服务，以使钱包功能正常运行。</translation>
+    </message>
+    <message>
+        <source>Portfolio view for your tokens</source>
+        <translation type="unfinished">您的代币组合视图</translation>
+    </message>
+    <message>
+        <source>Use multi-chain, multi-account, and fully self-custodial wallet</source>
+        <translation type="unfinished">使用多链、多账户和完全自主保管的钱包</translation>
+    </message>
+    <message>
+        <source>Fast &amp; easy token swaps</source>
+        <translation type="unfinished">快速简便的代币兑换</translation>
+    </message>
+    <message>
+        <source>Access wide token coverage and the best prices across top DEXes</source>
+        <translation type="unfinished">访问广泛的代币种类，并在顶级去中心化交易所获得最佳价格</translation>
+    </message>
+    <message>
+        <source>Organize collectibles your way</source>
+        <translation type="unfinished">以您喜欢的方式整理收藏品</translation>
+    </message>
+    <message>
+        <source>Search, filter, and sort your collectibles exactly how you want</source>
+        <translation type="unfinished">搜索、过滤和排序您的收藏品，完全按照您的意愿</translation>
+    </message>
+    <message>
+        <source>Multiple ways to buy tokens</source>
+        <translation type="unfinished">多种购买代币的方式</translation>
+    </message>
+    <message>
+        <source>Pay with cards, bank transfers, Apple/Google Pay, SEPA, and 9+ options</source>
+        <translation type="unfinished">使用信用卡、银行转账、Apple/Google Pay、SEPA等9种以上方式支付</translation>
+    </message>
+</context>
+<context>
+    <name>WalletSavedAddressesHeader</name>
+    <message>
+        <source>Add new address</source>
+        <translation type="unfinished">添加新地址</translation>
+    </message>
+    <message>
+        <source>Saved addresses</source>
+        <translation type="unfinished">已保存的地址</translation>
+    </message>
+    <message>
+        <source>Last refreshed %1</source>
+        <translation type="unfinished">上次刷新于 %1</translation>
+    </message>
+</context>
+<context>
+    <name>WalletUtils</name>
+    <message>
+        <source>~ Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>&lt; 1 minute</source>
+        <translation type="unfinished">不到 1 分钟</translation>
+    </message>
+    <message>
+        <source>&lt; 3 minutes</source>
+        <translation type="unfinished">不到 3 分钟</translation>
+    </message>
+    <message>
+        <source>&lt; 5 minutes</source>
+        <translation type="unfinished">不到 5 分钟</translation>
+    </message>
+    <message>
+        <source>&gt; 5 minutes</source>
+        <translation type="unfinished">超过 5 分钟</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>&gt;60s</source>
+        <translation type="unfinished">&gt;60秒</translation>
+    </message>
+    <message>
+        <source>~%1s</source>
+        <translation type="unfinished">~%1秒</translation>
+    </message>
+    <message>
+        <source>an internal error occurred</source>
+        <translation type="unfinished">发生内部错误</translation>
+    </message>
+    <message>
+        <source>unknown error occurred, try again later</source>
+        <translation type="unfinished">发生未知错误，请稍后重试</translation>
+    </message>
+    <message>
+        <source>processor internal error</source>
+        <translation type="unfinished">处理器内部错误</translation>
+    </message>
+    <message>
+        <source>processor network error</source>
+        <translation type="unfinished">处理器网络错误</translation>
+    </message>
+    <message>
+        <source>router network error</source>
+        <translation type="unfinished">路由器网络错误</translation>
+    </message>
+    <message>
+        <source>not enough token balance</source>
+        <translation type="unfinished">代币余额不足</translation>
+    </message>
+    <message>
+        <source>Not enough ETH to pay gas fees</source>
+        <translation type="unfinished">ETH 余额不足以支付 Gas 费用</translation>
+    </message>
+    <message>
+        <source>amount in too low</source>
+        <translation type="unfinished">金额过低</translation>
+    </message>
+    <message>
+        <source>no positive balance</source>
+        <translation type="unfinished">没有正余额</translation>
+    </message>
+    <message>
+        <source>unknown processor error</source>
+        <translation type="unfinished">未知处理器错误</translation>
+    </message>
+    <message>
+        <source>failed to parse base fee</source>
+        <translation type="unfinished">无法解析基本费用</translation>
+    </message>
+    <message>
+        <source>failed to parse percentage fee</source>
+        <translation type="unfinished">无法解析百分比费用</translation>
+    </message>
+    <message>
+        <source>contract not found</source>
+        <translation type="unfinished">未找到合约</translation>
+    </message>
+    <message>
+        <source>network not found</source>
+        <translation type="unfinished">未找到网络</translation>
+    </message>
+    <message>
+        <source>token not found</source>
+        <translation type="unfinished">未找到代币</translation>
+    </message>
+    <message>
+        <source>no estimation found</source>
+        <translation type="unfinished">未找到预估值</translation>
+    </message>
+    <message>
+        <source>not available for contract type</source>
+        <translation type="unfinished">此合约类型不可用</translation>
+    </message>
+    <message>
+        <source>no bonder fee found</source>
+        <translation type="unfinished">未找到质押费用</translation>
+    </message>
+    <message>
+        <source>contract type not supported</source>
+        <translation type="unfinished">不支持的合约类型</translation>
+    </message>
+    <message>
+        <source>from chain not supported</source>
+        <translation type="unfinished">不支持的源链</translation>
+    </message>
+    <message>
+        <source>to chain not supported</source>
+        <translation type="unfinished">不支持的目标链</translation>
+    </message>
+    <message>
+        <source>tx for chain not supported</source>
+        <translation type="unfinished">不支持该链上的交易</translation>
+    </message>
+    <message>
+        <source>ens resolver not found</source>
+        <translation type="unfinished">未找到 ENS 解析器</translation>
+    </message>
+    <message>
+        <source>ens registrar not found</source>
+        <translation type="unfinished">未找到 ENS 注册中心</translation>
+    </message>
+    <message>
+        <source>to and from tokens must be set</source>
+        <translation type="unfinished">必须设置目标代币和源代币</translation>
+    </message>
+    <message>
+        <source>cannot resolve tokens</source>
+        <translation type="unfinished">无法解析代币</translation>
+    </message>
+    <message>
+        <source>price route not found</source>
+        <translation type="unfinished">未找到价格路由</translation>
+    </message>
+    <message>
+        <source>converting amount issue</source>
+        <translation type="unfinished">转换金额时出现问题</translation>
+    </message>
+    <message>
+        <source>no chain set</source>
+        <translation type="unfinished">未设置链</translation>
+    </message>
+    <message>
+        <source>no token set</source>
+        <translation type="unfinished">未设置代币</translation>
+    </message>
+    <message>
+        <source>to token should not be set</source>
+        <translation type="unfinished">不应设置目标代币</translation>
+    </message>
+    <message>
+        <source>from and to chains must be different</source>
+        <translation type="unfinished">源链和目标链必须不同</translation>
+    </message>
+    <message>
+        <source>from and to chains must be same</source>
+        <translation type="unfinished">起始链和目标链必须相同</translation>
+    </message>
+    <message>
+        <source>from and to tokens must be different</source>
+        <translation type="unfinished">起始代币和目标代币必须不同</translation>
+    </message>
+    <message>
+        <source>context cancelled</source>
+        <translation type="unfinished">上下文已取消</translation>
+    </message>
+    <message>
+        <source>context deadline exceeded</source>
+        <translation type="unfinished">上下文超时</translation>
+    </message>
+    <message>
+        <source>fetching price timeout</source>
+        <translation type="unfinished">获取价格超时</translation>
+    </message>
+    <message>
+        <source>not enough liquidity</source>
+        <translation type="unfinished">流动性不足</translation>
+    </message>
+    <message>
+        <source>price impact too high</source>
+        <translation type="unfinished">价格影响过大</translation>
+    </message>
+    <message>
+        <source>username and public key are required for registering ens name</source>
+        <translation type="unfinished">注册 ENS 名称需要用户名和公钥</translation>
+    </message>
+    <message>
+        <source>only STT is supported for registering ens name on testnet</source>
+        <translation type="unfinished">仅支持在测试网上使用 STT 注册 ENS 名称</translation>
+    </message>
+    <message>
+        <source>only SNT is supported for registering ens name on mainnet</source>
+        <translation type="unfinished">仅支持在主网上使用 SNT 注册 ENS 名称</translation>
+    </message>
+    <message>
+        <source>username is required for releasing ens name</source>
+        <translation type="unfinished">释放 ENS 名称需要用户名</translation>
+    </message>
+    <message>
+        <source>username and public key are required for setting public key</source>
+        <translation type="unfinished">设置公钥需要用户名和公钥</translation>
+    </message>
+    <message>
+        <source>stickers pack id is required for buying stickers</source>
+        <translation type="unfinished">购买贴纸需要贴纸包 ID</translation>
+    </message>
+    <message>
+        <source>to token is required for Swap</source>
+        <translation type="unfinished">Swap 需要目标代币</translation>
+    </message>
+    <message>
+        <source>from and to token must be different</source>
+        <translation type="unfinished">起始代币和目标代币必须不同</translation>
+    </message>
+    <message>
+        <source>only one of amount to send or receiving amount can be set</source>
+        <translation type="unfinished">只能设置发送金额或接收金额中的一个</translation>
+    </message>
+    <message>
+        <source>amount to send must be positive</source>
+        <translation type="unfinished">发送金额必须为正数</translation>
+    </message>
+    <message>
+        <source>receiving amount must be positive</source>
+        <translation type="unfinished">接收金额必须为正数</translation>
+    </message>
+    <message>
+        <source>locked amount is not supported for the selected network</source>
+        <translation type="unfinished">所选网络不支持锁定金额</translation>
+    </message>
+    <message>
+        <source>locked amount must not be negative</source>
+        <translation type="unfinished">锁定金额不能为负数</translation>
+    </message>
+    <message>
+        <source>locked amount exceeds the total amount to send</source>
+        <translation type="unfinished">锁定的金额超过了要发送的总金额</translation>
+    </message>
+    <message>
+        <source>locked amount is less than the total amount to send, but all networks are locked</source>
+        <translation type="unfinished">锁定的金额小于要发送的总金额，但所有网络都已锁定</translation>
+    </message>
+    <message>
+        <source>native token not found</source>
+        <translation type="unfinished">未找到原生代币</translation>
+    </message>
+    <message>
+        <source>disabled chain found among locked networks</source>
+        <translation type="unfinished">在锁定的网络中找到了禁用的链</translation>
+    </message>
+    <message>
+        <source>a valid username, ending in &apos;.eth&apos;, is required for setting public key</source>
+        <translation type="unfinished">设置公钥需要一个以“.eth”结尾的有效用户名</translation>
+    </message>
+    <message>
+        <source>all supported chains are excluded, routing impossible</source>
+        <translation type="unfinished">所有受支持的链都被排除，无法进行路由</translation>
+    </message>
+    <message>
+        <source>no best route found</source>
+        <translation type="unfinished">未找到最佳路线</translation>
+    </message>
+    <message>
+        <source>cannot check balance</source>
+        <translation type="unfinished">无法检查余额</translation>
+    </message>
+    <message>
+        <source>cannot check locked amounts</source>
+        <translation type="unfinished">无法检查锁定的金额</translation>
+    </message>
+    <message>
+        <source>not enough balance for %1 on %2 chain</source>
+        <translation type="unfinished">在%2链上，您的账户余额不足以支付%1</translation>
+    </message>
+    <message>
+        <source>bonder fee greater than estimated received, a higher amount is needed to cover fees</source>
+        <translation type="unfinished">Bonder费用大于预估收到的金额，需要更高的金额来支付费用</translation>
+    </message>
+    <message>
+        <source>no positive balance for your account across chains</source>
+        <translation type="unfinished">您的账户在所有链上的余额均为零</translation>
+    </message>
+    <message>
+        <source>Fast</source>
+        <translation type="unfinished">快速</translation>
+    </message>
+    <message>
+        <source>Urgent</source>
+        <translation type="unfinished">紧急</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished">自定义</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">正常</translation>
+    </message>
+</context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">钱包</translation>
+    </message>
+    <message>
+        <source>Networks</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">保存</translation>
+    </message>
+    <message>
+        <source>Save and apply</source>
+        <translation type="unfinished">保存并应用</translation>
+    </message>
+    <message>
+        <source>New custom sort order created</source>
+        <translation type="unfinished">已创建新的自定义排序顺序</translation>
+    </message>
+    <message>
+        <source>Your new custom token order has been applied to your %1</source>
+        <comment>Go to Wallet</comment>
+        <translation type="unfinished">您的新自定义代币顺序已应用于您的 %1</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <comment>Go to Wallet</comment>
+        <translation type="unfinished">钱包</translation>
+    </message>
+    <message>
+        <source>Edit %1</source>
+        <translation type="unfinished">编辑 %1</translation>
+    </message>
+    <message>
+        <source>Edit account order</source>
+        <translation type="unfinished">编辑账户顺序</translation>
+    </message>
+    <message>
+        <source>Manage tokens</source>
+        <translation type="unfinished">管理代币</translation>
+    </message>
+    <message>
+        <source>Saved addresses</source>
+        <translation type="unfinished">已保存的地址</translation>
+    </message>
+    <message>
+        <source>Add new account</source>
+        <translation type="unfinished">添加新账户</translation>
+    </message>
+    <message>
+        <source>Testnet mode</source>
+        <translation type="unfinished">测试网络模式</translation>
+    </message>
+    <message>
+        <source>Add new address</source>
+        <translation type="unfinished">添加新地址</translation>
+    </message>
+</context>
+<context>
+    <name>WatchOnlyAddressSection</name>
+    <message>
+        <source>Ethereum address or ENS name</source>
+        <translation type="unfinished">以太坊地址或 ENS 名称</translation>
+    </message>
+    <message>
+        <source>Type or paste ETH address</source>
+        <translation type="unfinished">输入或粘贴 ETH 地址</translation>
+    </message>
+    <message>
+        <source>Checksum of the entered address is incorrect</source>
+        <translation type="unfinished">输入的地址校验和不正确</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">粘贴</translation>
+    </message>
+    <message>
+        <source>Please enter a valid Ethereum address or ENS name</source>
+        <translation type="unfinished">请输入有效的以太坊地址或 ENS 名称</translation>
+    </message>
+    <message>
+        <source>You will need to import your recovery phrase or use your Keycard to transact with this account</source>
+        <translation type="unfinished">您需要导入您的助记词或使用您的密钥卡才能使用此帐户进行交易</translation>
+    </message>
+</context>
+<context>
+    <name>WelcomeBannerPanel</name>
+    <message>
+        <source>Welcome to your community!</source>
+        <translation type="unfinished">欢迎来到您的社区！</translation>
+    </message>
+    <message>
+        <source>Add members</source>
+        <translation type="unfinished">添加成员</translation>
+    </message>
+    <message>
+        <source>Manage community</source>
+        <translation type="unfinished">管理社区</translation>
+    </message>
+</context>
+<context>
+    <name>WelcomePage</name>
+    <message>
+        <source>Own your crypto</source>
+        <translation type="unfinished">拥有您的加密货币</translation>
+    </message>
+    <message>
+        <source>Use the leading multi-chain self-custodial wallet</source>
+        <translation type="unfinished">使用领先的多链自托管钱包</translation>
+    </message>
+    <message>
+        <source>Chat privately with friends</source>
+        <translation type="unfinished">与朋友私下聊天</translation>
+    </message>
+    <message>
+        <source>With full metadata privacy and e2e encryption</source>
+        <translation type="unfinished">具有完整的元数据隐私和端到端加密</translation>
+    </message>
+    <message>
+        <source>Store your assets on Keycard</source>
+        <translation type="unfinished">将您的资产存储在 Keycard 上</translation>
+    </message>
+    <message>
+        <source>Be safe with secure cold wallet</source>
+        <translation type="unfinished">使用安全的冷钱包，确保安全</translation>
+    </message>
+    <message>
+        <source>Welcome to Status</source>
+        <translation type="unfinished">欢迎来到 Status</translation>
+    </message>
+    <message>
+        <source>The open-source, decentralised wallet and messenger</source>
+        <translation type="unfinished">开源、去中心化的钱包和消息应用程序</translation>
+    </message>
+    <message>
+        <source>Create profile</source>
+        <translation type="unfinished">创建个人资料</translation>
+    </message>
+    <message>
+        <source>Log in</source>
+        <translation type="unfinished">登录</translation>
+    </message>
+    <message>
+        <source>Third-party services %1</source>
+        <translation type="unfinished">第三方服务 %1</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <translation type="unfinished">已启用</translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <translation type="unfinished">已禁用</translation>
+    </message>
+    <message>
+        <source>By proceeding you accept Status&lt;br&gt;%1 and %2</source>
+        <translation type="unfinished">通过继续操作，您同意 Status&lt;br&gt;%1 和 %2</translation>
+    </message>
+    <message>
+        <source>Terms of Use</source>
+        <translation type="unfinished">使用条款</translation>
+    </message>
+    <message>
+        <source>Privacy Policy</source>
+        <translation type="unfinished">隐私政策</translation>
+    </message>
+</context>
+<context>
+    <name>WhitelistedDomainsView</name>
+    <message>
+        <source>Trusted sites</source>
+        <translation type="unfinished">受信任的网站</translation>
+    </message>
+    <message>
+        <source>Manage trusted sites. Their links open without confirmation.</source>
+        <translation type="unfinished">管理受信任的网站。它们的链接无需确认即可打开。</translation>
+    </message>
+    <message>
+        <source>No trusted sites added yet</source>
+        <translation type="unfinished">尚未添加任何受信任的网站</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>Status Desktop</source>
+        <translation type="unfinished">状态桌面</translation>
+    </message>
+    <message>
+        <source>Share logs or report a bug?</source>
+        <translation type="unfinished">分享日志或报告错误？</translation>
+    </message>
+    <message>
+        <source>Export log files</source>
+        <translation type="unfinished">导出日志文件</translation>
+    </message>
+    <message>
+        <source>No log files found</source>
+        <translation type="unfinished">未找到日志文件</translation>
+    </message>
+    <message>
+        <source>Report a bug on GitHub</source>
+        <translation type="unfinished">在 GitHub 上报告错误</translation>
+    </message>
+</context>
+<context>
+    <name>tst_StatusInput</name>
+    <message>
+        <source>Enter an account name...</source>
+        <translation type="unfinished">输入账户名称...</translation>
+    </message>
+    <message>
+        <source>You need to enter an account name</source>
+        <translation type="unfinished">您需要输入一个帐户名</translation>
+    </message>
+    <message>
+        <source>This is not a valid account name</source>
+        <translation type="unfinished">这不是一个有效的账户名称</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
> [!IMPORTANT]
> This needs to be proof-read, and signed off, clearing the "unfinished" flag from strings using, Qt Linguist

### What does the PR do

- codename `zh_CN`
- adjust cmake

Fixes #21887

### Affected areas

Translations

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

TBD

### Impact on end user

l10n

### How to test

- open Settings/Language, change to "Chinese"

### Risk 

low
