### PR TITLE
fix: setting up biometrics on mobile devices

### DIFF
--- a/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
+++ b/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
@@ -401,7 +401,10 @@ StatusDialog {
     }
 
     onClosed: {
-        root.keychain.cancelActiveRequest()
+        // Cancel the keychain request started from this popup, because the keychain is shared, and on success another flow
+        // (e.g. enabling biometrics) may have already started its own request by the time this popup closes.
+        if (d.biometricsInProgress)
+            root.keychain.cancelActiveRequest()
         if (root.closePopupAction)
             root.closePopupAction()
         destroy()

--- a/ui/imports/shared/popups/auth_sign_base/states/EnterPassword.qml
+++ b/ui/imports/shared/popups/auth_sign_base/states/EnterPassword.qml
@@ -29,7 +29,10 @@ Control {
 
         Image {
             Layout.alignment: Qt.AlignHCenter
+            Layout.fillHeight: true
+            Layout.minimumHeight: 0
             Layout.preferredHeight: Constants.keycard.shared.imageHeight
+            Layout.maximumHeight: Constants.keycard.shared.imageHeight
             Layout.preferredWidth: Constants.keycard.shared.imageWidth
             source: Assets.png("keycard/authenticate")
             fillMode: Image.PreserveAspectFit

--- a/ui/imports/shared/popups/auth_sign_base/states/EnterPin.qml
+++ b/ui/imports/shared/popups/auth_sign_base/states/EnterPin.qml
@@ -41,7 +41,10 @@ Control {
         Image {
             id: image
             Layout.alignment: Qt.AlignHCenter
+            Layout.fillHeight: true
+            Layout.minimumHeight: 0
             Layout.preferredHeight: Constants.keycard.shared.imageHeight
+            Layout.maximumHeight: Constants.keycard.shared.imageHeight
             Layout.preferredWidth: Constants.keycard.shared.imageWidth
             source: root.wrongPin ? Assets.png("keycard/pin/negative")
                                   : Assets.png("keycard/pin/in-progress")

--- a/ui/imports/shared/popups/authentication/stores/AuthenticationStore.qml
+++ b/ui/imports/shared/popups/authentication/stores/AuthenticationStore.qml
@@ -66,8 +66,8 @@ QtObject {
         if (d.keycardAuthentication) {
             d.mainModuleInst.authenticationModule.stopKeycardAuthentication()
         }
-        d.mainModuleInst.destroyAuthenticationModule()
         d.ready = false
+        d.mainModuleInst.destroyAuthenticationModule()
         d.keycardAuthentication = false
     }
 


### PR DESCRIPTION
PopupBase's onClosed was unconditionally calling keychain.cancelActiveRequest() and that way killing the biometric's prompt that was opened by saveCredential call.

An issue with coverd pin/password input by virtual keyboard on mobile devices is also fixed.

Fixes #21857
Fixes https://github.com/status-im/status-app/issues/21859

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/d724a4aa-9dec-47f2-a4cb-b425118c4e86" />
