### PR TITLE
tests(@qml): cover keycard login, management and re-auth UI states

### DIFF
--- a/storybook/pages/KeycardAuthPage.qml
+++ b/storybook/pages/KeycardAuthPage.qml
@@ -1,0 +1,46 @@
+import QtQuick
+import QtQuick.Controls
+
+import shared.popups.auth_sign_base.states
+
+Item {
+    id: root
+
+    KeycardAuth {
+        anchors.fill: parent
+        anchors.bottomMargin: 40
+
+        userProfilePublicKey: "0xpub"
+        keycardState: ctrlState.currentText
+        keycardInternalError: ctrlInternalError.checked
+        wrongKeycardProfile: ctrlWrongProfile.checked
+    }
+
+    Row {
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: 8
+        spacing: 8
+
+        CheckBox {
+            id: ctrlWrongProfile
+            text: "wrongKeycardProfile"
+        }
+
+        CheckBox {
+            id: ctrlInternalError
+            text: "keycardInternalError"
+        }
+
+        ComboBox {
+            id: ctrlState
+            width: 260
+            model: ["waiting-for-card", "connecting-card", "ready", "empty-keycard",
+                    "not-keycard", "blocked-pin", "blocked-puk", "pairing-error",
+                    "no-available-pairing-slots", "authorized"]
+        }
+    }
+}
+
+// category: Popups
+// status: good

--- a/storybook/pages/KeycardDetailsPagePage.qml
+++ b/storybook/pages/KeycardDetailsPagePage.qml
@@ -1,0 +1,73 @@
+import QtQuick
+import QtQuick.Controls
+
+import AppLayouts.Onboarding.pages
+
+Item {
+    id: root
+
+    ListModel {
+        id: loginAccounts
+
+        ListElement {
+            keyUid: "profile-key-uid-1"
+            username: "Alice"
+            colorId: 0
+            thumbnailImage: ""
+        }
+    }
+
+    ListModel {
+        id: emptyLoginAccounts
+    }
+
+    KeycardDetailsPage {
+        anchors.fill: parent
+        anchors.bottomMargin: 80
+
+        keycardState: ctrlState.currentText
+        keycardUid: "keycard-uid-1"
+        keyUid: ctrlOnlyPin.checked ? "" : "profile-key-uid-1"
+        keycardStatusAvailable: true
+        remainingPinAttempts: ctrlBlocked.checked ? 0 : 3
+        remainingPukAttempts: 5
+        availableSlots: ctrlNoSlots.checked ? 0 : 5
+        cardMetadataName: "My Keycard"
+        cardMetadataWalletAccountsJson: "[]"
+        loginAccountsModel: ctrlProfileExists.checked ? loginAccounts : emptyLoginAccounts
+    }
+
+    Column {
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: 8
+        spacing: 4
+
+        CheckBox {
+            id: ctrlProfileExists
+            text: "profile already exists"
+            checked: true
+        }
+        CheckBox {
+            id: ctrlOnlyPin
+            text: "only PIN set"
+        }
+        CheckBox {
+            id: ctrlNoSlots
+            text: "no free slots"
+        }
+        CheckBox {
+            id: ctrlBlocked
+            text: "blocked (0 PIN attempts)"
+        }
+        ComboBox {
+            id: ctrlState
+            width: 260
+            model: ["ready", "empty-keycard", "blocked-pin", "blocked-puk",
+                    "no-available-pairing-slots"]
+        }
+    }
+}
+
+// category: Onboarding
+// status: good

--- a/storybook/qmlTests/tests/tst_KeycardAuth.qml
+++ b/storybook/qmlTests/tests/tst_KeycardAuth.qml
@@ -1,0 +1,111 @@
+import QtQuick
+
+import QtTest
+
+import shared.popups.auth_sign_base.states
+
+import utils
+
+Item {
+    id: root
+
+    width: 480
+    height: 520
+
+    Component {
+        id: componentUnderTest
+
+        KeycardAuth {
+            width: root.width
+            height: root.height
+            userProfilePublicKey: "0xpub"
+            keycardState: Constants.keycard.state.waitingForCard
+            keycardInternalError: false
+            wrongKeycardProfile: false
+            keyPairForProcessing: null
+        }
+    }
+
+    TestCase {
+        name: "KeycardAuth_pinLoaderStates"
+        when: windowShown
+
+        function test_states_data() {
+            return [
+                {
+                    tag: "waiting-for-card",
+                    keycardState: Constants.keycard.state.waitingForCard,
+                    wrongKeycardProfile: false,
+                    expectedState: "waiting-for-card",
+                    expectedTitle: "Tap or insert Keycard..."
+                },
+                {
+                    tag: "reading-card-connecting",
+                    keycardState: Constants.keycard.state.connectingCard,
+                    wrongKeycardProfile: false,
+                    expectedState: "reading-card",
+                    expectedTitle: "Reading Keycard..."
+                },
+                {
+                    tag: "reading-card-ready",
+                    keycardState: Constants.keycard.state.ready,
+                    wrongKeycardProfile: false,
+                    expectedState: "reading-card",
+                    expectedTitle: "Reading Keycard..."
+                },
+                {
+                    tag: "wrong-keycard-profile",
+                    keycardState: Constants.keycard.state.ready,
+                    wrongKeycardProfile: true,
+                    expectedState: "wrong-keycard-profile",
+                    expectedTitle: "Wrong Keycard inserted"
+                },
+                {
+                    tag: "auth-success",
+                    keycardState: Constants.keycard.state.authorized,
+                    wrongKeycardProfile: false,
+                    expectedState: "auth-success",
+                    expectedTitle: "Success"
+                },
+                {
+                    tag: "blocked-pin",
+                    keycardState: Constants.keycard.state.blockedPIN,
+                    wrongKeycardProfile: false,
+                    expectedState: "blocked-pin",
+                    expectedTitle: "Keycard locked",
+                    expectedMessage: "PIN entered incorrectly too many times"
+                },
+                {
+                    tag: "blocked-puk",
+                    keycardState: Constants.keycard.state.blockedPUK,
+                    wrongKeycardProfile: false,
+                    expectedState: "blocked-puk",
+                    expectedTitle: "Keycard locked",
+                    expectedMessage: "PUK entered incorrectly too many times"
+                },
+            ]
+        }
+
+        function test_states(data) {
+            const auth = createTemporaryObject(componentUnderTest, root, {
+                                                   keycardState: data.keycardState,
+                                                   wrongKeycardProfile: data.wrongKeycardProfile
+                                               })
+            verify(!!auth)
+            compare(auth.state, data.expectedState)
+            compare(findChild(auth, "keycardAuthTitle").text, data.expectedTitle)
+            if (data.expectedMessage)
+                compare(findChild(auth, "keycardAuthMessage").text, data.expectedMessage)
+        }
+
+        function test_connectingCardShowsLoader() {
+            const auth = createTemporaryObject(componentUnderTest, root, {
+                                                   keycardState: Constants.keycard.state.connectingCard
+                                               })
+            verify(!!auth)
+            const loader = findChild(auth, "keycardAuthLoadingIndicator")
+            verify(!!loader)
+            verify(loader.visible)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_KeycardDetailsPage.qml
+++ b/storybook/qmlTests/tests/tst_KeycardDetailsPage.qml
@@ -1,0 +1,155 @@
+import QtQuick
+
+import QtTest
+
+import AppLayouts.Onboarding.pages
+
+import utils
+
+Item {
+    id: root
+
+    width: 800
+    height: 700
+
+    readonly property string profileKeyUid: "profile-key-uid-1"
+
+    ListModel {
+        id: loginAccounts
+
+        ListElement {
+            keyUid: "profile-key-uid-1"
+            username: "Alice"
+            colorId: 0
+            thumbnailImage: ""
+        }
+    }
+
+    ListModel {
+        id: emptyLoginAccounts
+    }
+
+    Component {
+        id: componentUnderTest
+
+        KeycardDetailsPage {
+            width: root.width
+            height: root.height
+
+            keycardState: Constants.keycard.state.ready
+            keycardUid: "keycard-uid-1"
+            keyUid: root.profileKeyUid
+            keycardStatusAvailable: true
+            remainingPinAttempts: 3
+            remainingPukAttempts: 5
+            availableSlots: 5
+            cardMetadataName: "My Keycard"
+            cardMetadataWalletAccountsJson: "[]"
+            loginAccountsModel: loginAccounts
+        }
+    }
+
+    SignalSpy {
+        id: goBackSpy
+        signalName: "goBackToLoginRequested"
+    }
+
+    TestCase {
+        name: "KeycardDetailsPage_profileAlreadyExists"
+        when: windowShown
+
+        function test_showsProfileAlreadyExists() {
+            const page = createTemporaryObject(componentUnderTest, root)
+            verify(!!page)
+
+            compare(findChild(page, "keycardDetailsTitle").text, "Profile already exists")
+            compare(findChild(page, "keycardDetailsInfoMessage").text,
+                    "Profile for key pair stored on Keycard already added to this device.")
+        }
+
+        function test_hidesLoginWithThisKeycard() {
+            const page = createTemporaryObject(componentUnderTest, root)
+            verify(!!page)
+
+            const loginItem = findChild(page, "keycardDetailsLoginWithThisKeycard")
+            verify(!!loginItem)
+            verify(!loginItem.visible,
+                   "login with this Keycard must be hidden when the profile is already on device")
+        }
+
+        function test_showsGoBackToLoginAndEmitsSignal() {
+            const page = createTemporaryObject(componentUnderTest, root)
+            verify(!!page)
+
+            goBackSpy.target = page
+            goBackSpy.clear()
+
+            const goBack = findChild(page, "keycardDetailsGoBackToLogin")
+            verify(!!goBack)
+            verify(goBack.visible)
+
+            mouseClick(goBack)
+            compare(goBackSpy.count, 1)
+        }
+
+        function test_withoutMatchingProfileOffersLogin() {
+            const page = createTemporaryObject(componentUnderTest, root, {
+                                                   loginAccountsModel: emptyLoginAccounts
+                                               })
+            verify(!!page)
+
+            compare(findChild(page, "keycardDetailsTitle").text, "Keycard stores key pair")
+            verify(findChild(page, "keycardDetailsLoginWithThisKeycard").visible)
+            verify(!findChild(page, "keycardDetailsGoBackToLogin").visible)
+        }
+    }
+
+    TestCase {
+        name: "KeycardDetailsPage_edgeStates"
+        when: windowShown
+
+        function test_onlyPinSet() {
+            const page = createTemporaryObject(componentUnderTest, root, {
+                                                   keyUid: "",
+                                                   loginAccountsModel: emptyLoginAccounts
+                                               })
+            verify(!!page)
+
+            compare(findChild(page, "keycardDetailsTitle").text, "Keycard stores only PIN")
+            verify(findChild(page, "keycardDetailsImportNewKeypair").visible)
+            verify(findChild(page, "keycardDetailsImportSeedPhrase").visible)
+            verify(findChild(page, "keycardDetailsFactoryReset").visible)
+            verify(!findChild(page, "keycardDetailsLoginWithThisKeycard").visible)
+            verify(!findChild(page, "keycardDetailsGoBackToLogin").visible)
+        }
+
+        function test_noFreePairingSlots() {
+            const page = createTemporaryObject(componentUnderTest, root, {
+                                                   keycardState: Constants.keycard.state.noAvailablePairingSlots,
+                                                   loginAccountsModel: emptyLoginAccounts
+                                               })
+            verify(!!page)
+
+            compare(findChild(page, "keycardDetailsTitle").text, "No free pairing slots")
+            compare(findChild(page, "keycardDetailsInfoMessage").text,
+                    "You can’t operate with Keycard content right now, because Keycard has no free pairing slots. But you can use it with previously paired installations.")
+            verify(findChild(page, "keycardDetailsFactoryReset").visible)
+            verify(!findChild(page, "keycardDetailsImportNewKeypair").visible)
+            verify(!findChild(page, "keycardDetailsLoginWithThisKeycard").visible)
+        }
+
+        function test_blockedPinOffersUnblockActions() {
+            const page = createTemporaryObject(componentUnderTest, root, {
+                                                   keycardState: Constants.keycard.state.blockedPIN,
+                                                   remainingPinAttempts: 0,
+                                                   loginAccountsModel: emptyLoginAccounts
+                                               })
+            verify(!!page)
+
+            compare(findChild(page, "keycardDetailsTitle").text, "Keycard is blocked")
+            verify(findChild(page, "keycardDetailsUnblockWithRecovery").visible)
+            verify(findChild(page, "keycardDetailsUnblockWithPuk").visible)
+            verify(!findChild(page, "keycardDetailsLoginWithThisKeycard").visible)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_KeycardManagementPopup.qml
+++ b/storybook/qmlTests/tests/tst_KeycardManagementPopup.qml
@@ -5,17 +5,8 @@ import QtTest
 
 import utils
 
-import shared.popups.keycard_new 1.0
+import shared.popups.keycard_new
 
-/*!
-    Covers the custom pairing password flow: cards provisioned outside the app (e.g. on the
-    Keycard shell) reject the default pairing password, and the popup has to ask the user for
-    theirs and re-run the *same* operation with the *same* arguments rather than abandoning the
-    flow and sending the user back to re-reading the card.
-
-    The re-invocation is driven by a stored `d.lastInvocation` callable, so the assertion that
-    matters most is argument-for-argument equality between the original call and the retry.
-*/
 Item {
     id: root
 
@@ -39,7 +30,6 @@ Item {
         property string userProfilePubKey: "0xpub"
         property bool isProfileMigratedToColdWallet: false
 
-        // Every invocation, so a test can assert the retry matches the original call exactly.
         property var calls: []
 
         function record(name, args) {
@@ -116,8 +106,6 @@ Item {
         id: componentUnderTest
 
         KeycardManagementPopup {
-            // readKeycard launches its operation from a single PIN entry, which makes it the
-            // cheapest flow to drive end to end.
             flow: Constants.keycard.flow.readKeycard
             keycardUid: mockStore.keycardUid
             keyUid: mockStore.keyUid
@@ -141,8 +129,6 @@ Item {
         name: "KeycardManagementPopup_pairingPassword"
         when: windowShown
 
-        // What a composite operation returns when the card rejects the pairing password: the
-        // session state is embedded in the error text, which is how the popup recognises it.
         readonly property string pairingErrorText: "Card not ready (state: pairing-error)"
         readonly property string testPin: "123456"
 
@@ -169,14 +155,10 @@ Item {
             return findChild(popup, "enterPairingPasswordStep")
         }
 
-        // Submission is owned by the popup's shared primary footer button, which has no
-        // objectName to bind to, so drive the step's action directly — that is exactly what the
-        // footer button's onClicked does.
         function submitPairingPassword() {
             pairingStep().accepted()
         }
 
-        // Enters the PIN, which launches startGetMetadata after the popup's 500ms debounce.
         function launchReadKeycard() {
             const pinInput = findChild(popup, "keycardManagementPinInput")
             verify(!!pinInput, "expected the PIN step to be shown")
@@ -200,15 +182,11 @@ Item {
             tryVerify(() => !!pairingPasswordInput(), 3000,
                       "expected the pairing password step to be shown")
 
-            // Nothing typed yet, so the footer button this drives stays disabled.
             verify(!pairingStep().pairingPasswordValid,
                    "an empty pairing password must not be submittable")
         }
 
         function test_pairingErrorStateShowsPasswordStepEvenWhenOperationSucceeds() {
-            // Reading a card without a PIN can come back "successful" while the card was never
-            // paired; only the reported state says so. Leaving the popup then would strand the
-            // user on a details view built from an unpaired card.
             launchReadKeycard()
             mockStore.keycardState = "pairing-error"
             mockStore.keycardGetMetadataSuccess()
@@ -219,7 +197,6 @@ Item {
         }
 
         function test_pairingErrorStateDoesNotPromptBeforeAnyAttempt() {
-            // Nothing has been attempted yet, so there would be nothing to retry.
             mockStore.keycardState = "pairing-error"
             wait(50)
 
@@ -228,7 +205,6 @@ Item {
         }
 
         function test_wrongPinErrorDoesNotShowPasswordStep() {
-            // Guards against the new branch swallowing unrelated errors.
             launchReadKeycard()
             mockStore.keycardGetMetadataError("Wrong PIN")
             wait(50)
@@ -237,7 +213,6 @@ Item {
         }
 
         function test_noAvailablePairingSlotsDoesNotShowPasswordStep() {
-            // Not recoverable by entering a password, so it keeps its own terminal handling.
             launchReadKeycard()
             mockStore.keycardGetMetadataError("Card not ready (state: no-available-pairing-slots)")
             wait(50)
@@ -263,7 +238,6 @@ Item {
 
             const retry = mockStore.calls[1]
             compare(retry.name, firstCall.name)
-            // Everything but the pairing password must be identical to the original call.
             compare(retry.args[0], firstCall.args[0], "the retry must reuse the original PIN")
             compare(retry.args[1], "MyCustomPass", "the retry must carry the entered pairing password")
         }
@@ -274,8 +248,6 @@ Item {
             mockStore.keycardGetMetadataError(pairingErrorText)
             tryVerify(() => !!pairingPasswordInput(), 3000)
 
-            // User swaps the card while the prompt is up. The entered password belongs to the
-            // previous card and must not be sent to this one.
             mockStore.keycardUid = "keycard-uid-2"
 
             pairingPasswordInput().text = "MyCustomPass"
@@ -295,14 +267,442 @@ Item {
             submitPairingPassword()
             tryVerify(() => mockStore.calls.length === 2, 3000)
 
-            // The card rejects it again; the step must come back flagged as incorrect so the
-            // user sees the password was wrong rather than a silent no-op.
             mockStore.keycardGetMetadataError(pairingErrorText)
             tryVerify(() => !!findChild(popup, "enterPairingPasswordStep"), 3000)
 
             const step = findChild(popup, "enterPairingPasswordStep")
             verify(step.wrongPairingPassword,
                    "a repeated pairing error while holding a password means that password was wrong")
+        }
+    }
+
+    Component {
+        id: popupFactory
+
+        KeycardManagementPopup {
+            keycardUid: mockStore.keycardUid
+            keyUid: mockStore.keyUid
+            cardMetadataName: mockStore.cardMetadataName
+            cardMetadataWalletAccountsJson: mockStore.cardMetadataWalletAccountsJson
+            store: mockStore
+            closePolicy: Popup.NoAutoClose
+            passwordStrengthScoreFunction: (password) => 4
+        }
+    }
+
+    TestCase {
+        name: "KeycardManagementPopup_changePin"
+        when: windowShown
+
+        readonly property string currentPin: "123456"
+        readonly property string newPin: "654321"
+        readonly property string mismatchedPin: "111111"
+
+        function init() {
+            mockStore.calls = []
+            mockStore.keycardState = "ready"
+            mockStore.keycardUid = "keycard-uid-1"
+            popup = createTemporaryObject(popupFactory, root, {
+                                              flow: Constants.keycard.flow.changePin
+                                          })
+            verify(!!popup)
+            popup.open()
+        }
+
+        function cleanup() {
+            if (popup)
+                popup.close()
+        }
+
+        function pinInput() {
+            return findChild(popup, "keycardManagementPinInput")
+        }
+
+        function pinTitle() {
+            return findChild(popup, "keycardPinStepTitle")
+        }
+
+        function pinError() {
+            return findChild(popup, "keycardPinStepError")
+        }
+
+        function enterPin(pin) {
+            const input = pinInput()
+            verify(!!input, "expected a PIN step")
+            input.setPin(pin)
+        }
+
+        function test_startsOnEnterCurrentPin() {
+            compare(pinTitle().text, "Enter Keycard PIN")
+        }
+
+        function test_happyPathChangesPin() {
+            enterPin(currentPin)
+            tryVerify(() => pinTitle().text === "Enter new PIN", 3000)
+
+            enterPin(newPin)
+            tryVerify(() => pinTitle().text === "Repeat new PIN", 3000)
+
+            enterPin(newPin)
+            tryVerify(() => mockStore.calls.length === 1, 3000)
+
+            const call = mockStore.calls[0]
+            compare(call.name, "startChangeKeycardPIN")
+            compare(call.args[0], currentPin)
+            compare(call.args[1], newPin)
+            compare(call.args[2], "", "change PIN starts with the default pairing password")
+
+            mockStore.keycardChangePinSuccess()
+
+            tryVerify(() => {
+                          const title = findChild(popup, "keycardProgressTitle")
+                          return !!title && title.text === "Keycard PIN has been changed"
+                      }, 3000)
+            compare(findChild(popup, "keycardProgressMessage").text,
+                    "New PIN is required to interact with Keycard.")
+        }
+
+        function test_repeatPinMismatchShowsError() {
+            enterPin(currentPin)
+            tryVerify(() => pinTitle().text === "Enter new PIN", 3000)
+
+            enterPin(newPin)
+            tryVerify(() => pinTitle().text === "Repeat new PIN", 3000)
+
+            enterPin(mismatchedPin)
+
+            tryVerify(() => pinError().visible, 3000)
+            compare(pinError().text, "PIN doesn't match")
+            compare(mockStore.calls.length, 0, "mismatch must not start the change-PIN operation")
+        }
+    }
+
+    TestCase {
+        name: "KeycardManagementPopup_setOrChangePuk"
+        when: windowShown
+
+        readonly property string currentPin: "123456"
+        readonly property string newPuk: "123456789012"
+        readonly property string mismatchedPuk: "999999999999"
+
+        function init() {
+            mockStore.calls = []
+            mockStore.keycardState = "ready"
+            mockStore.keycardUid = "keycard-uid-1"
+            popup = createTemporaryObject(popupFactory, root, {
+                                              flow: Constants.keycard.flow.setOrChangePuk
+                                          })
+            verify(!!popup)
+            popup.open()
+        }
+
+        function cleanup() {
+            if (popup)
+                popup.close()
+        }
+
+        function pinInput() { return findChild(popup, "keycardManagementPinInput") }
+        function pukInput() { return findChild(popup, "keycardManagementPukInput") }
+        function pukTitle() { return findChild(popup, "keycardPukStepTitle") }
+        function nextButton() { return findChild(popup, "keycardManagementNextButton") }
+
+        function enterPin(pin) {
+            const input = pinInput()
+            verify(!!input)
+            input.setPin(pin)
+        }
+
+        function enterPukAndNext(puk) {
+            const input = pukInput()
+            verify(!!input, "expected a PUK step")
+            input.setPin(puk)
+            tryVerify(() => nextButton().enabled, 3000)
+            nextButton().clicked()
+        }
+
+        function test_happyPathSetsPuk() {
+            enterPin(currentPin)
+            tryVerify(() => !!pukTitle() && pukTitle().text === "Choose a Keycard PUK", 3000)
+
+            enterPukAndNext(newPuk)
+            tryVerify(() => pukTitle().text === "Repeat your Keycard PUK", 3000)
+
+            enterPukAndNext(newPuk)
+            tryVerify(() => mockStore.calls.length === 1, 3000)
+
+            const call = mockStore.calls[0]
+            compare(call.name, "startChangeKeycardPUK")
+            compare(call.args[0], currentPin)
+            compare(call.args[1], newPuk)
+            compare(call.args[2], "")
+
+            mockStore.keycardChangePukSuccess()
+            tryVerify(() => {
+                          const title = findChild(popup, "keycardProgressTitle")
+                          return !!title && title.text === "Keycard’s PUK successfully set"
+                      }, 3000)
+        }
+
+        function test_repeatPukMismatchShowsError() {
+            enterPin(currentPin)
+            tryVerify(() => !!pukTitle() && pukTitle().text === "Choose a Keycard PUK", 3000)
+
+            enterPukAndNext(newPuk)
+            tryVerify(() => pukTitle().text === "Repeat your Keycard PUK", 3000)
+
+            pukInput().setPin(mismatchedPuk)
+            tryVerify(() => findChild(popup, "keycardPukStepError").visible, 3000)
+            compare(findChild(popup, "keycardPukStepError").text, "PUK doesn't match")
+            compare(mockStore.calls.length, 0)
+        }
+    }
+
+    TestCase {
+        name: "KeycardManagementPopup_rename"
+        when: windowShown
+
+        readonly property string currentPin: "123456"
+        readonly property string newName: "Renamed Card"
+
+        function init() {
+            mockStore.calls = []
+            mockStore.keycardState = "ready"
+            mockStore.keycardUid = "keycard-uid-1"
+            mockStore.cardMetadataName = "My Keycard"
+            popup = createTemporaryObject(popupFactory, root, {
+                                              flow: Constants.keycard.flow.rename
+                                          })
+            verify(!!popup)
+            popup.open()
+        }
+
+        function cleanup() {
+            if (popup)
+                popup.close()
+        }
+
+        function test_happyPathRenamesKeycard() {
+            const pinInput = findChild(popup, "keycardManagementPinInput")
+            verify(!!pinInput)
+            pinInput.setPin(currentPin)
+
+            tryVerify(() => !!findChild(popup, "keycardKeyPairNameInput"), 3000)
+            const nameInput = findChild(popup, "keycardKeyPairNameInput")
+            nameInput.text = newName
+
+            const next = findChild(popup, "keycardManagementNextButton")
+            tryVerify(() => next.visible && next.enabled, 3000)
+            compare(next.text, "Rename")
+            next.clicked()
+
+            tryVerify(() => mockStore.calls.length === 1, 3000)
+            const call = mockStore.calls[0]
+            compare(call.name, "startRenameKeycard")
+            compare(call.args[0], currentPin)
+            compare(call.args[1], newName)
+            compare(call.args[2], mockStore.cardMetadataWalletAccountsJson)
+            compare(call.args[3], "")
+
+            mockStore.keycardRenameSuccess()
+            tryVerify(() => {
+                          const title = findChild(popup, "keycardProgressTitle")
+                          return !!title && title.text === "Keycard has been renamed"
+                      }, 3000)
+            compare(findChild(popup, "keycardProgressMessage").text, "New name: Renamed Card")
+        }
+    }
+
+    TestCase {
+        name: "KeycardManagementPopup_addKeyPairToStatus"
+        when: windowShown
+
+        readonly property string pin: "123456"
+
+        function init() {
+            mockStore.calls = []
+            mockStore.keycardState = "ready"
+            mockStore.keycardUid = "keycard-uid-1"
+            mockStore.keyUid = "profile-key-uid"
+            mockStore.cardMetadataName = "My Keycard"
+            popup = createTemporaryObject(popupFactory, root, {
+                                              flow: Constants.keycard.flow.addKeyPairToStatus
+                                          })
+            verify(!!popup)
+            popup.open()
+        }
+
+        function cleanup() {
+            if (popup)
+                popup.close()
+        }
+
+        function test_happyPathAddsKeyPair() {
+            findChild(popup, "keycardManagementPinInput").setPin(pin)
+
+            tryVerify(() => {
+                          const title = findChild(popup, "keycardKeyPairNameTitle")
+                          return !!title && title.text === "Name your key pair"
+                      }, 3000)
+            compare(findChild(popup, "keycardKeyPairNameInput").text, "My Keycard")
+
+            const next = findChild(popup, "keycardManagementNextButton")
+            tryVerify(() => next.enabled, 3000)
+            next.clicked()
+
+            tryVerify(() => !!findChild(popup, "keycardManageAccountNameInput"), 3000)
+            findChild(popup, "keycardManageAccountNameInput").text = "Account One"
+            tryVerify(() => next.enabled && next.text === "Continue", 3000)
+            next.clicked()
+
+            tryVerify(() => mockStore.calls.length === 1, 3000)
+            const call = mockStore.calls[0]
+            compare(call.name, "startAddingKeyPairToStatusFromKeycard")
+            compare(call.args[0], pin)
+            compare(call.args[1], "profile-key-uid")
+            compare(call.args[2], "My Keycard")
+            verify(call.args[3].indexOf("Account One") !== -1)
+            compare(call.args[4], "")
+
+            mockStore.keycardAddKeyPairSuccess()
+            tryVerify(() => {
+                          const title = findChild(popup, "keycardProgressTitle")
+                          return !!title && title.text === "Key pair has been added to Status"
+                      }, 3000)
+            compare(findChild(popup, "keycardProgressMessage").text,
+                    "Now you can sign with this key pair using Keycard.")
+        }
+    }
+
+    TestCase {
+        name: "KeycardManagementPopup_factoryReset"
+        when: windowShown
+
+        function init() {
+            mockStore.calls = []
+            mockStore.keycardState = "ready"
+            mockStore.keycardUid = "keycard-uid-1"
+            popup = createTemporaryObject(popupFactory, root, {
+                                              flow: Constants.keycard.flow.factoryReset
+                                          })
+            verify(!!popup)
+            popup.open()
+        }
+
+        function cleanup() {
+            if (popup)
+                popup.close()
+        }
+
+        function test_happyPathFactoryResets() {
+            const checkbox = findChild(popup, "keycardFactoryResetConfirmCheckbox")
+            const resetButton = findChild(popup, "keycardManagementFactoryResetButton")
+            verify(!!checkbox)
+            verify(!!resetButton)
+            verify(!resetButton.enabled)
+
+            checkbox.checked = true
+            tryVerify(() => resetButton.enabled, 3000)
+            resetButton.clicked()
+
+            tryVerify(() => mockStore.calls.length === 1, 3000)
+            compare(mockStore.calls[0].name, "startFactoryReset")
+            compare(mockStore.calls[0].args[0], "keycard-uid-1")
+
+            mockStore.keycardFactoryResetSuccess()
+            tryVerify(() => {
+                          const title = findChild(popup, "keycardProgressTitle")
+                          return !!title && title.text === "Keycard has been reset"
+                      }, 3000)
+            compare(findChild(popup, "keycardProgressMessage").text, "Keycard is now empty.")
+        }
+    }
+
+    TestCase {
+        name: "KeycardManagementPopup_unblockWithPuk"
+        when: windowShown
+
+        readonly property string newPin: "654321"
+        readonly property string puk: "123456789012"
+
+        function init() {
+            mockStore.calls = []
+            mockStore.keycardState = "blocked-pin"
+            mockStore.keycardUid = "keycard-uid-1"
+            popup = createTemporaryObject(popupFactory, root, {
+                                              flow: Constants.keycard.flow.unblockWithPuk
+                                          })
+            verify(!!popup)
+            popup.open()
+        }
+
+        function cleanup() {
+            if (popup)
+                popup.close()
+        }
+
+        function test_happyPathUnblocksWithPuk() {
+            tryVerify(() => findChild(popup, "keycardPinStepTitle").text === "Enter new PIN", 3000)
+            findChild(popup, "keycardManagementPinInput").setPin(newPin)
+
+            tryVerify(() => findChild(popup, "keycardPinStepTitle").text === "Repeat new PIN", 3000)
+            findChild(popup, "keycardManagementPinInput").setPin(newPin)
+
+            tryVerify(() => findChild(popup, "keycardPukStepTitle").text === "Enter PUK", 3000)
+            findChild(popup, "keycardManagementPukInput").setPin(puk)
+            const next = findChild(popup, "keycardManagementNextButton")
+            tryVerify(() => next.enabled, 3000)
+            next.clicked()
+
+            tryVerify(() => mockStore.calls.length === 1, 3000)
+            const call = mockStore.calls[0]
+            compare(call.name, "startUnblockKeycardUsingPuk")
+            compare(call.args[0], newPin)
+            compare(call.args[1], puk)
+            compare(call.args[2], "")
+
+            mockStore.keycardUnblockSuccess()
+            tryVerify(() => {
+                          const title = findChild(popup, "keycardProgressTitle")
+                          return !!title && title.text === "Keycard has been unblocked"
+                      }, 3000)
+            compare(findChild(popup, "keycardProgressMessage").text,
+                    "You can now use your Keycard again")
+        }
+    }
+
+    TestCase {
+        name: "KeycardManagementPopup_unblockWithRecoveryPhrase"
+        when: windowShown
+
+        readonly property string newPin: "654321"
+
+        function init() {
+            mockStore.calls = []
+            mockStore.keycardState = "blocked-pin"
+            mockStore.keycardUid = "keycard-uid-1"
+            popup = createTemporaryObject(popupFactory, root, {
+                                              flow: Constants.keycard.flow.unblockWithRecoveryPhrase
+                                          })
+            verify(!!popup)
+            popup.open()
+        }
+
+        function cleanup() {
+            if (popup)
+                popup.close()
+        }
+
+        function test_reachesRecoveryPhraseStep() {
+            findChild(popup, "keycardManagementPinInput").setPin(newPin)
+            tryVerify(() => findChild(popup, "keycardPinStepTitle").text === "Repeat new PIN", 3000)
+            findChild(popup, "keycardManagementPinInput").setPin(newPin)
+
+            tryVerify(() => {
+                          const title = findChild(popup, "keycardSeedPhraseStepTitle")
+                          return !!title && title.text === "Enter recovery phrase"
+                      }, 3000)
+            compare(mockStore.calls.length, 0,
+                    "must not start unblock until the recovery phrase is submitted")
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_KeycardProgressState.qml
+++ b/storybook/qmlTests/tests/tst_KeycardProgressState.qml
@@ -4,16 +4,8 @@ import QtTest
 
 import utils
 
-import shared.popups.keycard_new.states 1.0
+import shared.popups.keycard_new.states
 
-/*!
-    KeycardProgressState is a pure state machine with no fallback: `failure` is bound to
-    \c root.failure rather than acting as a catch-all, so a card state that matches no \c when
-    clause applies no PropertyChanges at all and the step renders blank.
-
-    The readKeycard flow pins both \c processing and \c failure to false and is therefore driven
-    solely by the card state, which makes every unmapped value visible to the user there.
-*/
 Item {
     id: root
 
@@ -54,9 +46,6 @@ Item {
                 {tag: "waiting-for-reader", keycardState: Constants.keycard.state.waitingForReader},
                 {tag: "waiting-for-card", keycardState: Constants.keycard.state.waitingForCard},
                 {tag: "ready", keycardState: Constants.keycard.state.ready},
-                // Reached while a retry restarts the operation with a newly supplied pairing
-                // password: the card still reports the previous failure until detection produces
-                // a fresh status.
                 {tag: "pairing-error", keycardState: Constants.keycard.state.pairingError},
             ]
         }
@@ -67,6 +56,39 @@ Item {
             verify(!!progress)
             verify(progress.contentItem.state !== "",
                    "no state matched '%1', so the step would render blank".arg(data.keycardState))
+        }
+
+        function test_blockedAndFailureStates_data() {
+            return [
+                {
+                    tag: "blocked-pin",
+                    props: {
+                        failure: true,
+                        keycardState: Constants.keycard.state.blockedPIN
+                    },
+                    expectedState: "blocked-pin",
+                    expectedTitle: "Keycard is blocked",
+                    expectedMessage: "Keycard is blocked due to three failed PIN input attempts"
+                },
+                {
+                    tag: "blocked-puk",
+                    props: {
+                        failure: true,
+                        keycardState: Constants.keycard.state.blockedPUK
+                    },
+                    expectedState: "blocked-puk",
+                    expectedTitle: "Keycard is blocked",
+                    expectedMessage: "Keycard is blocked due to five failed PUK input attempts"
+                },
+            ]
+        }
+
+        function test_blockedAndFailureStates(data) {
+            const progress = createTemporaryObject(componentUnderTest, root, data.props)
+            verify(!!progress)
+            compare(progress.contentItem.state, data.expectedState)
+            compare(findChild(progress, "keycardProgressTitle").text, data.expectedTitle)
+            compare(findChild(progress, "keycardProgressMessage").text, data.expectedMessage)
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_LoginKeycardBox.qml
+++ b/storybook/qmlTests/tests/tst_LoginKeycardBox.qml
@@ -2,18 +2,11 @@ import QtQuick
 
 import QtTest
 
-import AppLayouts.Onboarding.components 1.0
-import AppLayouts.Onboarding.enums 1.0
+import StatusQ.Core.Theme
 
-/*!
-    Covers the custom pairing password step on the login screen: a card provisioned outside the
-    app (e.g. on the Keycard shell) rejects the default pairing password, and the box has to
-    collect the user's password and hand it back so the login can be re-run.
+import AppLayouts.Onboarding.components
+import AppLayouts.Onboarding.enums
 
-    Submitting is deliberately a separate signal from loginRequested(): every keycard login
-    failure is reported as a wrong PIN, which clears the PIN input, so the box has no PIN left to
-    re-send. The login screen keeps the last PIN and re-issues the login itself.
-*/
 Item {
     id: root
 
@@ -109,6 +102,57 @@ Item {
             passwordInput().accepted()
 
             compare(submittedSpy.count, 0)
+        }
+    }
+
+    TestCase {
+        name: "LoginKeycardBox_cardStates"
+        when: windowShown
+
+        function init() {
+            box = createTemporaryObject(componentUnderTest, root)
+            verify(!!box)
+        }
+
+        function infoText() {
+            return findChild(box, "loginKeycardInfoText")
+        }
+
+        function pinInput() {
+            return findChild(box, "pinInput")
+        }
+
+        function test_insertKeycardShowsWaitingForCard() {
+            box.keycardState = Onboarding.KeycardState.InsertKeycard
+
+            compare(box.state, "insert")
+            compare(infoText().text, "Tap or insert your Keycard...")
+            verify(!pinInput().visible, "PIN must stay hidden until a card is present")
+        }
+
+        function test_wrongKeycardShowsError() {
+            box.isWrongKeycard = true
+
+            compare(box.state, "wrongKeycard")
+            compare(infoText().text, "Wrong Keycard for this profile")
+            compare(infoText().color, Theme.palette.dangerColor1)
+            verify(pinInput().visible, "wrong-keycard extends notEmpty and keeps the PIN field")
+        }
+
+        function test_blockedShowsUnblock_data() {
+            return [
+                {tag: "blocked-pin", keycardState: Onboarding.KeycardState.BlockedPIN},
+                {tag: "blocked-puk", keycardState: Onboarding.KeycardState.BlockedPUK},
+            ]
+        }
+
+        function test_blockedShowsUnblock(data) {
+            box.keycardState = data.keycardState
+
+            compare(box.state, "blocked")
+            compare(infoText().text, "Keycard blocked")
+            verify(findChild(box, "btnUnblock").visible)
+            verify(!pinInput().visible)
         }
     }
 }

--- a/ui/app/AppLayouts/Onboarding/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding/components/LoginKeycardBox.qml
@@ -117,6 +117,7 @@ Control {
 
         StatusBaseText {
             id: infoText
+            objectName: "loginKeycardInfoText"
             Layout.fillWidth: true
             horizontalAlignment: Qt.AlignHCenter
             elide: Text.ElideRight

--- a/ui/app/AppLayouts/Onboarding/pages/KeycardDetailsPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/KeycardDetailsPage.qml
@@ -151,6 +151,7 @@ OnboardingPage {
                 }
 
                 StatusBaseText {
+                    objectName: "keycardDetailsInfoMessage"
                     Layout.fillWidth: true
                     Layout.topMargin: Theme.padding
                     visible: !!text
@@ -229,6 +230,7 @@ OnboardingPage {
 
                 StatusListItem {
                     Layout.fillWidth: true
+                    objectName: "keycardDetailsUnblockWithRecovery"
                     visible: stateInfo.isBlockedPIN
                              || stateInfo.isBlockedPUK
                     title: qsTr("Unblock with recovery phrase")
@@ -244,6 +246,7 @@ OnboardingPage {
 
                 StatusListItem {
                     Layout.fillWidth: true
+                    objectName: "keycardDetailsUnblockWithPuk"
                     visible: stateInfo.isBlockedPIN
                              && !stateInfo.isBlockedPUK
                     title: qsTr("Unblock with PUK")
@@ -259,6 +262,7 @@ OnboardingPage {
 
                 StatusListItem {
                     Layout.fillWidth: true
+                    objectName: "keycardDetailsLoginWithThisKeycard"
                     visible: stateInfo.hasKeyPair
                              && !stateInfo.isBlockedPIN
                              && !stateInfo.isBlockedPUK
@@ -277,6 +281,7 @@ OnboardingPage {
 
                 StatusListItem {
                     Layout.fillWidth: true
+                    objectName: "keycardDetailsGoBackToLogin"
                     visible: stateInfo.profileAlreadyExists
                              && !stateInfo.isBlockedPIN
                              && !stateInfo.isBlockedPUK
@@ -293,6 +298,7 @@ OnboardingPage {
 
                 StatusListItem {
                     Layout.fillWidth: true
+                    objectName: "keycardDetailsFactoryReset"
                     visible: stateInfo.hasKeyPair
                              || stateInfo.onlyPinSet
                              || stateInfo.noKnownAndNoAvailablePairingSlots

--- a/ui/imports/shared/popups/auth_sign_base/states/KeycardAuth.qml
+++ b/ui/imports/shared/popups/auth_sign_base/states/KeycardAuth.qml
@@ -38,12 +38,14 @@ Control {
 
         StatusLoadingIndicator {
             id: loading
+            objectName: "keycardAuthLoadingIndicator"
             Layout.alignment: Qt.AlignCenter
             visible: root.keycardState === Constants.keycard.state.connectingCard
         }
 
         StatusBaseText {
             id: title
+            objectName: "keycardAuthTitle"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
@@ -53,6 +55,7 @@ Control {
 
         StatusBaseText {
             id: message
+            objectName: "keycardAuthMessage"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap

--- a/ui/imports/shared/popups/auth_sign_base/states/qmldir
+++ b/ui/imports/shared/popups/auth_sign_base/states/qmldir
@@ -1,0 +1,4 @@
+KeycardAuth 1.0 KeycardAuth.qml
+EnterPin 1.0 EnterPin.qml
+EnterPassword 1.0 EnterPassword.qml
+Biometrics 1.0 Biometrics.qml

--- a/ui/imports/shared/popups/keycard_new/states/EnterKeyPairNameState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/EnterKeyPairNameState.qml
@@ -27,6 +27,7 @@ Control {
         spacing: Theme.padding
 
         StatusBaseText {
+            objectName: "keycardKeyPairNameTitle"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
@@ -38,6 +39,7 @@ Control {
 
         StatusInput {
             id: nameInput
+            objectName: "keycardKeyPairNameInput"
             Layout.preferredWidth: Constants.keycard.general.keycardNameInputWidth
             Layout.alignment: Qt.AlignHCenter
             charLimit: Constants.keypair.nameLengthMax

--- a/ui/imports/shared/popups/keycard_new/states/EnterPinState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/EnterPinState.qml
@@ -73,6 +73,7 @@ Control {
         }
 
         StatusBaseText {
+            objectName: "keycardPinStepTitle"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
@@ -103,6 +104,7 @@ Control {
         }
 
         StatusBaseText {
+            objectName: "keycardPinStepError"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap

--- a/ui/imports/shared/popups/keycard_new/states/EnterPukState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/EnterPukState.qml
@@ -73,6 +73,7 @@ Control {
         }
 
         StatusBaseText {
+            objectName: "keycardPukStepTitle"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
@@ -108,6 +109,7 @@ Control {
         }
 
         StatusBaseText {
+            objectName: "keycardPukStepError"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap

--- a/ui/imports/shared/popups/keycard_new/states/EnterSeedPhraseState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/EnterSeedPhraseState.qml
@@ -32,6 +32,7 @@ Control {
         spacing: Theme.padding
 
         StatusBaseText {
+            objectName: "keycardSeedPhraseStepTitle"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap

--- a/ui/imports/shared/popups/keycard_new/states/KeycardProgressState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/KeycardProgressState.qml
@@ -70,6 +70,7 @@ Control {
 
             StatusBaseText {
                 id: title
+                objectName: "keycardProgressTitle"
                 wrapMode: Text.WordWrap
                 font.weight: Font.Bold
                 font.pixelSize: Theme.fontSize(22)
@@ -78,6 +79,7 @@ Control {
 
         StatusBaseText {
             id: message
+            objectName: "keycardProgressMessage"
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap

--- a/ui/imports/shared/popups/keycard_new/states/ManageKeyPairAccountsState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/ManageKeyPairAccountsState.qml
@@ -181,6 +181,7 @@ Control {
 
         StatusInput {
             id: accountNameInput
+            objectName: "keycardManageAccountNameInput"
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
             charLimit: Constants.keycard.general.keycardNameLength


### PR DESCRIPTION
### What does the PR do

- QML tests for keycard login (insert / wrong / blocked), details (profile exists, only-PIN, no slots), management flows (change PIN/PUK, rename, add KP, factory reset, unblock) and KeycardAuth loader states
- Minimal `objectName`s for stable asserts; no simulator — mock store/props only


Closes #21613, #21614, #21635, #21638, #21640, #21641, #21642
Partially addresses #21621, #21622, #21629, #21630, #21632