### PR TITLE
fix(AppMain): close popups on activating OS notification

### DIFF
--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -17,6 +17,7 @@ logScope:
 const SIGNAL_DISPLAY_APP_NOTIFICATION* = "displayAppNotification"
 const SIGNAL_DISPLAY_WINDOWS_OS_NOTIFICATION* = "displayWindowsOsNotification"
 const SIGNAL_OS_NOTIFICATION_CLICKED* = "osNotificationClicked"
+const SIGNAL_CLOSE_POPUPS_REQUESTED* = "closePopupsRequested"
 const SIGNAL_PLAY_NOTIFICATION_SOUND* = "playNotificationSound"
 
 # Anonymous preferences
@@ -82,6 +83,8 @@ QtObject:
     if(details.notificationType == NotificationType.TestNotification):
       info "Test notification was clicked"
       return
+
+    self.events.emit(SIGNAL_CLOSE_POPUPS_REQUESTED, Args())
 
     if(details.notificationType == NotificationType.NewMessage or
       details.notificationType == NotificationType.NewMessageWithPersonalMention or

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -304,6 +304,9 @@ proc init*(self: Controller) =
     var args = ClickedNotificationArgs(e)
     self.delegate.osNotificationClicked(args.details)
 
+  self.events.on(SIGNAL_CLOSE_POPUPS_REQUESTED) do(e: Args):
+    self.delegate.emitClosePopupsRequested()
+
   if defined(windows):
     self.events.on(SIGNAL_DISPLAY_WINDOWS_OS_NOTIFICATION) do(e: Args):
       var args = NotificationArgs(e)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -211,6 +211,9 @@ method communityLeft*(self: AccessInterface, communityId: string) {.base.} =
 method resolvedENS*(self: AccessInterface, publicKey: string, address: string, uuid: string, reason: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method emitClosePopupsRequested*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method osNotificationClicked*(self: AccessInterface, details: NotificationDetails) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1664,6 +1664,9 @@ method osNotificationClicked*[T](self: Module[T], details: NotificationDetails) 
   elif(details.notificationType == NotificationType.MyRequestToJoinCommunityRejected):
     warn "There is no particular action clicking on a notification informing you about rejection to join community"
 
+method emitClosePopupsRequested*[T](self: Module[T]) =
+  self.view.closePopupsRequested()
+
 method newCommunityMembershipRequestReceived*[T](self: Module[T], membershipRequest: CommunityMembershipRequestDto) =
   let (contactName, _, _) = self.controller.getContactNameAndImage(membershipRequest.publicKey)
   let community {.cursor.} = self.controller.getCommunityById(membershipRequest.communityId)
@@ -2118,6 +2121,9 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   if not self.chatsLoaded:
     self.statusDeepLinkToActivate = statusDeepLink
     return
+
+  self.view.closePopupsRequested()
+
   if statusDeepLink.contains("/wc?"):
     self.view.wcLinkActivated(statusDeepLink)
     return
@@ -2141,8 +2147,10 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   else:
     info "No generic navigation target found in deep link"
     discard
+
   if self.activateChatDeepLink(statusDeepLink):
     return
+
   let urlData = self.sharedUrlsModule.parseSharedUrl(statusDeepLink)
   if urlData.notASupportedStatusLink:
     # Just open it in the browser

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -128,6 +128,8 @@ QtObject:
   proc ephemeralNotificationClicked*(self: View, id: string) {.slot.} =
     self.delegate.ephemeralNotificationClicked(id.parseInt)
 
+  proc closePopupsRequested*(self: View) {.signal.}
+
   proc playNotificationSound*(self: View) {.signal.}
 
   proc openStoreToKeychainPopup*(self: View) {.signal.}

--- a/storybook/pages/EnableMessageBackupPopupPage.qml
+++ b/storybook/pages/EnableMessageBackupPopupPage.qml
@@ -39,7 +39,6 @@ SplitView {
         Component {
             id: dlgComponent
             EnableMessageBackupPopup {
-                anchors.centerIn: parent
                 visible: true
                 modal: false
                 onAccepted: logs.logEvent("EnableMessageBackupPopup::onAccepted")

--- a/ui/StatusQ/include/StatusQ/osnotification.h
+++ b/ui/StatusQ/include/StatusQ/osnotification.h
@@ -2,9 +2,10 @@
 
 #include <QObject>
 #include <QString>
-#include <QHash>
 
 #ifdef Q_OS_WIN
+#include <QHash>
+
 #include "windows.h"
 #endif
 

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -71,6 +71,8 @@ public:
     // (native) screen helper
     Q_INVOKABLE qreal nativeDpr(QQuickWindow *window) const;
 
+    Q_INVOKABLE void tryCloseActivePopups();
+
 signals:
     // Emitted when event of type QEvent::Quit is detected by event filter on
     // QGuiApplication. It's helpful to handle close requests on mac coming from

--- a/ui/StatusQ/src/osnotification.cpp
+++ b/ui/StatusQ/src/osnotification.cpp
@@ -138,7 +138,7 @@ void OSNotification::showNotification(const QString& title,
         return;
     }
     QStringList args;
-    args << QStringLiteral("-a") << QStringLiteral("nim-status");
+    args << QStringLiteral("-a") << QCoreApplication::applicationName();
     args << QStringLiteral("-c") << QStringLiteral("im");
     args << title;
     args << message;

--- a/ui/StatusQ/src/statusemojimodel.cpp
+++ b/ui/StatusQ/src/statusemojimodel.cpp
@@ -23,7 +23,7 @@ constexpr auto kHasSkins = "hasSkins";
 constexpr auto kSkinColor = "skinColor";
 constexpr auto kBaseColor = "base";
 
-const auto skinColors = std::array<const char*, 5>{"1f3fb", "1f3fc", "1f3fd", "1f3fe", "1f3ff"};
+constexpr auto skinColors = std::array<const char*, 5>{"1f3fb", "1f3fc", "1f3fd", "1f3fe", "1f3ff"};
 
 constexpr auto MAX_EMOJI_NUMBER = 36;
 

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -29,6 +29,8 @@
 #include "ios_utils.h"
 #endif
 
+using namespace Qt::Literals::StringLiterals;
+
 class QuitFilter : public QObject
 {
     Q_OBJECT
@@ -714,6 +716,29 @@ qreal SystemUtilsInternal::nativeDpr(QQuickWindow *window) const
     qWarning() << Q_FUNC_INFO << "invalid native platform screen";
     return screen->devicePixelRatio();
 #endif
+}
+
+void SystemUtilsInternal::tryCloseActivePopups()
+{
+    qWarning() << "!!!" << Q_FUNC_INFO;
+    const auto windows = qGuiApp->topLevelWindows();
+    for (auto window: windows) {
+        const auto childrenList = window->findChildren<QObject *>();
+        for (auto child: childrenList) {
+            if (child && child->inherits("QQuickPopupItem")) {
+                auto popupObject = child->parent();
+
+                if (popupObject && !popupObject->inherits("QQuickToolTip")) {
+                    const auto opened = popupObject->property("opened").toBool();
+                    const auto closeable = popupObject->property("closePolicy").toInt() > 0; // Popup::NoAutoClose = 0x00
+                    if (opened && closeable) {
+                        qWarning() << "!!! CLOSING CHILD POPUP:" << child << child->property("title").toString();
+                        QMetaObject::invokeMethod(popupObject, "close");
+                    }
+                }
+            }
+        }
+    }
 }
 
 #ifdef Q_OS_IOS

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -357,7 +357,7 @@ StatusSectionLayout {
                 contactsStore: root.contactsStore
 
                 thirdpartyServicesEnabled: root.privacyStore.thirdpartyServicesEnabled
-                myPublicKey: root.contactsStore.myPublicKey
+                myPublicKey: userProfile.pubKey
                 currencySymbol: root.sharedRootStore.currencyStore.currentCurrency
                 emojiPopup: root.emojiPopup
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.wallet)

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -535,7 +535,7 @@ Item {
 
     Settings {
         id: walletLocalSettings
-        category: "WalletLocalSettings_%1".arg(root.contactsStore.myPublicKey)
+        category: "WalletLocalSettings_%1".arg(userProfile.pubKey)
         property alias selectedPanelIndex: walletSectionLayout.currentIndex
     }
 }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -199,7 +199,7 @@ RightTabBaseView {
 
         Settings {
             id: walletSettings
-            category: "walletSettings-" + root.contactsStore.myPublicKey
+            category: "walletSettings-" + userProfile.pubKey
             property real collectiblesViewCustomOrderApplyTimestamp: 0
             property bool buyBannerEnabled: true
             property bool receiveBannerEnabled: true
@@ -352,7 +352,7 @@ RightTabBaseView {
 
                         readonly property var walletSettings: Settings { /* https://bugreports.qt.io/browse/QTBUG-135039 */
                             id: walletSettings
-                            category: "walletSettings-" + root.contactsStore.myPublicKey
+                            category: "walletSettings-" + userProfile.pubKey
                             property var assetsViewCustomOrderApplyTimestamp
                             onAssetsViewCustomOrderApplyTimestampChanged: walletAssetsView.refreshSortSettings()
                         }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -164,6 +164,7 @@ QtObject {
     // Notifications related properties and functions that shall be moved to `NotificationsRootStore`
     readonly property var ephemeralNotificationModel: internal.mainModuleInst.ephemeralNotificationModel
 
+    signal closePopupsRequested()
     signal showEphemeralNewsNotification(string newsTitle, string notificationId)
     signal playNotificationSound()
     signal mailserverWorking()
@@ -193,6 +194,10 @@ QtObject {
 
     readonly property Connections _notificationsRelatedMainModuleConnections: Connections {
         target: internal.mainModuleInst
+
+        function onClosePopupsRequested() {
+            root.closePopupsRequested()
+        }
 
         function onNewsFeedEphemeralNotification(newsTitle: string, notificationId: string) {
             root.showEphemeralNewsNotification(newsTitle, notificationId)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -286,10 +286,13 @@ Item {
     Connections {
         target: rootStore
 
+        function onClosePopupsRequested() {
+            SystemUtils.tryCloseActivePopups()
+        }
+
         function onDisplayUserProfile(publicKey: string) {
             popups.openProfilePopup(publicKey)
         }
-
 
         function onPlayNotificationSound() {
             notificationSound.stop()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -113,7 +113,7 @@ Item {
     readonly property var keycardNewStore: rootStore.profileSectionStore?.keycardNewStore ?? null
     readonly property var walletProfileStore: rootStore.profileSectionStore?.walletStore ?? null
     readonly property var ensUsernamesStore: rootStore.profileSectionStore?.ensUsernamesStore ?? null
-    readonly property ProfileStores.LogosNetworkStore logosNetworkStore: rootStore.profileSectionStore.logosNetworkStore
+    readonly property ProfileStores.LogosNetworkStore logosNetworkStore: rootStore.profileSectionStore?.logosNetworkStore ?? null
 
     // Messaging (just references from `rootStore`)
     readonly property MessagingStores.MessagingRootStore messagingRootStore: rootStore.messagingRootStore
@@ -909,6 +909,8 @@ Item {
     QtObject {
         id: d
 
+        readonly property string myPublicKey: userProfile.pubKey // we need it very soon, before all the stores
+
         property bool messagingNetworkDisconnected: !appMain.rootStore.isMessagingNetworkConnected
         property bool doShowMessagingBanner: false
         readonly property bool canShowMessagingBanner: d.messagingNetworkDisconnected
@@ -1002,7 +1004,7 @@ Item {
 
         function maybeDisplayIntroduceYourselfPopup() {
             if (!appMainLocalSettings.introduceYourselfPopupSeen
-                    && allContacsAdaptor?.selfDisplayName === "") {
+                    && appMain.ownContactDetails?.displayName === "") {
                 introduceYourselfPopupComponent.createObject(appMain).open()
                 return true
             }
@@ -1061,15 +1063,9 @@ Item {
 
     Settings {
         id: appMainLocalSettings
-        category: "AppMainLocalSettings_%1".arg(allContacsAdaptor?.selfContactDetails?.publicKey
-                                                  ?? appMain.profileStore?.pubKey
-                                                  ?? "")
+        category: "AppMainLocalSettings_%1".arg(d.myPublicKey)
         property var whitelistedUnfurledDomains: []
         property bool introduceYourselfPopupSeen
-        property bool enableMessageBackupPopupSeen
-        property bool enablePushNotificationsFreshInstallSeen
-        property bool enablePushNotificationsDontAskAgain
-        property string enablePushNotificationsLastShownVersion
         property int theme: ThemeUtils.Style.System
         property int fontSize: {
             if (appMain.isPortraitMode) {
@@ -1174,6 +1170,7 @@ Item {
         privacyStore: appMain.privacyStore
         keychain: appMain.keychain
         notificationsStore: appMain.notificationsStore
+        devicesStore: appMain.devicesStore
 
         Component.onCompleted: {
             if (appMain.mainReady)
@@ -1508,7 +1505,7 @@ Item {
         sourceComponent: StatusEmojiPopup {
             directParent: appMain.Window.window.contentItem
             height: 440
-            userUID: allContacsAdaptor.selfContactDetails.publicKey
+            userUID: d.myPublicKey
             emojiModel: SQUtils.Emoji.emojiModel
         }
     }
@@ -1957,7 +1954,7 @@ Item {
                 hasMembership: (appMain.activityCenterStore?.membershipCount ?? 0) > 0
                 hasSystem: (appMain.activityCenterStore?.systemCount ?? 0) > 0
                 hasNews: (appMain.activityCenterStore?.newsCount ?? 0) > 0
-                activeGroup: appMain.activityCenterStore?.activeNotificationGroup ?? ""
+                activeGroup: appMain.activityCenterStore?.activeNotificationGroup ?? ActivityCenterTypes.ActivityCenterGroup.All
 
                 hasUnreadNotifications: (appMain.activityCenterStore?.unreadNotificationsCount ?? 0) > 0
                 readNotificationsStatus: appMain.activityCenterStore?.activityCenterReadType ?? 0
@@ -2246,9 +2243,9 @@ Item {
                             restoreMode: Binding.RestoreNone
                         }
 
+                        userUID: d.myPublicKey
                         rootStore: appMain.rootStore
                         featureFlagsStore: appMain.featureFlagsStore
-                        profileStore: appMain.profileStore
                         advancedStore: appMain.advancedStore
                         networksStore: appMain.networksStore
                         currencyStore: appMain.currencyStore
@@ -2478,7 +2475,7 @@ Item {
                 acHasUnseenNotifications: appMain.activityCenterStore?.hasUnseenNotifications ?? false
                 acUnreadNotificationsCount: appMain.activityCenterStore?.unreadNotificationsCount ?? 0
 
-                selfContactDetails: ownContactDetails ?? loadingContactDetails
+                selfContactDetails: appMain.ownContactDetails ?? appMain.loadingContactDetails
                 getEmojiHashFn: appMain.utilsStore.getEmojiHash
                 getLinkToProfileFn: appMain.contactsStore?.getLinkToProfile
                                     ?? function() { return "" }
@@ -2505,7 +2502,7 @@ Item {
                 }
                 onSetCurrentUserStatusRequested: status => appMain.rootStore.setCurrentUserStatus(status)
                 onViewProfileRequested: pubKey => Global.openProfilePopup(pubKey)
-                onShareOwnProfileRequested: Global.shareProfileDialogRequested(ownContactDetails.publicKey)
+                onShareOwnProfileRequested: Global.shareProfileDialogRequested(appMain.ownContactDetails.publicKey)
 
                 onItemActivated: function(sectionType, sectionId) {
                     // Ensure Activity Center Panel is closed when manual navigation done

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -1,3 +1,4 @@
+import QtCore
 import QtQuick
 
 import StatusQ
@@ -51,9 +52,18 @@ QtObject {
     required property ProfileStores.EnsUsernamesStore ensUsernamesStore
     required property ProfileStores.PrivacyStore privacyStore
     required property ProfileStores.NotificationsStore notificationsStore
+    required property ProfileStores.DevicesStore devicesStore
 
     required property Keychain keychain
 
+    readonly property var appMainLocalSettings: Settings {
+        id: appMainLocalSettings
+        category: "AppMainLocalSettings_%1".arg(userProfile.pubKey)
+        property bool enableMessageBackupPopupSeen
+        property bool enablePushNotificationsFreshInstallSeen
+        property bool enablePushNotificationsDontAskAgain
+        property string enablePushNotificationsLastShownVersion
+    }
 
     readonly property SwapModalHandler swapModalHandler: SwapModalHandler {
 
@@ -198,12 +208,12 @@ QtObject {
             visible: true
             destroyOnClose: true
             onClosed: appMainLocalSettings.enableMessageBackupPopupSeen = true
-            onAccepted: appMain.devicesStore.setMessagesBackupEnabled(true)
+            onAccepted: root.devicesStore.setMessagesBackupEnabled(true)
         }
     }
 
     function maybeDisplayEnableMessageBackupPopup() {
-        if (!appMainLocalSettings.enableMessageBackupPopupSeen && !appMain.devicesStore.messagesBackupEnabled) {
+        if (!appMainLocalSettings.enableMessageBackupPopupSeen && !root.devicesStore.messagesBackupEnabled) {
             enableMessageBackupPopupComponent.createObject(popupParent).open()
             return true
         }

--- a/ui/app/mainui/adaptors/AllContactsAdaptor.qml
+++ b/ui/app/mainui/adaptors/AllContactsAdaptor.qml
@@ -5,7 +5,6 @@ import StatusQ.Core.Utils
 import utils
 
 import QtModelsToolkit
-import SortFilterProxyModel
 import AppLayouts.Profile.helpers
 
 /**
@@ -26,7 +25,7 @@ QObject {
         id: concatModel
 
         function hasUser(pubKey) {
-            return pubKey === root.selfContactDetails.publicKey || contactsModel.hasUser(pubKey)
+            return pubKey === root.selfContactDetails.publicKey || root.contactsModel.hasUser(pubKey)
         }
 
         expectedRoles: [

--- a/ui/app/mainui/sectionLoaders/BrowserLoader.qml
+++ b/ui/app/mainui/sectionLoaders/BrowserLoader.qml
@@ -18,9 +18,9 @@ import mainui.sectionLoaders
 Loader {
     id: root
 
+    required property string userUID
     required property AppStores.RootStore rootStore
     required property AppStores.FeatureFlagsStore featureFlagsStore
-    required property ProfileStores.ProfileStore profileStore
     required property ProfileStores.AdvancedStore advancedStore
     required property SharedStores.NetworksStore networksStore
     required property SharedStores.CurrenciesStore currencyStore
@@ -92,7 +92,7 @@ Loader {
             browserPreferencesStore:    browserPreferencesStore,
             browserWalletStore:         browserWalletStore,
             browserActivityStore:       browserActivityStore,
-            userUID:                    Qt.binding(() => root.profileStore.pubKey),
+            userUID:                    root.userUID,
             thirdpartyServicesEnabled:  Qt.binding(() => root.rootStore.thirdpartyServicesEnabled),
             dappsEnabled:               Qt.binding(() => root.featureFlagsStore.dappsEnabled),
             currencyStore:              Qt.binding(() => root.currencyStore),

--- a/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
+++ b/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
@@ -33,6 +33,7 @@ Loader {
     required property WalletStores.TransactionStoreNew transactionStoreNew
     required property WalletStores.TokensStore tokensStore
     required property ProfileStores.NotificationsStore notificationsStore
+    required property ProfileStores.DevicesStore devicesStore
     
     required property ChatStores.RootStore rootChatStore
 
@@ -85,7 +86,8 @@ Loader {
             ensUsernamesStore:      Qt.binding(() => root.ensUsernamesStore),
             privacyStore:           Qt.binding(() => root.privacyStore),
             keychain:               Qt.binding(() => root.keychain),
-            notificationsStore:     Qt.binding(() => root.notificationsStore)
+            notificationsStore:     Qt.binding(() => root.notificationsStore),
+            devicesStore:           Qt.binding(() => root.devicesStore)
         })
     }
 

--- a/ui/app/mainui/sectionLoaders/HomePageLoader.qml
+++ b/ui/app/mainui/sectionLoaders/HomePageLoader.qml
@@ -63,7 +63,7 @@ Loader {
 
             searchPhrase: root.item ? root.item.searchPhrase : ""
 
-            profileId: root.profileStore.pubKey
+            profileId: userProfile.pubKey
 
             // no automatic propagation to QtObject, needs to be specified explicitely
             Theme.style: root.Theme.style

--- a/ui/imports/shared/popups/EnableMessageBackupPopup.qml
+++ b/ui/imports/shared/popups/EnableMessageBackupPopup.qml
@@ -11,7 +11,7 @@ import StatusQ.Popups.Dialog
 
 import utils
 
-StatusDialog {
+StatusAdaptiveDialog {
     id: root
 
     title: {
@@ -22,11 +22,9 @@ StatusDialog {
         return qsTr("Enable on-device message backup?")
     }
 
-    padding: 20
-    width: 480
     closePolicy: Popup.NoAutoClose
 
-    contentItem: ColumnLayout {
+    contentComponent: ColumnLayout {
         spacing: Theme.padding
 
         StatusImage {
@@ -53,26 +51,24 @@ StatusDialog {
         }
     }
 
-    footer: StatusDialogFooter {
-        leftButtons: ObjectModel {
-            StatusFlatButton {
-                objectName: "backupMessageSkipStatusFlatButton"
-                text: qsTr("Skip")
-                onClicked: root.close()
-            }
+    footerLeftButtons: ObjectModel {
+        StatusFlatButton {
+            objectName: "backupMessageSkipStatusFlatButton"
+            text: qsTr("Skip")
+            onClicked: root.close()
         }
-        rightButtons: ObjectModel {
-            StatusButton {
-                objectName: "backupMessageEnableStatusFlatButton"
-                text: SQUtils.Utils.isAndroid ? qsTr("Go to settings") : qsTr("Enable")
-                onClicked: {
-                    if (SQUtils.Utils.isAndroid) {
-                        Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.backupSettings)
-                        root.close()
-                        return
-                    }
-                    root.accept()
+    }
+    footerRightButtons: ObjectModel {
+        StatusButton {
+            objectName: "backupMessageEnableStatusFlatButton"
+            text: SQUtils.Utils.isAndroid ? qsTr("Go to settings") : qsTr("Enable")
+            onClicked: {
+                if (SQUtils.Utils.isAndroid) {
+                    Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.backupSettings)
+                    root.close()
+                    return
                 }
+                root.accept()
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

> [!NOTE]
> Best review commit by commit 

- [feat: close popups on clicking a push notification](https://github.com/status-im/status-app/commit/c2eca4333742edc8a679262d6b7aa923c505dafc)
- [fix(AppMain): prevent accessing empty Settings](https://github.com/status-im/status-app/commit/17af3fdf70ebaa423ed639c47e59f993c37c8b54) 
- [fix(EnableMessageBackupPopup): add scrolling](https://github.com/status-im/status-app/commit/724e744e40263aba5141bddd75cea305ba65bd84)

Fixes #21292

### Affected areas

AppMain, HandlersManager

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Fixed/added scrolling in EnableMessagesBackupPopup
<img width="904" height="924" alt="Snímek obrazovky z 2026-08-12 11-26-39" src="https://github.com/user-attachments/assets/3e812e95-d15e-447f-b06c-933d6725351e" />

More TBD

### Impact on end user

- nicer OS Notifications interactions
- some aux popups unbroken (EnableMessageBackupPopup, EnablePushNotificationsPopup, ...)

### How to test

- with a new profile/installation on mobile, you should get the prompt to Enable push notifications
- clicking the push notifications should close any closeable popup in the app

### Risk 

low
