### PR TITLE
ci: add flatpak to nightly and releases

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -128,6 +128,13 @@ pipeline {
             }
           }
         }
+        stage('Linux/Flatpak/x86_64') {
+          steps { script {
+            flatpak_x86_64 = getArtifacts(
+              'Linux/Flatpak', jenkins.Build('status-app/systems/linux-flatpak/x86_64/package')
+            )
+          } }
+        }
         stage('MacOS/aarch64') { steps { script {
           macos_aarch64 = getArtifacts(
             'MacOS/aarch64', jenkins.Build('status-app/systems/macos/aarch64/package')


### PR DESCRIPTION
## Summary

This ensures flatpak is built in nightly and release jobs.
After this we will disable the flatpak job from PRs. 
We can re-enable it when we can handle more traffic OR after we have refactored linux job to produce both the artifacts.