### PR TITLE
perf(chat): drive the message view by a model window with staged reveal

### DIFF
--- a/storybook/pages/ChatBenchmarkComponents/MessageViewCensus.qml
+++ b/storybook/pages/ChatBenchmarkComponents/MessageViewCensus.qml
@@ -1,0 +1,239 @@
+import QtQuick
+
+// Benchmark instrumentation shared by the ChatLoader and CommunityChatLoader
+// pages, so both measure the message view the same way.
+//
+// Positional arguments (storybook's CLI parser rejects unknown --options):
+//   census    keep logging built message delegates and the row count of the
+//             model the view sees
+//   scrollup  drag the view a screen towards history per census tick for the
+//             first half of the census, then back towards the newest messages
+//   rerefresh re-run the page's Refresh once the first load has settled, so the
+//             warm path is measured as well as the fresh one
+Item {
+    id: root
+
+    // Instrumentation only: the pages that host it are SplitViews, which would
+    // otherwise give it a pane of its own
+    visible: false
+
+    // Root of the loaded section harness to search for the message view
+    property Item harnessItem: null
+
+    // Prefix for every log line, so runs of the two pages stay distinguishable
+    property string label: ""
+
+    // Set by the page right before it activates the harness
+    property double loadStartTime: 0
+
+    readonly property bool censusMode: Qt.application.arguments.indexOf("census") >= 0
+    readonly property bool scrollUpMode: Qt.application.arguments.indexOf("scrollup") >= 0
+
+    readonly property alias view: d.messageView
+
+    // Milliseconds the message view took to show its first built delegate,
+    // -1 while it has not
+    property int messagesShownMs: -1
+
+    signal messagesShown(int ms)
+
+    // Emitted when the page should re-run its Refresh (see "rerefresh")
+    signal refreshRequested()
+
+    readonly property bool rerefreshMode: Qt.application.arguments.indexOf("rerefresh") >= 0
+
+    // Which load the numbers being logged belong to
+    property string pass: "fresh"
+
+    // Highest number of message delegates built at any sampled moment since
+    // the load started — a view that materializes the history and then settles
+    // still made the user watch it happen, so the resting count alone lies.
+    property int peakDelegates: 0
+
+    function restart() {
+        d.messageView = null
+        root.messagesShownMs = -1
+        root.peakDelegates = 0
+        d.viewForSampling = null
+        d.trajectory = []
+        censusTimer.stop()
+        peakProbe.restart()
+        messagesProbe.restart()
+    }
+
+    // Counts built message delegates without descending into them, so the
+    // traversal cost stays proportional to the container tree + delegate count.
+    function countDelegates(obj) {
+        if (!obj)
+            return 0
+        if (obj.objectName === "chatMessageViewDelegate")
+            return 1
+        let n = 0
+        const kids = obj.children || []
+        for (let i = 0; i < kids.length; ++i)
+            n += countDelegates(kids[i])
+        return n
+    }
+
+    function findByName(obj, name) {
+        if (!obj)
+            return null
+        if (obj.objectName === name)
+            return obj
+        const kids = obj.children || []
+        for (let i = 0; i < kids.length; ++i) {
+            const r = findByName(kids[i], name)
+            if (r)
+                return r
+        }
+        return null
+    }
+
+    QtObject {
+        id: d
+
+        property Item messageView: null
+
+        // The view is looked up ignoring visibility, so delegates built while
+        // the section is still incubating behind its skeleton are counted too
+        property Item viewForSampling: null
+
+        property var trajectory: []
+    }
+
+    Timer {
+        id: peakProbe
+
+        interval: 50
+        repeat: true
+        running: false
+
+        onTriggered: {
+            if (!root.harnessItem)
+                return
+            if (!d.viewForSampling) {
+                d.viewForSampling = root.findByName(root.harnessItem, "chatLogView")
+                if (d.viewForSampling)
+                    console.info(root.label, "view found after",
+                                 Date.now() - root.loadStartTime, "ms")
+            }
+            if (!d.viewForSampling)
+                return
+            root.peakDelegates = Math.max(root.peakDelegates,
+                                          root.countDelegates(d.viewForSampling))
+
+            // Concurrent delegates stay low even while a view streams the whole
+            // history past the viewport, so also record where the view is
+            // looking: a traversal shows up as contentY sweeping the content.
+            const y = Math.round(d.viewForSampling.contentY)
+            if (d.trajectory.length === 0 || d.trajectory[d.trajectory.length - 1] !== y)
+                d.trajectory.push(y)
+            if (d.trajectory.length > 400)
+                d.trajectory.shift()
+        }
+    }
+
+    // Total distance the view travelled while loading; a bottom-anchored open
+    // should be a single jump, not a sweep across the history.
+    function reportTrajectory(phase) {
+        const t = d.trajectory
+        if (t.length === 0) {
+            console.info(root.label, "TRAJECTORY", phase, "none")
+            return
+        }
+        let travelled = 0
+        for (let i = 1; i < t.length; ++i)
+            travelled += Math.abs(t[i] - t[i - 1])
+        console.info(root.label, "TRAJECTORY " + phase + " samples=" + t.length,
+                     "min=" + Math.min(...t), "max=" + Math.max(...t),
+                     "travelled=" + travelled)
+        console.info(root.label, "TRAJECTORY path", JSON.stringify(t.slice(0, 60)))
+    }
+
+    // READY alone does not mean the user sees messages (a state may build them
+    // after the section is Ready, behind a skeleton). Poll until the message
+    // view has at least one built, visible delegate and no covering skeleton.
+    Timer {
+        id: messagesProbe
+
+        interval: 16
+        repeat: true
+
+        onTriggered: {
+            if (!root.harnessItem)
+                return
+            const skeleton = root.findByName(root.harnessItem, "chatMessagesSkeleton")
+            if (skeleton && skeleton.visible)
+                return
+            if (!d.messageView)
+                d.messageView = root.findByName(root.harnessItem, "chatLogView")
+            if (!d.messageView || !d.messageView.visible || !d.messageView.contentItem)
+                return
+
+            const delegate = root.findByName(d.messageView.contentItem, "chatMessageViewDelegate")
+            if (!delegate || !delegate.visible)
+                return
+
+            const ms = Date.now() - root.loadStartTime
+            root.messagesShownMs = ms
+            console.info(root.label, "MESSAGES", root.pass, "in", ms, "ms")
+            console.info(root.label, "model rows:", d.messageView.count,
+                         "peak delegates since load:", root.peakDelegates)
+            running = false
+            root.reportTrajectory("to-first-paint")
+            root.messagesShown(ms)
+
+            if (root.censusMode) {
+                censusTimer.ticks = 0
+                censusTimer.restart()
+            }
+            if (root.rerefreshMode && root.pass === "fresh")
+                rerefreshTimer.restart()
+        }
+    }
+
+    Timer {
+        id: rerefreshTimer
+
+        interval: 2000
+        onTriggered: {
+            root.pass = "refresh"
+            root.refreshRequested()
+        }
+    }
+
+    // The peak matters as much as the resting count: a view that materializes
+    // the history and then settles still made the user watch it happen.
+    Timer {
+        id: censusTimer
+
+        property int ticks: 0
+        property int peakDelegates: 0
+
+        interval: 500
+        repeat: true
+
+        onTriggered: {
+            const view = d.messageView
+            if (!view)
+                return
+            ++ticks
+            if (root.scrollUpMode)
+                view.contentY += view.height * 0.9 * (ticks > 20 ? 1 : -1)
+
+            // One report covering load plus the settle window: a bottom-anchored
+            // open travels once, a traversal keeps sweeping
+            if (ticks === 4)
+                root.reportTrajectory("through-settle")
+
+            const built = root.countDelegates(view)
+            peakDelegates = Math.max(peakDelegates, built)
+            console.info(root.label + " CENSUS t=" + (ticks * interval)
+                         + " delegates=" + built
+                         + " peak=" + peakDelegates
+                         + " rows=" + view.count
+                         + " contentHeight=" + Math.round(view.contentHeight)
+                         + " contentY=" + Math.round(view.contentY))
+        }
+    }
+}

--- a/storybook/pages/ChatLoaderPage.qml
+++ b/storybook/pages/ChatLoaderPage.qml
@@ -20,6 +20,8 @@ import mainui.sectionLoaders
 import Models
 import Storybook
 
+import "ChatBenchmarkComponents"
+
 // Exercises the real ChatLoader: loader-owned section chrome with skeleton
 // panels, async incubation of the real ChatLayout/ChatView, and the
 // skeleton → real panel swap. Refresh recreates the whole loader.
@@ -37,10 +39,44 @@ SplitView {
     // clean exit (storybook's CLI parser rejects unknown --options)
     readonly property bool profileExitMode: Qt.application.arguments.indexOf("profile-exit") >= 0
 
+    // Optional "messages=N" / "contacts=N" positional arguments override the
+    // corresponding spinboxes for headless benchmark runs
+    function argValue(name, fallback) {
+        const prefix = name + "="
+        for (const arg of Qt.application.arguments) {
+            if (arg.indexOf(prefix) === 0)
+                return parseInt(arg.substring(prefix.length))
+        }
+        return fallback
+    }
+
+    readonly property int cliMessages: argValue("messages", -1)
+    readonly property int cliContacts: argValue("contacts", -1)
+
     Timer {
         id: profilerExitTimer
         interval: 4000
         onTriggered: Qt.exit(0)
+    }
+
+    MessageViewCensus {
+        id: census
+
+        harnessItem: harness.item
+        label: "ChatLoader"
+        loadStartTime: d.loadStartTime
+
+        onRefreshRequested: root.refresh()
+
+        onMessagesShown: ms => {
+            logs.logEvent("ChatLoader MESSAGES in " + ms + " ms")
+            if (root.profileExitMode) {
+                profilerExitTimer.interval = census.scrollUpMode ? 24000
+                    : (census.rerefreshMode && census.pass === "fresh") ? 12000
+                    : (census.censusMode ? 3000 : 2000)
+                profilerExitTimer.restart()
+            }
+        }
     }
 
     ListModel { id: chatsModel }
@@ -146,9 +182,12 @@ SplitView {
             // `offset` continue into older history
             for (let j = 0; j < count; ++j) {
                 const i = offset + j
-                const own = i % 3 === 1
-                const ts = now - i * 60000
-                model.append({
+                model.append(messageRow(peerIdx, i, now - i * 60000, i % 3 === 1, offset + count - i))
+            }
+        }
+
+        function messageRow(peerIdx, i, ts, own, seq) {
+            return ({
                     id: "msg-" + peerIdx + "-" + i,
                     prevMsgIndex: i + 1,
                     nextMsgIndex: i - 1,
@@ -167,9 +206,9 @@ SplitView {
                     senderEnsVerified: false,
                     senderTrustStatus: 0,
                     amISender: own,
-                    messageText: "Message " + i + " — the quick brown fox jumps over the lazy dog. "
+                    messageText: "Message " + seq + " — the quick brown fox jumps over the lazy dog. "
                                  + (i % 5 === 0 ? "A somewhat longer paragraph to vary the bubble heights and make the layout work harder while measuring text. " : ""),
-                    unparsedText: "Message " + i,
+                    unparsedText: "Message " + seq,
                     messageImage: "",
                     messageAttachments: "",
                     contentType: Constants.messageContentType.messageType,
@@ -212,7 +251,105 @@ SplitView {
                     albumImagesCount: 0,
                     usesDefaultName: false
                 })
+        }
+
+        property int injectedCounter: 0
+
+        function injectedRow() {
+            injectedCounter++
+            const row = messageRow(0, injectedCounter, Date.now(), false, injectedCounter)
+            row.id = "msg-injected-" + injectedCounter
+            row.senderDisplayName = "Injected"
+            row.messageText = "Injected message #" + injectedCounter
+            row.unparsedText = row.messageText
+            return row
+        }
+
+        function activeMessagesModel() {
+            const module = contentModuleFor(activeChatId)
+            return module ? module.messagesModel : null
+        }
+
+        // The window bounds live in the active ChatMessagesView's private
+        // object; the visible chatLogView identifies which chat's view that is
+        function activeWindowBounds() {
+            const stack = [harness]
+            while (stack.length) {
+                const item = stack.pop()
+                if (!item || item.visible === false)
+                    continue
+                if (item.objectName === "chatLogView") {
+                    // the private object is a resource, not a visual child —
+                    // StorybookUtils.findChild walks children only, so scan
+                    // the view root's data list directly
+                    const data = item.parent ? item.parent.data : []
+                    for (let i = 0; i < data.length; ++i) {
+                        if (data[i].objectName === "chatMessagesViewInternal")
+                            return { start: data[i].windowStart,
+                                     end: data[i].windowEnd }
+                    }
+                    return null
+                }
+                const kids = item.children
+                for (let i = 0; i < (kids ? kids.length : 0); ++i)
+                    stack.push(kids[i])
             }
+            return null
+        }
+
+        // Source index 0 = newest = view bottom; count-1 = oldest = view top.
+        // The window covers source rows [start..end].
+        function modelOp(op) {
+            const model = activeMessagesModel()
+            if (!model) {
+                logs.logEvent("model op '" + op + "': no active chat")
+                return
+            }
+            const bounds = activeWindowBounds()
+            const needsBounds = op.indexOf("Window") !== -1
+            if (needsBounds && !bounds) {
+                logs.logEvent("model op '" + op + "': window bounds not reachable")
+                return
+            }
+            const mid = bounds ? Math.floor((bounds.start + bounds.end) / 2) : -1
+            const n = ctrlOpRows.value
+            switch (op) {
+            case "removeTop":
+                model.remove(Math.max(0, model.count - n), Math.min(n, model.count))
+                break
+            case "removeBottom":
+                model.remove(0, Math.min(n, model.count))
+                break
+            case "addTop":
+                for (let i = 0; i < n; ++i)
+                    model.append(injectedRow())
+                break
+            case "addBottom":
+                for (let i = 0; i < n; ++i)
+                    model.insert(0, injectedRow())
+                break
+            case "addAboveWindow":
+                for (let i = 0; i < n; ++i)
+                    model.insert(Math.min(model.count, bounds.end + 1), injectedRow())
+                break
+            case "addBelowWindow":
+                // with the window at the recent end there is no "below" —
+                // the row lands inside the window as the new newest
+                for (let i = 0; i < n; ++i)
+                    model.insert(Math.min(model.count, bounds.start), injectedRow())
+                break
+            case "addMidWindow":
+                for (let i = 0; i < n; ++i)
+                    model.insert(Math.min(model.count, Math.max(0, mid)), injectedRow())
+                break
+            case "removeMidWindow":
+                if (mid >= 0 && mid < model.count)
+                    model.remove(mid, Math.min(n, model.count - mid))
+                break
+            }
+            logs.logEvent(op + " ×" + n + " → count=" + model.count
+                          + (bounds ? " window=[" + bounds.start + ".." + bounds.end + "]"
+                                    : ""))
         }
 
         // The message history is filled only when a chat becomes active —
@@ -426,8 +563,12 @@ SplitView {
                             const ms = Date.now() - d.loadStartTime
                             logs.logEvent("ChatLoader READY in " + ms + " ms")
                             console.info("ChatLoader READY in", ms, "ms")
-                            if (root.profileExitMode)
-                                profilerExitTimer.start()
+                            if (root.profileExitMode) {
+                                // long fallback; the messages probe shortens
+                                // it once the message area is actually built
+                                profilerExitTimer.interval = 30000
+                                profilerExitTimer.restart()
+                            }
                         }
                     }
                 }
@@ -442,8 +583,11 @@ SplitView {
 
         logsView.logText: logs.logText
 
-        RowLayout {
+        ColumnLayout {
             anchors.fill: parent
+
+            RowLayout {
+            Layout.fillWidth: true
             spacing: Theme.bigPadding
 
             Button {
@@ -460,7 +604,7 @@ SplitView {
                     from: 0
                     to: 5000
                     stepSize: 50
-                    value: 1000
+                    value: root.cliContacts >= 0 ? root.cliContacts : 1000
                     editable: true
                 }
             }
@@ -471,9 +615,11 @@ SplitView {
                     id: ctrlMessages
                     objectName: "chatLoaderMessagesSpinBox"
                     from: 0
-                    to: 10000
+                    // High enough that the scaling benchmarks are not silently
+                    // clamped to the spinbox maximum
+                    to: 1000000
                     stepSize: 100
-                    value: 2000
+                    value: root.cliMessages >= 0 ? root.cliMessages : 2000
                     editable: true
                 }
             }
@@ -484,6 +630,35 @@ SplitView {
             }
 
             Item { Layout.fillWidth: true }
+            }
+
+            // Live model surgery on the active chat, in view-visual terms:
+            // top = oldest (source count-1), bottom = newest (source 0)
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.halfPadding
+
+                Label { text: "Model:" }
+                SpinBox {
+                    id: ctrlOpRows
+                    objectName: "modelOpRowsSpinBox"
+                    from: 1
+                    to: 100000
+                    stepSize: 1
+                    value: 1
+                    editable: true
+                }
+                Button { objectName: "modelOp_addTop"; text: "Add top"; onClicked: d.modelOp("addTop") }
+                Button { objectName: "modelOp_removeTop"; text: "Del top"; onClicked: d.modelOp("removeTop") }
+                Button { objectName: "modelOp_addBottom"; text: "Add bottom"; onClicked: d.modelOp("addBottom") }
+                Button { objectName: "modelOp_removeBottom"; text: "Del bottom"; onClicked: d.modelOp("removeBottom") }
+                Button { objectName: "modelOp_addAboveWindow"; text: "Add above win"; onClicked: d.modelOp("addAboveWindow") }
+                Button { objectName: "modelOp_addBelowWindow"; text: "Add below win"; onClicked: d.modelOp("addBelowWindow") }
+                Button { objectName: "modelOp_addMidWindow"; text: "Add mid win"; onClicked: d.modelOp("addMidWindow") }
+                Button { objectName: "modelOp_removeMidWindow"; text: "Del mid win"; onClicked: d.modelOp("removeMidWindow") }
+
+                Item { Layout.fillWidth: true }
+            }
         }
     }
 
@@ -500,10 +675,22 @@ SplitView {
             d.contentModules[key].destroy()
         d.contentModules = {}
         d.mockState.preparedChatId = ""
+
+        // Mock construction is measured separately: the ListModel.append loop
+        // that builds the history is page cost, not message-view cost, and it
+        // runs before the harness is activated so it is outside loadStartTime.
+        const tChats = Date.now()
         d.buildChats(ctrlChats.value)
+        const tMessages = Date.now()
         d.setActiveChat(chatsModel.count > 0 ? "chat-0" : "")
+        const tDone = Date.now()
+        console.info("ChatLoader MOCK chats", tMessages - tChats, "ms, messages",
+                     tDone - tMessages, "ms for", ctrlMessages.value, "rows")
+        logs.logEvent("mock: chats %1 ms, messages %2 ms".arg(tMessages - tChats).arg(tDone - tMessages))
+
         d.loadStartTime = Date.now()
         harness.active = true
+        census.restart()
         logs.logEvent("refresh: %1 contacts, %2 messages each".arg(chatsModel.count).arg(ctrlMessages.value))
     }
 

--- a/storybook/pages/CommunityChatLoaderPage.qml
+++ b/storybook/pages/CommunityChatLoaderPage.qml
@@ -22,6 +22,8 @@ import mainui.sectionLoaders
 import Models
 import Storybook
 
+import "ChatBenchmarkComponents"
+
 // Exercises the real CommunityChatLoader against a fully configurable mock
 // community (CommunitySectionMock): membership/join state, member role,
 // categories, private channels and their members, token permissions and
@@ -53,6 +55,26 @@ SplitView {
         id: profilerExitTimer
         interval: 4000
         onTriggered: Qt.exit(0)
+    }
+
+    MessageViewCensus {
+        id: census
+
+        harnessItem: harness.item
+        label: "CommunityChatLoader"
+        loadStartTime: d.loadStartTime
+
+        onRefreshRequested: root.refresh()
+
+        onMessagesShown: ms => {
+            logs.logEvent("CommunityChatLoader MESSAGES in " + ms + " ms")
+            if (root.profileExitMode) {
+                profilerExitTimer.interval = census.scrollUpMode ? 24000
+                    : (census.rerefreshMode && census.pass === "fresh") ? 12000
+                    : (census.censusMode ? 3000 : 2000)
+                profilerExitTimer.restart()
+            }
+        }
     }
 
     QtObject {
@@ -183,8 +205,12 @@ SplitView {
                             const ms = Date.now() - d.loadStartTime
                             logs.logEvent("CommunityChatLoader READY in " + ms + " ms")
                             console.info("CommunityChatLoader READY in", ms, "ms")
-                            if (root.profileExitMode)
-                                profilerExitTimer.start()
+                            if (root.profileExitMode) {
+                                // long fallback; the census shortens it once
+                                // the message view is actually built
+                                profilerExitTimer.interval = 30000
+                                profilerExitTimer.restart()
+                            }
                         }
                     }
                 }
@@ -308,7 +334,9 @@ SplitView {
                     SpinBox {
                         id: ctrlMessages
                         objectName: "communityLoaderMessagesSpinBox"
-                        from: 0; to: 10000; stepSize: 100; editable: true
+                        // High enough that the scaling benchmarks are not
+                        // silently clamped to the spinbox maximum
+                        from: 0; to: 1000000; stepSize: 100; editable: true
                         value: root.argValue("messages", 500)
                     }
                 }
@@ -328,6 +356,7 @@ SplitView {
         console.info("mock: applyConfig", t1 - t0, "ms, install", Date.now() - t1, "ms")
         d.loadStartTime = Date.now()
         harness.active = true
+        census.restart()
         logs.logEvent("refresh: %1 (%2) — %3 members, %4 channels, %5 msgs each"
                       .arg(d.joinStates[ctrlJoinState.currentIndex].name)
                       .arg(d.memberRoles[ctrlRole.currentIndex].name)

--- a/storybook/qmlTests/tests/tst_ChatContentView.qml
+++ b/storybook/qmlTests/tests/tst_ChatContentView.qml
@@ -44,6 +44,7 @@ Item {
             readonly property var model: messagesModel
             property bool loading: false
             property bool keepUnread: false
+            property int fetchCalls: 0
 
             signal messageSuccessfullySent()
             signal sendingMessageFailed(string error)
@@ -51,7 +52,7 @@ Item {
             signal scrollToMessage(string messageId)
 
             function getChatId() { return "chat-1" }
-            function loadMoreMessages() {}
+            function loadMoreMessages() { fetchCalls++ }
             function updateKeepUnread(flag) {}
         }
 
@@ -81,6 +82,7 @@ Item {
 
         function cleanup() {
             contentModuleMock.messagesModule.loading = false
+            contentModuleMock.messagesModule.fetchCalls = 0
             contentModuleMock.markAllMessagesReadCalls = 0
             contentModuleMock.chatDetails.hasUnreadMessages = false
             messagesModel.clear()
@@ -105,6 +107,89 @@ Item {
 
             tryVerify(() => contentModuleMock.markAllMessagesReadCalls > 0, 10000,
                       "a cold-opened unread chat must still get marked read")
+        }
+
+        // The view is driven by a window proxy over the messages model; the
+        // lazy-attach gate applies to the proxy's source.
+        function sourceOf(listView) {
+            return listView.model ? listView.model.sourceModel : null
+        }
+
+        // Full role set (every model.* the delegate reads) so MessageView
+        // rows build without warnings and with realistic heights.
+        function appendMessage(i, contentType) {
+            messagesModel.append(messageRoles("msg-" + i, i, Date.now() - i * 60000, contentType))
+        }
+
+        // A message arriving while the chat is open: the newest row, entering
+        // at the recent end of the model.
+        function insertNewest(i) {
+            messagesModel.insert(0, messageRoles("msg-new-" + i, -1 - i,
+                                                 Date.now() + (i + 1) * 60000))
+        }
+
+        function messageRoles(id, i, ts, contentType) {
+            return {
+                id: id,
+                communityId: "",
+                compressedKey: "zQ3peer",
+                prevMsgIndex: i + 1,
+                nextMsgIndex: i - 1,
+                prevMsgTimestamp: ts - 60000,
+                nextMsgTimestamp: ts + 60000,
+                prevMsgSenderId: "",
+                prevMsgContentType: 1,
+                prevMsgDeleted: false,
+                timestamp: ts,
+                responseToMessageWithId: "",
+                senderId: "0xpeer",
+                senderDisplayName: "Peer",
+                senderOptionalName: "",
+                senderIcon: "",
+                senderIsAdded: true,
+                senderEnsVerified: false,
+                senderTrustStatus: 0,
+                amISender: false,
+                usesDefaultName: true,
+                messageText: "Message " + i + " — the quick brown fox jumps over the lazy dog.",
+                unparsedText: "Message " + i,
+                messageImage: "",
+                messageAttachments: "",
+                albumImagesCount: 0,
+                albumMessageImages: "",
+                contentType: contentType === undefined ? 1 : contentType,
+                sticker: "",
+                stickerPack: -1,
+                editMode: false,
+                isEdited: false,
+                outgoingStatus: "",
+                resendError: "",
+                mentioned: false,
+                gapFrom: 0,
+                gapTo: 0,
+                quotedMessageText: "",
+                quotedMessageParsedText: "",
+                quotedMessageFrom: "",
+                quotedMessageContentType: 1,
+                quotedMessageDeleted: false,
+                quotedMessageAuthorName: "",
+                quotedMessageAuthorDisplayName: "",
+                quotedMessageAuthorThumbnailImage: "",
+                quotedMessageAuthorEnsVerified: false,
+                quotedMessageAuthorIsContact: false,
+                quotedMessageAlbumImagesCount: 0,
+                quotedMessageAlbumMessageImages: "",
+                reactions: "",
+                pinned: false,
+                pinnedBy: "",
+                deleted: false,
+                deletedBy: "",
+                deletedByContactDisplayName: "",
+                deletedByContactIcon: "",
+                bridgeName: "",
+                links: "",
+                transactionParameters: ""
+            }
         }
 
         function test_messagesViewIncubatesAsynchronously() {
@@ -169,6 +254,433 @@ Item {
             tryVerify(() => view.chatMessagesLoader.item.visible)
             tryVerify(() => !findChild(view, "chatMessagesSkeleton"), 5000,
                       "skeleton must be released once the view is shown")
+        }
+
+        // Bug repro (device): the initial fetch runs with the model detached,
+        // and the paging placeholder must not unstick the view meanwhile —
+        // once loading finishes the view must sit at the newest message, not
+        // at the top showing the placeholder skeleton.
+        function test_opensAtNewestAfterLoadingFinishes() {
+            contentModuleMock.messagesModule.loading = true
+
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+
+            // give the paging timer time to fire against the empty window
+            wait(400)
+
+            for (let i = 0; i < 200; ++i)
+                appendMessage(i)
+            contentModuleMock.messagesModule.loading = false
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            tryVerify(() => listView.count > 0, 5000)
+            tryVerify(() => listView.stickingToNewest, 5000,
+                      "view must stay stuck to the newest message across the loading phase")
+            tryVerify(() => listView.atNewest, 5000,
+                      "view must open anchored on the newest message, contentY="
+                      + listView.contentY + " contentHeight=" + listView.contentHeight)
+        }
+
+        // Bug repro (device): a channel whose oldest row is the chat
+        // identifier has its entire history in the model — the view must not
+        // keep requesting more history (fetch storm) nor advertise older
+        // messages above the channel start.
+        function test_noFetchStormAtChannelStart() {
+            for (let i = 0; i < 10; ++i)
+                appendMessage(i)
+            appendMessage(10, Constants.messageContentType.chatIdentifier)
+
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            tryVerify(() => listView.count > 0, 5000)
+
+            // whole history is in the window; let the paging timer run
+            wait(500)
+            compare(contentModuleMock.messagesModule.fetchCalls, 0,
+                    "no history fetch may fire when the channel start is already loaded")
+            verify(!listView.moreUpAvailable,
+                   "no older messages may be advertised above the channel start")
+        }
+
+        // The backend keeps a fetch-more row above the chat identifier while
+        // older messages can be requested — the view must page the backend
+        // through it (the identifier alone is present in every chat and must
+        // not read as "history exhausted").
+        function test_fetchesMoreHistoryWhileChannelStartNotLoaded() {
+            // few enough rows that the content stays shorter than the viewport,
+            // keeping the paging placeholder visible without any scrolling
+            for (let i = 0; i < 3; ++i)
+                appendMessage(i)
+            appendMessage(3, Constants.messageContentType.fetchMoreMessagesButton)
+            appendMessage(4, Constants.messageContentType.chatIdentifier)
+
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            tryVerify(() => listView.count > 0, 5000)
+
+            tryVerify(() => contentModuleMock.messagesModule.fetchCalls > 0, 5000,
+                      "the view must page the backend while older messages can be requested")
+        }
+
+        // A sent message slides the window to the recent end; it must not
+        // rebuild it — the teardown flashed the paging skeleton over the
+        // user's own messages on every send.
+        function test_sentMessageDoesNotRebuildTheWindow() {
+            for (let i = 0; i < 200; ++i)
+                appendMessage(i)
+
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            tryVerify(() => listView.count >= 20, 5000)
+            tryVerify(() => listView.atNewest, 5000)
+
+            // slide the window into history through the test seam
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            internal.windowStart = 30
+            internal.windowStartGoal = 30
+            internal.windowEnd = 60
+            internal.windowEndGoal = 60
+            tryVerify(() => listView.count > 0, 5000)
+
+            const preSendCount = listView.count
+            let minCount = preSendCount
+            listView.countChanged.connect(() => {
+                minCount = Math.min(minCount, listView.count)
+            })
+
+            contentModuleMock.messagesModule.messageSuccessfullySent()
+
+            tryVerify(() => listView.atNewest, 5000,
+                      "a sent message must land the view on the newest message")
+            verify(minCount >= preSendCount,
+                   "the window must not be torn down on send: count dropped to " + minCount
+                   + " from " + preSendCount)
+        }
+
+        // A jump to a message deep in history collapses the window around the
+        // target; the content shrink must not re-stick the view or walk the
+        // window back to the recent end — the user must stay on the target.
+        function test_jumpToMessageDeepInHistoryStaysOnTarget() {
+            for (let i = 0; i < 300; ++i)
+                appendMessage(i)
+
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            tryVerify(() => listView.count >= 20, 5000)
+            tryVerify(() => listView.atNewest, 5000)
+
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            internal.goToMessage(150)
+
+            tryVerify(() => internal.windowStart > 0, 5000,
+                      "the window must move to the jump target")
+
+            // the window must SETTLE away from the recent end: sample over a
+            // second and require windowStart never to converge back to 0
+            let minStart = internal.windowStart
+            for (let i = 0; i < 20; ++i) {
+                wait(50)
+                minStart = Math.min(minStart, internal.windowStart)
+            }
+            verify(minStart > 0,
+                   "the jump must not be cancelled by the window collapse, "
+                   + "windowStart fell back to " + minStart)
+            verify(!listView.stickingToNewest,
+                   "the view must not stick to the newest after a jump into history")
+        }
+
+        // The window must grow towards its initial size in bounded steps —
+        // building the whole initial window in one synchronous batch is what
+        // froze the app on window moves.
+        function test_windowGrowsInBoundedSteps() {
+            for (let i = 0; i < 500; ++i)
+                appendMessage(i)
+
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+
+            // watch the window bound itself: every growth step must stay
+            // within the driver's per-frame budget, no matter when the test
+            // process gets to observe the item count
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            let maxJump = 0
+            let prev = internal.windowEnd
+            internal.windowEndChanged.connect(() => {
+                maxJump = Math.max(maxJump, internal.windowEnd - prev)
+                prev = internal.windowEnd
+            })
+
+            // the window reaches its initial size, anchored on the newest
+            // message, having grown only in budgeted steps
+            tryVerify(() => listView.count >= 20, 5000)
+            verify(maxJump <= internal.moveBudget,
+                   "window bound may only move moveBudget rows at a time, jumped " + maxJump)
+            const deadline = Date.now() + 5000
+            while (Date.now() < deadline && !listView.atNewest)
+                wait(50)
+            verify(listView.atNewest,
+                   "must settle at the newest message: contentY=" + listView.contentY
+                   + " bottom=" + (listView.contentHeight - listView.height)
+                   + " stick=" + listView.stickingToNewest
+                   + " moreDown=" + listView.moreDownAvailable
+                   + " count=" + listView.count)
+        }
+
+        // Builds the view on a history of the given size and waits until it
+        // shows the newest message.
+        function openAtNewest(messageCount) {
+            for (let i = 0; i < messageCount; ++i)
+                appendMessage(i)
+
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            tryVerify(() => listView.count > 0, 20000)
+
+            const chat = { view: view, listView: listView, internal: internal }
+            // Paging is an independent mover of the same geometry: with the
+            // whole history in the model it keeps sliding the window for as
+            // long as a placeholder shows, which a measurement could not tell
+            // apart from the insert under test. The window is driven through
+            // the seam from here on.
+            listView.moreUpAvailable = false
+            listView.moreDownAvailable = false
+
+            // the window still walks towards its goal a few rows per frame;
+            // scrolling only means something once the content outgrew the
+            // viewport
+            waitForQuietWindow(chat)
+            waitForRendered(listView, () => listView.contentHeight > listView.height * 2,
+                            () => "the window must fill more than the viewport, contentHeight="
+                                  + listView.contentHeight + " count=" + listView.count)
+            waitForRendered(listView, () => listView.atNewest,
+                            () => "the view must open on the newest message, contentY="
+                                  + listView.contentY + " contentHeight=" + listView.contentHeight)
+            return chat
+        }
+
+        // Layout positions and content height only catch up on a frame, so
+        // conditions about them have to be waited for with rendering.
+        function waitForRendered(listView, condition, message) {
+            for (let i = 0; i < 600; ++i) {
+                if (condition())
+                    return
+                wait(16)
+                waitForRendering(listView)
+            }
+            fail(message())
+        }
+
+        // The window walks towards its goals a few rows per frame and the
+        // paging timer may slide it further; a measurement is only meaningful
+        // once it stands still — which takes both bounds at their goal and no
+        // paging request for longer than the paging interval.
+        function waitForQuietWindow(chat) {
+            const internal = chat.internal
+            const where = () => internal.windowStart + ".." + internal.windowEnd
+                                + " goals " + internal.windowStartGoal + ".."
+                                + internal.windowEndGoal
+            // opening pages the window a chunk at a time while the content is
+            // still shorter than the viewport, so the goals may run ahead of
+            // the bounds before everything settles
+            tryVerify(() => internal.windowStart === internal.windowStartGoal
+                            && internal.windowEnd === internal.windowEndGoal,
+                      30000, "the window must reach its goals, at " + where())
+
+            let last = ""
+            let stable = 0
+            for (let i = 0; i < 400 && stable < 8; ++i) {
+                wait(25)
+                const now = where()
+                stable = (now === last) ? stable + 1 : 0
+                last = now
+            }
+            verify(stable >= 8, "the window must stop moving, at " + where())
+            waitForRendering(chat.listView)
+        }
+
+        // The grid re-flows on polish and a freshly built MessageView settles
+        // its height over a few frames; reading positions before that reads
+        // the pre-insert layout.
+        function waitForSettledLayout(listView) {
+            let last = ""
+            let stable = 0
+            let placed = false
+            // the grid only re-flows on a frame, so the wait has to render
+            for (let i = 0; i < 600 && (!placed || stable < 3); ++i) {
+                wait(16)
+                waitForRendering(listView)
+                const newest = listView.itemAtRow(0)
+                const next = listView.itemAtRow(1)
+                placed = !!newest && !!next && newest.y > next.y
+                const now = listView.contentHeight + ":" + (newest ? newest.y : -1)
+                          + ":" + listView.contentY
+                stable = (now === last) ? stable + 1 : 0
+                last = now
+            }
+            verify(placed, "the newest row must end up laid out below the older ones")
+            verify(stable >= 3, "the layout must settle, at " + last)
+        }
+
+        // Grows the window to its cap at the recent end, through the test
+        // seam: paging there row by row would take the whole test.
+        function growToCap(chat) {
+            chat.internal.windowEnd = chat.internal.maxWindowSize - 1
+            chat.internal.windowEndGoal = chat.internal.windowEnd
+            tryCompare(chat.listView, "count", chat.internal.maxWindowSize, 30000)
+            waitForQuietWindow(chat)
+        }
+
+        // Records a delegate inside the viewport together with where it sits
+        // on screen, once its height stopped settling.
+        function trackVisibleRow(listView) {
+            for (let attempt = 0; attempt < 20; ++attempt) {
+                let item = null
+                for (let k = 0; k < listView.count && !item; ++k) {
+                    const candidate = listView.itemAtRow(k)
+                    if (!candidate)
+                        continue
+                    const y = candidate.mapToItem(listView, 0, 0).y
+                    if (y >= 100 && y <= listView.height - 100)
+                        item = candidate
+                }
+                verify(!!item, "no delegate inside the viewport, contentY=" + listView.contentY)
+
+                const before = item.mapToItem(listView, 0, 0).y
+                waitForRendering(listView)
+                const after = item.mapToItem(listView, 0, 0).y
+                if (before === after)
+                    return { item: item, messageId: item.messageId, y: after }
+            }
+            fail("the tracked row never stopped moving")
+        }
+
+        // A message arriving while the user reads back in history must not
+        // move what is on screen, neither by entering at the bottom nor by
+        // pushing the oldest window row out at the top.
+        function test_bottomInsertWhileUnstuckKeepsViewAnchored() {
+            const chat = openAtNewest(200)
+            const listView = chat.listView
+
+            listView.contentY = listView.contentHeight - listView.height - 150
+            verify(!listView.stickingToNewest)
+            waitForRendering(listView)
+
+            const tracked = trackVisibleRow(listView)
+            const preCount = listView.count
+            const oldestBefore = listView.itemAtRow(listView.count - 1).messageId
+            const windowEndBefore = chat.internal.windowEnd
+
+            insertNewest(0)
+
+            tryVerify(() => listView.itemAtRow(listView.count - 1).messageId !== oldestBefore,
+                      20000, "the oldest window row must be evicted as the new one enters")
+            tryCompare(listView, "count", preCount, 20000)
+            waitForSettledLayout(listView)
+
+            compare(tracked.item.messageId, tracked.messageId)
+            fuzzyCompare(tracked.item.mapToItem(listView, 0, 0).y, tracked.y, 1)
+            verify(!listView.stickingToNewest)
+            compare(chat.internal.windowEnd, windowEndBefore)
+        }
+
+        // Same, with the window at its cap and slid into history: the insert
+        // shifts the window bounds instead of evicting, and the rows on screen
+        // must survive that round trip in place.
+        function test_bottomInsertAtMaxWindowKeepsViewAnchored() {
+            const chat = openAtNewest(500)
+            const listView = chat.listView
+            const internal = chat.internal
+
+            growToCap(chat)
+
+            listView.contentY = listView.height + 100
+            verify(!listView.stickingToNewest)
+            waitForRendering(listView)
+
+            // slide the full window into history, overlapping the rows already
+            // built: a window emptied in between would leave the view with
+            // nothing to hold on to
+            internal.windowStart = 30
+            internal.windowStartGoal = 30
+            internal.windowEnd = 30 + internal.maxWindowSize - 1
+            internal.windowEndGoal = internal.windowEnd
+            tryCompare(listView, "count", internal.maxWindowSize, 10000)
+            waitForQuietWindow(chat)
+            compare(internal.windowStart, 30)
+
+            const tracked = trackVisibleRow(listView)
+            const startBefore = internal.windowStart
+
+            insertNewest(1)
+
+            tryCompare(internal, "windowStart", startBefore + 1, 20000)
+            waitForSettledLayout(listView)
+
+            compare(tracked.item.messageId, tracked.messageId)
+            fuzzyCompare(tracked.item.mapToItem(listView, 0, 0).y, tracked.y, 1)
+            compare(listView.count, internal.maxWindowSize)
+            verify(!listView.stickingToNewest)
+        }
+
+        // The same cap, pinned to the recent end: no bound shift, the oldest
+        // window row is evicted instead.
+        function test_bottomInsertAtCapRecentEndKeepsViewAnchored() {
+            const chat = openAtNewest(500)
+            const listView = chat.listView
+            const internal = chat.internal
+
+            growToCap(chat)
+
+            listView.contentY = listView.height + 100
+            verify(!listView.stickingToNewest)
+            waitForRendering(listView)
+
+            const tracked = trackVisibleRow(listView)
+            const oldestBefore = listView.itemAtRow(listView.count - 1).messageId
+
+            insertNewest(2)
+
+            tryVerify(() => listView.itemAtRow(listView.count - 1).messageId !== oldestBefore,
+                      20000, "the oldest window row must be evicted as the new one enters")
+            tryCompare(listView, "count", internal.maxWindowSize, 20000)
+            waitForSettledLayout(listView)
+
+            compare(tracked.item.messageId, tracked.messageId)
+            fuzzyCompare(tracked.item.mapToItem(listView, 0, 0).y, tracked.y, 1)
+            compare(internal.windowStart, 0)
+            verify(!listView.stickingToNewest)
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_ChatContentView.qml
+++ b/storybook/qmlTests/tests/tst_ChatContentView.qml
@@ -1,6 +1,8 @@
 import QtQuick
 import QtTest
 
+import StatusQ 0.1
+import SortFilterProxyModel 0.2
 import utils
 
 import AppLayouts.Chat.views
@@ -76,6 +78,73 @@ Item {
         }
     }
 
+    // The messages view on its own, so a test can hand its store a model.
+    Component {
+        id: bareViewComp
+
+        ChatMessagesView {
+            width: 800
+            height: 600
+
+            rootStore: rootStoreMock
+            chatContentModule: contentModuleMock
+            messageStore: ChatStores.MessageStore {
+                messageModule: contentModuleMock.messagesModule
+            }
+            chatId: "chat-1"
+            usersModel: ListModel {}
+            joined: true
+        }
+    }
+
+    // A source that can reset without the view's store handing it a
+    // different model: the production messages model resets in place.
+    ListModel { id: resetSourceA }
+    ListModel { id: resetSourceB }
+    SortFilterProxyModel { id: resettableMessages; sourceModel: resetSourceA }
+
+    // The chat as production mounts it: inside a subtree that is itself still
+    // incubating asynchronously (section loaders on a slow device). While the
+    // ancestor incubation is alive, every Repeater delegate resolves
+    // AsynchronousIfNested to asynchronous — shells are NOT created inside
+    // the window mutation. The heavy tail keeps that ancestor incubation
+    // alive long enough for the test to act within it.
+    property Item earlyChatView: null
+
+    Component {
+        id: incubatingHostComp
+
+        Loader {
+            asynchronous: true
+            sourceComponent: Item {
+                width: 800
+                height: 600
+
+                ChatContentView {
+                    id: hostedChatView
+
+                    width: 800
+                    height: 600
+
+                    rootStore: rootStoreMock
+                    chatContentModule: contentModuleMock
+                    chatId: "chat-1"
+                    chatType: Constants.chatType.oneToOne
+                    usersModel: ListModel {}
+                    joined: true
+
+                    Component.onCompleted: root.earlyChatView = hostedChatView
+                }
+
+                Repeater {
+                    model: 50000
+
+                    delegate: Item {}
+                }
+            }
+        }
+    }
+
     TestCase {
         name: "ChatContentView"
         when: windowShown
@@ -86,6 +155,9 @@ Item {
             contentModuleMock.markAllMessagesReadCalls = 0
             contentModuleMock.chatDetails.hasUnreadMessages = false
             messagesModel.clear()
+            resetSourceA.clear()
+            resetSourceB.clear()
+            resettableMessages.sourceModel = resetSourceA
         }
 
         // chatDetails.active is set by the backend (onMadeActive) before the
@@ -333,7 +405,8 @@ Item {
                       "the view must page the backend while older messages can be requested")
         }
 
-        // A sent message slides the window to the recent end; it must not
+        // A sent message lands the view on the newest message; with the
+        // window already at the recent end (the common case) it must not
         // rebuild it — the teardown flashed the paging skeleton over the
         // user's own messages on every send.
         function test_sentMessageDoesNotRebuildTheWindow() {
@@ -349,14 +422,11 @@ Item {
             tryVerify(() => listView.count >= 20, 5000)
             tryVerify(() => listView.atNewest, 5000)
 
-            // slide the window into history through the test seam
+            // window grown at the recent end through the test seam
             const internal = findChild(view, "chatMessagesViewInternal")
             verify(!!internal)
-            internal.windowStart = 30
-            internal.windowStartGoal = 30
             internal.windowEnd = 60
-            internal.windowEndGoal = 60
-            tryVerify(() => listView.count > 0, 5000)
+            tryVerify(() => listView.count === 61, 5000)
 
             const preSendCount = listView.count
             let minCount = preSendCount
@@ -371,6 +441,46 @@ Item {
             verify(minCount >= preSendCount,
                    "the window must not be torn down on send: count dropped to " + minCount
                    + " from " + preSendCount)
+        }
+
+        // The recent-messages button from deep in history is a JUMP: the
+        // window collapses to a recent-end screenful — it must not readmit
+        // and unroll every row between the window and the newest message.
+        function test_recentButtonJumpsFromDeepHistory() {
+            for (let i = 0; i < 500; ++i)
+                appendMessage(i)
+
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            tryVerify(() => listView.count >= 20, 5000)
+
+            // reading deep in history
+            internal.windowStart = 60
+            internal.windowEnd = 120
+            tryVerify(() => listView.count === 61, 5000)
+
+            let maxCount = 0
+            listView.countChanged.connect(() => {
+                maxCount = Math.max(maxCount, listView.count)
+            })
+
+            internal.scrollToBottom()
+
+            tryVerify(() => internal.windowStart === 0, 5000)
+            verify(internal.windowEnd < 60,
+                   "the window must collapse to a recent-end screenful, "
+                   + "ends at " + internal.windowEnd)
+            verify(maxCount <= 61,
+                   "the jump must not readmit the rows in between, "
+                   + "count peaked at " + maxCount)
+            tryVerify(() => listView.atNewest, 10000,
+                      "the jump must land on the newest message")
         }
 
         // A jump to a message deep in history collapses the window around the
@@ -410,10 +520,10 @@ Item {
                    "the view must not stick to the newest after a jump into history")
         }
 
-        // The window must grow towards its initial size in bounded steps —
-        // building the whole initial window in one synchronous batch is what
-        // froze the app on window moves.
-        function test_windowGrowsInBoundedSteps() {
+        // The initial fill builds its heavy rows asynchronously (the shells
+        // are cheap): the window may snap to its full initial size in one
+        // step, and the view must settle anchored on the newest message.
+        function test_initialFillSettlesAtNewest() {
             for (let i = 0; i < 500; ++i)
                 appendMessage(i)
 
@@ -424,23 +534,7 @@ Item {
             const listView = findChild(view, "chatLogView")
             verify(!!listView)
 
-            // watch the window bound itself: every growth step must stay
-            // within the driver's per-frame budget, no matter when the test
-            // process gets to observe the item count
-            const internal = findChild(view, "chatMessagesViewInternal")
-            verify(!!internal)
-            let maxJump = 0
-            let prev = internal.windowEnd
-            internal.windowEndChanged.connect(() => {
-                maxJump = Math.max(maxJump, internal.windowEnd - prev)
-                prev = internal.windowEnd
-            })
-
-            // the window reaches its initial size, anchored on the newest
-            // message, having grown only in budgeted steps
             tryVerify(() => listView.count >= 20, 5000)
-            verify(maxJump <= internal.moveBudget,
-                   "window bound may only move moveBudget rows at a time, jumped " + maxJump)
             const deadline = Date.now() + 5000
             while (Date.now() < deadline && !listView.atNewest)
                 wait(50)
@@ -502,21 +596,15 @@ Item {
             fail(message())
         }
 
-        // The window walks towards its goals a few rows per frame and the
-        // paging timer may slide it further; a measurement is only meaningful
-        // once it stands still — which takes both bounds at their goal and no
-        // paging request for longer than the paging interval.
+        // Staged batches reveal asynchronously and the paging timer may slide
+        // the window further; a measurement is only meaningful once nothing
+        // is staged and the bounds stand still.
         function waitForQuietWindow(chat) {
             const internal = chat.internal
             const where = () => internal.windowStart + ".." + internal.windowEnd
-                                + " goals " + internal.windowStartGoal + ".."
-                                + internal.windowEndGoal
-            // opening pages the window a chunk at a time while the content is
-            // still shorter than the viewport, so the goals may run ahead of
-            // the bounds before everything settles
-            tryVerify(() => internal.windowStart === internal.windowStartGoal
-                            && internal.windowEnd === internal.windowEndGoal,
-                      30000, "the window must reach its goals, at " + where())
+                                + " staged " + internal.stagedCount
+            tryVerify(() => internal.stagedCount === 0,
+                      30000, "staged rows must all reveal, at " + where())
 
             let last = ""
             let stable = 0
@@ -557,7 +645,6 @@ Item {
         // seam: paging there row by row would take the whole test.
         function growToCap(chat) {
             chat.internal.windowEnd = chat.internal.maxWindowSize - 1
-            chat.internal.windowEndGoal = chat.internal.windowEnd
             tryCompare(chat.listView, "count", chat.internal.maxWindowSize, 30000)
             waitForQuietWindow(chat)
         }
@@ -569,7 +656,7 @@ Item {
                 let item = null
                 for (let k = 0; k < listView.count && !item; ++k) {
                     const candidate = listView.itemAtRow(k)
-                    if (!candidate)
+                    if (!candidate || !candidate.visible)
                         continue
                     const y = candidate.mapToItem(listView, 0, 0).y
                     if (y >= 100 && y <= listView.height - 100)
@@ -584,6 +671,163 @@ Item {
                     return { item: item, messageId: item.messageId, y: after }
             }
             fail("the tracked row never stopped moving")
+        }
+
+        // Counts window rows that actually hold visual space — a row still
+        // being built must never be one of them.
+        function visibleRowCount(listView) {
+            let n = 0
+            for (let k = 0; k < listView.count; ++k) {
+                const item = listView.itemAtRow(k)
+                if (item && item.visible && item.height > 0)
+                    ++n
+            }
+            return n
+        }
+
+        // Review feedback on the window PR: rows built freely on the fly while
+        // paging made the view flicker between skeleton and half-built rows.
+        // A slide must be all-or-nothing: the placeholder keeps covering the
+        // incoming chunk until every row is ready, then the whole chunk
+        // appears at once.
+        function test_pagingRevealsChunkAtomically() {
+            const chat = openAtNewest(300)
+            const listView = chat.listView
+
+            const pre = visibleRowCount(listView)
+            chat.internal.slideWindowToHistory()
+
+            // sample the visible-row count through the whole slide: it may
+            // only ever read as "before" or "after", never in between
+            const seen = new Set()
+            let last = -1
+            let stable = 0
+            // stability only counts once the reveal happened — building and
+            // settling the batch legitimately takes a while
+            for (let i = 0; i < 1000 && !(last > pre && stable >= 40); ++i) {
+                wait(8)
+                const now = visibleRowCount(listView)
+                seen.add(now)
+                stable = (now === last) ? stable + 1 : 0
+                last = now
+            }
+            verify(last > pre, "the slide must eventually show more rows, still at " + last)
+            const inBetween = [...seen].filter(n => n !== pre && n !== last)
+            compare(inBetween.join(","), "",
+                    "rows became visible mid-build, visible counts seen: "
+                    + [...seen].join(","))
+        }
+
+        // Paging must not move what the user is reading: the chunk reveals
+        // above the viewport and the anchored row stays put on screen.
+        function test_pagingKeepsViewportAnchored() {
+            const chat = openAtNewest(300)
+            const listView = chat.listView
+
+            listView.contentY = listView.contentHeight - listView.height - 150
+            verify(!listView.stickingToNewest)
+            waitForRendering(listView)
+
+            const tracked = trackVisibleRow(listView)
+            const pre = listView.count
+
+            chat.internal.slideWindowToHistory()
+            tryVerify(() => visibleRowCount(listView) > pre, 20000,
+                      "the slide must show its rows")
+            waitForSettledLayout(listView)
+
+            compare(tracked.item.messageId, tracked.messageId)
+            fuzzyCompare(tracked.item.mapToItem(listView, 0, 0).y, tracked.y, 2)
+        }
+
+        // Scrolling must hold a gentle incubation hint, so staged rows build
+        // in small paced bites while the user interacts instead of stealing
+        // whole frames on low-end devices.
+        function test_scrollingHoldsGentleIncubationHint() {
+            const chat = openAtNewest(200)
+            const listView = chat.listView
+
+            compare(IncubationHints.gentleActive, false)
+
+            listView.flick(0, 1500)
+            tryVerify(() => listView.moving, 1000)
+            verify(IncubationHints.gentleActive,
+                   "a gentle hint must be held while the view is moving")
+
+            tryVerify(() => !listView.moving, 10000)
+            tryVerify(() => !IncubationHints.gentleActive, 1000,
+                      "the hint must be released when scrolling stops")
+        }
+
+        // First shell of the current staged batch, i.e. an admitted row that
+        // holds no visual space yet.
+        function stagedShellAt(listView) {
+            for (let k = 0; k < listView.count; ++k) {
+                const item = listView.itemAtRow(k)
+                if (item && !item.visible)
+                    return item
+            }
+            return null
+        }
+
+        // A pathological row must never wedge paging: the safety timeout
+        // reveals whatever the batch managed to build.
+        function test_revealTimeoutUnblocksBatch() {
+            const chat = openAtNewest(300)
+            const listView = chat.listView
+            const internal = chat.internal
+
+            const timeout = findChild(chat.view, "batchRevealTimeout")
+            verify(!!timeout)
+            timeout.interval = 300
+
+            const pre = visibleRowCount(listView)
+            internal.slideWindowToHistory()
+            verify(internal.stagedCount > 0, "the slide must stage its rows")
+
+            // hold the batch open: one row never finishes building
+            const held = stagedShellAt(listView)
+            verify(!!held)
+            held.active = false
+
+            tryVerify(() => internal.stagedCount === 0, 5000,
+                      "the timeout must flush the held batch")
+            tryVerify(() => visibleRowCount(listView) > pre, 5000,
+                      "the built rows must show after the timeout")
+        }
+
+        // A message arriving mid-slide enters outside the staged batch and
+        // must show as soon as it is built — never wait for the batch.
+        function test_liveMessageBypassesStaging() {
+            const chat = openAtNewest(300)
+            const listView = chat.listView
+            const internal = chat.internal
+
+            // keep the safety timeout out of the picture
+            const timeout = findChild(chat.view, "batchRevealTimeout")
+            verify(!!timeout)
+            timeout.interval = 60000
+
+            internal.slideWindowToHistory()
+            verify(internal.stagedCount > 0, "the slide must stage its rows")
+
+            // hold the batch open so the live message demonstrably overtakes it
+            const held = stagedShellAt(listView)
+            verify(!!held)
+            held.active = false
+
+            insertNewest(7)
+
+            tryVerify(() => {
+                const newest = listView.itemAtRow(0)
+                return !!newest && newest.visible && newest.height > 0
+                        && internal.stagedCount > 0
+            }, 5000, "the live message must show while the batch is still staged")
+
+            // release the batch
+            held.active = true
+            tryVerify(() => internal.stagedCount === 0, 10000,
+                      "the released batch must reveal")
         }
 
         // A message arriving while the user reads back in history must not
@@ -633,9 +877,7 @@ Item {
             // built: a window emptied in between would leave the view with
             // nothing to hold on to
             internal.windowStart = 30
-            internal.windowStartGoal = 30
             internal.windowEnd = 30 + internal.maxWindowSize - 1
-            internal.windowEndGoal = internal.windowEnd
             tryCompare(listView, "count", internal.maxWindowSize, 10000)
             waitForQuietWindow(chat)
             compare(internal.windowStart, 30)
@@ -681,6 +923,307 @@ Item {
             fuzzyCompare(tracked.item.mapToItem(listView, 0, 0).y, tracked.y, 1)
             compare(internal.windowStart, 0)
             verify(!listView.stickingToNewest)
+        }
+
+        // Device livelock repro: with the chat inside a still-incubating
+        // ancestor, delegate shells are created asynchronously — AFTER the
+        // admit mutator returned. Staging keyed on creation timing never
+        // engages, so nothing throttles the paging timer: the window
+        // ping-pongs at timer rate, evicting rows faster than the starved
+        // incubator can build them, and the user watches the skeleton
+        // indefinitely. Staging must engage regardless of when the shells
+        // are created.
+        function test_slideStagesRowsWhileAncestorIncubationIsLive() {
+            // Outside a gentle phase the incubation controller drains its
+            // whole queue in one blocking burst, so the test would only run
+            // once the ancestor had finished. A section transition holds the
+            // gentle hint on device; hold it here to keep the ancestor alive.
+            IncubationHints.pushGentle()
+            try {
+                slideStagesRowsWhileAncestorIncubationIsLive()
+            } finally {
+                IncubationHints.popGentle()
+            }
+        }
+
+        function slideStagesRowsWhileAncestorIncubationIsLive() {
+            for (let i = 0; i < 300; ++i)
+                appendMessage(i)
+
+            root.earlyChatView = null
+            const host = createTemporaryObject(incubatingHostComp, root)
+            verify(!!host)
+
+            tryVerify(() => root.earlyChatView !== null, 20000,
+                      "the hosted chat must complete inside the ancestor incubation")
+            const view = root.earlyChatView
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 20000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            tryVerify(() => listView.count > 0, 20000)
+
+            // the paging timer must not slide on its own mid-measurement
+            listView.moreUpAvailable = false
+            listView.moreDownAvailable = false
+
+            verify(host.status === Loader.Loading,
+                   "precondition lost: the ancestor incubation finished before the "
+                   + "slide — grow the incubation tail")
+
+            const endBefore = internal.windowEnd
+            internal.slideWindowToHistory()
+            compare(internal.windowEnd, endBefore + internal.windowChunkSize)
+            verify(internal.stagedCount > 0,
+                   "the slide must stage its rows even when the shells are "
+                   + "created asynchronously")
+
+            // and the staged batch must keep throttling: a second slide right
+            // behind the first must not move the window
+            internal.slideWindowToHistory()
+            compare(internal.windowEnd, endBefore + internal.windowChunkSize)
+
+            // the batch eventually builds and reveals even under the ancestor
+            // incubation
+            tryVerify(() => internal.stagedCount === 0, 60000,
+                      "the staged batch must reveal once its rows are built")
+        }
+
+        // ---- the bare messages view ----
+
+        function openBare() {
+            const view = createTemporaryObject(bareViewComp, root)
+            verify(!!view)
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            tryVerify(() => listView.count > 0, 20000)
+            return { view: view, listView: listView, internal: internal }
+        }
+
+        function fillModel(model, count) {
+            for (let i = 0; i < count; ++i)
+                model.append(messageRoles("msg-" + i, i, Date.now() - i * 60000))
+        }
+
+        // Attaching a source schedules the open-at-newest for after the proxy
+        // churn; a jump issued in the same turn must win, not be yanked back
+        // to the bottom when the deferred reposition lands.
+        function test_jumpInTheAttachTurnIsNotYankedToNewest() {
+            for (let i = 0; i < 300; ++i)
+                appendMessage(i)
+            fillModel(resetSourceA, 300)
+
+            const chat = openBare()
+            waitForQuietWindow(chat)
+
+            chat.view.messageStore.messagesModel = resettableMessages
+            chat.internal.goToMessage(150)
+
+            tryVerify(() => chat.internal.windowStart > 0, 5000,
+                      "the window must move to the jump target")
+            let minStart = chat.internal.windowStart
+            for (let i = 0; i < 10; ++i) {
+                wait(30)
+                minStart = Math.min(minStart, chat.internal.windowStart)
+            }
+            verify(minStart > 0, "the jump was undone, windowStart fell to " + minStart)
+            verify(!chat.listView.stickingToNewest,
+                   "the deferred open-at-newest must not re-stick the view")
+        }
+
+        // A reset removes every row without per-row signals: a batch staged
+        // across it would wait on rows that no longer exist and wedge paging
+        // until the stall timeout.
+        // The batch is still a set of captured ids when its shells are
+        // created asynchronously (see the ancestor-incubation test below), and
+        // those ids never see a shell's destruction.
+        function test_sourceResetReleasesAStagedBatch() {
+            IncubationHints.pushGentle()
+            try {
+                sourceResetReleasesAStagedBatch()
+            } finally {
+                IncubationHints.popGentle()
+            }
+        }
+
+        function sourceResetReleasesAStagedBatch() {
+            fillModel(resetSourceA, 300)
+            fillModel(resetSourceB, 300)
+
+            root.earlyChatView = null
+            const host = createTemporaryObject(incubatingHostComp, root)
+            verify(!!host)
+            tryVerify(() => root.earlyChatView !== null, 20000)
+            const view = root.earlyChatView
+            view.messageStore.messagesModel = resettableMessages
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 20000)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            tryVerify(() => listView.count > 0, 20000)
+            listView.moreUpAvailable = false
+            listView.moreDownAvailable = false
+            tryVerify(() => internal.stagedCount === 0, 20000)
+
+            verify(host.status === Loader.Loading,
+                   "precondition lost: the ancestor incubation finished before the slide")
+            internal.slideWindowToHistory()
+            verify(internal.stagedCount > 0, "the slide must stage its rows")
+
+            resettableMessages.sourceModel = resetSourceB
+            compare(internal.stagedCount, 0,
+                    "a reset must release the batch staged over the old rows")
+        }
+
+        // ---- per-side placeholders ----
+
+        // A slide towards history moves only the history end of the window;
+        // the placeholder standing for the recent rows below it must not
+        // resize with it, or it pops into the viewport and the window
+        // ping-pongs.
+        function test_historySlideLeavesTheRecentPlaceholderAlone() {
+            const chat = openAtNewest(200)
+            const internal = chat.internal
+            establishRowHeight(internal)
+
+            internal.windowStart = 60
+            internal.windowEnd = 120
+            tryVerify(() => chat.listView.count === 61, 10000)
+            waitForQuietWindow(chat)
+
+            const bottomBefore = chat.listView.bottomPlaceholderHeight
+            const topBefore = chat.listView.topPlaceholderHeight
+            internal.slideWindowToHistory()
+            waitForQuietWindow(chat)
+
+            verify(chat.listView.topPlaceholderHeight < topBefore,
+                   "the history placeholder must shrink by the rows the slide admitted")
+            compare(chat.listView.bottomPlaceholderHeight, bottomBefore,
+                    "the recent placeholder must not follow a history slide")
+        }
+
+        // ---- paging waits for rest ----
+
+        // A slide mid-fling changes geometry under the physics, and the
+        // position correction that follows cancels the flick.
+        function test_pagingWaitsForTheViewToComeToRest() {
+            const chat = openAtNewest(300)
+            const listView = chat.listView
+            const internal = chat.internal
+            listView.moreUpAvailable = true
+
+            let slidMidMotion = false
+            const onEnd = () => { if (listView.moving) slidMidMotion = true }
+            internal.windowEndChanged.connect(onEnd)
+
+            listView.flick(0, 4000)
+            tryVerify(() => listView.moving, 1000)
+            tryVerify(() => !listView.moving, 20000)
+            internal.windowEndChanged.disconnect(onEnd)
+
+            verify(!slidMidMotion, "the window slid while the view was moving")
+        }
+
+        // ---- the row-height estimate settles ----
+
+        // Tops the sample up to where the estimate may hold, without moving
+        // it: every row fed here is exactly the estimated height.
+        function establishRowHeight(internal) {
+            verify(internal.rowHeightSampleCount > 0,
+                   "the reveals that already happened must have fed the sample")
+            for (let i = 0; i < 200
+                 && internal.rowHeightSampleCount < internal.rowHeightSettleCount; ++i)
+                internal.observeRowHeights(internal.avgRowHeight * 8, 8)
+            verify(internal.rowHeightSampleCount >= internal.rowHeightSettleCount,
+                   "the sample must reach the settle count")
+        }
+
+        // Batch means wander either side of the truth, and the placeholders
+        // multiply the estimate by up to 300 rows: an estimate that followed
+        // each batch resized them by thousands of pixels on every reveal.
+        function test_rowHeightEstimateHoldsUnderVaryingBatches() {
+            const chat = openAtNewest(1000)
+            const internal = chat.internal
+            establishRowHeight(internal)
+
+            const base = internal.avgRowHeight
+            verify(base > 0)
+            const basePlaceholder = chat.listView.topPlaceholderHeight
+            verify(basePlaceholder > 5000,
+                   "the placeholder must stand for hundreds of rows, is " + basePlaceholder)
+
+            const wobble = [0.85, 1.14, 0.9, 1.12, 0.88, 1.15, 0.93, 1.08,
+                            0.86, 1.11, 0.95, 1.05, 0.87, 1.13, 0.91, 1.09]
+            let worstEstimate = 0
+            let worstGeometry = 0
+            for (let i = 0; i < wobble.length; ++i) {
+                internal.observeRowHeights(base * wobble[i] * 20, 20)
+                worstEstimate = Math.max(worstEstimate,
+                                         Math.abs(internal.avgRowHeight - base) / base)
+                worstGeometry = Math.max(worstGeometry,
+                                         Math.abs(chat.listView.topPlaceholderHeight
+                                                  - basePlaceholder))
+            }
+            verify(worstEstimate < 0.02, "the estimate drifted "
+                   + (worstEstimate * 100).toFixed(1) + "% across wobbling batches")
+            verify(worstGeometry < 1, "the placeholder moved "
+                   + worstGeometry.toFixed(0) + "px across wobbling batches")
+        }
+
+        // An estimate that could never move would be a constant: sustained
+        // evidence of a different row shape re-estimates, then holds again.
+        function test_rowHeightEstimateRelatchesOnADifferentShape() {
+            const chat = openAtNewest(300)
+            const internal = chat.internal
+            establishRowHeight(internal)
+
+            const base = internal.avgRowHeight
+            const tall = base * 3
+
+            let rows = 0
+            for (let i = 0; i < 60 && internal.avgRowHeight < base * 1.5; ++i) {
+                internal.observeRowHeights(tall * 20, 20)
+                rows += 20
+            }
+            verify(internal.avgRowHeight >= base * 1.5,
+                   "a sustained different shape must re-estimate, still at "
+                   + internal.avgRowHeight + " from " + base)
+            verify(rows <= 400, "and within a few batches, took " + rows + " rows")
+
+            for (let i = 0; i < 300 && internal.avgRowHeight < tall * 0.9; ++i)
+                internal.observeRowHeights(tall * 20, 20)
+            verify(internal.avgRowHeight >= tall * 0.9,
+                   "the estimate must converge on the evidence, reached "
+                   + internal.avgRowHeight + " of " + tall)
+
+            const settled = internal.avgRowHeight
+            for (let i = 0; i < 20; ++i)
+                internal.observeRowHeights(tall * 20, 20)
+            fuzzyCompare(internal.avgRowHeight, settled, 0.001)
+        }
+
+        // A different chat is a different row shape: its first batch must
+        // establish the estimate, not argue with the last chat's.
+        function test_rowHeightEstimateIsForgottenPerChat() {
+            const chat = openAtNewest(300)
+            const internal = chat.internal
+            establishRowHeight(internal)
+            const base = internal.avgRowHeight
+
+            chat.view.chatId = "chat-2"
+            compare(internal.rowHeightSampleCount, 0,
+                    "a chat switch must drop the previous chat's evidence")
+
+            internal.observeRowHeights(base * 3 * 8, 8)
+            verify(internal.avgRowHeight >= base * 2.5,
+                   "the new chat's first batch must establish the estimate, at "
+                   + internal.avgRowHeight + " from " + base)
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_ChatLoaderSection.qml
+++ b/storybook/qmlTests/tests/tst_ChatLoaderSection.qml
@@ -415,8 +415,8 @@ Item {
                    + " ms @150 vs " + large.ms + " ms @3000")
         }
 
-        // Opening a chat must only build delegates for the messages that fit
-        // the viewport (plus cache) — never one per historic message.
+        // Opening a chat must only ever hold a bounded window of the message
+        // history — never one row per historic message.
         function test_messagesListVirtualized() {
             harness.active = true
             const loader = harness.item
@@ -425,14 +425,13 @@ Item {
 
             const lv = findChild(loader, "chatLogView")
             verify(!!lv)
-            tryVerify(() => lv.count === 150, 10000)
+            tryVerify(() => lv.count > 0, 10000)
             waitForRendering(lv)
 
-            const created = lv.contentItem.children.length
-            verify(created > 0, "some message rows must be built")
-            verify(created < 75,
-                   "only viewport+cache rows may be built, got " + created
-                   + " of " + lv.count)
+            // the window is capped below the history size at all times
+            verify(lv.count < 150,
+                   "the view may only hold a bounded window, got " + lv.count
+                   + " rows of a 150-message history")
         }
 
         // Loading the section must cost the same whether the chat list holds

--- a/storybook/qmlTests/tests/tst_ChatMessagesFlickable.qml
+++ b/storybook/qmlTests/tests/tst_ChatMessagesFlickable.qml
@@ -1,0 +1,561 @@
+import QtQuick
+import QtQuick.Layouts
+import QtTest
+
+import SortFilterProxyModel 0.2
+
+import shared.views.chat
+
+Item {
+    id: root
+
+    width: 400
+    height: 300
+
+    // 1000 rows, index 0 being the newest message, as in the messages model
+    ListModel {
+        id: history
+
+        Component.onCompleted: {
+            for (let i = 0; i < 1000; ++i)
+                append({ text: "message " + i })
+        }
+
+        onRowsInserted: (parent, first, last) => {
+            if (window.start > 0 && first <= window.start) {
+                const inserted = last - first + 1
+                window.start += inserted
+                window.end += inserted
+            }
+            if (first <= window.end)
+                Qt.callLater(window.refilter)
+        }
+    }
+
+    QtObject {
+        id: window
+
+        readonly property int size: 40
+        readonly property int chunk: 10
+        readonly property int max: 60
+
+        property int start: 0
+        property int end: size - 1
+
+        function reset() {
+            start = 0
+            end = size - 1
+        }
+
+        // Mirrors the owner-side workaround for QSortFilterProxyModel not
+        // re-evaluating existing rows when the source shifts them.
+        function refilter() {
+            const e = end
+            end = e + 1
+            end = e
+        }
+
+        function slideToHistory() {
+            if (end >= history.count - 1)
+                return
+            end = Math.min(history.count - 1, end + chunk)
+            if (end - start + 1 > max)
+                start = end - max + 1
+        }
+
+        function slideToRecent() {
+            if (start <= 0)
+                return
+            start = Math.max(0, start - chunk)
+            if (end - start + 1 > max)
+                end = start + max - 1
+        }
+    }
+
+    Component {
+        id: viewComponent
+
+        ChatMessagesFlickable {
+            id: flick
+
+            anchors.fill: parent
+
+            placeholderHeight: 100
+
+            moreUpAvailable: window.end < history.count - 1
+            moreDownAvailable: window.start > 0
+
+            onMoreUpRequested: window.slideToHistory()
+            onMoreDownRequested: window.slideToRecent()
+
+            placeholder: Rectangle { color: "transparent" }
+
+            model: SortFilterProxyModel {
+                sourceModel: history
+
+                filters: IndexFilter {
+                    minimumIndex: window.start
+                    maximumIndex: window.end
+                }
+            }
+
+            delegate: Rectangle {
+                objectName: "row"
+
+                readonly property string rowText: model.text
+
+                Layout.row: flick.rowCount - index
+                Layout.column: 0
+                Layout.fillWidth: true
+                Layout.preferredHeight: 20
+            }
+        }
+    }
+
+    TestCase {
+        id: testCase
+
+        name: "ChatMessagesFlickable"
+        when: windowShown
+
+        property ChatMessagesFlickable view: null
+
+        function cleanup() {
+            // the view outlives the test that made it (destruction is
+            // deferred): left advertising more rows, its paging timer keeps
+            // sliding the window the next test is running against
+            if (view) {
+                view.moreUpAvailable = false
+                view.moreDownAvailable = false
+            }
+            while (history.count > 1000)
+                history.remove(0)
+            // tests may shrink the shared history; rebuild it even when they
+            // fail mid-way so the damage does not cascade into later tests
+            for (let i = history.count; i < 1000; ++i)
+                history.append({ text: "message " + i })
+        }
+
+        function init() {
+            cleanup()
+            window.reset()
+            view = createTemporaryObject(viewComponent, root)
+            verify(!!view)
+            waitForRendering(view)
+        }
+
+        function test_renders_exactly_the_window_newest_last() {
+            compare(view.count, window.size)
+
+            const newest = view.itemAtRow(0)
+            const oldest = view.itemAtRow(window.size - 1)
+            compare(newest.rowText, "message 0")
+            compare(oldest.rowText, "message " + (window.size - 1))
+            verify(newest.y > oldest.y, "row 0 must be laid out below the older rows")
+        }
+
+        function test_opens_anchored_on_the_newest_message() {
+            verify(view.stickingToNewest)
+            fuzzyCompare(view.contentY, view.contentHeight - view.height, 1)
+        }
+
+        // The paging is level-triggered: parking the viewport on the history
+        // placeholder may slide the window several chunks per pass, so the
+        // assertions are on the end state, not on per-step growth.
+        function test_scrolling_into_history_grows_then_slides_the_window() {
+            let peak = 0
+            tryVerify(() => {
+                view.contentY = 0
+                peak = Math.max(peak, view.count)
+                return window.start > 0
+            }, 10000, "the window must slide once it hit its cap, end="
+                      + window.end + " count=" + view.count)
+
+            // grew exactly up to the cap — never past it — and stays there
+            // while sliding further back
+            tryVerify(() => {
+                peak = Math.max(peak, view.count)
+                return view.count === window.max
+            }, 2000, "the window must settle at its cap, count=" + view.count)
+            compare(peak, window.max, "the window may never exceed its cap")
+            verify(view.itemAtRow(0).rowText !== "message 0",
+                   "the newest messages must have left the window")
+        }
+
+        function test_new_message_follows_the_bottom_while_sticking() {
+            verify(view.stickingToNewest)
+            history.insert(0, { text: "brand new" })
+            waitForRendering(view)
+
+            compare(view.itemAtRow(0).rowText, "brand new")
+            tryCompare(view, "count", window.size, 1000, "the window must not grow with the history")
+            tryVerify(() => Math.abs(view.contentY - (view.contentHeight - view.height)) <= 1, 1000,
+                      "contentY=" + view.contentY + " contentHeight=" + view.contentHeight)
+        }
+
+        function test_positionAtRow_centers_the_row_and_reports_it() {
+            const positioned = signalSpy.createObject(root, { target: view, signalName: "rowPositioned" })
+
+            view.positionAtRow(30)
+            waitForRendering(view)
+
+            verify(positioned.count > 0)
+            const item = view.itemAtRow(30)
+            const itemCenter = item.y + item.height / 2
+            verify(itemCenter >= view.contentY && itemCenter <= view.contentY + view.height,
+                   "the requested row must end up inside the viewport")
+            verify(!view.stickingToNewest)
+        }
+
+        function test_positionAtRow_reports_once_across_content_changes() {
+            const positioned = signalSpy.createObject(root, { target: view, signalName: "rowPositioned" })
+
+            view.positionAtRow(30)
+            waitForRendering(view)
+            tryVerify(() => positioned.count > 0, 1000)
+
+            // content keeps changing afterwards — the fulfilled request must
+            // not re-fire, and the anchor must hold the row instead
+            history.insert(0, { text: "new arrival" })
+            waitForRendering(view)
+            compare(positioned.count, 1)
+        }
+
+        function test_scrolling_to_the_bottom_resticks() {
+            view.contentY = 0
+            verify(!view.stickingToNewest)
+
+            // any user scroll landing on the newest message re-sticks —
+            // scrollbar drags included, which emit no movement signals
+            view.contentY = view.contentHeight - view.height
+            verify(view.stickingToNewest,
+                   "scrolling to the bottom must re-stick the view")
+
+            history.insert(0, { text: "revealed" })
+            waitForRendering(view)
+            compare(view.itemAtRow(0).rowText, "revealed")
+            tryVerify(() => Math.abs(view.contentY - (view.contentHeight - view.height)) <= 1, 1000,
+                      "the arriving message must be revealed at the bottom")
+        }
+
+        // The reported field scenario: slide into history (down placeholder
+        // active), scroll all the way back to the newest message, then a new
+        // message arrives — the view must follow it.
+        function test_returning_from_history_to_the_bottom_resticks() {
+            // slide the window into history until it leaves the recent end
+            for (let i = 0; i < 6 && window.start === 0; ++i) {
+                const before = window.end
+                view.contentY = 0
+                tryVerify(() => window.end > before, 2000,
+                          "iteration " + i + ": end=" + window.end)
+                waitForRendering(view)
+            }
+            verify(window.start > 0, "the window must have slid into history")
+            verify(view.moreDownAvailable)
+
+            // scroll back down through the bottom placeholder until the
+            // window returns to the recent end
+            tryVerify(() => {
+                view.contentY = view.contentHeight - view.height
+                return window.start === 0
+            }, 10000, "the window must return to the recent end, start=" + window.start)
+
+            // settle on the newest message; the nudge guarantees the final
+            // write is a real change even if the view already sits at the
+            // bottom (a no-op write emits no signal to derive the state from)
+            tryVerify(() => !view.moreDownAvailable)
+            view.contentY = Math.max(0, view.contentY - 2)
+            view.contentY = view.contentHeight - view.height
+            waitForRendering(view)
+            verify(view.stickingToNewest,
+                   "settling on the newest message must re-stick the view")
+
+            history.insert(0, { text: "fresh arrival" })
+            waitForRendering(view)
+            tryVerify(() => Math.abs(view.contentY - (view.contentHeight - view.height)) <= 1, 1000,
+                      "a message arriving at the newest position must be revealed")
+            compare(view.itemAtRow(0).rowText, "fresh arrival")
+        }
+
+        function test_direct_contentY_write_unsticks_like_a_scrollbar_drag() {
+            verify(view.stickingToNewest)
+
+            // scrollbar drags write contentY without any movement signals
+            view.contentY = 0
+            verify(!view.stickingToNewest,
+                   "a contentY write not made by the view must count as a user move")
+
+            history.insert(0, { text: "while away" })
+            waitForRendering(view)
+            verify(!view.stickingToNewest,
+                   "a new message must not re-stick a view the user scrolled away")
+        }
+
+        // The bottom of a window slid into history is NOT the newest message —
+        // landing there must not stick (atNewest semantics, not content-bottom
+        // semantics). Sticking here makes every later content change call
+        // goToBottom() and walk the window back to the recent end.
+        function test_bottom_of_a_slid_window_is_not_the_newest() {
+            window.start = 30
+            window.end = 89
+            tryCompare(view, "count", 60, 2000)
+            // bounded wait for the grid to lay the rows out; the offscreen
+            // harness occasionally starves layout for minutes, in which case
+            // the geometry this test measures never materializes — skip then
+            // rather than fail on an environment artifact
+            const deadline = Date.now() + 2000
+            while (Date.now() < deadline && view.contentHeight < 60 * 20)
+                wait(50)
+            if (view.contentHeight < 60 * 20) {
+                skip("layout starved, geometry untestable in this run")
+                return
+            }
+            waitForRendering(view)
+            verify(view.moreDownAvailable)
+            unstick(100)
+
+            view.contentY = view.contentHeight - view.height
+            verify(!view.stickingToNewest,
+                   "the bottom of a slid window must not read as the newest message")
+        }
+
+        // A jump into history collapses the window to a few rows around the
+        // target; the Flickable clamp that follows lands on the content
+        // bottom and must NOT re-stick the view — newer messages still exist
+        // below the window, so its bottom is not the newest message. A
+        // re-stick here cancels the jump and walks the window back to the
+        // recent end.
+        function test_window_collapse_while_slid_does_not_restick() {
+            window.start = 30
+            window.end = 89
+            waitForRendering(view)
+            unstick(100)
+
+            // goToMessage-style collapse to a handful of rows
+            window.start = 40
+            window.end = 44
+            waitForRendering(view)
+
+            verify(!view.stickingToNewest,
+                   "a window collapse must not re-stick the view while newer "
+                   + "messages exist below the window")
+        }
+
+        // History exhaustion collapses the top placeholder, shrinking the
+        // content by a viewport; a reader sitting just above the newest must
+        // hold position and must not be re-stuck.
+        function test_history_exhaustion_holds_an_unstuck_reader() {
+            const tracked = unstickAndTrack(5, 50)
+
+            // no rows beyond the window any more → placeholder collapses
+            history.remove(window.size, history.count - window.size)
+            waitForRendering(view)
+
+            verify(!view.stickingToNewest,
+                   "exhausting history must not re-stick a reader who scrolled away")
+            const item = view.itemAtRow(5)
+            verify(!!item)
+            compare(item.rowText, tracked.text)
+            fuzzyCompare(item.mapToItem(view, 0, 0).y, tracked.y, 1)
+        }
+
+        // Scrolls away from the bottom with a scrollbar-drag-like write.
+        function unstick(distanceFromBottom) {
+            view.contentY = view.contentHeight - view.height - distanceFromBottom
+            waitForRendering(view)
+            verify(!view.stickingToNewest)
+        }
+
+        // Records where a window row sits on screen, to compare it against
+        // where it sits once the model changed.
+        function track(row) {
+            const item = view.itemAtRow(row)
+            verify(!!item)
+            return { item: item, text: item.rowText, y: item.mapToItem(view, 0, 0).y }
+        }
+
+        function unstickAndTrack(row, distanceFromBottom) {
+            unstick(distanceFromBottom)
+            return track(row)
+        }
+
+        // The paging timer keeps sliding the window while a placeholder is in
+        // the viewport; a measurement is only meaningful once it stopped.
+        function waitForQuietWindow() {
+            let last = ""
+            let stable = 0
+            tryVerify(() => {
+                const now = window.start + ":" + window.end
+                stable = (now === last) ? stable + 1 : 0
+                last = now
+                // over the paging interval, so a pending slide would show up
+                return stable >= 6
+            }, 3000, "the window must stop sliding, start=" + window.start + " end=" + window.end)
+            waitForRendering(view)
+        }
+
+        // Waits for the deferred refilter to evict the rows the inserts pushed
+        // out of the window, and for the layout to place the survivors.
+        function waitForEviction(oldestText) {
+            tryVerify(() => view.itemAtRow(view.count - 1).rowText === oldestText,
+                      1000, "oldest=" + view.itemAtRow(view.count - 1).rowText)
+            tryCompare(view, "count", window.size, 1000)
+            waitForRendering(view)
+        }
+
+        function test_bottom_insert_while_unstuck_keeps_rows_anchored() {
+            const tracked = unstickAndTrack(20, 150)
+
+            history.insert(0, { text: "brand new" })
+
+            // the window keeps its size: the oldest row is evicted as the new
+            // one enters at the bottom
+            waitForEviction("message " + (window.size - 2))
+
+            compare(tracked.item.rowText, tracked.text)
+            fuzzyCompare(tracked.item.mapToItem(view, 0, 0).y, tracked.y, 1)
+            verify(!view.stickingToNewest)
+        }
+
+        function test_bottom_insert_batch_keeps_rows_anchored() {
+            const tracked = unstickAndTrack(20, 150)
+
+            for (let i = 0; i < 5; ++i)
+                history.insert(0, { text: "brand new " + i })
+
+            waitForEviction("message " + (window.size - 6))
+
+            compare(tracked.item.rowText, tracked.text)
+            fuzzyCompare(tracked.item.mapToItem(view, 0, 0).y, tracked.y, 1)
+            verify(!view.stickingToNewest)
+        }
+
+        // With the window slid into history the insert shifts its bounds
+        // instead of evicting, which re-filters the oldest row out and back in
+        // — the rows on screen must survive that round trip in place.
+        function test_bottom_insert_with_slid_window_keeps_rows_anchored() {
+            // the window is put where paging would leave it, with paging
+            // itself switched off: what is under test is the insert, and a
+            // slide arriving mid-measurement would be indistinguishable from
+            // one
+            view.moreUpAvailable = false
+            view.moreDownAvailable = false
+
+            window.start = 10
+            window.end = window.start + window.max - 1
+            waitForRendering(view)
+            compare(view.count, window.max)
+
+            const tracked = unstickAndTrack(25, 400)
+            const startBefore = window.start
+
+            history.insert(0, { text: "brand new" })
+            waitForRendering(view)
+
+            compare(window.start, startBefore + 1)
+            compare(window.end - window.start + 1, window.max,
+                    "the shifted window must cover the same rows")
+            compare(tracked.item.rowText, tracked.text)
+            fuzzyCompare(tracked.item.mapToItem(view, 0, 0).y, tracked.y, 1)
+            compare(view.count, window.max)
+            verify(!view.stickingToNewest)
+        }
+
+        // A reader parked at the top of the window is anchored on its oldest
+        // row — the very row a bottom insert evicts. The view must re-anchor
+        // on a surviving row instead of being left behind by the eviction.
+        function test_bottom_insert_evicting_the_anchor_row_reanchors() {
+            // viewport top exactly on the oldest row, the placeholder just
+            // above it and out of sight
+            view.contentY = 100
+            waitForRendering(view)
+            verify(!view.stickingToNewest)
+
+            compare(view.itemAtRow(view.count - 1).rowText, "message " + (window.size - 1))
+            const neighbor = track(view.count - 2)
+
+            history.insert(0, { text: "brand new" })
+
+            tryVerify(() => view.itemAtRow(0).rowText === "brand new", 1000)
+            waitForQuietWindow()
+
+            compare(neighbor.item.rowText, neighbor.text)
+            fuzzyCompare(neighbor.item.mapToItem(view, 0, 0).y, neighbor.y, 1)
+        }
+
+        function test_positionAtNewest_returns_to_the_bottom() {
+            view.contentY = 0
+            waitForRendering(view)
+
+            view.positionAtNewest()
+            waitForRendering(view)
+
+            verify(view.stickingToNewest)
+            fuzzyCompare(view.contentY, view.contentHeight - view.height, 1)
+        }
+    }
+
+    Component {
+        id: signalSpy
+        SignalSpy {}
+    }
+
+    // An empty view advertising more history: the paging machinery must stay
+    // inert — with no rows there is nothing to anchor on, and unsticking
+    // would leave the view parked at the top once rows do arrive (the
+    // device-observed "opens at the top showing the placeholder" bug).
+    Component {
+        id: emptyViewComponent
+
+        ChatMessagesFlickable {
+            anchors.fill: parent
+
+            id: emptyFlick
+
+            placeholderHeight: 100
+            moreUpAvailable: true
+
+            placeholder: Rectangle { color: "transparent" }
+
+            model: emptyHistory
+            delegate: Rectangle {
+                objectName: "row"
+                Layout.row: emptyFlick.rowCount - index
+                Layout.column: 0
+                Layout.fillWidth: true
+                Layout.preferredHeight: 20
+            }
+        }
+    }
+
+    ListModel { id: emptyHistory }
+
+    TestCase {
+        name: "ChatMessagesFlickableEmpty"
+        when: windowShown
+
+        function cleanup() {
+            emptyHistory.clear()
+        }
+
+        function test_emptyPhaseDoesNotUnstick() {
+            const view = createTemporaryObject(emptyViewComponent, root)
+            verify(!!view)
+            waitForRendering(view)
+
+            // let the level-triggered paging timer fire several times
+            wait(400)
+            verify(view.stickingToNewest,
+                   "an empty view must not unstick from the bottom")
+
+            for (let i = 0; i < 10; ++i)
+                emptyHistory.append({ text: "message " + i })
+            waitForRendering(view)
+
+            verify(view.stickingToNewest)
+            tryVerify(() => Math.abs(view.contentY - (view.contentHeight - view.height)) <= 1,
+                      1000, "rows arriving after an empty phase must land at the bottom, contentY="
+                      + view.contentY)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ChatMessagesFlickable.qml
+++ b/storybook/qmlTests/tests/tst_ChatMessagesFlickable.qml
@@ -80,7 +80,8 @@ Item {
 
             anchors.fill: parent
 
-            placeholderHeight: 100
+            topPlaceholderHeight: 100
+            bottomPlaceholderHeight: 100
 
             moreUpAvailable: window.end < history.count - 1
             moreDownAvailable: window.start > 0
@@ -104,7 +105,7 @@ Item {
 
                 readonly property string rowText: model.text
 
-                Layout.row: flick.rowCount - index
+                Layout.row: flick.rowCount - index + 1
                 Layout.column: 0
                 Layout.fillWidth: true
                 Layout.preferredHeight: 20
@@ -512,7 +513,8 @@ Item {
 
             id: emptyFlick
 
-            placeholderHeight: 100
+            topPlaceholderHeight: 100
+            bottomPlaceholderHeight: 100
             moreUpAvailable: true
 
             placeholder: Rectangle { color: "transparent" }
@@ -520,7 +522,7 @@ Item {
             model: emptyHistory
             delegate: Rectangle {
                 objectName: "row"
-                Layout.row: emptyFlick.rowCount - index
+                Layout.row: emptyFlick.rowCount - index + 1
                 Layout.column: 0
                 Layout.fillWidth: true
                 Layout.preferredHeight: 20

--- a/storybook/qmlTests/tests/tst_MessageRowsSkeleton.qml
+++ b/storybook/qmlTests/tests/tst_MessageRowsSkeleton.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Chat.panels
+
+/*
+ The message-rows skeleton doubles as the paging placeholder, which can stand
+ in for many screens of out-of-window messages. A fast fling travels deep into
+ it, so the pattern must fill the whole height — a single bottom-anchored
+ block leaves white screens above it (device repro on PR #21970).
+*/
+Item {
+    id: root
+
+    width: 800
+    height: 600
+
+    Component {
+        id: skeletonComp
+
+        MessageRowsSkeleton {
+            width: 800
+        }
+    }
+
+    TestCase {
+        name: "MessageRowsSkeleton"
+        when: windowShown
+
+        function tilesIntersecting(item, yFrom, yTo) {
+            let n = 0
+            function walk(obj) {
+                for (let i = 0; i < obj.children.length; ++i) {
+                    const child = obj.children[i]
+                    if (child.height > 0 && child.width > 0 && !child.children.length) {
+                        const top = child.mapToItem(item, 0, 0).y
+                        if (top < yTo && top + child.height > yFrom)
+                            ++n
+                    }
+                    walk(child)
+                }
+            }
+            walk(item)
+            return n
+        }
+
+        function test_patternFillsTallPlaceholder() {
+            const skeleton = createTemporaryObject(skeletonComp, root, { height: 12000 })
+            verify(!!skeleton)
+            waitForRendering(skeleton)
+
+            // every screenful of the placeholder must show skeleton rows,
+            // including the regions far above the bottom-anchored start
+            for (let y = 0; y < 12000; y += 600) {
+                verify(tilesIntersecting(skeleton, y, y + 600) > 0,
+                       "no skeleton tiles between y=" + y + " and y=" + (y + 600))
+            }
+        }
+
+        function test_smallSkeletonStillRendersOneBlock() {
+            const skeleton = createTemporaryObject(skeletonComp, root, { height: 400 })
+            verify(!!skeleton)
+            waitForRendering(skeleton)
+
+            verify(tilesIntersecting(skeleton, 0, 400) > 0,
+                   "a viewport-sized skeleton must render its pattern")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusMessageAlbumWidth.qml
+++ b/storybook/qmlTests/tests/tst_StatusMessageAlbumWidth.qml
@@ -1,0 +1,75 @@
+import QtQuick
+import QtQuick.Layouts
+import QtTest
+
+import StatusQ.Components
+
+import Models
+
+/*
+ Device-observed livelock: an image-album message inside a QQuickLayout host
+ diverges — StatusMessageImageAlbum was bound to messageLayout.width, the
+ wrapping Loader mirrors its item's width as implicitWidth, and that implicit
+ flows back out through the contentItem into the width, adding margins on
+ every polish pass (+~57 px, forever, 100% main thread). A ListView host
+ masked it by hard-pinning the delegate width; layout hosts (the flickable
+ message view) do not.
+*/
+Item {
+    id: root
+
+    width: 600
+    height: 800
+
+    Component {
+        id: hostComponent
+
+        GridLayout {
+            width: 600
+            columns: 1
+
+            StatusMessage {
+                objectName: "albumMessage"
+
+                Layout.fillWidth: true
+
+                timestamp: Date.now()
+
+                messageDetails {
+                    contentType: StatusMessage.ContentType.Image
+                    messageText: ""
+                    unparsedText: ""
+                    amISender: false
+                    album: [ModelsData.banners.coinbase, ModelsData.icons.status]
+                    albumCount: 2
+                    sender.displayName: "Peer"
+                }
+            }
+        }
+    }
+
+    TestCase {
+        name: "StatusMessageAlbumWidth"
+        when: windowShown
+
+        function test_albumMessageWidthStaysBoundedInLayoutHost() {
+            const host = createTemporaryObject(hostComponent, root)
+            verify(!!host)
+            const message = findChild(root, "albumMessage")
+            verify(!!message)
+
+            // let several polish passes run — the runaway grows every pass
+            for (let i = 0; i < 6; ++i)
+                waitForRendering(host)
+
+            const sampled = message.width
+            compare(sampled, root.width,
+                    "album message must fill its host exactly — neither outgrow nor undershoot it")
+
+            wait(200)
+            fuzzyCompare(message.width, sampled, 1,
+                         "album message width must be stable across polish passes, "
+                         + sampled + " -> " + message.width)
+        }
+    }
+}

--- a/storybook/src/Models/CommunitySectionMock.qml
+++ b/storybook/src/Models/CommunitySectionMock.qml
@@ -1,5 +1,7 @@
 import QtQuick
 
+import StatusQ.Core.Theme
+
 import utils
 
 import AppLayouts.Chat.stores as ChatStores
@@ -534,9 +536,10 @@ QtObject {
             const now = Date.now()
             const count = root.messagesPerChannel
             const senderCount = Math.max(1, Math.min(root.membersCount, 20))
-            // Deterministic local photos: image rows must not hit the network
-            const photoA = "file:///private/tmp/claude-501/-Users-alexjbanca-Repos-status-desktop/367af37d-a18f-4e58-9856-5ecd5112f2cc/scratchpad/mock_photo_a.png"
-            const photoB = "file:///private/tmp/claude-501/-Users-alexjbanca-Repos-status-desktop/367af37d-a18f-4e58-9856-5ecd5112f2cc/scratchpad/mock_photo_b.png"
+            // Deterministic repo-local photos: image rows must not hit the
+            // network or depend on files outside the checkout
+            const photoA = Assets.png("chat/chat@2x")
+            const photoB = Assets.png("chat/request_payment_banner")
             // like the production model: index 0 is the newest message and
             // history grows towards higher indexes
             for (let i = 0; i < count; ++i) {

--- a/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
@@ -9,6 +9,9 @@ QtObject {
     // store is created internally by a component under test (section loaders)
     property var chatCommunitySectionModule: ChatStoresConfig.chatSectionModule
     property var contactsStore
+
+    // MessageView senders resolve through this model; null is a valid empty source
+    property var contactsModel: null
     property bool isChatSectionModule
     property var communityId
 

--- a/ui/StatusQ/src/StatusQ/Components/LoadingSkeletonGroup.qml
+++ b/ui/StatusQ/src/StatusQ/Components/LoadingSkeletonGroup.qml
@@ -39,6 +39,13 @@ Item {
 
     default property alias contentData: shapesContainer.data
 
+    // The effect is backed by FBOs the size of the whole group; beyond GPU
+    // texture limits it silently paints nothing (a very tall group — e.g. a
+    // paging placeholder — would white out entirely). Past this height the
+    // tiles render plain, without the sweep.
+    readonly property bool shimmerEnabled: root.visible && root.height > 0
+                                           && root.height <= 6000
+
     Item {
         id: shapesContainer
         anchors.fill: parent
@@ -53,7 +60,7 @@ Item {
 
         Loader {
             anchors.fill: parent
-            active: root.visible
+            active: root.shimmerEnabled
             sourceComponent: Rectangle {
                 id: sweep
 
@@ -88,10 +95,15 @@ Item {
         }
     }
 
-    OpacityMask {
+    // Loader-gated, not just hidden: the mask's source bindings keep its
+    // layer textures alive even while the effect item is invisible.
+    Loader {
         anchors.fill: parent
-        source: sweepContainer
-        maskSource: shapesContainer
-        visible: root.visible
+        active: root.shimmerEnabled
+
+        sourceComponent: OpacityMask {
+            source: sweepContainer
+            maskSource: shapesContainer
+        }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -325,7 +325,8 @@ Control {
                                     objectName: "StatusMessage_imageAlbum"
                                     readonly property int effectiveAlbumCount: Math.max(1, root.messageDetails.albumCount)
 
-                                    width: messageLayout.width
+                                    // Deliberately no `width: messageLayout.width`: the Loader mirrors it
+                                    // back as implicitWidth, which livelocks QQuickLayout hosts.
                                     album: root.messageDetails.albumCount > 0 ? root.messageDetails.album : [root.messageDetails.messageContent]
                                     albumCount: effectiveAlbumCount
                                     imageWidth: Math.max(1, Math.min((messageLayout.width - 9 * (effectiveAlbumCount - 1)) / effectiveAlbumCount, 144))

--- a/ui/app/AppLayouts/Chat/panels/MessageRowsSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/MessageRowsSkeleton.qml
@@ -24,73 +24,87 @@ LoadingSkeletonGroup {
         }
         spacing: Theme.padding
 
-        // name/line widths are fractions of the available text width so the
-        // shape survives narrow and wide panels alike
+        // The pattern block is repeated to fill whatever height the skeleton
+        // is given — as a paging placeholder it can stand in for many screens
+        // of messages, and a fast fling must never reach blank space. The
+        // divisor is a safe underestimate of the block height; the surplus
+        // block is clipped at the top.
         Repeater {
-            model: [
-                { name: 0.22, lines: [0.95, 0.9, 0.86, 0.5] },
-                { separator: true },
-                { name: 0.18, lines: [0.6], card: true },
-                { name: 0.26, lines: [0.92, 0.35] },
-                { separator: true },
-                { name: 0.2, lines: [0.88, 0.44] },
-            ]
+            model: Math.max(1, Math.ceil(root.height / 500))
 
-            delegate: DelegateChooser {
-                role: "separator"
+            delegate: Column {
+                width: parent ? parent.width : 0
+                spacing: Theme.padding
 
-                DelegateChoice {
-                    roleValue: true
+                // name/line widths are fractions of the available text width
+                // so the shape survives narrow and wide panels alike
+                Repeater {
+                    model: [
+                        { name: 0.22, lines: [0.95, 0.9, 0.86, 0.5] },
+                        { separator: true },
+                        { name: 0.18, lines: [0.6], card: true },
+                        { name: 0.26, lines: [0.92, 0.35] },
+                        { separator: true },
+                        { name: 0.2, lines: [0.88, 0.44] },
+                    ]
 
-                    LoadingSkeletonTile {
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        implicitWidth: 96
-                        implicitHeight: 12
-                    }
-                }
-                DelegateChoice {
-                    Row {
-                        id: entry
+                    delegate: DelegateChooser {
+                        role: "separator"
 
-                        required property var modelData
-
-                        // available width for the text bars; derived from the
-                        // stable root width, not the row itself, to avoid a
-                        // sizing cycle
-                        readonly property real textWidth:
-                            Math.max(0, root.width - 40 - Theme.halfPadding)
-
-                        width: parent.width
-                        spacing: Theme.halfPadding
-
-                        LoadingSkeletonTile {
-                            implicitWidth: 40
-                            implicitHeight: 40
-                            radius: width / 2
-                        }
-                        Column {
-                            spacing: 6
+                        DelegateChoice {
+                            roleValue: true
 
                             LoadingSkeletonTile {
-                                implicitWidth: entry.textWidth * (entry.modelData.name ?? 0.2)
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                implicitWidth: 96
                                 implicitHeight: 12
                             }
-                            Repeater {
-                                model: entry.modelData.lines ?? []
+                        }
+                        DelegateChoice {
+                            Row {
+                                id: entry
+
+                                required property var modelData
+
+                                // available width for the text bars; derived
+                                // from the stable root width, not the row
+                                // itself, to avoid a sizing cycle
+                                readonly property real textWidth:
+                                    Math.max(0, root.width - 40 - Theme.halfPadding)
+
+                                width: parent.width
+                                spacing: Theme.halfPadding
 
                                 LoadingSkeletonTile {
-                                    required property real modelData
-
-                                    implicitWidth: entry.textWidth * modelData
-                                    implicitHeight: 14
+                                    implicitWidth: 40
+                                    implicitHeight: 40
+                                    radius: width / 2
                                 }
-                            }
-                            // attachment / link-preview card
-                            LoadingSkeletonTile {
-                                visible: !!entry.modelData.card
-                                implicitWidth: Math.min(320, entry.textWidth * 0.6)
-                                implicitHeight: 150
-                                radius: Theme.radius
+                                Column {
+                                    spacing: 6
+
+                                    LoadingSkeletonTile {
+                                        implicitWidth: entry.textWidth * (entry.modelData.name ?? 0.2)
+                                        implicitHeight: 12
+                                    }
+                                    Repeater {
+                                        model: entry.modelData.lines ?? []
+
+                                        LoadingSkeletonTile {
+                                            required property real modelData
+
+                                            implicitWidth: entry.textWidth * modelData
+                                            implicitHeight: 14
+                                        }
+                                    }
+                                    // attachment / link-preview card
+                                    LoadingSkeletonTile {
+                                        visible: !!entry.modelData.card
+                                        implicitWidth: Math.min(320, entry.textWidth * 0.6)
+                                        implicitHeight: 150
+                                        radius: Theme.radius
+                                    }
+                                }
                             }
                         }
                     }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -6,9 +6,12 @@ import QtQuick.Layouts
 import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Core
-import StatusQ.Core.Backpressure
 import StatusQ.Core.Theme
 import StatusQ.Popups.Dialog
+
+import SortFilterProxyModel 0.2
+
+import StatusQ.Core.Utils as SQUtils
 
 import utils
 import shared
@@ -95,18 +98,133 @@ Item {
 
     QtObject {
         id: d
+        objectName: "chatMessagesViewInternal"
 
-        readonly property real scrollY: chatLogView.visibleArea.yPosition * chatLogView.contentHeight
-        readonly property bool isMostRecentMessageInViewport: chatLogView.visibleArea.yPosition >= 0.99 - chatLogView.visibleArea.heightRatio
+        readonly property bool isMostRecentMessageInViewport: chatLogView.atNewest
         readonly property var chatDetails: chatContentModule && chatContentModule.chatDetails || null
         readonly property bool keepUnread: messageStore.keepUnread
 
-        // Tracks whether the user was at the bottom of the chat to know if we must scroll back there when coming back
-        property bool isAtBottom: false
+        // Sliding model window over messageStore.messagesModel (source row 0 =
+        // newest); the view only ever holds the window's rows, never the history.
+        // The initial size is derived from the viewport (assuming compact rows)
+        // so the placeholder cannot start on screen and fire paging on open.
+        readonly property int assumedMinRowHeight: 24
+        readonly property int estimatedViewportRows: Math.ceil(chatLogView.height / d.assumedMinRowHeight)
+        readonly property int initialWindowSize: Math.max(20, Math.min(d.maxWindowSize,
+                                                                       d.estimatedViewportRows))
+        readonly property int windowChunkSize: 30
+        readonly property int maxWindowSize: 140
 
-        readonly property var loadMoreMessagesIfScrollBelowThreshold: Backpressure.oneInTimeQueued(root, 100, function() {
-            if(scrollY < 1000) messageStore.loadMoreMessages()
-        })
+        property int windowStart: 0
+        property int windowEnd: initialWindowSize - 1
+
+        // Goals the live bounds walk towards a few rows per frame (windowDriver):
+        // admitting a whole window in one dispatch stalls slow devices for
+        // seconds. Shrinking only destroys rows and is applied at once.
+        readonly property int moveBudget: 8
+        property int windowStartGoal: 0
+        property int windowEndGoal: initialWindowSize - 1
+
+        // The chat identifier (clock -2) is the last row of every chat; the
+        // backend keeps a fetch-more row (clock -1) directly above it for as
+        // long as older messages can be requested. History is exhausted only
+        // when the identifier is not preceded by that row. The count heuristic
+        // alone never settles (fetch churn re-arms it).
+        property bool historyExhausted: false
+
+        function updateHistoryExhausted() {
+            const model = root.messageStore?.messagesModel ?? null
+            if (!model || model.count === 0) {
+                historyExhausted = false
+                return
+            }
+            const last = SQUtils.ModelUtils.get(model, model.count - 1, "contentType")
+            const beforeLast = model.count > 1
+                    ? SQUtils.ModelUtils.get(model, model.count - 2, "contentType")
+                    : undefined
+            historyExhausted = last === Constants.messageContentType.chatIdentifier
+                    && beforeLast !== Constants.messageContentType.fetchMoreMessagesButton
+        }
+
+        // The initial size is re-derived once the view has a height; growth
+        // only, shrinking would destroy rows the viewport may be showing.
+        property bool windowAtInitial: true
+
+        onInitialWindowSizeChanged: {
+            if (d.windowAtInitial && d.initialWindowSize - 1 > d.windowEndGoal)
+                d.windowEndGoal = d.initialWindowSize - 1
+        }
+
+        readonly property int historyCount: messageStore.messagesModel ? messageStore.messagesModel.count : 0
+
+        // History count at the last fetch: stops the placeholder once a fetch
+        // brings nothing, re-arms when history grows.
+        property int lastFetchHistoryCount: -1
+        readonly property bool mayFetchMoreHistory: d.historyCount !== d.lastFetchHistoryCount
+
+        readonly property bool olderMessagesAvailable: d.historyCount > 0
+                                                       && (d.windowEnd < d.historyCount - 1
+                                                           || (!d.historyExhausted
+                                                               && (d.mayFetchMoreHistory
+                                                                   || root.rootStore.loadingHistoryMessagesInProgress)))
+
+        function resetWindow() {
+            windowStart = 0
+            windowEnd = Math.min(initialWindowSize, moveBudget) - 1
+            windowStartGoal = 0
+            windowEndGoal = initialWindowSize - 1
+            windowAtInitial = true
+            lastFetchHistoryCount = -1
+        }
+
+        function slideWindowToHistory() {
+            if (d.windowEndGoal < d.historyCount - 1) {
+                d.windowAtInitial = false
+                d.windowEndGoal = Math.min(d.historyCount - 1, d.windowEndGoal + d.windowChunkSize)
+                if (d.windowEndGoal - d.windowStartGoal + 1 > d.maxWindowSize)
+                    d.windowStartGoal = d.windowEndGoal - d.maxWindowSize + 1
+                return
+            }
+
+            if (root.rootStore.loadingHistoryMessagesInProgress || d.historyExhausted
+                    || !d.mayFetchMoreHistory)
+                return
+
+            d.lastFetchHistoryCount = d.historyCount
+            messageStore.loadMoreMessages()
+        }
+
+        function slideWindowToRecent() {
+            if (d.windowStartGoal <= 0)
+                return
+
+            d.windowStartGoal = Math.max(0, d.windowStartGoal - d.windowChunkSize)
+            if (d.windowEndGoal - d.windowStartGoal + 1 > d.maxWindowSize)
+                d.windowEndGoal = d.windowStartGoal + d.maxWindowSize - 1
+        }
+
+        // QSFPM only re-evaluates inserted rows; nudge the bound so the filter
+        // re-checks all rows (deferred — the proxy may lag the source change).
+        function refilterWindow() {
+            const end = d.windowEnd
+            d.windowEnd = end + 1
+            d.windowEnd = end
+        }
+
+        // Moves the window so that a source index sits in the middle of it and
+        // can therefore be scrolled to.
+        function centerWindowOn(messageIndex) {
+            d.windowAtInitial = false
+            // a tiny instant window around the target so it can be positioned
+            // at once; growth happens on the history side only, keeping the
+            // target's window row stable while rows stream in below it
+            d.windowStart = Math.max(0, messageIndex - 2)
+            d.windowEnd = messageIndex + 2
+            d.windowStartGoal = d.windowStart
+            d.windowEndGoal = Math.max(d.windowEnd,
+                                       Math.min(d.historyCount - 1,
+                                                d.windowStart + d.maxWindowSize - 1))
+        }
 
         function markAllMessagesReadIfMostRecentMessageIsInViewport() {
             if (Qt.application.state != Qt.ApplicationActive || !isMostRecentMessageInViewport || !chatLogView.visible || keepUnread) {
@@ -119,19 +237,80 @@ Item {
         }
 
         function goToMessage(messageIndex) {
-            chatLogView.currentIndex = -1
-            chatLogView.currentIndex = messageIndex
-            // Reset isAtBottom since the new message may be up high
-            d.isAtBottom = d.isMostRecentMessageInViewport
+            d.centerWindowOn(messageIndex)
+            chatLogView.positionAtRow(messageIndex - d.windowStart)
         }
 
+        // Slides the window to the recent end without rebuilding it — a reset
+        // here would destroy and regrow the delegates on every sent message.
         function scrollToBottom() {
-            chatLogView.positionViewAtBeginning()
-            d.isAtBottom = true
+            if (d.windowStart > 0 || d.windowStartGoal > 0) {
+                d.windowStart = 0
+                d.windowStartGoal = 0
+                if (d.windowEndGoal - d.windowStartGoal + 1 > d.maxWindowSize)
+                    d.windowEndGoal = d.maxWindowSize - 1
+            }
+            chatLogView.positionAtNewest()
             markAllMessagesReadIfMostRecentMessageIsInViewport()
         }
 
         onIsMostRecentMessageInViewportChanged: markAllMessagesReadIfMostRecentMessageIsInViewport()
+    }
+
+    // Source-model inserts and removals below the window would otherwise shift
+    // which messages the index window selects; keep it pinned to the same rows.
+    Connections {
+        target: root.messageStore?.messagesModel ?? null
+
+        function onRowsInserted(parent, first, last) {
+            if (d.windowStart > 0 && first <= d.windowStart) {
+                const inserted = last - first + 1
+                d.windowStart += inserted
+                d.windowEnd += inserted
+                d.windowStartGoal += inserted
+                d.windowEndGoal += inserted
+            }
+            if (first <= d.windowEnd)
+                Qt.callLater(d.refilterWindow)
+            Qt.callLater(d.updateHistoryExhausted)
+        }
+
+        function onRowsRemoved(parent, first, last) {
+            if (d.windowStart > 0 && first < d.windowStart) {
+                const removed = Math.min(last, d.windowStart - 1) - first + 1
+                d.windowStart -= removed
+                d.windowEnd -= removed
+                d.windowStartGoal = Math.max(0, d.windowStartGoal - removed)
+                d.windowEndGoal = Math.max(d.windowEnd, d.windowEndGoal - removed)
+            }
+            if (first <= d.windowEnd)
+                Qt.callLater(d.refilterWindow)
+            Qt.callLater(d.updateHistoryExhausted)
+        }
+    }
+
+    // Walks the live window bounds towards their goals a few rows per frame,
+    // so a window move admits its delegates in small batches across frames
+    // instead of building them all inside a single dispatch.
+    Timer {
+        id: windowDriver
+
+        interval: 16
+        repeat: true
+        triggeredOnStart: true
+        running: d.windowEnd !== d.windowEndGoal || d.windowStart !== d.windowStartGoal
+
+        onTriggered: {
+            if (d.windowEnd > d.windowEndGoal)
+                d.windowEnd = d.windowEndGoal
+            else if (d.windowEnd < d.windowEndGoal)
+                d.windowEnd = Math.min(d.windowEndGoal, d.windowEnd + d.moveBudget)
+
+            if (d.windowStart < d.windowStartGoal)
+                d.windowStart = d.windowStartGoal
+            else if (d.windowStart > d.windowStartGoal)
+                d.windowStart = Math.max(d.windowStartGoal, d.windowStart - d.moveBudget)
+        }
     }
 
     Connections {
@@ -179,7 +358,7 @@ Item {
 
         function onLoadingChanged() {
             d.markAllMessagesReadIfMostRecentMessageIsInViewport()
-            if (!messageStore.loading && d.isAtBottom) {
+            if (!messageStore.loading && chatLogView.stickingToNewest) {
                 Qt.callLater(d.scrollToBottom)
             }
         }
@@ -189,12 +368,11 @@ Item {
         target: !!d.chatDetails ? d.chatDetails : null
 
         function onActiveChanged() {
-            if (active && d.isAtBottom) {
+            if (active && chatLogView.stickingToNewest) {
                 Qt.callLater(d.scrollToBottom)
             }
 
             d.markAllMessagesReadIfMostRecentMessageIsInViewport()
-            d.loadMoreMessagesIfScrollBelowThreshold()
         }
 
         function onHasUnreadMessagesChanged() {
@@ -202,21 +380,11 @@ Item {
                 return
             }
 
+            // The marker enters the view when the window slides over it.
             // HACK: we call `addNewMessagesMarker` later because messages model
             // may not be yet propagated with unread messages when this signal is emitted
             if (chatLogView.visible && (Qt.application.state != Qt.ApplicationActive || !d.isMostRecentMessageInViewport)) {
                 Qt.callLater(() => messageStore.addNewMessagesMarker())
-            }
-        }
-    }
-
-    Connections {
-        target: root.rootStore
-        enabled: d.chatDetails && d.chatDetails.active
-
-        function onLoadingHistoryMessagesInProgressChanged() {
-            if(!root.rootStore.loadingHistoryMessagesInProgress) {
-                d.loadMoreMessagesIfScrollBelowThreshold()
             }
         }
     }
@@ -242,7 +410,7 @@ Item {
         }
     }
 
-    StatusListView {
+    ChatMessagesFlickable {
         id: chatLogView
         visible: !messageStore.loading
         objectName: "chatLogView"
@@ -250,15 +418,25 @@ Item {
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        spacing: 0
-        bottomMargin: Theme.halfPadding
-        verticalLayoutDirection: ListView.BottomToTop
-        cacheBuffer: height > 0 ? height * 2 : 0 // cache 2 screens worth of items
 
-        highlightRangeMode: ListView.ApplyRange
-        highlightMoveDuration: 200
-        preferredHighlightBegin: 0
-        preferredHighlightEnd: chatLogView.height / 2
+        contentBottomPadding: Theme.halfPadding
+
+        moreUpAvailable: d.olderMessagesAvailable
+        moreDownAvailable: d.windowStart > 0
+
+        onMoreUpRequested: d.slideWindowToHistory()
+        onMoreDownRequested: d.slideWindowToRecent()
+
+        onRowPositioned: row => {
+            const item = chatLogView.itemAtRow(row)
+            if (item && item.startMessageFoundAnimation)
+                item.startMessageFoundAnimation()
+        }
+
+        onMovementEnded: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
+        onVisibleChanged: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
+
+        placeholder: MessageRowsSkeleton {}
 
         Binding on flickDeceleration {
             when: localAppSettings.isCustomMouseScrollingEnabled
@@ -272,81 +450,55 @@ Item {
             restoreMode: Binding.RestoreBindingOrValue
         }
 
-        model: messageStore.messagesModel
+        // The view is handed only the [windowStart..windowEnd] slice. The
+        // source stays detached until the initial fetch is done — attaching
+        // earlier costs one incubation per row; the covering skeleton in
+        // ChatContentView hides both that phase and the view's incubation.
+        model: SortFilterProxyModel {
+            id: messagesWindow
 
-        onContentYChanged: d.loadMoreMessagesIfScrollBelowThreshold()
-
-        onMovementEnded: {
-            d.isAtBottom = d.isMostRecentMessageInViewport
-        }
-
-        onCountChanged: {
-            d.markAllMessagesReadIfMostRecentMessageIsInViewport()
-
-            // after inilial messages are loaded
-            // load as much messages as the view requires
-            if (!messageStore.loading) {
-                d.loadMoreMessagesIfScrollBelowThreshold()
+            sourceModel: messageStore.loading ? null : messageStore.messagesModel
+            onSourceModelChanged: {
+                d.resetWindow()
+                d.updateHistoryExhausted()
+                // whatever the paging timer did against the detached window,
+                // the view opens on the newest message
+                if (sourceModel)
+                    Qt.callLater(chatLogView.positionAtNewest)
             }
 
-            // When a new item is added (new message or new-messages marker) and
-            // the user was already at the bottom, snap back so the few pixels of
-            // upward drift caused by the item insertion are immediately corrected.
-            if (d.isAtBottom) {
-                Qt.callLater(d.scrollToBottom)
+            filters: IndexFilter {
+                minimumIndex: d.windowStart
+                maximumIndex: d.windowEnd
             }
-        }
 
-        onVisibleChanged: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
-
-        onCurrentItemChanged: {
-            if(currentItem && currentIndex > 0) {
-                currentItem.startMessageFoundAnimation()
-            }
+            onCountChanged: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
         }
 
         ScrollBar.vertical: StatusScrollBar {
-            visible: chatLogView.visibleArea.heightRatio < 1
-        }
-
-        ChatAnchorButtonsPanel {
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: Theme.padding
-            anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
-
-            // Don't show the mention anchor in 1-1 chats, because all messages count as mentions
-            mentionsCount: d.chatDetails && d.chatDetails.type !== Constants.chatType.oneToOne ?
-                        d.chatDetails.notificationCount : 0
-            recentMessagesCount: root.messageStore.newMessagesCount
-            recentMessagesButtonVisible: {
-                chatLogView.contentY // trigger binding on contentY change
-                return chatLogView.contentHeight - (d.scrollY + chatLogView.height) > 400
-            }
-
-            onRecentMessagesButtonClicked: d.scrollToBottom()
-            onMentionsButtonClicked: {
-                let id = messageStore.firstUnseenMentionMessageId()
-                if (id !== "") {
-                    messageStore.jumpToMessage(id)
-                    chatContentModule.markMessageRead(id)
-                }
-            }
+            visible: chatLogView.contentHeight > chatLogView.height
         }
 
         delegate: MessageView {
             id: msgDelegate
 
-            width: ListView.view.width
-
             objectName: "chatMessageViewDelegate"
+
+            // Row 0 is the newest message and belongs at the bottom
+            Layout.row: root.chatLogView.rowCount - index
+            Layout.column: 0
+            // Hard-pin the cell width (as ListView did) instead of fillWidth:
+            // message implicit-width echoes livelock the GridLayout otherwise.
+            Layout.preferredWidth: root.chatLogView.width
+            Layout.minimumWidth: root.chatLogView.width
+            Layout.maximumWidth: root.chatLogView.width
 
             rootStore: root.rootStore
             messageStore: root.messageStore
             channelEmoji: root.channelEmoji
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
-            chatLogView: ListView.view
+            chatLogView: root.chatLogView
             chatContentModule: root.chatContentModule
             formatBalance: root.formatBalance
             usersModel: root.usersModel
@@ -476,7 +628,7 @@ Item {
                 root.spectateCommunityRequested(communityId)
             }
         }
-        header: {
+        bottomContent: {
             if (!root.isContactBlocked && root.isOneToOne && root.rootStore.oneToOneChatContact) {
                 switch (root.rootStore.oneToOneChatContact.contactRequestState) {
                 case Constants.ContactRequestState.None: // no break
@@ -492,20 +644,30 @@ Item {
             }
             return null
         }
+    }
 
-        property int prevHeight: height
+    ChatAnchorButtonsPanel {
+        anchors.bottom: chatLogView.bottom
+        anchors.bottomMargin: Theme.padding
+        anchors.right: chatLogView.right
+        anchors.rightMargin: Theme.padding
 
-        onHeightChanged: {
-            const heightDiff = prevHeight - height
+        visible: chatLogView.visible
 
-            // Keep position at the end on resize when it was at the end before.
-            // Without this workaround, when the keyboard opens or window is
-            // resized, the position is slightly changed and not at the end anymore.
-            if (d.isAtBottom && contentHeight - (d.scrollY + height) <= heightDiff) {
-                Qt.callLater(d.scrollToBottom)
+        // Don't show the mention anchor in 1-1 chats, because all messages count as mentions
+        mentionsCount: d.chatDetails && d.chatDetails.type !== Constants.chatType.oneToOne ?
+                    d.chatDetails.notificationCount : 0
+        recentMessagesCount: root.messageStore.newMessagesCount
+        recentMessagesButtonVisible: chatLogView.moreDownAvailable
+                                     || chatLogView.contentHeight - chatLogView.contentY - chatLogView.height > 400
+
+        onRecentMessagesButtonClicked: d.scrollToBottom()
+        onMentionsButtonClicked: {
+            let id = messageStore.firstUnseenMentionMessageId()
+            if (id !== "") {
+                messageStore.jumpToMessage(id)
+                chatContentModule.markMessageRead(id)
             }
-
-            prevHeight = height
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -3,6 +3,7 @@ import QtQml
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import StatusQ 0.1
 import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Core
@@ -96,6 +97,16 @@ Item {
     // Community access related requests:
     signal spectateCommunityRequested(string communityId)
 
+    // A different chat is a different row shape.
+    onChatIdChanged: d.forgetRowHeights()
+
+    // The hint singleton outlives this view: a chat switch mid-scroll must
+    // not leak the pushed hint.
+    Component.onDestruction: {
+        if (d.userScrolling)
+            IncubationHints.popGentle()
+    }
+
     QtObject {
         id: d
         objectName: "chatMessagesViewInternal"
@@ -118,12 +129,214 @@ Item {
         property int windowStart: 0
         property int windowEnd: initialWindowSize - 1
 
-        // Goals the live bounds walk towards a few rows per frame (windowDriver):
-        // admitting a whole window in one dispatch stalls slow devices for
-        // seconds. Shrinking only destroys rows and is applied at once.
-        readonly property int moveBudget: 8
-        property int windowStartGoal: 0
-        property int windowEndGoal: initialWindowSize - 1
+        // ---- Staged rows (PR review: no rows assembling on screen) ----
+        // A slide admits its whole chunk at once, but the rows enter as cheap
+        // shells whose content incubates asynchronously and holds no visual
+        // space — the placeholder keeps covering the region. Only when every
+        // row of the batch is built (or the safety timeout fires) does the
+        // batch reveal, in one frame: one relayout, one anchor restore, and
+        // the user never sees a chunk assemble row by row.
+        //
+        // Rows created outside a staged admit — the initial fill and live
+        // incoming messages — show as soon as they load: the initial fill
+        // grows above the bottom-stuck viewport, and a live message must
+        // never wait for an unrelated batch.
+        property var stagedShells: []
+        // Rows admitted by a staged slide whose shells the engine has not
+        // created yet, keyed by message id. Shell creation is asynchronous
+        // whenever an ancestor is still incubating (AsynchronousIfNested), so
+        // admission is captured at row insertion — synchronous with the
+        // window mutation — never inferred from shell creation timing.
+        property var stagedIds: new Set()
+        property int stagedCount: 0
+        property bool admittingStaged: false
+
+        function syncStagedCount() {
+            stagedCount = stagedShells.length + stagedIds.size
+        }
+
+        // Row-height estimate, in two parts: the evidence, and the figure the
+        // placeholders are allowed to read.
+        //
+        // Evidence is a decaying sample of every revealed row's height, capped
+        // and halved on overflow so it stays weighted towards what was
+        // measured recently and no single batch can swing it far.
+        property real rowHeightSampleSum: 0
+        property real rowHeightSampleCount: 0
+        readonly property int rowHeightSampleCap: 512
+
+        // Rows the sample needs before the estimate stops following it: the
+        // chat has just opened and its shape is still being established.
+        readonly property int rowHeightSettleCount: 24
+
+        // How wrong the evidence has to say the estimate is before it moves
+        // again. The placeholders multiply it by up to 300 out-of-window rows,
+        // so an estimate re-averaged on every reveal resized them by thousands
+        // of pixels once a batch. A genuinely different row shape (one-line
+        // rows scrolled into an image-heavy stretch) still re-estimates.
+        readonly property real rowHeightRelatchRatio: 0.25
+
+        // The published estimate: changes only when it re-latches.
+        property real avgRowHeight: 0
+
+        function observeRowHeights(sum, count) {
+            if (count <= 0 || sum <= 0)
+                return
+            d.rowHeightSampleSum += sum
+            d.rowHeightSampleCount += count
+            if (d.rowHeightSampleCount > d.rowHeightSampleCap) {
+                d.rowHeightSampleSum /= 2
+                d.rowHeightSampleCount /= 2
+            }
+            const mean = d.rowHeightSampleSum / d.rowHeightSampleCount
+            if (d.avgRowHeight <= 0
+                    || d.rowHeightSampleCount < d.rowHeightSettleCount) {
+                d.avgRowHeight = mean
+                return
+            }
+            if (Math.abs(mean - d.avgRowHeight)
+                    >= d.avgRowHeight * d.rowHeightRelatchRatio)
+                d.avgRowHeight = mean
+        }
+
+        // The next chat's first rows establish the estimate rather than argue
+        // with the last chat's.
+        function forgetRowHeights() {
+            d.rowHeightSampleSum = 0
+            d.rowHeightSampleCount = 0
+        }
+
+        function rowHeightOr48() {
+            return d.avgRowHeight > 0 ? d.avgRowHeight : 48
+        }
+
+        // Scrolling competes with incubation for frame time on low-end
+        // devices: hold a gentle hint while the user scrolls so staged rows
+        // build in small paced bites and the flick stays smooth.
+        readonly property bool userScrolling: chatLogView.moving || verticalScrollBar.pressed
+
+        onUserScrollingChanged: {
+            if (userScrolling)
+                IncubationHints.pushGentle()
+            else
+                IncubationHints.popGentle()
+        }
+
+        function admitStaged(mutator) {
+            d.admittingStaged = true
+            mutator()
+            d.admittingStaged = false
+            if (d.stagedCount > 0)
+                revealTimeout.restart()
+        }
+
+        // Rows entering the window during a staged admit, captured while they
+        // are inserted. Their shells may only be created later (async
+        // incubation) — the ids bridge that gap.
+        function captureStagedRows(first, last) {
+            if (!d.admittingStaged)
+                return
+            for (let i = first; i <= last; ++i) {
+                const id = SQUtils.ModelUtils.get(messagesWindow, i, "id")
+                if (id !== undefined && id !== null)
+                    d.stagedIds.add(id)
+            }
+            d.syncStagedCount()
+        }
+
+        // A staged row leaving the window before its shell was ever created
+        // must not hold the batch open.
+        function dropStagedRows(first, last) {
+            if (d.stagedIds.size === 0)
+                return
+            let dropped = false
+            for (let i = first; i <= last; ++i) {
+                const id = SQUtils.ModelUtils.get(messagesWindow, i, "id")
+                if (id !== undefined && id !== null && d.stagedIds.delete(id))
+                    dropped = true
+            }
+            if (dropped) {
+                d.syncStagedCount()
+                d.checkStagedReady()
+            }
+        }
+
+        // The shell for a captured row arrived: it joins the batch. Rows
+        // never captured (initial fill, live messages) reveal on their own.
+        function takeStagedId(id) {
+            return d.stagedIds.delete(id)
+        }
+
+        function stageShell(shell) {
+            d.stagedShells.push(shell)
+            d.syncStagedCount()
+        }
+
+        function unstageShell(shell) {
+            const i = d.stagedShells.indexOf(shell)
+            if (i < 0)
+                return
+            d.stagedShells.splice(i, 1)
+            d.syncStagedCount()
+            // the batch may have become complete by losing its last unbuilt row
+            d.checkStagedReady()
+        }
+
+        function checkStagedReady() {
+            if (d.stagedCount === 0) {
+                revealTimeout.stop()
+                return
+            }
+            if (d.stagedIds.size > 0) {
+                // shells still to be created: progress is expected, keep the
+                // stall detector armed (see below)
+                revealTimeout.restart()
+                return
+            }
+            for (let i = 0; i < d.stagedShells.length; ++i) {
+                if (!d.stagedShells[i].contentReady) {
+                    // called on every row completion, so this makes the
+                    // timeout a stall detector: it only fires after a full
+                    // interval with NO build progress. A slow-but-progressing
+                    // batch must never be flushed half-built — flushed rows
+                    // hold no space, so the placeholder would keep admitting
+                    // more rows and race the window into an endless
+                    // build-and-fetch loop the device can never catch up with
+                    revealTimeout.restart()
+                    return
+                }
+            }
+            d.revealStaged()
+        }
+
+        function clearStaging() {
+            d.stagedShells = []
+            d.stagedIds.clear()
+            d.syncStagedCount()
+            revealTimeout.stop()
+        }
+
+        // Reveals whatever is staged — normally a complete batch, on timeout
+        // a partial one (better than wedging paging on a pathological row).
+        function revealStaged() {
+            revealTimeout.stop()
+            // stragglers whose shells never got created (timeout path) fall
+            // back to revealing individually on their own completion
+            d.stagedIds.clear()
+            const batch = d.stagedShells
+            d.stagedShells = []
+            d.syncStagedCount()
+            let sum = 0
+            let measured = 0
+            for (let i = 0; i < batch.length; ++i) {
+                batch[i].revealed = true
+                if (batch[i].height > 0) {
+                    sum += batch[i].height
+                    ++measured
+                }
+            }
+            d.observeRowHeights(sum, measured)
+        }
 
         // The chat identifier (clock -2) is the last row of every chat; the
         // backend keeps a fetch-more row (clock -1) directly above it for as
@@ -151,8 +364,8 @@ Item {
         property bool windowAtInitial: true
 
         onInitialWindowSizeChanged: {
-            if (d.windowAtInitial && d.initialWindowSize - 1 > d.windowEndGoal)
-                d.windowEndGoal = d.initialWindowSize - 1
+            if (d.windowAtInitial && d.initialWindowSize - 1 > d.windowEnd)
+                d.windowEnd = d.initialWindowSize - 1
         }
 
         readonly property int historyCount: messageStore.messagesModel ? messageStore.messagesModel.count : 0
@@ -169,20 +382,26 @@ Item {
                                                                    || root.rootStore.loadingHistoryMessagesInProgress)))
 
         function resetWindow() {
+            clearStaging()
             windowStart = 0
-            windowEnd = Math.min(initialWindowSize, moveBudget) - 1
-            windowStartGoal = 0
-            windowEndGoal = initialWindowSize - 1
+            windowEnd = initialWindowSize - 1
             windowAtInitial = true
             lastFetchHistoryCount = -1
         }
 
         function slideWindowToHistory() {
-            if (d.windowEndGoal < d.historyCount - 1) {
+            // one batch at a time: the paging timer keeps asking while the
+            // placeholder shows, and the next chunk must wait for this one
+            if (d.stagedCount > 0)
+                return
+
+            if (d.windowEnd < d.historyCount - 1) {
                 d.windowAtInitial = false
-                d.windowEndGoal = Math.min(d.historyCount - 1, d.windowEndGoal + d.windowChunkSize)
-                if (d.windowEndGoal - d.windowStartGoal + 1 > d.maxWindowSize)
-                    d.windowStartGoal = d.windowEndGoal - d.maxWindowSize + 1
+                d.admitStaged(function() {
+                    d.windowEnd = Math.min(d.historyCount - 1, d.windowEnd + d.windowChunkSize)
+                    if (d.windowEnd - d.windowStart + 1 > d.maxWindowSize)
+                        d.windowStart = d.windowEnd - d.maxWindowSize + 1
+                })
                 return
             }
 
@@ -195,35 +414,38 @@ Item {
         }
 
         function slideWindowToRecent() {
-            if (d.windowStartGoal <= 0)
+            if (d.stagedCount > 0 || d.windowStart <= 0)
                 return
 
-            d.windowStartGoal = Math.max(0, d.windowStartGoal - d.windowChunkSize)
-            if (d.windowEndGoal - d.windowStartGoal + 1 > d.maxWindowSize)
-                d.windowEndGoal = d.windowStartGoal + d.maxWindowSize - 1
+            d.admitStaged(function() {
+                d.windowStart = Math.max(0, d.windowStart - d.windowChunkSize)
+                if (d.windowEnd - d.windowStart + 1 > d.maxWindowSize)
+                    d.windowEnd = d.windowStart + d.maxWindowSize - 1
+            })
         }
 
         // QSFPM only re-evaluates inserted rows; nudge the bound so the filter
         // re-checks all rows (deferred — the proxy may lag the source change).
+        // Staged: the nudge can transiently admit an extra row, which must not
+        // pop in half-built.
         function refilterWindow() {
-            const end = d.windowEnd
-            d.windowEnd = end + 1
-            d.windowEnd = end
+            d.admitStaged(function() {
+                const end = d.windowEnd
+                d.windowEnd = end + 1
+                d.windowEnd = end
+            })
         }
 
         // Moves the window so that a source index sits in the middle of it and
-        // can therefore be scrolled to.
+        // can therefore be scrolled to. Only a tiny window around the target:
+        // it builds and reveals fast, and the placeholders then grow the
+        // window chunk by chunk through the ordinary paging path.
         function centerWindowOn(messageIndex) {
             d.windowAtInitial = false
-            // a tiny instant window around the target so it can be positioned
-            // at once; growth happens on the history side only, keeping the
-            // target's window row stable while rows stream in below it
-            d.windowStart = Math.max(0, messageIndex - 2)
-            d.windowEnd = messageIndex + 2
-            d.windowStartGoal = d.windowStart
-            d.windowEndGoal = Math.max(d.windowEnd,
-                                       Math.min(d.historyCount - 1,
-                                                d.windowStart + d.maxWindowSize - 1))
+            d.admitStaged(function() {
+                d.windowStart = Math.max(0, messageIndex - 2)
+                d.windowEnd = Math.min(Math.max(0, d.historyCount - 1), messageIndex + 2)
+            })
         }
 
         function markAllMessagesReadIfMostRecentMessageIsInViewport() {
@@ -236,19 +458,45 @@ Item {
             }
         }
 
+        // Deferred so the proxy churn of an attach settles first, but a jump
+        // issued meanwhile wins: the stale reposition must not yank the view
+        // back to the bottom.
+        property bool pendingPositionAtNewest: false
+
+        function schedulePositionAtNewest() {
+            d.pendingPositionAtNewest = true
+            Qt.callLater(d.applyScheduledPositionAtNewest)
+        }
+
+        function applyScheduledPositionAtNewest() {
+            if (!d.pendingPositionAtNewest)
+                return
+            d.pendingPositionAtNewest = false
+            chatLogView.positionAtNewest()
+        }
+
         function goToMessage(messageIndex) {
+            d.pendingPositionAtNewest = false
             d.centerWindowOn(messageIndex)
             chatLogView.positionAtRow(messageIndex - d.windowStart)
         }
 
-        // Slides the window to the recent end without rebuilding it — a reset
-        // here would destroy and regrow the delegates on every sent message.
+        // Returns the view to the newest message. With the window already at
+        // the recent end (every sent message lands here) nothing is rebuilt —
+        // a teardown would flash the paging skeleton over the user's own
+        // messages. From deep in history it is a JUMP: the window collapses
+        // to a recent-end screenful instead of readmitting and unrolling
+        // every row in between.
         function scrollToBottom() {
-            if (d.windowStart > 0 || d.windowStartGoal > 0) {
-                d.windowStart = 0
-                d.windowStartGoal = 0
-                if (d.windowEndGoal - d.windowStartGoal + 1 > d.maxWindowSize)
-                    d.windowEndGoal = d.maxWindowSize - 1
+            if (d.windowStart > 0) {
+                d.windowAtInitial = false
+                d.admitStaged(function() {
+                    // end first: emptying the window before re-basing it at 0
+                    // avoids transiently admitting the whole span in between
+                    d.windowEnd = Math.min(Math.max(0, d.historyCount - 1),
+                                           d.initialWindowSize - 1)
+                    d.windowStart = 0
+                })
             }
             chatLogView.positionAtNewest()
             markAllMessagesReadIfMostRecentMessageIsInViewport()
@@ -267,8 +515,6 @@ Item {
                 const inserted = last - first + 1
                 d.windowStart += inserted
                 d.windowEnd += inserted
-                d.windowStartGoal += inserted
-                d.windowEndGoal += inserted
             }
             if (first <= d.windowEnd)
                 Qt.callLater(d.refilterWindow)
@@ -280,8 +526,6 @@ Item {
                 const removed = Math.min(last, d.windowStart - 1) - first + 1
                 d.windowStart -= removed
                 d.windowEnd -= removed
-                d.windowStartGoal = Math.max(0, d.windowStartGoal - removed)
-                d.windowEndGoal = Math.max(d.windowEnd, d.windowEndGoal - removed)
             }
             if (first <= d.windowEnd)
                 Qt.callLater(d.refilterWindow)
@@ -289,29 +533,19 @@ Item {
         }
     }
 
-    // Walks the live window bounds towards their goals a few rows per frame,
-    // so a window move admits its delegates in small batches across frames
-    // instead of building them all inside a single dispatch.
+    // Safety valve for staged batches: restarted on every row completion, so
+    // it fires only after a full interval without any build progress — a
+    // genuinely wedged batch, not a slow one. Whatever is built is shown;
+    // the stuck rows stay hidden and appear if they ever finish.
     Timer {
-        id: windowDriver
+        id: revealTimeout
 
-        interval: 16
-        repeat: true
-        triggeredOnStart: true
-        running: d.windowEnd !== d.windowEndGoal || d.windowStart !== d.windowStartGoal
+        objectName: "batchRevealTimeout"
+        interval: 1000
 
-        onTriggered: {
-            if (d.windowEnd > d.windowEndGoal)
-                d.windowEnd = d.windowEndGoal
-            else if (d.windowEnd < d.windowEndGoal)
-                d.windowEnd = Math.min(d.windowEndGoal, d.windowEnd + d.moveBudget)
-
-            if (d.windowStart < d.windowStartGoal)
-                d.windowStart = d.windowStartGoal
-            else if (d.windowStart > d.windowStartGoal)
-                d.windowStart = Math.max(d.windowStartGoal, d.windowStart - d.moveBudget)
-        }
+        onTriggered: d.revealStaged()
     }
+
 
     Connections {
         target: Qt.application
@@ -421,8 +655,29 @@ Item {
 
         contentBottomPadding: Theme.halfPadding
 
-        moreUpAvailable: d.olderMessagesAvailable
+        // A staged batch keeps the placeholder up: its rows hold no space
+        // until they reveal, and dropping the placeholder meanwhile would
+        // collapse the region they are about to fill.
+        moreUpAvailable: d.olderMessagesAvailable || d.stagedCount > 0
         moreDownAvailable: d.windowStart > 0
+
+        // Approximate the out-of-window content so the scrollbar stays
+        // roughly proportional across reveals: the rows a reveal adds are
+        // taken out of the placeholder, keeping the content height steady.
+        // One per side, each standing for its own span, so a slide resizes
+        // only the end it moved — a shared height popped the opposite
+        // placeholder into the viewport and ping-ponged the slide direction.
+        topPlaceholderHeight: {
+            const remaining = Math.max(0, d.historyCount - 1 - d.windowEnd)
+            return Math.max(chatLogView.height,
+                            Math.min(remaining, 300) * d.rowHeightOr48())
+        }
+        bottomPlaceholderHeight: Math.max(chatLogView.height,
+                                          Math.min(d.windowStart, 300) * d.rowHeightOr48())
+
+        // Page one viewport ahead of the scroll so a batch is usually
+        // revealed before its placeholder is ever seen.
+        prefetchMargin: chatLogView.height
 
         onMoreUpRequested: d.slideWindowToHistory()
         onMoreDownRequested: d.slideWindowToRecent()
@@ -464,7 +719,7 @@ Item {
                 // whatever the paging timer did against the detached window,
                 // the view opens on the newest message
                 if (sourceModel)
-                    Qt.callLater(chatLogView.positionAtNewest)
+                    d.schedulePositionAtNewest()
             }
 
             filters: IndexFilter {
@@ -472,20 +727,34 @@ Item {
                 maximumIndex: d.windowEnd
             }
 
+            // Declared on the model itself so these connections run before the
+            // Repeater's: a synchronously created shell must already find its
+            // id captured.
+            onRowsInserted: (parent, first, last) => d.captureStagedRows(first, last)
+            onRowsAboutToBeRemoved: (parent, first, last) => d.dropStagedRows(first, last)
+            // a reset removes every row without per-row signals: a staged
+            // batch would otherwise wait on ids that no longer exist
+            onModelAboutToBeReset: d.clearStaging()
+
             onCountChanged: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
         }
 
         ScrollBar.vertical: StatusScrollBar {
+            id: verticalScrollBar
+
             visible: chatLogView.contentHeight > chatLogView.height
         }
 
-        delegate: MessageView {
-            id: msgDelegate
+        // Shell + inline async Loader: the Repeater only ever builds the cheap
+        // shell synchronously; the actual MessageView incubates asynchronously
+        // (paced by the app's incubation controller). The component must stay
+        // inline — an external one would lose the model roles' context.
+        delegate: Loader {
+            id: shell
 
-            objectName: "chatMessageViewDelegate"
-
-            // Row 0 is the newest message and belongs at the bottom
-            Layout.row: root.chatLogView.rowCount - index
+            // Row 0 is the newest message and belongs at the bottom; +1
+            // keeps grid row 0 free as the spawn cell (see the view's docs)
+            Layout.row: root.chatLogView.rowCount - index + 1
             Layout.column: 0
             // Hard-pin the cell width (as ListView did) instead of fillWidth:
             // message implicit-width echoes livelock the GridLayout otherwise.
@@ -493,139 +762,189 @@ Item {
             Layout.minimumWidth: root.chatLogView.width
             Layout.maximumWidth: root.chatLogView.width
 
-            rootStore: root.rootStore
-            messageStore: root.messageStore
-            channelEmoji: root.channelEmoji
-            emojiPopup: root.emojiPopup
-            stickersPopup: root.stickersPopup
-            chatLogView: root.chatLogView
-            chatContentModule: root.chatContentModule
-            formatBalance: root.formatBalance
-            usersModel: root.usersModel
-            // covers the message body and the quoted reply, whose mentions
-            // also render through this map
-            mentionsMap: mentionResolver.resolveFor(model.unparsedText + " " + model.quotedMessageText)
+            // Pinned while staged too (the layout ignores invisible items),
+            // so the message lays out its text at its final width and the
+            // reveal-frame polish only places pre-measured rows.
+            width: root.chatLogView.width
 
-            isChatBlocked: root.isChatBlocked
-            joined: root.joined
+            asynchronous: true
 
-            sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
-            messageLinkSharingEnabled: root.messageLinkSharingEnabled
-            createMessageLink: (chatId, messageId) => root.messageStore.createMessageLink(chatId, messageId)
-            disabledTooltipText: root.disabledTooltipText
-            areTestNetworksEnabled: root.areTestNetworksEnabled
-            extraLeftPadding: root.extraLeftPadding
+            // The shell being Ready only means the MessageView *instance*
+            // exists — MessageView is itself a Loader whose content keeps
+            // incubating (with a 50px fallback height). A row is only ready
+            // once that inner content is fully built and measured; a content
+            // type without a component (inner status Null) is ready as is.
+            readonly property bool contentReady: status === Loader.Ready && item
+                                                 && item.status !== Loader.Loading
 
-            chatId: root.chatId
-            messageId: model.id
-            communityId: model.communityId
-            responseToMessageWithId: model.responseToMessageWithId
-            senderId: model.senderId
-            senderDisplayName: model.senderDisplayName
-            usesDefaultName: model.usesDefaultName
-            senderOptionalName: model.senderOptionalName
-            senderIsEnsVerified: model.senderEnsVerified
-            senderIcon: model.senderIcon
-            senderIsAdded: model.senderIsAdded
-            senderTrustStatus: model.senderTrustStatus
-            compressedKey: model.compressedKey
-            amISender: model.amISender
-            messageText: model.messageText
-            unparsedText: model.unparsedText
-            messageImage: model.messageImage
-            album: model.albumMessageImages.split(" ")
-            albumCount: model.albumImagesCount
-            messageTimestamp: model.timestamp
-            messageOutgoingStatus: model.outgoingStatus
-            resendError: model.resendError
-            messageContentType: model.contentType
-            pinnedMessage: model.pinned
-            messagePinnedBy: model.pinnedBy
-            reactionsModel: model.reactions
-            sticker: model.sticker
-            stickerPack: model.stickerPack
-            editModeOn: model.editMode
-            onEditModeOnChanged: root.editModeChanged(editModeOn, model.id)
-            isEdited: model.isEdited
-            deleted: model.deleted
-            deletedBy: model.deletedBy
-            deletedByContactDisplayName: model.deletedByContactDisplayName
-            deletedByContactIcon: model.deletedByContactIcon
-            linkPreviewModel: model.linkPreviewModel
-            links: model.links
-            paymentRequestModel: model.paymentRequestModel
-            messageAttachments: model.messageAttachments
-            transactionParams: model.transactionParameters
-            hasMention: model.mentioned
-            quotedMessageText: model.quotedMessageParsedText
-            quotedMessageUnparsedText: model.quotedMessageText
-            quotedMessageFrom: model.quotedMessageFrom
-            quotedMessageContentType: model.quotedMessageContentType
-            quotedMessageDeleted: model.quotedMessageDeleted
-            quotedMessageAuthorDetailsName: model.quotedMessageAuthorName
-            quotedMessageAuthorDetailsDisplayName: model.quotedMessageAuthorDisplayName
-            quotedMessageAuthorDetailsThumbnailImage: model.quotedMessageAuthorThumbnailImage
-            quotedMessageAuthorDetailsEnsVerified: model.quotedMessageAuthorEnsVerified
-            quotedMessageAuthorDetailsIsContact: model.quotedMessageAuthorIsContact
-            quotedMessageAlbumMessageImages: model.quotedMessageAlbumMessageImages.split(" ")
-            quotedMessageAlbumImagesCount: model.quotedMessageAlbumImagesCount
-            bridgeName: model.bridgeName
+            // Rows admitted by a staged slide hold no visual space until the
+            // whole batch is ready; everything else shows as soon as it is
+            // ready itself. A row that is still loading is never shown.
+            property bool revealed: false
+            visible: revealed && contentReady
 
-            gapFrom: model.gapFrom
-            gapTo: model.gapTo
+            readonly property string messageId: model.id
 
-             // This is possible since we have all data loaded before we load qml.
-             // When we fetch messages to fulfill a gap we have to set them at once.
-             // Also one important thing here is that messages are set in descending order
-             // in terms of `timestamp` of a message, that means a message with the most
-             // recent time is added at index 0.
-            prevMessageIndex: model.prevMsgIndex
-            prevMessageTimestamp: model.prevMsgTimestamp
-            prevMessageSenderId: model.prevMsgSenderId
-            prevMessageContentType: model.prevMsgContentType
-            prevMessageDeleted: model.prevMsgDeleted
-            nextMessageIndex: model.nextMsgIndex
-            nextMessageTimestamp: model.nextMsgTimestamp
-
-            // Unfurling related data:
-            gifUnfurlingEnabled: root.gifUnfurlingEnabled
-            neverAskAboutUnfurlingAgain: root.neverAskAboutUnfurlingAgain
-
-            // Contacts related data:
-            myPublicKey: root.myPublicKey
-
-            onOpenStickerPackPopup: stickerPackId => root.openStickerPackPopup(stickerPackId)
-            onTokenPaymentRequested: root.tokenPaymentRequested(recipientAddress, tokenKey, rawAmount)
-
-            onShowReplyArea: (messageId, author) => root.showReplyArea(messageId, author)
-
-            stickersLoaded: root.stickersLoaded
-
-            onSendViaPersonalChatRequested: {
-                Global.sendToRecipientRequested(recipientAddress)
+            function startMessageFoundAnimation() {
+                if (item)
+                    item.startMessageFoundAnimation()
             }
 
-            onVisibleChanged: {
-                if(!visible && model.editMode)
-                    messageStore.setEditModeOff(model.id)
+            // Membership in a staged batch is decided by the captured row id,
+            // not by creation timing: under a still-incubating ancestor the
+            // shell is created asynchronously, long after the admit returned.
+            Component.onCompleted: {
+                if (d.takeStagedId(messageId))
+                    d.stageShell(this)
+                else
+                    revealed = true
+            }
+            Component.onDestruction: d.unstageShell(this)
+
+            onContentReadyChanged: {
+                if (contentReady && !revealed)
+                    d.checkStagedReady()
             }
 
-            onEmojiReactionToggled: (messageId, hexcode) => {
-                root.messageStore.toggleReaction(messageId, hexcode)
-            }
+            sourceComponent: MessageView {
+                id: msgDelegate
 
-            // Unfurling related requests:
-            onSetNeverAskAboutUnfurlingAgain: neverAskAgain => root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+                objectName: "chatMessageViewDelegate"
 
-            onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) => root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
+                rootStore: root.rootStore
+                messageStore: root.messageStore
+                channelEmoji: root.channelEmoji
+                emojiPopup: root.emojiPopup
+                stickersPopup: root.stickersPopup
+                chatLogView: root.chatLogView
+                chatContentModule: root.chatContentModule
+                formatBalance: root.formatBalance
+                usersModel: root.usersModel
+                // covers the message body and the quoted reply, whose mentions
+                // also render through this map
+                mentionsMap: mentionResolver.resolveFor(model.unparsedText + " " + model.quotedMessageText)
 
-            // Contacts related requests:
-            onChangeContactNicknameRequest: root.changeContactNicknameRequest(pubKey, nickname, displayName, isEdit)
-            onRemoveTrustStatusRequest: root.removeTrustStatusRequest(pubKey)
+                isChatBlocked: root.isChatBlocked
+                joined: root.joined
 
-            // Community access related requests:
-            onSpectateCommunityRequested: (communityId) => {
-                root.spectateCommunityRequested(communityId)
+                sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+                messageLinkSharingEnabled: root.messageLinkSharingEnabled
+                createMessageLink: (chatId, messageId) => root.messageStore.createMessageLink(chatId, messageId)
+                disabledTooltipText: root.disabledTooltipText
+                areTestNetworksEnabled: root.areTestNetworksEnabled
+                extraLeftPadding: root.extraLeftPadding
+
+                chatId: root.chatId
+                messageId: model.id
+                communityId: model.communityId
+                responseToMessageWithId: model.responseToMessageWithId
+                senderId: model.senderId
+                senderDisplayName: model.senderDisplayName
+                usesDefaultName: model.usesDefaultName
+                senderOptionalName: model.senderOptionalName
+                senderIsEnsVerified: model.senderEnsVerified
+                senderIcon: model.senderIcon
+                senderIsAdded: model.senderIsAdded
+                senderTrustStatus: model.senderTrustStatus
+                compressedKey: model.compressedKey
+                amISender: model.amISender
+                messageText: model.messageText
+                unparsedText: model.unparsedText
+                messageImage: model.messageImage
+                album: model.albumMessageImages.split(" ")
+                albumCount: model.albumImagesCount
+                messageTimestamp: model.timestamp
+                messageOutgoingStatus: model.outgoingStatus
+                resendError: model.resendError
+                messageContentType: model.contentType
+                pinnedMessage: model.pinned
+                messagePinnedBy: model.pinnedBy
+                reactionsModel: model.reactions
+                sticker: model.sticker
+                stickerPack: model.stickerPack
+                editModeOn: model.editMode
+                onEditModeOnChanged: root.editModeChanged(editModeOn, model.id)
+                isEdited: model.isEdited
+                deleted: model.deleted
+                deletedBy: model.deletedBy
+                deletedByContactDisplayName: model.deletedByContactDisplayName
+                deletedByContactIcon: model.deletedByContactIcon
+                linkPreviewModel: model.linkPreviewModel
+                links: model.links
+                paymentRequestModel: model.paymentRequestModel
+                messageAttachments: model.messageAttachments
+                transactionParams: model.transactionParameters
+                hasMention: model.mentioned
+                quotedMessageText: model.quotedMessageParsedText
+                quotedMessageUnparsedText: model.quotedMessageText
+                quotedMessageFrom: model.quotedMessageFrom
+                quotedMessageContentType: model.quotedMessageContentType
+                quotedMessageDeleted: model.quotedMessageDeleted
+                quotedMessageAuthorDetailsName: model.quotedMessageAuthorName
+                quotedMessageAuthorDetailsDisplayName: model.quotedMessageAuthorDisplayName
+                quotedMessageAuthorDetailsThumbnailImage: model.quotedMessageAuthorThumbnailImage
+                quotedMessageAuthorDetailsEnsVerified: model.quotedMessageAuthorEnsVerified
+                quotedMessageAuthorDetailsIsContact: model.quotedMessageAuthorIsContact
+                quotedMessageAlbumMessageImages: model.quotedMessageAlbumMessageImages.split(" ")
+                quotedMessageAlbumImagesCount: model.quotedMessageAlbumImagesCount
+                bridgeName: model.bridgeName
+
+                gapFrom: model.gapFrom
+                gapTo: model.gapTo
+
+                 // This is possible since we have all data loaded before we load qml.
+                 // When we fetch messages to fulfill a gap we have to set them at once.
+                 // Also one important thing here is that messages are set in descending order
+                 // in terms of `timestamp` of a message, that means a message with the most
+                 // recent time is added at index 0.
+                prevMessageIndex: model.prevMsgIndex
+                prevMessageTimestamp: model.prevMsgTimestamp
+                prevMessageSenderId: model.prevMsgSenderId
+                prevMessageContentType: model.prevMsgContentType
+                prevMessageDeleted: model.prevMsgDeleted
+                nextMessageIndex: model.nextMsgIndex
+                nextMessageTimestamp: model.nextMsgTimestamp
+
+                // Unfurling related data:
+                gifUnfurlingEnabled: root.gifUnfurlingEnabled
+                neverAskAboutUnfurlingAgain: root.neverAskAboutUnfurlingAgain
+
+                // Contacts related data:
+                myPublicKey: root.myPublicKey
+
+                onOpenStickerPackPopup: stickerPackId => root.openStickerPackPopup(stickerPackId)
+                onTokenPaymentRequested: root.tokenPaymentRequested(recipientAddress, tokenKey, rawAmount)
+
+                onShowReplyArea: (messageId, author) => root.showReplyArea(messageId, author)
+
+                stickersLoaded: root.stickersLoaded
+
+                onSendViaPersonalChatRequested: {
+                    Global.sendToRecipientRequested(recipientAddress)
+                }
+
+                onVisibleChanged: {
+                    if(!visible && model.editMode)
+                        messageStore.setEditModeOff(model.id)
+                }
+
+                onEmojiReactionToggled: (messageId, hexcode) => {
+                    root.messageStore.toggleReaction(messageId, hexcode)
+                }
+
+                // Unfurling related requests:
+                onSetNeverAskAboutUnfurlingAgain: neverAskAgain => root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+
+                onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) => root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
+
+                // Contacts related requests:
+                onChangeContactNicknameRequest: root.changeContactNicknameRequest(pubKey, nickname, displayName, isEdit)
+                onRemoveTrustStatusRequest: root.removeTrustStatusRequest(pubKey)
+
+                // Community access related requests:
+                onSpectateCommunityRequested: (communityId) => {
+                    root.spectateCommunityRequested(communityId)
+                }
             }
         }
         bottomContent: {

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -335,6 +335,8 @@ Item {
         // Loaded only while shown — hiding the members list discards it —
         // and asynchronously behind the skeleton: the members list must
         // never delay a chat switch.
+        // No Ready-gate on visible here: it would also hide the nested
+        // membersPanelSkeleton, whose whole purpose is that phase.
         active: root.showRightPanel
         asynchronous: true
 

--- a/ui/app/AppLayouts/Chat/views/qmldir
+++ b/ui/app/AppLayouts/Chat/views/qmldir
@@ -1,5 +1,6 @@
 ChatContentView 1.0 ChatContentView.qml
 ChatHeaderContentView 1.0 ChatHeaderContentView.qml
+ChatMessagesView 1.0 ChatMessagesView.qml
 ContactsColumnView 1.0 ContactsColumnView.qml
 CreateChatView 1.0 CreateChatView.qml
 MembersEditSelectorView 1.0 MembersEditSelectorView.qml

--- a/ui/imports/shared/views/chat/ChatMessagesFlickable.qml
+++ b/ui/imports/shared/views/chat/ChatMessagesFlickable.qml
@@ -1,0 +1,438 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+/*!
+   \qmltype ChatMessagesFlickable
+   \brief Bottom-anchored message view driven purely by model operations
+   (productized from PoC #17999).
+
+   Renders exactly the rows its \c model holds, row 0 (newest) at the bottom.
+   Paging: when the placeholder standing in for out-of-window messages scrolls
+   into the viewport, \c moreUpRequested / \c moreDownRequested ask the owner
+   to slide its window. Across model changes the view holds position by
+   anchoring to the viewport-edge item, and follows the newest message when it
+   was already showing it.
+*/
+Flickable {
+    id: root
+
+    /*!
+       Window model. Row 0 is the newest message and is rendered last.
+    */
+    property alias model: repeater.model
+
+    /*!
+       Instantiated once per model row, roles and \c index available as in a
+       ListView delegate. The delegate must reverse the order itself with
+       \c {Layout.row: view.rowCount - index} so row 0 lands at the bottom.
+    */
+    property Component delegate
+
+    /*!
+       Stands in for the messages that exist outside the window. Scrolling it
+       into the viewport is what asks the owner for more rows.
+    */
+    property Component placeholder
+
+    /*!
+       Height given to the placeholder. It doubles as the depth of the region
+       in which scrolling asks for more rows, so it must stay well above zero.
+    */
+    property real placeholderHeight: root.height
+
+    /*!
+       Content pinned below the newest message (\c ListView.header equivalent
+       for a bottom-to-top list).
+    */
+    property Component bottomContent
+
+    /*!
+       Blank space kept below the bottom-most content.
+    */
+    property real contentBottomPadding: 0
+
+    property bool moreUpAvailable: false
+    property bool moreDownAvailable: false
+
+    readonly property alias count: repeater.count
+
+    /*!
+       Number of laid-out rows; the delegate needs it to reverse its layout row.
+    */
+    readonly property alias rowCount: repeater.count
+
+    /*!
+       The newest message of the whole history is in the viewport.
+    */
+    readonly property bool atNewest: !root.moreDownAvailable && d.atContentBottom
+
+    /*!
+       The view is showing (and following) the newest message.
+    */
+    readonly property alias stickingToNewest: d.stickToBottom
+
+    signal moreUpRequested()
+    signal moreDownRequested()
+
+    /*!
+       Emitted once the row requested through \c positionAtRow is actually laid
+       out and in the viewport.
+    */
+    signal rowPositioned(int row)
+
+    clip: true
+    contentWidth: root.width
+    boundsMovement: Flickable.StopAtBounds
+
+    // contentHeight is assigned inside the apply() guard (not bound): setting
+    // it makes the Flickable clamp contentY immediately, and that clamp must
+    // never read as a user move.
+    Component.onCompleted: d.applyContentHeight()
+
+    /*!
+       Jump to the newest message and follow it from there on.
+    */
+    function positionAtNewest() {
+        d.releaseAnchor()
+        d.pendingRow = -1
+        d.seekingNewest = false
+        d.stickToBottom = true
+        d.goToBottom()
+    }
+
+    /*!
+       Center the viewport on a window row and keep it there until the user
+       scrolls away — the row may still be laid out, in which case it is
+       positioned as soon as it is.
+    */
+    function positionAtRow(row) {
+        d.releaseAnchor()
+        d.seekingNewest = false
+        d.stickToBottom = false
+        d.pendingRow = row
+        d.restorePosition()
+    }
+
+    /*!
+       The delegate instance built for a window row, or null when the row is
+       outside the window.
+    */
+    function itemAtRow(row) {
+        return repeater.itemAt(row)
+    }
+
+    QtObject {
+        id: d
+
+        // Derived from the content directly rather than from contentHeight, so
+        // it is already correct while reacting to a content height change.
+        readonly property real bottomContentY: Math.max(0, content.height - root.height)
+        readonly property bool atContentBottom: root.contentY >= d.bottomContentY - 1
+
+        // Whether the viewport was showing the bottom of the content before
+        // the last content change, i.e. whether it should follow it.
+        property bool stickToBottom: true
+
+        // The user scrolled onto the bottom of a window that still has newer
+        // messages behind it — they are heading for the newest, the window
+        // just has not caught up. Chase the content bottom until it does,
+        // then latch onto the newest for real.
+        property bool seekingNewest: false
+
+        // Item the viewport position is measured against while the window is
+        // being slid, so rows entering above the viewport do not move it.
+        property Item anchorItem: null
+        property real anchorOffset: 0
+
+        // Row positionAtRow() was asked to show, kept until the user scrolls.
+        property int pendingRow: -1
+
+        readonly property bool placeholderUpVisible:
+            topPlaceholder.active && content.y + topPlaceholder.y + topPlaceholder.height > root.contentY
+        readonly property bool placeholderDownVisible:
+            bottomPlaceholder.active && content.y + bottomPlaceholder.y < root.contentY + root.height
+
+        // From live values, not the bottomContentY binding: inside an
+        // onHeightChanged handler the binding still holds the pre-change value.
+        function freshBottomY() {
+            return Math.max(0, content.height - root.height)
+        }
+
+        function clampContentY(y) {
+            return Math.max(0, Math.min(d.freshBottomY(), y))
+        }
+
+        // All internal writes go through apply()/applyContentHeight() so
+        // onContentYChanged can tell them apart from user moves (wheel,
+        // touch, scrollbar drags — the scrollbar writes contentY without any
+        // movement signals). Save/restore keeps nested calls guarded.
+        property bool applyingPosition: false
+
+        function apply(y) {
+            const was = applyingPosition
+            applyingPosition = true
+            root.contentY = y
+            applyingPosition = was
+        }
+
+        function applyContentHeight() {
+            const was = applyingPosition
+            applyingPosition = true
+            root.contentHeight = Math.max(root.height, content.height)
+            applyingPosition = was
+        }
+
+        function goToBottom() {
+            d.apply(d.freshBottomY())
+        }
+
+        function releaseAnchor() {
+            anchorItem = null
+        }
+
+        // Which viewport edge the anchor was taken at, so an eviction re-arm
+        // stays on the same side.
+        property bool anchorAtTop: true
+
+        // Anchors on the built row closest to the given viewport edge, so that
+        // row keeps its place on screen while the window slides. \a excluded
+        // is a row on its way out, which must not be anchored on again.
+        function anchorAtViewportEdge(top, excluded) {
+            anchorAtTop = top
+            const edge = top ? root.contentY : root.contentY + root.height
+            let best = null
+            let bestDistance = Number.MAX_VALUE
+            let fallback = null
+            for (let i = 0; i < repeater.count; ++i) {
+                const item = repeater.itemAt(i)
+                if (!item || item === excluded)
+                    continue
+                // an unpolished row still sits at y 0 — a position no laid-out
+                // delegate can hold while the top placeholder occupies it —
+                // so its geometry cannot be measured yet
+                if (item.y === 0 && topPlaceholder.active) {
+                    fallback = item
+                    continue
+                }
+                const distance = Math.abs(content.y + item.y - edge)
+                if (distance < bestDistance) {
+                    bestDistance = distance
+                    best = item
+                }
+            }
+            if (!best) {
+                // never trade a working anchor for an unmeasurable one
+                if (anchorItem && anchorItem !== excluded)
+                    return
+                if (fallback && excluded) {
+                    // survivors are not re-laid yet; the evicted row's
+                    // position is the only trustworthy coordinate — hand its
+                    // offset over and let the next polish walk it into place
+                    anchorItem = fallback
+                    anchorOffset = content.y + excluded.y - root.contentY
+                } else {
+                    anchorItem = null
+                    anchorOffset = 0
+                }
+                return
+            }
+            anchorItem = best
+            anchorOffset = content.y + best.y - root.contentY
+        }
+
+        function restorePosition() {
+            if (d.seekingNewest) {
+                // keep chasing the content bottom while the window catches
+                // up with the newest; latch on once it has
+                d.goToBottom()
+                if (!root.moreDownAvailable) {
+                    d.seekingNewest = false
+                    d.stickToBottom = true
+                    d.releaseAnchor()
+                }
+                return
+            }
+            if (d.pendingRow >= 0) {
+                const target = repeater.itemAt(d.pendingRow)
+                // height > 0 keeps a pre-polish item from being positioned on
+                // stale geometry
+                if (target && target.height > 0) {
+                    d.apply(d.clampContentY(
+                                content.y + target.y + target.height / 2 - root.height / 2))
+                    // hand over to the anchor: later content changes hold this
+                    // row in place without re-firing the request — the window
+                    // may slide meanwhile, making the row a different message
+                    const row = d.pendingRow
+                    d.anchorItem = target
+                    d.anchorOffset = content.y + target.y - root.contentY
+                    d.pendingRow = -1
+                    root.rowPositioned(row)
+                    return
+                }
+            }
+            if (d.stickToBottom) {
+                d.goToBottom()
+                return
+            }
+            if (d.anchorItem)
+                d.apply(d.clampContentY(content.y + d.anchorItem.y - d.anchorOffset))
+        }
+    }
+
+    onHeightChanged: {
+        d.applyContentHeight()
+        d.restorePosition()
+    }
+
+    // A slide replaces rows on one side of the window with rows on the other,
+    // which moves the surviving rows without changing the content height.
+    Connections {
+        target: d.anchorItem
+
+        function onYChanged() {
+            d.restorePosition()
+        }
+    }
+
+    // Sticking is derived from position: any contentY write outside the
+    // apply() guard is a user move — wheel, touch, and scrollbar drags,
+    // which emit no movement signals at all. Landing on the newest message
+    // re-sticks, leaving it unsticks; anything in between keeps the view
+    // anchored where the user put it, so content changes above or below it
+    // hold it in place. "Newest" is the atNewest semantic, not the content
+    // bottom: the bottom of a window slid into history has newer messages
+    // behind it and must not stick.
+    onContentYChanged: {
+        if (d.applyingPosition)
+            return
+        d.pendingRow = -1
+        const atBottom = root.contentY >= d.freshBottomY() - 1
+        d.stickToBottom = atBottom && !root.moreDownAvailable
+        d.seekingNewest = atBottom && root.moreDownAvailable
+        if (d.stickToBottom)
+            d.releaseAnchor()
+        else
+            d.anchorAtViewportEdge(true)
+    }
+
+    // Level-triggered while a placeholder is in the viewport: one request per
+    // tick until the window covers it or the owner reports nothing more to
+    // show. The owner is expected to guard backend fetches.
+    Timer {
+        interval: 150
+        repeat: true
+        running: (root.moreUpAvailable && d.placeholderUpVisible)
+                 || (root.moreDownAvailable && d.placeholderDownVisible)
+        triggeredOnStart: true
+
+        onTriggered: {
+            // an empty view has nothing to anchor on, and unsticking it would
+            // leave it parked at the top once rows arrive
+            if (repeater.count === 0)
+                return
+            if (root.moreUpAvailable && d.placeholderUpVisible) {
+                // keep an already-armed anchor: re-picking mid-churn can land
+                // on a freshly inserted row whose geometry has not been
+                // polished yet, pinning the view to a stale position
+                if (!d.anchorItem)
+                    d.anchorAtViewportEdge(true)
+                // only a view that left the content bottom stops following it:
+                // with short content the placeholder is visible at the bottom
+                // too, and rows still to come must keep landing there
+                if (!d.atContentBottom)
+                    d.stickToBottom = false
+                root.moreUpRequested()
+            } else if (root.moreDownAvailable && d.placeholderDownVisible) {
+                if (!d.anchorItem)
+                    d.anchorAtViewportEdge(false)
+                root.moreDownRequested()
+            }
+        }
+    }
+
+    // Rows are laid out oldest first so the newest message ends up at the
+    // bottom; the explicit row assignment reverses the model order without a
+    // proxy, keeping the model's index semantics intact.
+    GridLayout {
+        id: content
+
+        property real previousHeight: 0
+
+        columns: 1
+        columnSpacing: 0
+        rowSpacing: 0
+
+        width: root.width
+        height: implicitHeight
+        y: Math.max(0, root.height - height)
+
+        onHeightChanged: {
+            if (height === previousHeight)
+                return
+            previousHeight = height
+            d.applyContentHeight()
+            d.restorePosition()
+        }
+
+        Loader {
+            id: topPlaceholder
+
+            Layout.row: 0
+            Layout.column: 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: active ? root.placeholderHeight : 0
+
+            active: root.moreUpAvailable
+            visible: active
+            sourceComponent: root.placeholder
+        }
+
+        // The delegate is instantiated directly by the repeater: routing it
+        // through a wrapping Loader would create it in the component's own
+        // creation context and hide the model roles.
+        Repeater {
+            id: repeater
+
+            delegate: root.delegate
+
+            // The row leaving the window may be the one the viewport is
+            // measured against. The survivors still hold their pre-relayout
+            // positions here, so the offset taken now is the one to keep.
+            onItemRemoved: (index, item) => {
+                if (item === d.anchorItem)
+                    d.anchorAtViewportEdge(d.anchorAtTop, item)
+            }
+        }
+
+        Loader {
+            id: bottomPlaceholder
+
+            Layout.row: repeater.count + 1
+            Layout.column: 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: active ? root.placeholderHeight : 0
+
+            active: root.moreDownAvailable
+            visible: active
+            sourceComponent: root.placeholder
+        }
+
+        Loader {
+            Layout.row: repeater.count + 2
+            Layout.column: 0
+            Layout.fillWidth: true
+
+            active: !!root.bottomContent
+            visible: active
+            sourceComponent: root.bottomContent
+        }
+
+        Item {
+            Layout.row: repeater.count + 3
+            Layout.column: 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.contentBottomPadding
+        }
+    }
+}

--- a/ui/imports/shared/views/chat/ChatMessagesFlickable.qml
+++ b/ui/imports/shared/views/chat/ChatMessagesFlickable.qml
@@ -25,7 +25,11 @@ Flickable {
     /*!
        Instantiated once per model row, roles and \c index available as in a
        ListView delegate. The delegate must reverse the order itself with
-       \c {Layout.row: view.rowCount - index} so row 0 lands at the bottom.
+       \c {Layout.row: view.rowCount - index + 1} so row 0 lands at the
+       bottom. Grid row 0 is reserved as an empty spawn cell: a freshly
+       created delegate is added to the layout before its \c Layout.row
+       binding applies and lands in the default cell (0,0) — reserving it
+       keeps that landing free instead of fighting the placeholder's cell.
     */
     property Component delegate
 
@@ -36,10 +40,20 @@ Flickable {
     property Component placeholder
 
     /*!
-       Height given to the placeholder. It doubles as the depth of the region
-       in which scrolling asks for more rows, so it must stay well above zero.
+       Heights given to the placeholders, one per side: each side stands in
+       for its own out-of-window span, so a window slide resizes only the end
+       it moved. A height doubles as the depth of the region in which
+       scrolling asks for more rows, so it must stay well above zero.
     */
-    property real placeholderHeight: root.height
+    property real topPlaceholderHeight: root.height
+    property real bottomPlaceholderHeight: root.height
+
+    /*!
+       Distance beyond the viewport within which a placeholder already asks
+       for more rows, so the next batch is usually ready before the user
+       scrolls the placeholder itself into view.
+    */
+    property real prefetchMargin: 0
 
     /*!
        Content pinned below the newest message (\c ListView.header equivalent
@@ -149,9 +163,11 @@ Flickable {
         property int pendingRow: -1
 
         readonly property bool placeholderUpVisible:
-            topPlaceholder.active && content.y + topPlaceholder.y + topPlaceholder.height > root.contentY
+            topPlaceholder.active && content.y + topPlaceholder.y + topPlaceholder.height
+                                     > root.contentY - root.prefetchMargin
         readonly property bool placeholderDownVisible:
-            bottomPlaceholder.active && content.y + bottomPlaceholder.y < root.contentY + root.height
+            bottomPlaceholder.active && content.y + bottomPlaceholder.y
+                                        < root.contentY + root.height + root.prefetchMargin
 
         // From live values, not the bottomContentY binding: inside an
         // onHeightChanged handler the binding still holds the pre-change value.
@@ -206,7 +222,9 @@ Flickable {
             let fallback = null
             for (let i = 0; i < repeater.count; ++i) {
                 const item = repeater.itemAt(i)
-                if (!item || item === excluded)
+                // an invisible row (still being staged by the owner) holds no
+                // screen position to anchor on
+                if (!item || item === excluded || !item.visible)
                     continue
                 // an unpolished row still sits at y 0 — a position no laid-out
                 // delegate can hold while the top placeholder occupies it —
@@ -255,9 +273,9 @@ Flickable {
             }
             if (d.pendingRow >= 0) {
                 const target = repeater.itemAt(d.pendingRow)
-                // height > 0 keeps a pre-polish item from being positioned on
-                // stale geometry
-                if (target && target.height > 0) {
+                // visible + height > 0 keeps a staged or pre-polish item from
+                // being positioned on stale geometry
+                if (target && target.visible && target.height > 0) {
                     d.apply(d.clampContentY(
                                 content.y + target.y + target.height / 2 - root.height / 2))
                     // hand over to the anchor: later content changes hold this
@@ -318,12 +336,15 @@ Flickable {
 
     // Level-triggered while a placeholder is in the viewport: one request per
     // tick until the window covers it or the owner reports nothing more to
-    // show. The owner is expected to guard backend fetches.
+    // show. The owner is expected to guard backend fetches. Only at rest: a
+    // slide mid-fling mutates geometry under the physics, and the contentY
+    // correction that follows cancels the flick.
     Timer {
         interval: 150
         repeat: true
-        running: (root.moreUpAvailable && d.placeholderUpVisible)
-                 || (root.moreDownAvailable && d.placeholderDownVisible)
+        running: !root.moving
+                 && ((root.moreUpAvailable && d.placeholderUpVisible)
+                     || (root.moreDownAvailable && d.placeholderDownVisible))
         triggeredOnStart: true
 
         onTriggered: {
@@ -378,10 +399,11 @@ Flickable {
         Loader {
             id: topPlaceholder
 
-            Layout.row: 0
+            // row 0 is the reserved spawn cell (see the delegate contract)
+            Layout.row: 1
             Layout.column: 0
             Layout.fillWidth: true
-            Layout.preferredHeight: active ? root.placeholderHeight : 0
+            Layout.preferredHeight: active ? root.topPlaceholderHeight : 0
 
             active: root.moreUpAvailable
             visible: active
@@ -408,10 +430,10 @@ Flickable {
         Loader {
             id: bottomPlaceholder
 
-            Layout.row: repeater.count + 1
+            Layout.row: repeater.count + 2
             Layout.column: 0
             Layout.fillWidth: true
-            Layout.preferredHeight: active ? root.placeholderHeight : 0
+            Layout.preferredHeight: active ? root.bottomPlaceholderHeight : 0
 
             active: root.moreDownAvailable
             visible: active
@@ -419,7 +441,7 @@ Flickable {
         }
 
         Loader {
-            Layout.row: repeater.count + 2
+            Layout.row: repeater.count + 3
             Layout.column: 0
             Layout.fillWidth: true
 
@@ -429,7 +451,7 @@ Flickable {
         }
 
         Item {
-            Layout.row: repeater.count + 3
+            Layout.row: repeater.count + 4
             Layout.column: 0
             Layout.fillWidth: true
             Layout.preferredHeight: root.contentBottomPadding

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -850,6 +850,10 @@ Loader {
         ColumnLayout {
             spacing: 0
 
+            // Pinned to the hosting Loader: unanchored, the layout follows message
+            // content implicit-width echoes and layout hosts re-polish forever.
+            width: root.width
+
             function startMessageFoundAnimation() {
                 delegate.startMessageFoundAnimation();
             }

--- a/ui/imports/shared/views/chat/qmldir
+++ b/ui/imports/shared/views/chat/qmldir
@@ -1,5 +1,6 @@
 ChannelIdentifierView 1.0 ChannelIdentifierView.qml
 ChatContextMenuView 1.0 ChatContextMenuView.qml
+ChatMessagesFlickable 1.0 ChatMessagesFlickable.qml
 CompactMessageView 1.0 CompactMessageView.qml
 InvitationBubbleView 1.0 InvitationBubbleView.qml
 LinksMessageView 1.0 LinksMessageView.qml


### PR DESCRIPTION
> **Stack 1/3** — message view performance
> 1. **#21970** model window + staged reveal ← _this PR_
> 2. #22409 pooled, rebindable message rows
> 3. #22411 low-end device lag fixes
>
> Message-history virtualization (dense model over new status-go window/rank APIs) follows later, separately.

### What does the PR do

The chat message view was a `ListView` over the full messages model: delegates and proxy rows grew with the loaded history, and paging built rows on screen one by one (the "messy scrolling" from the review below).

This productizes the model-window POC (#17999) for the chat view:

- **Model window.** `ChatMessagesFlickable` (bottom-anchored `Flickable`) renders only an SFPM index window over the messages model. Built delegates are capped by the window size, whatever the history length. Paging is placeholder-driven: scrolling a placeholder into view (one viewport of prefetch margin) slides the window.
- **Staged atomic reveal.** A slide admits its whole chunk as cheap shells whose `MessageView` incubates asynchronously and holds no space. The batch becomes visible in one layout pass when every row is built, so the user never sees rows assembling. Live messages and the initial fill are not staged.
- **Geometry stability.** One placeholder per side sized from a latched row-height estimate (it moves only when a quarter wrong, and resets per chat). Slides only happen at rest, so a fling is never cancelled by a mid-motion relayout. Anchoring on the viewport-edge row keeps what the user reads in place.
- **Hardening.** A model reset releases a staged batch. A jump cancels a pending open-at-newest. Staged membership is captured by row id, not by shell creation timing, which fixes an endless-skeleton livelock under a still-incubating ancestor.

Commits (review in order):
1. `fix(chat)`: stop message content feeding implicit-width echoes into layout hosts. Independent; fixes a layout livelock.
2. `perf(chat)`: model window.
3. `perf(chat)`: staged atomic reveal and hardening.
4. `chore(storybook)`: message-view census and model-ops row for manual verification.

### Affected areas

Chat: message list (1:1, group, community channels), jump-to-message, scroll-to-newest, paging.

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/7dbee125-f996-4b67-8a11-9ee0c62a8bfc

### Impact on end user

- Opening and scrolling long chats no longer builds a delegate per loaded message.
- Paging reveals whole chunks at once instead of rows popping in.

### How to test

- Storybook: **ChatLoader** / **CommunityChatLoader** pages. The census row shows peak delegate counts; the Model row does live model surgery (insert/remove at the ends, above/below/inside the window).
- App: open a long community channel, fling deep into history and back, jump to a replied message, use the recent-messages button from deep history, and switch chats mid-scroll.
- Tests: `tst_ChatContentView`, `tst_ChatMessagesFlickable`, `tst_MessageRowsSkeleton`, `tst_StatusMessageAlbumWidth`.

### Risk

- There's no feature flag: this replaces the live chat message view.
- Worst case is a stuck skeleton or a lost scroll position while paging. The reveal has a 1 s stall timeout, so a pathological row can't wedge paging.
