### PR TITLE
Chat input: custom context menu restored, pasting images and inserting not-existing mentions fixed

### DIFF
--- a/storybook/qmlTests/tests/tst_ChatTextArea.qml
+++ b/storybook/qmlTests/tests/tst_ChatTextArea.qml
@@ -52,6 +52,12 @@ Item {
         signalName: "attemptToExceedHardLimit"
     }
 
+    SignalSpy {
+        id: pasteImageSpy
+        target: testCase.control
+        signalName: "pasteImageRequested"
+    }
+
     TestCase {
         id: testCase
         name: "ChatTextArea"
@@ -674,6 +680,48 @@ Item {
             // Caret restored to the end of the originally-selected text ("bc"), not collapsed to
             // the document start.
             compare(control.cursorPosition, 3)
+        }
+
+        // ── image paste ─────────────────────────────────────────────────────────
+
+        // A valid PNG as a data URI, used to put a real image on the clipboard.
+        readonly property string testImage:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ix"
+            + "AAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUI"
+            + "YQiNITSG0BhCExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPb"
+            + "qeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0"
+            + "htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
+
+        // Pasting while the clipboard holds an image emits pasteImageRequested (desktop only) and
+        // inserts no text — the host is responsible for handling the image.
+        function test_pasteImage_emitsRequestAndInsertsNoText() {
+            ClipboardUtils.clear()
+            ClipboardUtils.setImageByUrl(testImage)
+            tryVerify(() => ClipboardUtils.hasImage)
+
+            control.text = ""
+            control.forceActiveFocus()
+            pasteImageSpy.clear()
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            compare(pasteImageSpy.count, 1)
+            compare(control.text, "") // no text inserted for an image paste
+        }
+
+        // A plain text paste must not emit the image signal.
+        function test_pasteText_doesNotEmitImageRequest() {
+            ClipboardUtils.setText("hello")
+            tryVerify(() => ClipboardUtils.hasText && !ClipboardUtils.hasImage)
+
+            control.text = ""
+            control.forceActiveFocus()
+            pasteImageSpy.clear()
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            compare(pasteImageSpy.count, 0)
+            tryCompare(control, "text", "hello")
         }
 
         // ── hard character limit ────────────────────────────────────────────────

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -351,7 +351,34 @@ Item {
             tryVerify(() => controlUnderTest.getPlainText() === "Hello @0x0JohnDoe ")
         }
 
-        // ── typed emoji-shortcode flow (migrated from tst_StatusChatInput, re-enabled) ──
+        // Typing "@" + a name that matches no user (nor "everyone") must not open a
+        // visible-but-empty suggestion box. Otherwise Enter/Send would commit a
+        // non-existent row and insert an "@undefined" pill instead of sending;
+        // here it must send the text as-is.
+        function test_typedMention_noMatchSendsTextAsIs() {
+            appendContact("JohnDoe")
+            waitForRendering(controlUnderTest)
+
+            controlUnderTest.textInput.forceActiveFocus()
+            typeText("Hello @zzz")
+            waitForRendering(controlUnderTest)
+
+            // enteringSuggestion is true, but there are no matches, so the box stays hidden.
+            verify(controlUnderTest.textInput.enteringSuggestion)
+            const box = findChild(controlUnderTest, "suggestionsBox")
+            verify(!!box)
+            verify(!box.visible, "no suggestion box for a non-matching name")
+
+            signalSpy.setup(controlUnderTest, "sendMessageRequested")
+            keyClick(Qt.Key_Return) // send (NoModifier maps to send on desktop/offscreen)
+            waitForRendering(controlUnderTest)
+
+            verify(!controlUnderTest.getPlainText().includes("@undefined"))
+            compare(controlUnderTest.getPlainText(), "Hello @zzz")
+            compare(signalSpy.count, 1)
+        }
+
+        // ── typed emoji-shortcode flow
         //
         // Typing ":" + a shortcode makes ChatTextArea report enteringEmoji/emojiFilter, which
         // drives the emoji suggestion popup. Committing (Tab) replaces the shortcode with the emoji.

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -81,30 +81,17 @@ TextField {
     Loader {
         id: contextMenuLoader
         active: false
-        sourceComponent: StatusMenu {
-            hideDisabledItems: false
-    
-            StatusAction {
-                text: qsTr("Cut")
-                enabled: !root.noSelection
-                onTriggered: root.cut()
-            }
-            StatusAction {
-                text: qsTr("Copy")
-                enabled: !root.noSelection
-                onTriggered: root.copy()
-            }
-            StatusAction {
-                text: qsTr("Paste")
-                enabled: root.canPaste
-                onTriggered: root.paste()
-            }
-            StatusMenuSeparator {}
-            StatusAction {
-                text: qsTr("Select All")
-                enabled: !root.noSelection
-                onTriggered: root.selectAll()
-            }
+
+        sourceComponent: StatusTextEditMenu {
+            canCut: !root.noSelection
+            canCopy: !root.noSelection
+            canPaste: root.canPaste
+            canSelectAll: root.length > 0
+
+            onCutRequested: root.cut()
+            onCopyRequested: root.copy()
+            onPasteRequested: root.paste()
+            onSelectAllRequested: root.selectAll()
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -83,9 +83,9 @@ TextField {
         active: false
 
         sourceComponent: StatusTextEditMenu {
-            canCut: !root.noSelection
+            canCut: !root.readOnly && !root.noSelection
             canCopy: !root.noSelection
-            canPaste: root.canPaste
+            canPaste: !root.readOnly && root.canPaste
             canSelectAll: root.length > 0
 
             onCutRequested: root.cut()

--- a/ui/StatusQ/src/StatusQ/Popups/StatusTextEditMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusTextEditMenu.qml
@@ -1,0 +1,56 @@
+import QtQuick
+import QtQuick.Controls
+
+import StatusQ.Core.Utils
+import StatusQ.Popups
+
+// Standard text-editing context menu (Cut / Copy / Paste / Select All) for text
+// inputs. It owns only the menu items and their enablement; the editor wires the
+// *Requested signals to its own cut/copy/paste/selectAll routines and decides how
+// (and whether) to attach it (e.g. via the ContextMenu.menu attached property).
+StatusMenu {
+    id: root
+
+    // There is a selection to cut — enables Cut.
+    property bool canCut: false
+
+    // There is a selection to copy — enables Copy.
+    property bool canCopy: false
+
+    // Something is available to paste — enables Paste. The caller passes its own
+    // clipboard check; the menu deliberately does not read the clipboard itself
+    // (on iOS a mere read triggers the system "paste from…" prompt).
+    property bool canPaste: true
+
+    // There is content to select — enables Select All.
+    property bool canSelectAll: true
+
+    signal cutRequested()
+    signal copyRequested()
+    signal pasteRequested()
+    signal selectAllRequested()
+
+    hideDisabledItems: false
+
+    StatusAction {
+        text: qsTr("Cut")
+        enabled: root.canCut
+        onTriggered: root.cutRequested()
+    }
+    StatusAction {
+        text: qsTr("Copy")
+        enabled: root.canCopy
+        onTriggered: root.copyRequested()
+    }
+    StatusAction {
+        text: qsTr("Paste")
+        enabled: root.canPaste
+        onTriggered: root.pasteRequested()
+    }
+    StatusMenuSeparator {}
+    StatusAction {
+        text: qsTr("Select All")
+        enabled: root.canSelectAll
+        onTriggered: root.selectAllRequested()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/qmldir
+++ b/ui/StatusQ/src/StatusQ/Popups/qmldir
@@ -17,3 +17,4 @@ StatusSearchPopupMenuItem 0.1 StatusSearchPopupMenuItem.qml
 StatusSimpleTextPopup 0.1 StatusSimpleTextPopup.qml
 StatusStackModal 0.1 StatusStackModal.qml
 StatusSuccessAction 0.1 StatusSuccessAction.qml
+StatusTextEditMenu 0.1 StatusTextEditMenu.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -264,6 +264,7 @@
         <file>StatusQ/Popups/StatusSimpleTextPopup.qml</file>
         <file>StatusQ/Popups/StatusStackModal.qml</file>
         <file>StatusQ/Popups/StatusSuccessAction.qml</file>
+        <file>StatusQ/Popups/StatusTextEditMenu.qml</file>
         <file>StatusQ/Popups/qmldir</file>
         <file>StatusQ/Popups/statusModal/StatusImageWithTitle.qml</file>
         <file>StatusQ/Popups/statusModal/StatusModalFooter.qml</file>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -15914,22 +15914,6 @@ to load</source>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Cut</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Paste</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Select All</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>
@@ -16540,7 +16524,7 @@ to load</source>
     </message>
 </context>
 <context>
-    <name>StatusTextField</name>
+    <name>StatusTextEditMenu</name>
     <message>
         <source>Cut</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -15914,6 +15914,22 @@ to load</source>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -16001,6 +16001,22 @@ selhalo</translation>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">Kopírovat</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">Vložit</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -16001,22 +16001,6 @@ selhalo</translation>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>
-    <message>
-        <source>Cut</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy</source>
-        <translation type="unfinished">Kopírovat</translation>
-    </message>
-    <message>
-        <source>Paste</source>
-        <translation type="unfinished">Vložit</translation>
-    </message>
-    <message>
-        <source>Select All</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>
@@ -16630,7 +16614,7 @@ selhalo</translation>
     </message>
 </context>
 <context>
-    <name>StatusTextField</name>
+    <name>StatusTextEditMenu</name>
     <message>
         <source>Cut</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -15929,6 +15929,22 @@ al cargar</translation>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">Copiar</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">Pegar</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -15929,22 +15929,6 @@ al cargar</translation>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
-    <message>
-        <source>Cut</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy</source>
-        <translation type="unfinished">Copiar</translation>
-    </message>
-    <message>
-        <source>Paste</source>
-        <translation type="unfinished">Pegar</translation>
-    </message>
-    <message>
-        <source>Select All</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>
@@ -16556,7 +16540,7 @@ al cargar</translation>
     </message>
 </context>
 <context>
-    <name>StatusTextField</name>
+    <name>StatusTextEditMenu</name>
     <message>
         <source>Cut</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -15858,22 +15858,6 @@ to load</source>
         <source>Edit</source>
         <translation type="unfinished">편집</translation>
     </message>
-    <message>
-        <source>Cut</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy</source>
-        <translation type="unfinished">클립보드로 복사</translation>
-    </message>
-    <message>
-        <source>Paste</source>
-        <translation type="unfinished">붙여넣기</translation>
-    </message>
-    <message>
-        <source>Select All</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>
@@ -16483,7 +16467,7 @@ to load</source>
     </message>
 </context>
 <context>
-    <name>StatusTextField</name>
+    <name>StatusTextEditMenu</name>
     <message>
         <source>Cut</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -15858,6 +15858,22 @@ to load</source>
         <source>Edit</source>
         <translation type="unfinished">편집</translation>
     </message>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">클립보드로 복사</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">붙여넣기</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/imports/shared/status/ChatTextArea.qml
+++ b/ui/imports/shared/status/ChatTextArea.qml
@@ -126,6 +126,48 @@ StatusTextArea {
         return highlighter.inUnclosedCodeFence(pos)
     }
 
+    // Custom copy/cut/paste preserving mention pills via a private clipboard MIME.
+    // Exposed so the external context menu and the Ctrl+C/X/V shortcuts
+    // share the exact same logic.
+
+    // Copy the current selection. No-op when there is no selection.
+    function copySelection() {
+        if (root.selectionStart === root.selectionEnd)
+            return
+        highlighter.copySelectionToClipboard(root.selectionStart, root.selectionEnd)
+    }
+
+    // Copy the selection then delete it as one joinable, mention-aware edit
+    // (deleteRange, not remove). No-op when there is no selection.
+    function cutSelection() {
+        if (root.selectionStart === root.selectionEnd)
+            return
+        highlighter.copySelectionToClipboard(root.selectionStart, root.selectionEnd)
+        TextDocumentUtils.deleteRange(root.textDocument,
+                                      root.selectionStart, root.selectionEnd)
+    }
+
+    // Paste clipboard text at the caret/selection, restoring pills and enforcing
+    // the hard character limit. Rejects the whole paste (inserts nothing) when it
+    // would exceed the limit.
+    function pasteText() {
+        // The clipboard's plain text length is the character count; for an internal
+        // mention paste this slightly over-counts (names vs 1-char pills), erring
+        // toward stricter blocking.
+        const selLen = root.selectionEnd - root.selectionStart
+        if (root.length - selLen + ClipboardUtils.text.length > root.characterLimit) {
+            root.attemptToExceedHardLimit()
+            return
+        }
+        highlighter.pasteFromClipboard(root.selectionStart, root.selectionEnd,
+                                       root.cursorPosition)
+        d.ensureCursorRectanglePosition()
+    }
+
+    // no default menu, as default actions like copy/paste won't work correctly,
+    // custom routines must be used for handling such actions.
+    ContextMenu.menu: null
+
     wrapMode: TextEdit.Wrap
     background: null
 
@@ -422,32 +464,18 @@ StatusTextArea {
         if (event.matches(StandardKey.Copy)
                 && root.selectionStart !== root.selectionEnd) {
             event.accepted = true
-            highlighter.copySelectionToClipboard(root.selectionStart, root.selectionEnd)
+            root.copySelection()
             return
         }
         if (event.matches(StandardKey.Cut)
                 && root.selectionStart !== root.selectionEnd) {
             event.accepted = true
-            highlighter.copySelectionToClipboard(root.selectionStart, root.selectionEnd)
-            // deleteRange (not root.remove) so a reactive mention demotion folds into one
-            // undo step, matching the mention-aware deletion below.
-            TextDocumentUtils.deleteRange(root.textDocument,
-                                          root.selectionStart, root.selectionEnd)
+            root.cutSelection()
             return
         }
         if (event.matches(StandardKey.Paste)) {
             event.accepted = true
-            // Reject the whole paste when it would exceed the limit (nothing is inserted). The
-            // clipboard's plain text length is the character count; for an internal mention paste
-            // this slightly over-counts (names vs 1-char pills), erring toward stricter blocking.
-            const selLen = root.selectionEnd - root.selectionStart
-            if (root.length - selLen + ClipboardUtils.text.length > root.characterLimit) {
-                root.attemptToExceedHardLimit()
-                return
-            }
-            highlighter.pasteFromClipboard(root.selectionStart, root.selectionEnd,
-                                           root.cursorPosition)
-            d.ensureCursorRectanglePosition()
+            root.pasteText()
             return
         }
 

--- a/ui/imports/shared/status/ChatTextArea.qml
+++ b/ui/imports/shared/status/ChatTextArea.qml
@@ -175,10 +175,6 @@ StatusTextArea {
         d.ensureCursorRectanglePosition()
     }
 
-    // no default menu, as default actions like copy/paste won't work correctly,
-    // custom routines must be used for handling such actions.
-    ContextMenu.menu: null
-
     wrapMode: TextEdit.Wrap
     background: null
 

--- a/ui/imports/shared/status/ChatTextArea.qml
+++ b/ui/imports/shared/status/ChatTextArea.qml
@@ -39,6 +39,11 @@ StatusTextArea {
     // exceed characterLimit.
     signal attemptToExceedHardLimit()
 
+    // Emitted when a paste is attempted while the clipboard holds an image (desktop only).
+    // ChatTextArea does not handle images itself — it signals the intent and the host decides
+    // what to do (e.g. read ClipboardUtils.imageBase64 and add it to the input's image area).
+    signal pasteImageRequested()
+
     readonly property alias linksModel: highlighter.linksModel
     readonly property alias mentionsModel: highlighter.mentionsModel
 
@@ -151,6 +156,12 @@ StatusTextArea {
     // the hard character limit. Rejects the whole paste (inserts nothing) when it
     // would exceed the limit.
     function pasteText() {
+        // Image paste is desktop-only and handled by the host: signal the intent and stop
+        // (no text is pasted). Reading the clipboard image is left to the host.
+        if (!Utils.isMobile && ClipboardUtils.hasImage) {
+            root.pasteImageRequested()
+            return
+        }
         // The clipboard's plain text length is the character count; for an internal
         // mention paste this slightly over-counts (names vs 1-char pills), erring
         // toward stricter blocking.

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -878,6 +878,37 @@ Control {
                             onActivated: toolBar.strikeThroughButton.click()
                         }
 
+                        // Edit context menu (Cut/Copy/Paste/Select All), driving the
+                        // same public methods the Ctrl+C/X/V shortcuts use so the
+                        // two stay consistent. No `id` on the StatusMenu: ContextMenu.menu
+                        // lazy-loads it on first open.
+                        ContextMenu.menu: StatusMenu {
+                            hideDisabledItems: false
+                            popupType: StatusQUtils.Utils.isIOS ? Popup.Native : Popup.Item
+
+                            StatusAction {
+                                text: qsTr("Cut")
+                                enabled: !messageInputField.noSelection
+                                onTriggered: messageInputField.cutSelection()
+                            }
+                            StatusAction {
+                                text: qsTr("Copy")
+                                enabled: !messageInputField.noSelection
+                                onTriggered: messageInputField.copySelection()
+                            }
+                            StatusAction {
+                                text: qsTr("Paste")
+                                enabled: ClipboardUtils.hasText
+                                onTriggered: messageInputField.pasteText()
+                            }
+                            StatusMenuSeparator {}
+                            StatusAction {
+                                text: qsTr("Select All")
+                                enabled: messageInputField.length > 0
+                                onTriggered: messageInputField.selectAll()
+                            }
+                        }
+
                         StatusChatInputSelectionMarker {
                             anchors.fill: parent
                             clip: true

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -892,23 +892,6 @@ Control {
                             onActivated: toolBar.strikeThroughButton.click()
                         }
 
-                        // Edit context menu (Cut/Copy/Paste/Select All), driving the
-                        // same public methods the Ctrl+C/X/V shortcuts use so the
-                        // two stay consistent. No `id` on the menu: ContextMenu.menu
-                        // lazy-loads it on first open.
-                        ContextMenu.menu: StatusTextEditMenu {
-                            canCut: !messageInputField.noSelection
-                            canCopy: !messageInputField.noSelection
-                            canPaste: ClipboardUtils.hasText
-                                      || (root.imageFeaturesEnabled && ClipboardUtils.hasImage)
-                            canSelectAll: messageInputField.length > 0
-
-                            onCutRequested: messageInputField.cutSelection()
-                            onCopyRequested: messageInputField.copySelection()
-                            onPasteRequested: messageInputField.pasteText()
-                            onSelectAllRequested: messageInputField.selectAll()
-                        }
-
                         StatusChatInputSelectionMarker {
                             anchors.fill: parent
                             clip: true
@@ -925,6 +908,12 @@ Control {
                                 messageInputField.positionToRectangle(
                                             messageInputField.selectionEnd)
                             }
+                        }
+
+                        // Lazily instantiate context menu
+                        onActiveFocusChanged: {
+                            if (activeFocus && !StatusQUtils.Utils.isMobile)
+                                contextMenuLoader.active = true
                         }
                     }
                 }
@@ -1126,6 +1115,29 @@ Control {
                     suggestionsBox.shouldHide = true
                 }
             }
+        }
+    }
+
+    Loader {
+        id: contextMenuLoader
+        active: false
+
+        // Edit context menu (Cut/Copy/Paste/Select All), driving the
+        // same public methods the Ctrl+C/X/V shortcuts use so the
+        // two stay consistent.
+        sourceComponent: StatusTextEditMenu {
+            canCut: !messageInputField.noSelection
+            canCopy: !messageInputField.noSelection
+            canPaste: ClipboardUtils.hasText
+                      || (root.imageFeaturesEnabled && ClipboardUtils.hasImage)
+            canSelectAll: messageInputField.length > 0
+
+            onCutRequested: messageInputField.cutSelection()
+            onCopyRequested: messageInputField.copySelection()
+            onPasteRequested: messageInputField.pasteText()
+            onSelectAllRequested: messageInputField.selectAll()
+
+            Component.onCompleted: messageInputField.ContextMenu.menu = this
         }
     }
 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -557,15 +557,22 @@ Control {
         height: Math.min(400, implicitHeight)
         z: parent.z + 100
 
+        // Only visible when there are actual matches. Otherwise the box would be
+        // visible-but-empty and hijack Enter/Send (checkTextInsert) into committing a
+        // non-existent row, inserting an "@undefined" pill instead of sending the text.
         visible: !shouldHide && messageInputField.enteringSuggestion
+                 && mentionsAdaptor.model.ModelCount.count > 0
 
         property bool shouldHide: false
 
         function selectItem(index: int) {
             InputMethod.commit()
 
+            if (index < 0)
+                return
+
             const item = StatusQUtils.ModelUtils.get(mentionsAdaptor.model, index)
-            if (!item)
+            if (!item || item.pubKey === undefined)
                 return
 
             messageInputField.forceActiveFocus()

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1126,10 +1126,10 @@ Control {
         // same public methods the Ctrl+C/X/V shortcuts use so the
         // two stay consistent.
         sourceComponent: StatusTextEditMenu {
-            canCut: !messageInputField.noSelection
+            canCut: !messageInputField.readOnly && !messageInputField.noSelection
             canCopy: !messageInputField.noSelection
-            canPaste: ClipboardUtils.hasText
-                      || (root.imageFeaturesEnabled && ClipboardUtils.hasImage)
+            canPaste: !messageInputField.readOnly && (ClipboardUtils.hasText
+                      || (root.imageFeaturesEnabled && ClipboardUtils.hasImage))
             canSelectAll: messageInputField.length > 0
 
             onCutRequested: messageInputField.cutSelection()

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -854,6 +854,13 @@ Control {
                                 emojiSuggestions.close()
                         }
 
+                        // Pasting an image (Ctrl+V or the context menu) adds it to the image
+                        // area instead of inserting text, when image features are enabled.
+                        onPasteImageRequested: {
+                            if (root.imageFeaturesEnabled)
+                                root.validateImagesAndShowImageArea([ClipboardUtils.imageBase64])
+                        }
+
                         Shortcut {
                             enabled: messageInputField.activeFocus
                             sequences: ["Ctrl+Meta+Space", "Ctrl+E"]
@@ -886,6 +893,7 @@ Control {
                             canCut: !messageInputField.noSelection
                             canCopy: !messageInputField.noSelection
                             canPaste: ClipboardUtils.hasText
+                                      || (root.imageFeaturesEnabled && ClipboardUtils.hasImage)
                             canSelectAll: messageInputField.length > 0
 
                             onCutRequested: messageInputField.cutSelection()

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -880,33 +880,18 @@ Control {
 
                         // Edit context menu (Cut/Copy/Paste/Select All), driving the
                         // same public methods the Ctrl+C/X/V shortcuts use so the
-                        // two stay consistent. No `id` on the StatusMenu: ContextMenu.menu
+                        // two stay consistent. No `id` on the menu: ContextMenu.menu
                         // lazy-loads it on first open.
-                        ContextMenu.menu: StatusMenu {
-                            hideDisabledItems: false
-                            popupType: StatusQUtils.Utils.isIOS ? Popup.Native : Popup.Item
+                        ContextMenu.menu: StatusTextEditMenu {
+                            canCut: !messageInputField.noSelection
+                            canCopy: !messageInputField.noSelection
+                            canPaste: ClipboardUtils.hasText
+                            canSelectAll: messageInputField.length > 0
 
-                            StatusAction {
-                                text: qsTr("Cut")
-                                enabled: !messageInputField.noSelection
-                                onTriggered: messageInputField.cutSelection()
-                            }
-                            StatusAction {
-                                text: qsTr("Copy")
-                                enabled: !messageInputField.noSelection
-                                onTriggered: messageInputField.copySelection()
-                            }
-                            StatusAction {
-                                text: qsTr("Paste")
-                                enabled: ClipboardUtils.hasText
-                                onTriggered: messageInputField.pasteText()
-                            }
-                            StatusMenuSeparator {}
-                            StatusAction {
-                                text: qsTr("Select All")
-                                enabled: messageInputField.length > 0
-                                onTriggered: messageInputField.selectAll()
-                            }
+                            onCutRequested: messageInputField.cutSelection()
+                            onCopyRequested: messageInputField.copySelection()
+                            onPasteRequested: messageInputField.pasteText()
+                            onSelectAllRequested: messageInputField.selectAll()
                         }
 
                         StatusChatInputSelectionMarker {


### PR DESCRIPTION
### What does the PR do

- restores custom context menu on desktop
- fixes pasting images by keyboard shortcut
- fixes inserting @undefined when clicking enter when cursors is after @ and some text not matching any user name

Closes: #21926
Closes: #21885

### Affected areas
Chat input

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Low

### How to test

- go to chat, right click on text area, custom menu should appear (desktop)
- type @something and accept by pressing Enter, message should be sent
- copy image to clipboard (e.g. from the browser), go to chat input, hit ctrl+V

### Risk 

Low