### PR TITLE
chore: Universal style imports dropped

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusCurrencySelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCurrencySelector.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 import QtQuick.Layouts
 
 import StatusQ

--- a/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 import QtQuick.Layouts
 
 import StatusQ

--- a/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 import QtQuick.Layouts
 
 import StatusQ.Core

--- a/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import QtQuick.Controls.Universal
 
 import StatusQ.Core
 import StatusQ.Core.Theme

--- a/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 
 import StatusQ.Core
 import StatusQ.Core.Theme

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRadioButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRadioButton.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 
 import StatusQ.Core
 import StatusQ.Core.Theme

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 
 import StatusQ.Core.Theme
 import StatusQ.Components

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 
 import StatusQ.Components
 import StatusQ.Core

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogHeader.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 import QtQuick.Layouts
 
 import StatusQ.Core

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogHeader.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 import QtQuick.Layouts
 import QtQuick.Window
 import Qt5Compat.GraphicalEffects

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQml
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuInstantiator.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuInstantiator.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 import QtQml.Models
 
 Instantiator {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuSeparator.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuSeparator.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 
 import StatusQ.Core.Theme
 

--- a/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 


### PR DESCRIPTION
### What does the PR do

Follow-up of https://github.com/status-im/status-app/pull/21956

Drops all `QtQuick.Controls.Universal` imports as they seem to be currently not necessary. Removing it prevents entire module from being loaded to memory. Os-default style is used consistently across the whole app.

> [!WARNING]
> It was tested on Linux, Android and IOS, Mac and Windows needs to be checked to ensure no regression.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

-

### Impact on end user

Medium

### How to test

Check visual appearance of all touched components on all platforms.

### Risk 

Risk of visual regressions, especially on Windows
