### PR TITLE
chore(@e2e): fix aut shutdown on windows and make local waku fleet ports assignment cross platform

### DIFF
--- a/assets/local-waku-fleets-config.json
+++ b/assets/local-waku-fleets-config.json
@@ -2,22 +2,22 @@
   "status-app.test": {
     "clusterId": 16,
     "wakuNodes": [
-      "enr:-K-4QCaLys0F9CWHiXr9igN3oYGf3iWW-S444Xt49rCTpyiQQwMyfjCX52UeXPVG8vPGSSkP0mISMw-an-0HMhlZ-C4BgmlkgnY0gmlwhH8AAAGKbXVsdGlhZGRyc4CCcnONABAFAAEAIABAAIABAIlzZWNwMjU2azGhA4YfRwZtCsMoYkplRF4RErG9ohxKT-lneUgtogv3SJkCg3RjcILqYYN1ZHCCv2iFd2FrdTIN"
+      "enr:-Lm4QCl4if4UH7E2MBHbYSvgbcVeJMrg0c_7NfITr7b3L-M-M68CMxScf31FU4gDWqDo8S81NG-2lKIPoWEwMP6Vl40CgmlkgnY0gmlwhH8AAAGKbXVsdGlhZGRyc4oACASsEgADBphZgnJzjQAQBQABACAAQACAAQCJc2VjcDI1NmsxoQOGH0cGbQrDKGJKZUReERKxvaIcSk_pZ3lILaIL90iZAoN0Y3CCmFmDdWRwgr9ohXdha3UyDQ"
     ],
     "discV5BootstrapNodes": [
-      "enr:-K-4QCaLys0F9CWHiXr9igN3oYGf3iWW-S444Xt49rCTpyiQQwMyfjCX52UeXPVG8vPGSSkP0mISMw-an-0HMhlZ-C4BgmlkgnY0gmlwhH8AAAGKbXVsdGlhZGRyc4CCcnONABAFAAEAIABAAIABAIlzZWNwMjU2azGhA4YfRwZtCsMoYkplRF4RErG9ohxKT-lneUgtogv3SJkCg3RjcILqYYN1ZHCCv2iFd2FrdTIN"
+      "enr:-Lm4QCl4if4UH7E2MBHbYSvgbcVeJMrg0c_7NfITr7b3L-M-M68CMxScf31FU4gDWqDo8S81NG-2lKIPoWEwMP6Vl40CgmlkgnY0gmlwhH8AAAGKbXVsdGlhZGRyc4oACASsEgADBphZgnJzjQAQBQABACAAQACAAQCJc2VjcDI1NmsxoQOGH0cGbQrDKGJKZUReERKxvaIcSk_pZ3lILaIL90iZAoN0Y3CCmFmDdWRwgr9ohXdha3UyDQ"
     ],
     "storeNodes": [
       {
         "id": "store-1",
-        "enr": "enr:-K-4QI3LQZZaLyS6kA5lvmIcroksqNBZ1fRozAT9t_3yBVT6Vu5VHeNKa9u4eST4yGJ7M8K7Py53ZH7Zb6S6g2WbFrUBgmlkgnY0gmlwhH8AAAGKbXVsdGlhZGRyc4CCcnONABAFAAEAIABAAIABAIlzZWNwMjU2azGhAo3JozGxzJ2AeSAtgU0YzmxURKi6sveikwnF2cvZAhY1g3RjcILqYoN1ZHCCv2mFd2FrdTID",
-        "addr": "/ip4/127.0.0.1/tcp/60002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
+        "enr": "enr:-Lm4QPwCRYjiv1J1y8SRtvJMjdYwmtJ5LCMffRdUHtIJVq5UMKLlwdnF8jYltAeF0KEGDwOvzOraj3bosT6Wkxy_xzICgmlkgnY0gmlwhH8AAAGKbXVsdGlhZGRyc4oACASsEgACBphagnJzjQAQBQABACAAQACAAQCJc2VjcDI1NmsxoQKNyaMxscydgHkgLYFNGM5sVESourL3opMJxdnL2QIWNYN0Y3CCmFqDdWRwgr9phXdha3UyAw",
+        "addr": "/ip4/127.0.0.1/tcp/39002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
         "fleet": "status-desktop.test"
       },
       {
         "id": "store-2",
-        "enr": "enr:-K-4QP3hbp7CDP7Gn6NuVAtrrYRdqIiq-vX-Ofp-DY3UiRehM1kY2irkHLCfrTMQAwU8imS2A1SSPDV6pIvDrnRsJFABgmlkgnY0gmlwhH8AAAGKbXVsdGlhZGRyc4CCcnONABAFAAEAIABAAIABAIlzZWNwMjU2azGhAl0GSz7dmpanBV_zsW3Jwlp4CAf7-Vh2SMU4-NZt23Cpg3RjcILqY4N1ZHCCv2qFd2FrdTID",
-        "addr": "/ip4/127.0.0.1/tcp/60003/p2p/16Uiu2HAm1goTmM1zjARKFw82u71Zxhj5gvQDXPFEPW9xea4Zt6dv",
+        "enr": "enr:-Lm4QLfu3Sr6alb9CyHvGZpNAVhzC6caUzca57-ffm2vz4E5CNNP7vDe0RA3lsERYBYAdrTRPcUErDtSXCg6xgdOtCQCgmlkgnY0gmlwhH8AAAGKbXVsdGlhZGRyc4oACASsEgAEBphbgnJzjQAQBQABACAAQACAAQCJc2VjcDI1NmsxoQJdBks-3ZqWpwVf87FtycJaeAgH-_lYdkjFOPjWbdtwqYN0Y3CCmFuDdWRwgr9qhXdha3UyAw",
+        "addr": "/ip4/127.0.0.1/tcp/39003/p2p/16Uiu2HAm1goTmM1zjARKFw82u71Zxhj5gvQDXPFEPW9xea4Zt6dv",
         "fleet": "status-desktop.test"
       }
     ]

--- a/docker-compose.waku.yml
+++ b/docker-compose.waku.yml
@@ -2,7 +2,7 @@ services:
   boot-1:
     image: wakuorg/nwaku:v0.38.1
     ports:
-      - "60001:60001"
+      - "39001:39001"
       - "8645:8645"
       - "49000:49000/udp"
     entrypoint: [
@@ -31,9 +31,9 @@ services:
       "--shard=64",
       "--shard=128",
       "--shard=256",
-      "--staticnode=/dns4/store/tcp/60002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
-      "--storenode=/dns4/store/tcp/60002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
-      "--tcp-port=60001",
+      "--staticnode=/dns4/store/tcp/39002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
+      "--storenode=/dns4/store/tcp/39002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
+      "--tcp-port=39001",
       "--nat=extip:127.0.0.1",
     ]
     healthcheck:
@@ -45,7 +45,7 @@ services:
   store:
     image: wakuorg/nwaku:v0.38.1
     ports:
-      - "60002:60002"
+      - "39002:39002"
       - "8646:8646"
       - "49001:49001/udp"
     entrypoint: [
@@ -72,11 +72,11 @@ services:
       "--shard=64",
       "--shard=128",
       "--shard=256",
-      "--staticnode=/dns4/boot-1/tcp/60001/p2p/16Uiu2HAmMgYeJrjruJGCgL96aaP2nf85PGsRVkXLyhG2joJMH4pH",
+      "--staticnode=/dns4/boot-1/tcp/39001/p2p/16Uiu2HAmMgYeJrjruJGCgL96aaP2nf85PGsRVkXLyhG2joJMH4pH",
       "--store=true",
       "--store-message-db-url=sqlite:///tmp/store1.db",
       "--store-message-retention-policy=time:86400",
-      "--tcp-port=60002",
+      "--tcp-port=39002",
       "--nat=extip:127.0.0.1",
     ]
     healthcheck:
@@ -88,7 +88,7 @@ services:
   store-2:
     image: wakuorg/nwaku:v0.38.1
     ports:
-      - "60003:60003"
+      - "39003:39003"
       - "8647:8647"
       - "49002:49002/udp"
     entrypoint: [
@@ -115,11 +115,11 @@ services:
       "--shard=64",
       "--shard=128",
       "--shard=256",
-      "--staticnode=/dns4/boot-1/tcp/60001/p2p/16Uiu2HAmMgYeJrjruJGCgL96aaP2nf85PGsRVkXLyhG2joJMH4pH",
+      "--staticnode=/dns4/boot-1/tcp/39001/p2p/16Uiu2HAmMgYeJrjruJGCgL96aaP2nf85PGsRVkXLyhG2joJMH4pH",
       "--store=true",
       "--store-message-db-url=sqlite:///tmp/store2.db",
       "--store-message-retention-policy=time:86400",
-      "--tcp-port=60003",
+      "--tcp-port=39003",
       "--nat=extip:127.0.0.1",
     ]
     healthcheck:

--- a/test/e2e/driver/aut.py
+++ b/test/e2e/driver/aut.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import allure
 import logging
@@ -133,44 +132,29 @@ class AUT:
     def stop(self):
         LOG.info('Stopping AUT: %s', self.path)
         self.detach_context()
-        if self.pid:
-            local_system.kill_process(self.pid)
-            # Wait for process to exit with timeout to avoid hanging on Windows CI
-            max_wait_seconds = 5
-            check_interval = 0.1
-            elapsed = 0
-            
-            while elapsed < max_wait_seconds:
-                try:
-                    # Check if process is still running using psutil
-                    if psutil:
-                        try:
-                            proc = psutil.Process(self.pid)
-                            if not proc.is_running():
-                                LOG.info('Process %d exited', self.pid)
-                                break
-                        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
-                            # Process doesn't exist or can't be checked
-                            LOG.info('Process %d no longer exists', self.pid)
-                            break
-                    else:
-                        # If psutil not available, use shorter wait
-                        elapsed = max_wait_seconds
-                        break
-                except Exception as e:
-                    LOG.debug('Error checking process status: %s', e)
-                    # Continue and let timeout handle it
-                
-                # Calculate sleep duration before incrementing elapsed, ensuring it's non-negative
-                remaining = max_wait_seconds - elapsed
-                sleep_duration = min(check_interval, max(0, remaining))
-                if sleep_duration > 0:
-                    time.sleep(sleep_duration)
-                
-                elapsed += check_interval
-            
-            if elapsed >= max_wait_seconds and psutil:
-                LOG.warning('Process %d may still be running after %d seconds', self.pid, max_wait_seconds)
+        if not self.pid:
+            return
+
+        app_pids = local_system.get_pid_by_process_name(
+            os.path.basename(str(self.path)),
+            str(self.app_data),
+        ) or []
+        pids = {self.pid, *app_pids}
+        processes = []
+        for pid in pids:
+            try:
+                processes.append(psutil.Process(pid))
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                pass
+            local_system.kill_process(pid)
+
+        _, alive = psutil.wait_procs(processes, timeout=5)
+        if alive:
+            LOG.warning(
+                'AUT processes may still be running: %s',
+                [proc.pid for proc in alive],
+            )
+        self.pid = None
 
     @allure.step("Start and attach AUT")
     def launch(self) -> 'AUT':

--- a/test/e2e/scripts/utils/local_system.py
+++ b/test/e2e/scripts/utils/local_system.py
@@ -91,12 +91,15 @@ def run(
 
 
 @allure.step('Get pid by process name')
-def get_pid_by_process_name(name):
+def get_pid_by_process_name(name, command_line_argument=None):
     pid_list = []
     for proc in psutil.process_iter():
         try:
-            if proc.name() == name and proc.status() != 'zombie':
-                pid_list.append(proc.pid)
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            if proc.name() != name or proc.status() == 'zombie':
+                continue
+            if command_line_argument and command_line_argument not in ' '.join(proc.cmdline()):
+                continue
+            pid_list.append(proc.pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             continue
     return pid_list if len(pid_list) > 0 else None

--- a/test/e2e/scripts/utils/process_metrics.py
+++ b/test/e2e/scripts/utils/process_metrics.py
@@ -35,20 +35,12 @@ def resolve_monitored_pid(pid: int, app_path=None, app_data=None) -> int:
     except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
         pass
 
-    candidate_pids = local_system.get_pid_by_process_name(exe_name) or []
     if app_data is not None:
-        datadir = str(app_data)
-        matched = []
-        for candidate_pid in candidate_pids:
-            try:
-                cmdline = ' '.join(psutil.Process(candidate_pid).cmdline())
-                if datadir in cmdline:
-                    matched.append(candidate_pid)
-            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
-                continue
+        matched = local_system.get_pid_by_process_name(exe_name, str(app_data))
         if matched:
             return matched[-1]
 
+    candidate_pids = local_system.get_pid_by_process_name(exe_name) or []
     if candidate_pids:
         return candidate_pids[-1]
     return pid


### PR DESCRIPTION
### What does the PR do

Fix https://github.com/status-im/status-app/issues/21959

## Summary

- Stop both the Squish startaut wrapper and the matching Status process on e2e teardown, so orphaned `Status.exe` cannot keep locks on DLLs
- Move the local Waku fleet to TCP ports `39001-39003` on both host and container, below the Windows dynamic port range that blocked `60001-60003`.
- Advertise `127.0.0.1` and refresh fleet ENRs so e2e can reach the same stack on Windows, Linux, macOS, and CI.

## Why

Teardown previously killed only the `startaut` PID. On Windows the real `Status.exe` could stay alive after the wrapper died and hold `.dll` files in the repo.

Separately, Docker failed to start the local Waku fleet on Windows because `60001-60003` fell into a Hyper-V/WSL reserved range. Mapping host `61001` to container `60001` was not enough: the app reads ENRs, which still advertised `60001`. Host, container, and ENR ports now match.