### PR TITLE
StatusTextArea: drop Universal style import to use os-default style

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 
 import StatusQ.Core.Theme
 import StatusQ.Components


### PR DESCRIPTION
### What does the PR do

It restores the native text edit (allowing handy text selection) menu on IOS which was overriden by the one provided by Universal style.

Differently than on Qt 5, with Qt 6 every file may import custom style separately, allowing mixing them within single app.

Closes: #21570

### Affected areas
`StatusTextArea`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality


https://github.com/user-attachments/assets/d3c7e18b-a402-45a8-889f-cca6d2258aa9


### Impact on end user

Low

### How to test

Use Status chat input, especially context menu on all platforms.

### Risk 

Medium - Windows needs to be checked to avoid regressions
