### PR TITLE
fix(Notifications): use a real DBUS backend on Linux

### DIFF
--- a/nim-status.desktop
+++ b/nim-status.desktop
@@ -4,4 +4,4 @@ Name=Status Desktop
 Exec=nim_status_client
 Icon=status
 Comment=Desktop client for the Status Network
-Categories=Network;
+Categories=Network;InstantMessaging;Chat;

--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -39,7 +39,6 @@ QtObject:
     events: EventEmitter
     settingsService: settings_service.Service
     osNotification: StatusOSNotification
-    notificationSetUp: bool
 
   proc processNotification(self: NotificationsManager, title: string, message: string, details: NotificationDetails)
 
@@ -215,8 +214,6 @@ QtObject:
     discard QObject.connect(singletonInstance.globalEvents, showCommunityMemberBannedNotification, self, onShowCommunityMemberBannedNotification, ConnectionType.QueuedConnection)
     discard QObject.connect(singletonInstance.globalEvents, showCommunityMemberUnbannedNotification, self, onShowCommunityMemberUnbannedNotification, ConnectionType.QueuedConnection)
     discard QObject.connect(singletonInstance.globalEvents, showNewsMessageNotification, self, onShowNewsMessageNotification, ConnectionType.QueuedConnection)
-
-    self.notificationSetUp = true
 
   proc init*(self: NotificationsManager) =
     discard

--- a/src/app/global/app_window.nim
+++ b/src/app/global/app_window.nim
@@ -10,16 +10,14 @@ import seaqt/QtCore/gen_qnamespace
 from seaqt/qqmlapplicationengine import rootObjects
 
 proc app_isActive*(): bool =
-  QGuiApplication.applicationState() == cint(ApplicationStateEnum.ApplicationActive)
+  QGuiApplication.applicationState() == ApplicationStateEnum.ApplicationActive
 
 proc app_makeItActive*(engine: QQmlApplicationEngine) =
   ## Brings the main QQuickWindow to the front and requests focus.
   let rootObjs = engine.seaqt.rootObjects()
-  if rootObjs.len == 0:
-    return
-  let topObj = rootObjs[0]
-  if topObj.objectName() == "mainWindow" and topObj.inherits("QQuickWindow"):
-    let win = gen_qquickwindow_types.QQuickWindow(h: topObj.h, owned: false)
-    win.show()
-    win.raiseX()
-    win.requestActivate()
+  for topObj in rootObjs:
+    if topObj.objectName() == "mainWindow" and topObj.inherits("QQuickWindow"):
+      let win = gen_qquickwindow_types.QQuickWindow(h: topObj.h, owned: false)
+      win.show()
+      win.raiseX()
+      win.requestActivate()

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -32,8 +32,12 @@ endif()
 
 find_package(QT 6.11 NAMES Qt6 REQUIRED COMPONENTS Core)
 
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS
+find_package(Qt6 COMPONENTS
         Core CorePrivate Qml Gui GuiPrivate Quick QuickControls2 WebChannel Svg Network REQUIRED)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT ANDROID)
+    find_package(Qt6 COMPONENTS DBus REQUIRED)
+endif()
 
 # --- QML test hooks flag and TestConfig generation ---
 option(STATUSQ_TESTMODE "Enable QML test hooks (TestConfig.testMode)" OFF)
@@ -73,7 +77,7 @@ qt_add_resources(STATUSQ_TESTCONFIG_RCC ${_gen_qrc})
 # --- END test hooks ---
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS QuickTest REQUIRED)
+    find_package(Qt6 COMPONENTS QuickTest REQUIRED)
 endif()
 
 add_subdirectory(../../vendor/SortFilterProxyModel SortFilterProxyModel)
@@ -339,6 +343,10 @@ if(WIN32)
     target_link_libraries(StatusQ PRIVATE shell32 user32)
 endif()
 
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT ANDROID)
+    target_link_libraries(StatusQ PRIVATE Qt::DBus)
+endif()
+
 include(FetchContent)
 set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
 
@@ -425,7 +433,7 @@ target_link_libraries(StatusQ PRIVATE
         )
 
 if(NOT (IOS OR ANDROID))
-    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS WebEngineQuick QUIET)
+    find_package(Qt6 COMPONENTS WebEngineQuick QUIET)
     if(TARGET Qt::WebEngineQuick)
         target_sources(StatusQ PRIVATE
             include/StatusQ/browserprofileutils.h

--- a/ui/StatusQ/include/StatusQ/osnotification.h
+++ b/ui/StatusQ/include/StatusQ/osnotification.h
@@ -2,12 +2,14 @@
 
 #include <QObject>
 #include <QString>
+#include <QHash>
+#include <QLoggingCategory>
 
 #ifdef Q_OS_WIN
-#include <QHash>
-
 #include "windows.h"
 #endif
+
+Q_DECLARE_LOGGING_CATEGORY(osNotification)
 
 namespace Status
 {
@@ -17,7 +19,7 @@ namespace Status
 
     public:
         explicit OSNotification(QObject *parent = nullptr);
-        ~OSNotification();
+        ~OSNotification() override;
 
         void showNotification(const QString& title, const QString& message,
                               const QString& identifier);
@@ -40,6 +42,15 @@ namespace Status
         void initNotificationMacOs();
         void showNotificationMacOs(QString title, QString message, QString identifier);
         void* m_delegate = nullptr; // StatusQNotificationDelegate* (opaque to C++)
+
+#elif defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    private:
+        QHash<quint32, QString> m_identifiers;
+        QHash<quint32, QString> m_activationTokens;
+    private slots:
+        void onActionInvoked(quint32 id, const QString& actionKey);
+        void onActivationToken(quint32 id, const QString& token);
+        void onNotificationClosed(quint32 id, quint32 reason);
 #endif
     };
 }

--- a/ui/StatusQ/src/osnotification.cpp
+++ b/ui/StatusQ/src/osnotification.cpp
@@ -2,13 +2,14 @@
 
 #include "StatusQ/osnotification.h"
 
+#include <QDebug>
+
 #ifdef Q_OS_WIN
 #include <shellapi.h>
 #include <stdlib.h>
 #include <string.h>
 #include <winuser.h>
 #include <comdef.h>
-#include <QDebug>
 
 using namespace Status;
 
@@ -16,10 +17,21 @@ static const UINT NOTIFYICONID = 0;
 static std::pair<HWND, OSNotification *> HWND_INSTANCE_PAIR;
 #endif
 
-#ifdef Q_OS_LINUX
-#include <QProcess>
-#include <QStandardPaths>
-#include <QDebug>
+using namespace Qt::Literals::StringLiterals;
+
+Q_LOGGING_CATEGORY(osNotification, "status.osNotification", QtInfoMsg)
+
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+#include <QDBusMessage>
+#include <QDBusConnection>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+
+constexpr auto kDbusService = "org.freedesktop.Notifications"_L1;
+constexpr auto kDbusPath = "/org/freedesktop/Notifications"_L1;
+constexpr auto kDbusInterface = "org.freedesktop.Notifications"_L1;
+
+constexpr auto kDefaultAction = "default"_L1;
 #endif
 
 using namespace Status;
@@ -31,6 +43,17 @@ OSNotification::OSNotification(QObject *parent)
     initNotificationWin();
 #elif defined Q_OS_MACOS
     initNotificationMacOs();
+#elif defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    auto bus = QDBusConnection::sessionBus();
+    // NB see https://specifications.freedesktop.org/notification/latest-single/#signal-action-invoked
+    bus.connect(kDbusService, kDbusPath, kDbusInterface, "ActionInvoked"_L1,
+                this, SLOT(onActionInvoked(quint32, QString)));
+    // NB see https://specifications.freedesktop.org/notification/latest-single/#signal-activation-token
+    bus.connect(kDbusService, kDbusPath, kDbusInterface, "ActivationToken"_L1,
+                this, SLOT(onActivationToken(quint32, QString)));
+    // NB see https://specifications.freedesktop.org/notification/latest-single/#signal-notification-closed
+    bus.connect(kDbusService, kDbusPath, kDbusInterface, "NotificationClosed"_L1,
+                this, SLOT(onNotificationClosed(quint32, quint32)));
 #endif
 }
 
@@ -131,22 +154,85 @@ void OSNotification::showNotification(const QString& title,
 
 #elif defined Q_OS_MACOS
     showNotificationMacOs(title, message, identifier);
-#elif defined Q_OS_LINUX
-    static QString notifyExe = QStandardPaths::findExecutable(QStringLiteral("notify-send"));
-    if (notifyExe.isEmpty()) {
-        qWarning() << "'notify-send' not found; OS notifications will not work";
-        return;
-    }
-    QStringList args;
-    args << QStringLiteral("-a") << QCoreApplication::applicationName();
-    args << QStringLiteral("-c") << QStringLiteral("im");
-    args << title;
-    args << message;
-    QProcess::execute(notifyExe, args);
+#elif defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    // NB see https://specifications.freedesktop.org/notification/latest-single/#protocol for the API
+    auto notifyMsg = QDBusMessage::createMethodCall(kDbusService, kDbusPath, kDbusInterface, "Notify"_L1);
+    notifyMsg << QCoreApplication::applicationName(); // STRING app_name
+    notifyMsg << quint32(0); // UINT32 replaces_id (0 == does not replace anything)
+    notifyMsg << QString(); // STRING app_icon (using the app icon as decoration by default)
+    notifyMsg << title; // STRING summary
+    notifyMsg << message; // STRING body
+    notifyMsg << QStringList{kDefaultAction, {}}; // AS actions ("default" == invoked on click)
+    notifyMsg << QVariantMap(); // A{SV} hints
+    notifyMsg << -1; // INT32 expire_timeout (-1 == impl dependent/default)
+
+    auto pendingCall = QDBusConnection::sessionBus().asyncCall(notifyMsg);
+    auto watcher = new QDBusPendingCallWatcher(pendingCall, this);
+
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, [=](QDBusPendingCallWatcher *self) {
+        QDBusPendingReply<quint32> reply = *self;
+        if (reply.isValid()) {
+            quint32 notificationId = reply.value();
+            qCDebug(osNotification) << Q_FUNC_INFO << "Fired notification:" << notificationId << identifier;
+            m_identifiers.insert(notificationId, identifier);
+        } else {
+            qCWarning(osNotification) << Q_FUNC_INFO << reply.error().name() << reply.error().message();
+        }
+        self->deleteLater();
+    });
+
 #else
     Q_UNUSED(title) Q_UNUSED(message) Q_UNUSED(identifier)
 #endif
 }
+
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+void OSNotification::onActionInvoked(quint32 id, const QString& actionKey)
+{
+    // NB see https://specifications.freedesktop.org/notification/latest-single/#signal-action-invoked
+    // The "default" action is emitted when the user clicks the notification body itself.
+    if (actionKey != kDefaultAction)
+        return;
+    if (!m_identifiers.contains(id)) {
+        qCWarning(osNotification) << Q_FUNC_INFO << "Ignoring unknown notification with id:" << id;
+        return;
+    }
+
+    if (m_activationTokens.contains(id)) {
+        const auto token = m_activationTokens.take(id);
+        if (!token.isEmpty())
+            qputenv("XDG_ACTIVATION_TOKEN", token.toUtf8());
+    }
+
+    const auto identifier = m_identifiers.value(id);
+    qCDebug(osNotification) << Q_FUNC_INFO << "User clicked notification:" << id << identifier;
+    emit notificationClicked(identifier);
+}
+
+void OSNotification::onActivationToken(quint32 id, const QString& token)
+{
+    if (!m_identifiers.contains(id)) {
+        qCWarning(osNotification) << Q_FUNC_INFO << "Ignoring activation token for unknown notification id:" << id;
+        return;
+    }
+    qCDebug(osNotification) << Q_FUNC_INFO << "Got activation token for notification id:" << id;
+    m_activationTokens.insert(id, token);
+}
+
+void OSNotification::onNotificationClosed(quint32 id, quint32 reason)
+{
+    // NB see https://specifications.freedesktop.org/notification/latest-single/#signal-notification-closed
+    // Reason 1 = expired, 2 = dismissed by user, 3 = closed by CloseNotification call, 4 = undefined.
+    // We only clean up the identifier map here; actual click handling is done in onActionInvoked.
+    if (!m_identifiers.contains(id)) {
+        qCWarning(osNotification) << Q_FUNC_INFO << "Ignoring unknown notification with id:" << id;
+        return;
+    }
+    qCDebug(osNotification) << Q_FUNC_INFO << "Notification closed, id:" << id << "reason:" << reason;
+    m_identifiers.remove(id);
+    m_activationTokens.remove(id);
+}
+#endif
 
 void OSNotification::showIconBadgeNotification(int notificationsCount)
 {

--- a/ui/app/AppLayouts/Onboarding/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding/components/LoginKeycardBox.qml
@@ -237,7 +237,7 @@ Control {
             }
             PropertyChanges {
                 target: background
-                border.color: Theme.palette.primaryColor1
+                border.color: root.Theme.palette.primaryColor1
             }
             PropertyChanges {
                 target: pinInputField


### PR DESCRIPTION
### What does the PR do

- using the standard `org.freedesktop.Notifications` DBUS backend/API; see https://specifications.freedesktop.org/notification/latest-single/ for details
- allows tracking the OS Notifications, including being clicked/closed by the user and navigating Status to the respective section/chat/channel like other OSs
- fully async using DBUS pending call/watcher paradigm, no more fire and forget using a cmd line wrapper (`notify-send`)

Iterates #2520
Iterates https://github.com/status-im/status-app/issues/21292

### Affected areas

OS Notifications on Linux

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Clicking a DM notification:

https://github.com/user-attachments/assets/4a7c03fb-faa7-4e1b-97b0-6af2d59b3051

Test notification:
<img width="4266" height="2399" alt="Snímek obrazovky z 2026-08-12 15-37-36" src="https://github.com/user-attachments/assets/ee027aa9-3234-45f7-a83d-de399c905ad5" />

### Impact on end user

Fully working OS Notifications on Linux; including navigating to the correct section/chat/channel upon clicking

### How to test

- have the app inactive
- get a DM
- check your Notifications (distro dependent)

### Risk 

low
