### PR TITLE
fix(ci): set GOPROXY while installing protobuf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,6 +512,7 @@ $(STATUSGO): | deps status-go-deps $(NIMSDS_LIBFILE) platform-cleanup
 
 status-go: $(STATUSGO)
 
+status-go-deps: export GOPROXY ?= https://proxy.golang.org|direct
 status-go-deps:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 


### PR DESCRIPTION
Otherwise we end up with errors like this :

```
[2026-08-11T11:43:37.039Z] go:
google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1: google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1: reading https://proxy.golang.org/google.golang.org/protobuf/cmd/protoc-gen-go/@v/v1.34.1.info: 429 Too Many Requests

[2026-08-11T11:43:37.039Z] make: *** [Makefile:516: status-go-deps] Error 1

[2026-08-11T11:43:37.040Z] make: *** Waiting for unfinished jobs....

script returned exit code 2
```