### PR TITLE
fix(collectibles): fixes 16s cold-start spinner on empty accounts

### DIFF
--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -89,6 +89,9 @@ QtObject:
   proc hasOwnership(self: CollectiblesEntry): bool =
     return self.data != nil and isSome(self.data.ownership)
 
+  proc getBackendCollectible*(self: CollectiblesEntry): backend.Collectible =
+    return self.data
+
   proc getOwnership*(self: CollectiblesEntry): seq[backend.AccountBalance] =
     if not self.hasOwnership():
       return @[]

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -22,7 +22,6 @@ type
     CollectionName
     CollectionSlug
     CollectionImageUrl
-    IsLoading
     Ownership
     # Community-related roles
     CommunityId
@@ -140,7 +139,6 @@ QtObject:
       CollectibleRole.CollectionName.int:"collectionName",
       CollectibleRole.CollectionSlug.int:"collectionSlug",
       CollectibleRole.CollectionImageUrl.int:"collectionImageUrl",
-      CollectibleRole.IsLoading.int:"isLoading",
       CollectibleRole.Ownership.int:"ownership",
       CollectibleRole.CommunityId.int:"communityId",
       CollectibleRole.CommunityPrivilegesLevel.int:"communityPrivilegesLevel",
@@ -183,8 +181,6 @@ QtObject:
         result = newQVariant(item.getCollectionSlug())
       of CollectibleRole.CollectionImageUrl:
         result = newQVariant(item.getCollectionImageURL())
-      of CollectibleRole.IsLoading:
-        result = newQVariant(false)
       of CollectibleRole.Ownership:
         result = item.getOwnershipModelAsVariant()
       of CollectibleRole.CommunityId:

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -237,6 +237,65 @@ QtObject:
     self.endRemoveRows()
     self.countChanged()
 
+  proc itemsDataUpdated*(self: Model) {.signal.}
+
+  proc sameOwnership(a, b: seq[backend_collectibles.AccountBalance]): bool =
+    if len(a) != len(b):
+      return false
+    for i in 0 ..< len(a):
+      if a[i].address != b[i].address or a[i].balance != b[i].balance or a[i].txTimestamp != b[i].txTimestamp:
+        return false
+    return true
+
+  # Refreshes the entry at `ind` from `update`, emitting dataChanged for the
+  # roles whose values actually changed. Returns whether anything changed.
+  proc updateEntryData(self: Model, ind: int, update: backend_collectibles.Collectible): bool =
+    let entry = self.items[ind]
+    let name = entry.getName()
+    let imageUrl = entry.getImageURL()
+    let mediaUrl = entry.getMediaURL()
+    let mediaType = entry.getMediaType()
+    let backgroundColor = entry.getBackgroundColor()
+    let collectionName = entry.getCollectionName()
+    let collectionSlug = entry.getCollectionSlug()
+    let collectionImageUrl = entry.getCollectionImageURL()
+    let communityId = entry.getCommunityId()
+    let communityPrivilegesLevel = entry.getCommunityPrivilegesLevel()
+    let tokenType = entry.getTokenType()
+    let soulbound = entry.getSoulbound()
+    let metadataAvailable = entry.getIsMetaDataValid()
+    let ownership = entry.getOwnership()
+
+    if not entry.updateDataIfSameID(update):
+      return false
+
+    var changedRoles: seq[int] = @[]
+    addChangedRole(changedRoles, name, entry.getName(), CollectibleRole.Name.int): discard
+    addChangedRole(changedRoles, imageUrl, entry.getImageURL(), CollectibleRole.ImageUrl.int): discard
+    addChangedRole(changedRoles, mediaUrl, entry.getMediaURL(), CollectibleRole.MediaUrl.int): discard
+    addChangedRole(changedRoles, mediaType, entry.getMediaType(), CollectibleRole.MediaType.int): discard
+    addChangedRole(changedRoles, backgroundColor, entry.getBackgroundColor(), CollectibleRole.BackgroundColor.int): discard
+    addChangedRole(changedRoles, collectionName, entry.getCollectionName(), CollectibleRole.CollectionName.int): discard
+    addChangedRole(changedRoles, collectionSlug, entry.getCollectionSlug(), CollectibleRole.CollectionSlug.int): discard
+    addChangedRole(changedRoles, collectionImageUrl, entry.getCollectionImageURL(), CollectibleRole.CollectionImageUrl.int): discard
+    addChangedRole(changedRoles, communityId, entry.getCommunityId(), CollectibleRole.CommunityId.int): discard
+    addChangedRole(changedRoles, communityPrivilegesLevel, entry.getCommunityPrivilegesLevel(), CollectibleRole.CommunityPrivilegesLevel.int): discard
+    addChangedRole(changedRoles, tokenType, entry.getTokenType(), CollectibleRole.TokenType.int): discard
+    addChangedRole(changedRoles, soulbound, entry.getSoulbound(), CollectibleRole.Soulbound.int): discard
+    # Must be part of the diff: this is the role that makes a tile stop
+    # rendering as loading once its metadata arrives, and it can flip even
+    # when every other role above happens to keep its value.
+    addChangedRole(changedRoles, metadataAvailable, entry.getIsMetaDataValid(), CollectibleRole.MetadataAvailable.int): discard
+    # Ownership is a submodel, compare by value: balances and owning accounts
+    # can change while the collectible ID stays the same.
+    if not sameOwnership(ownership, entry.getOwnership()):
+      changedRoles.add(CollectibleRole.Ownership.int)
+
+    if changedRoles.len > 0:
+      notifyRangeRolesChanged(ind, ind, changedRoles)
+      return true
+    return false
+
   proc updateCollectibleItems(self: Model, newItems: seq[CollectiblesEntry]) =
     if len(self.items) == 0:
       # Current list is empty, just replace with new list
@@ -253,6 +312,7 @@ QtObject:
       newTable[newItems[i].getIDAsString()] = i
 
     # Needs to be built in sequential index order
+    var anyKeptItemUpdated = false
     var oldIndicesToRemove: seq[int] = @[]
     for idx in 0 ..< len(self.items):
       let uid = self.items[idx].getIDAsString()
@@ -260,8 +320,12 @@ QtObject:
         # Item in old list but not in new -> Must remove
         oldIndicesToRemove.add(idx)
       else:
-        # Item both in old and new lists -> Nothing to do in the current list,
-        # remove from the new list so it only holds new items.
+        # Item both in old and new lists -> Keep the existing entry, but
+        # refresh its data: ownership (balances, owning accounts) can change
+        # while the collectible ID stays the same.
+        if self.updateEntryData(idx, newItems[newTable[uid]].getBackendCollectible()):
+          anyKeptItemUpdated = true
+        # Remove from the new list so it only holds new items.
         newTable.del(uid)
 
     if len(oldIndicesToRemove) > 0:
@@ -276,6 +340,9 @@ QtObject:
     for uid, idx in newTable:
       newItemsToAdd.add(newItems[idx])
     self.appendCollectibleItems(newItemsToAdd)
+
+    if anyKeptItemUpdated:
+      self.itemsDataUpdated()
 
   proc getItems*(self: Model): seq[CollectiblesEntry] =
     return self.items
@@ -304,57 +371,14 @@ QtObject:
     self.updateCollectibleItems(newItems)
     self.setHasMore(false)
 
-  proc itemsDataUpdated*(self: Model) {.signal.}
   proc updateItemsData*(self: Model, updates: seq[backend_collectibles.Collectible]) =
     var anyUpdated = false
-
-    proc updateEntry(ind: int, update: backend_collectibles.Collectible): bool =
-      let entry = self.items[ind]
-      let name = entry.getName()
-      let imageUrl = entry.getImageURL()
-      let mediaUrl = entry.getMediaURL()
-      let mediaType = entry.getMediaType()
-      let backgroundColor = entry.getBackgroundColor()
-      let collectionName = entry.getCollectionName()
-      let collectionSlug = entry.getCollectionSlug()
-      let collectionImageUrl = entry.getCollectionImageURL()
-      let communityId = entry.getCommunityId()
-      let communityPrivilegesLevel = entry.getCommunityPrivilegesLevel()
-      let tokenType = entry.getTokenType()
-      let soulbound = entry.getSoulbound()
-      let metadataAvailable = entry.getIsMetaDataValid()
-
-      if not entry.updateDataIfSameID(update):
-        return false
-
-      var changedRoles: seq[int] = @[]
-      addChangedRole(changedRoles, name, entry.getName(), CollectibleRole.Name.int): discard
-      addChangedRole(changedRoles, imageUrl, entry.getImageURL(), CollectibleRole.ImageUrl.int): discard
-      addChangedRole(changedRoles, mediaUrl, entry.getMediaURL(), CollectibleRole.MediaUrl.int): discard
-      addChangedRole(changedRoles, mediaType, entry.getMediaType(), CollectibleRole.MediaType.int): discard
-      addChangedRole(changedRoles, backgroundColor, entry.getBackgroundColor(), CollectibleRole.BackgroundColor.int): discard
-      addChangedRole(changedRoles, collectionName, entry.getCollectionName(), CollectibleRole.CollectionName.int): discard
-      addChangedRole(changedRoles, collectionSlug, entry.getCollectionSlug(), CollectibleRole.CollectionSlug.int): discard
-      addChangedRole(changedRoles, collectionImageUrl, entry.getCollectionImageURL(), CollectibleRole.CollectionImageUrl.int): discard
-      addChangedRole(changedRoles, communityId, entry.getCommunityId(), CollectibleRole.CommunityId.int): discard
-      addChangedRole(changedRoles, communityPrivilegesLevel, entry.getCommunityPrivilegesLevel(), CollectibleRole.CommunityPrivilegesLevel.int): discard
-      addChangedRole(changedRoles, tokenType, entry.getTokenType(), CollectibleRole.TokenType.int): discard
-      addChangedRole(changedRoles, soulbound, entry.getSoulbound(), CollectibleRole.Soulbound.int): discard
-      # Must be part of the diff: this is the role that makes a tile stop
-      # rendering as loading once its metadata arrives, and it can flip even
-      # when every other role above happens to keep its value.
-      addChangedRole(changedRoles, metadataAvailable, entry.getIsMetaDataValid(), CollectibleRole.MetadataAvailable.int): discard
-
-      if changedRoles.len > 0:
-        notifyRangeRolesChanged(ind, ind, changedRoles)
-        return true
-      return false
 
     for i in countdown(self.items.high, 0):
       for j in countdown(updates.high, 0):
         let update = updates[j]
         if self.items[i].getID() == update.id:
-          if updateEntry(i, update):
+          if self.updateEntryData(i, update):
             anyUpdated = true
           break
     if anyUpdated:

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -28,6 +28,9 @@ type
     CommunityPrivilegesLevel
     TokenType
     Soulbound
+    # False until the collectible's metadata (name, collection, image URLs)
+    # arrives; the tile exists before that and renders as loading.
+    MetadataAvailable
 
 QtObject:
   type
@@ -143,7 +146,8 @@ QtObject:
       CollectibleRole.CommunityId.int:"communityId",
       CollectibleRole.CommunityPrivilegesLevel.int:"communityPrivilegesLevel",
       CollectibleRole.TokenType.int:"tokenType",
-      CollectibleRole.Soulbound.int:"soulbound"
+      CollectibleRole.Soulbound.int:"soulbound",
+      CollectibleRole.MetadataAvailable.int:"metadataAvailable"
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -191,6 +195,8 @@ QtObject:
         result = newQVariant(item.getTokenType())
       of CollectibleRole.Soulbound:
         result = newQVariant(item.getSoulbound())
+      of CollectibleRole.MetadataAvailable:
+        result = newQVariant(item.getIsMetaDataValid())
       else:
         result = newQVariant()
     else:
@@ -316,6 +322,7 @@ QtObject:
       let communityPrivilegesLevel = entry.getCommunityPrivilegesLevel()
       let tokenType = entry.getTokenType()
       let soulbound = entry.getSoulbound()
+      let metadataAvailable = entry.getIsMetaDataValid()
 
       if not entry.updateDataIfSameID(update):
         return false
@@ -333,6 +340,10 @@ QtObject:
       addChangedRole(changedRoles, communityPrivilegesLevel, entry.getCommunityPrivilegesLevel(), CollectibleRole.CommunityPrivilegesLevel.int): discard
       addChangedRole(changedRoles, tokenType, entry.getTokenType(), CollectibleRole.TokenType.int): discard
       addChangedRole(changedRoles, soulbound, entry.getSoulbound(), CollectibleRole.Soulbound.int): discard
+      # Must be part of the diff: this is the role that makes a tile stop
+      # rendering as loading once its metadata arrives, and it can flip even
+      # when every other role above happens to keep its value.
+      addChangedRole(changedRoles, metadataAvailable, entry.getIsMetaDataValid(), CollectibleRole.MetadataAvailable.int): discard
 
       if changedRoles.len > 0:
         notifyRangeRolesChanged(ind, ind, changedRoles)

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -163,18 +163,18 @@ QtObject:
     # If any address+chainID is error, then the whole model is error
     # Otherwise, if any address+chainID is updating, then the whole model is updating
     # Otherwise, the model is idle
-    for address, statusPerChainID in self.ownershipStatus.pairs:
-      if not self.addresses.contains(address) or (self.selectedAddress != "" and self.selectedAddress != address):
-        continue
-      for chainID, status in statusPerChainID:
-        if not self.chainIds.contains(chainID):
+    block aggregation:
+      for address, statusPerChainID in self.ownershipStatus.pairs:
+        if not self.addresses.contains(address) or (self.selectedAddress != "" and self.selectedAddress != address):
           continue
-        if status.state == OwnershipStateError:
-          overallState = OwnershipStateError
-          break
-        elif status.state == OwnershipStateUpdating:
-          overallState = OwnershipStateUpdating
-          break
+        for chainID, status in statusPerChainID:
+          if not self.chainIds.contains(chainID):
+            continue
+          if status.state == OwnershipStateError:
+            overallState = OwnershipStateError
+            break aggregation
+          elif status.state == OwnershipStateUpdating:
+            overallState = OwnershipStateUpdating
 
     case overallState:
       of OwnershipStateIdle, OwnershipStateDelayed:

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -1,5 +1,7 @@
-import nimqml, std/json, sequtils, sugar, strutils
+import nimqml, std/json, sequtils, sugar, strutils, algorithm
 import stint, chronicles, tables
+from seaqt/qtimer import QTimer, create, setSingleShot, onTimeout, start, stop,
+    setInterval, isActive
 
 import app/modules/shared_models/collectibles_entry
 import app/modules/shared_models/collectibles_model
@@ -12,6 +14,11 @@ import backend/collectibles as backend_collectibles
 import app_service/service/network/service as network_service
 
 const FETCH_BATCH_COUNT_DEFAULT = 50
+
+# Ownership changes are reported by status-go per address and per chain, so a
+# single sync produces a burst of "something changed" events. Wait for the burst
+# to settle before refetching the list instead of refetching once per event.
+const OWNERSHIP_REFRESH_DEBOUNCE_MS = 1000
 
 type
   LoadType* {.pure.} = enum
@@ -49,9 +56,21 @@ QtObject:
       dataType: backend_collectibles.CollectibleDataType
       fetchCriteria: backend_collectibles.FetchCriteria
 
+      # A (re)fetch was requested while one was already in flight. It is executed
+      # once the in-flight one completes, so bursts of triggers result in a
+      # single trailing refetch instead of one reload each.
+      pendingReset: bool
+      # The in-flight fetch was made obsolete by a filter change: its results
+      # must not be applied to the model.
+      discardInFlightResponse: bool
+      # Debounces ownership-change driven refetches (seaqt QTimer, auto-destroyed
+      # via =destroy)
+      refreshTimer: QTimer
+
   proc setup(self: Controller)
   proc delete*(self: Controller)
   proc setupEventHandlers(self: Controller)
+  proc requestReset(self: Controller, clearItems: bool)
 
   proc doLoadMore(self: Controller) =
     if self.model.getIsFetching():
@@ -111,6 +130,17 @@ QtObject:
     result.addresses = @[]
     result.chainIds = @[]
     result.filter = backend_collectibles.newCollectibleFilterAllEntries()
+
+    result.refreshTimer = QTimer.create()
+    result.refreshTimer.setSingleShot(true)
+    result.refreshTimer.setInterval(cint(OWNERSHIP_REFRESH_DEBOUNCE_MS))
+    let ctrl = result
+    result.refreshTimer.onTimeout(proc() {.closure, raises: [].} =
+      try:
+        # Keep the current items visible: the refetch ends in a diff update.
+        ctrl.requestReset(clearItems = false)
+      except Exception as e:
+        error "error refreshing collectibles: ", error = e.msg)
 
     result.setup()
 
@@ -204,7 +234,16 @@ QtObject:
     self.tempItems.add(newItems)
 
   proc processGetOwnedCollectiblesResponse(self: Controller, response: JsonNode) =
-    try: 
+    if self.discardInFlightResponse:
+      # The filter changed after this fetch was started, its results don't match
+      # what has to be displayed anymore.
+      self.discardInFlightResponse = false
+      self.model.setIsFetching(false)
+      if self.pendingReset:
+        self.requestReset(clearItems = false)
+      return
+
+    try:
       let res = fromJson(response, backend_collectibles.GetOwnedCollectiblesResponse)
 
       let isError = res.errorCode != backend_collectibles.ErrorCodeSuccess
@@ -213,6 +252,8 @@ QtObject:
         error "error fetching collectibles entries: ", code = res.errorCode
         self.model.setIsError(true)
         self.model.setIsFetching(false)
+        if self.pendingReset:
+          self.requestReset(clearItems = false)
         return
 
       let items = res.collectibles.map(header => (block:
@@ -231,9 +272,15 @@ QtObject:
       self.model.setIsFetching(false)
       self.setOwnershipStatus(res.ownershipStatus)
 
+      if self.pendingReset:
+        # Triggers received while this fetch was running, collapsed into a
+        # single refetch.
+        self.requestReset(clearItems = false)
+        return
+
       if self.loadType.isAutoLoad() and res.hasMore:
         self.doLoadMore()
-      
+
     except Exception as e:
       error "Error converting activity entries: ", error = e.msg
 
@@ -256,12 +303,47 @@ QtObject:
       if not self.loadType.isPaginated():
         self.updateTempItems(collectibles)
 
-  proc resetModel(self: Controller) {.slot.} =
+  # Requests a fetch of the whole list from the start.
+  #
+  # `clearItems` == true drops what is currently displayed right away, because
+  # the data it shows is no longer valid (the address/chain or the item filter
+  # changed). Results of a fetch that is already in flight are discarded too.
+  #
+  # `clearItems` == false keeps the current items visible while the refetch runs.
+  # AutoLoadSingleUpdate accumulates the batches privately and applies them with
+  # a single diff update at the end, so only the collectibles that actually
+  # appeared/disappeared are touched — no flicker, no delegate rebuild.
+  # Paginated load types append every batch straight to the model, so for those
+  # the visible list still has to be dropped before restarting.
+  proc requestReset(self: Controller, clearItems: bool) =
+    let dropCurrentItems = clearItems or self.loadType.isPaginated()
+
+    if dropCurrentItems:
+      self.tempItems = @[]
+      self.model.setItems(@[], 0, true)
+
+    if self.model.getIsFetching():
+      # Coalesce: run a single fresh fetch once the in-flight one completes.
+      self.pendingReset = true
+      self.discardInFlightResponse = self.discardInFlightResponse or dropCurrentItems
+      return
+
+    self.pendingReset = false
+    self.discardInFlightResponse = false
     self.tempItems = @[]
-    self.model.setItems(@[], 0, true)
     self.fetchFromStart = true
     if self.loadType.isAutoLoad():
-      self.doLoadMore() 
+      self.doLoadMore()
+
+  proc resetModel(self: Controller) {.slot.} =
+    self.refreshTimer.stop()
+    self.requestReset(clearItems = true)
+
+  proc scheduleRefresh(self: Controller) =
+    # Debounce: the first event of a burst arms the timer, the ones following
+    # within the debounce window are absorbed by it.
+    if not self.refreshTimer.isActive():
+      self.refreshTimer.start()
 
   proc setupEventHandlers(self: Controller) =
     self.eventsHandler.onOwnedCollectiblesFilteringDone(proc (jsonObj: JsonNode) =
@@ -279,13 +361,13 @@ QtObject:
     self.eventsHandler.onCollectiblesOwnershipUpdatePartial(proc (address: string, chainID: int, changes: backend_collectibles.OwnershipUpdateMessage) =
       self.setOwnershipState(address, chainID, OwnershipStateUpdating)
       if changes.hasChanges():
-        self.resetModel() 
+        self.scheduleRefresh()
     )
 
     self.eventsHandler.onCollectiblesOwnershipUpdateFinished(proc (address: string, chainID: int, changes: backend_collectibles.OwnershipUpdateMessage) =
       self.setOwnershipState(address, chainID, OwnershipStateIdle)
       if changes.hasChanges():
-        self.resetModel()
+        self.scheduleRefresh()
     )
 
     self.eventsHandler.onCollectiblesOwnershipUpdateFinishedWithError(proc (address: string, chainID: int) =
@@ -296,8 +378,10 @@ QtObject:
     self.selectedAddress = address
     self.checkModelState()
 
-  proc setFilterAddressesAndChains*(self: Controller, addresses: seq[string], chainIds: seq[int]) = 
-    if chainIds == self.chainIds and addresses == self.addresses:
+  proc setFilterAddressesAndChains*(self: Controller, addresses: seq[string], chainIds: seq[int]) =
+    # Compare as sets: only the contents matter for the fetched list, so a mere
+    # reordering (e.g. accounts reordered by the user) must not trigger a reload.
+    if chainIds.sorted() == self.chainIds.sorted() and addresses.sorted() == self.addresses.sorted():
       return
 
     self.chainIds = chainIds
@@ -326,5 +410,7 @@ QtObject:
     self.QObject.setup
 
   proc delete*(self: Controller) =
+    if not self.refreshTimer.h.isNil:
+      self.refreshTimer.stop()
     self.QObject.delete
 

--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -177,20 +177,27 @@ SplitView {
                 checked: true
             }
 
+            // The spinner/empty/error placeholders are only shown while there is
+            // nothing to display: switch both collectible types off to see them.
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                text: "States below only show up on an empty list (switch both collectible types off)"
+            }
             CheckBox {
                 id: ctrlUpdatingCheckbox
                 checked: false
-                text: "isUpdating"
+                text: "isUpdating (spinner, ownership check)"
             }
             CheckBox {
                 id: ctrlFetchingCheckbox
                 checked: false
-                text: "isFetching"
+                text: "isFetching (spinner, loading)"
             }
             CheckBox {
                 id: ctrlErrorCheckbox
                 checked: false
-                text: "isError"
+                text: "isError (error placeholder)"
             }
             CheckBox {
                 id: buyBannerCheckbox

--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -37,6 +37,7 @@ SplitView {
         id: collectiblesModel
         includeRegularCollectibles: ctrlIncludeRegularCollectibles.checked
         includeCommunityCollectibles: ctrlIncludeCommunityCollectibles.checked
+        metadataAvailable: ctrlMetadataAvailable.checked
     }
 
     RolesRenamingModel {
@@ -130,8 +131,6 @@ SplitView {
         onReceiveRequested: logs.logEvent("onReceiveRequested", ["symbol"], arguments)
         onSwitchToCommunityRequested: logs.logEvent("onSwitchToCommunityRequested", ["communityId"], arguments)
         onManageTokensRequested: logs.logEvent("onManageTokensRequested")
-        isUpdating: ctrlUpdatingCheckbox.checked
-        isFetching: ctrlFetchingCheckbox.checked
         isError: ctrlErrorCheckbox.checked
         bannerComponent: BuyReceiveBanner {
             id: buyReceiveBanner
@@ -177,22 +176,23 @@ SplitView {
                 checked: true
             }
 
-            // The spinner/empty/error placeholders are only shown while there is
-            // nothing to display: switch both collectible types off to see them.
+            // Per-tile state: uncheck to list every collectible without its
+            // metadata, the way tiles look between being listed and their
+            // metadata arriving.
+            Switch {
+                id: ctrlMetadataAvailable
+                text: "Collectible metadata available"
+                checked: true
+            }
+
+            // With both collectible types off the list is empty: the empty state
+            // shows immediately, and is replaced by the error state below.
+            // The ownership check is NOT indicated here — its indicator lives in
+            // the wallet tab header (RightTabView), above this view.
             Text {
                 Layout.fillWidth: true
                 wrapMode: Text.Wrap
-                text: "States below only show up on an empty list (switch both collectible types off)"
-            }
-            CheckBox {
-                id: ctrlUpdatingCheckbox
-                checked: false
-                text: "isUpdating (spinner, ownership check)"
-            }
-            CheckBox {
-                id: ctrlFetchingCheckbox
-                checked: false
-                text: "isFetching (spinner, loading)"
+                text: "Empty/error states need an empty list (switch both collectible types off)"
             }
             CheckBox {
                 id: ctrlErrorCheckbox

--- a/storybook/qmlTests/tests/tst_CollectiblesView.qml
+++ b/storybook/qmlTests/tests/tst_CollectiblesView.qml
@@ -49,6 +49,7 @@ Item {
                     communityImage: "",
                     imageUrl: "",
                     backgroundColor: "",
+                    metadataAvailable: true,
                     ownership: [{
                         accountAddress: root.testAccount,
                         balance: "1",
@@ -68,6 +69,7 @@ Item {
                     communityImage: "",
                     imageUrl: "",
                     backgroundColor: "",
+                    metadataAvailable: true,
                     ownership: [{
                         accountAddress: root.testAccount,
                         balance: "1",
@@ -87,6 +89,7 @@ Item {
                     communityImage: "",
                     imageUrl: "",
                     backgroundColor: "",
+                    metadataAvailable: true,
                     ownership: [{
                         accountAddress: root.testAccount,
                         balance: "1",
@@ -106,6 +109,7 @@ Item {
                     communityImage: "",
                     imageUrl: "",
                     backgroundColor: "",
+                    metadataAvailable: true,
                     ownership: [{
                         accountAddress: root.testAccount,
                         balance: "1",
@@ -354,6 +358,40 @@ Item {
         function test_sortByUi_asc_desc(data) {
             verifySortByUi(data.optionText, data.communityAsc, data.communityDesc,
                            data.regularAsc, data.regularDesc)
+        }
+
+        function findGridItemByTitle(gridObjectName, title) {
+            const grid = findChild(controlUnderTest, gridObjectName)
+            verify(!!grid)
+            for (let i = 0; i < grid.count; ++i) {
+                const item = grid.itemAtIndex(i)
+                if (!!item && item.title === title)
+                    return item
+            }
+            return null
+        }
+
+        // A tile is listed before its metadata arrives: until then it must render
+        // as loading, and it must stop doing so the moment the metadata lands.
+        function test_tileRendersAsLoadingUntilMetadataArrives() {
+            const sourceIndex = 2 // "Reg Charlie"
+            compare(collectiblesModel.get(sourceIndex).name, "Reg Charlie")
+
+            let tile = findGridItemByTitle("regularCollectiblesView", "Reg Charlie")
+            verify(!!tile)
+            compare(tile.isLoading, false)
+
+            collectiblesModel.setProperty(sourceIndex, "metadataAvailable", false)
+            tryVerify(() => {
+                const item = findGridItemByTitle("regularCollectiblesView", "Reg Charlie")
+                return !!item && item.isLoading === true
+            })
+
+            collectiblesModel.setProperty(sourceIndex, "metadataAvailable", true)
+            tryVerify(() => {
+                const item = findGridItemByTitle("regularCollectiblesView", "Reg Charlie")
+                return !!item && item.isLoading === false
+            })
         }
     }
 

--- a/storybook/qmlTests/tests/tst_CollectiblesView.qml
+++ b/storybook/qmlTests/tests/tst_CollectiblesView.qml
@@ -48,7 +48,6 @@ Item {
                     communityName: "Alpha Community",
                     communityImage: "",
                     imageUrl: "",
-                    isLoading: false,
                     backgroundColor: "",
                     ownership: [{
                         accountAddress: root.testAccount,
@@ -68,7 +67,6 @@ Item {
                     communityName: "Zeta Community",
                     communityImage: "",
                     imageUrl: "",
-                    isLoading: false,
                     backgroundColor: "",
                     ownership: [{
                         accountAddress: root.testAccount,
@@ -88,7 +86,6 @@ Item {
                     communityName: "",
                     communityImage: "",
                     imageUrl: "",
-                    isLoading: false,
                     backgroundColor: "",
                     ownership: [{
                         accountAddress: root.testAccount,
@@ -108,7 +105,6 @@ Item {
                     communityName: "",
                     communityImage: "",
                     imageUrl: "",
-                    isLoading: false,
                     backgroundColor: "",
                     ownership: [{
                         accountAddress: root.testAccount,

--- a/storybook/src/Models/ManageCollectiblesModel.qml
+++ b/storybook/src/Models/ManageCollectiblesModel.qml
@@ -4,17 +4,32 @@ import QtQml.Models
 import utils
 
 ListModel {
+    id: root
+
     property bool includeRegularCollectibles: true
     onIncludeRegularCollectiblesChanged: fillData()
     property bool includeCommunityCollectibles: true
     onIncludeCommunityCollectiblesChanged: fillData()
 
+    // When false, every tile is listed without its metadata (name, collection,
+    // image URLs) — the state a tile is in between being listed and its metadata
+    // arriving. Entries carrying `isMetadataValid: false` are in that state even
+    // when this is true.
+    property bool metadataAvailable: true
+    onMetadataAvailableChanged: fillData()
+
+    function withMetadataFlag(entries) {
+        return entries.map(entry => Object.assign({}, entry, {
+            metadataAvailable: root.metadataAvailable && entry.isMetadataValid !== false
+        }))
+    }
+
     function fillData() {
         clear()
         if (includeRegularCollectibles)
-            append(data)
+            append(withMetadataFlag(data))
         if (includeCommunityCollectibles)
-            append(communityData)
+            append(withMetadataFlag(communityData))
     }
 
     readonly property var data: [

--- a/storybook/src/Models/ManageCollectiblesModel.qml
+++ b/storybook/src/Models/ManageCollectiblesModel.qml
@@ -30,7 +30,6 @@ ListModel {
             communityName: "",
             communityImage: "",
             imageUrl: ModelsData.collectibles.cryptoPunks,
-            isLoading: false,
             backgroundColor: "",
             permalink:"opensea.com",
             domain:"opensea",
@@ -80,7 +79,6 @@ ListModel {
             communityName: "",
             communityImage: "",
             imageUrl: "https://i.seadn.io/s/raw/files/ba2811bb5cd0bed67529d69fa92ef5aa.jpg?auto=format&dpr=1&w=1000",
-            isLoading: false,
             backgroundColor: "",
             permalink:"opensea.com",
             domain:"opensea",
@@ -125,7 +123,6 @@ ListModel {
             communityName: "",
             communityImage: "",
             imageUrl: "https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/386.svg",
-            isLoading: true,
             backgroundColor: "",
             permalink:"opensea.com",
             domain:"opensea",
@@ -170,7 +167,6 @@ ListModel {
             communityName: "",
             communityImage: "",
             imageUrl: "https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/3395.svg",
-            isLoading: false,
             backgroundColor: "",
             permalink:"opensea.com",
             domain:"opensea",
@@ -215,7 +211,6 @@ ListModel {
             communityName: "",
             communityImage: "",
             imageUrl: "https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/163.png",
-            isLoading: false,
             backgroundColor: "",
             permalink:"opensea.com",
             domain:"opensea",
@@ -265,7 +260,6 @@ ListModel {
             communityName: "",
             communityImage: "",
             imageUrl: "https://i.seadn.io/s/raw/files/cfa559bb63e4378f17649c1e3b8f18fe.jpg?auto=format&dpr=1&w=1000",
-            isLoading: false,
             backgroundColor: "",
             permalink:"opensea.com",
             domain:"opensea",
@@ -302,7 +296,6 @@ ListModel {
             communityName: "",
             communityImage: "",
             imageUrl: "",
-            isLoading: false,
             backgroundColor: "ivory",
             permalink:"opensea.com",
             domain:"opensea",
@@ -339,7 +332,6 @@ ListModel {
             communityName: "",
             communityImage: "",
             imageUrl: "",
-            isLoading: false,
             backgroundColor: "",
             permalink:"",
             domain:"",
@@ -374,7 +366,6 @@ ListModel {
             communityName: "Frenly Pandas",
             communityImage: "https://pbs.twimg.com/profile_images/1599347398769143808/C6qG3RQv_400x400.jpg",
             imageUrl: "https://i.seadn.io/gae/qPfQjj4P1w0xVQXAmQJLmQ4ZtLFAJU6oiH69Lsny82LFbipLAgXhHKrcLBx2U09SmRnzeHY0ygz-3NIb-JegE_hWrZquFeL-qUPXPdw",
-            isLoading: false,
             backgroundColor: "pink",
             ownership: [
                 {
@@ -401,7 +392,6 @@ ListModel {
             communityName: "Bearz",
             communityImage: "https://i.seadn.io/gcs/files/4a875f997063f4f3772190852c1c44f0.png?w=128&auto=format",
             imageUrl: "https://assets.killabears.com/content/killabears/gif/691-e81f892696a8ae700e0dbc62eb072060679a2046d1ef5eb2671bdb1fad1f68e3.gif",
-            isLoading: true,
             backgroundColor: "navy",
             ownership: [
                 {
@@ -428,7 +418,6 @@ ListModel {
             communityName: "Bearz",
             communityImage: "https://i.seadn.io/gcs/files/4a875f997063f4f3772190852c1c44f0.png?w=128&auto=format",
             imageUrl: "https://assets.killabears.com/content/killabears/transparent-512/2385-86ba13cc6945ed0aea7c32a363a96be2f218898358745ae07b947452cb7e4e79.png",
-            isLoading: false,
             backgroundColor: "",
             ownership: [
                 {
@@ -457,7 +446,6 @@ ListModel {
             communityName: "Frenly Pandas",
             communityImage: "https://pbs.twimg.com/profile_images/1599347398769143808/C6qG3RQv_400x400.jpg",
             imageUrl: "https://i.seadn.io/s/raw/files/59ad1f2e3c5eb5d4b62c06e200076514.png",
-            isLoading: false,
             backgroundColor: "",
             ownership: [
                 {
@@ -484,7 +472,6 @@ ListModel {
             communityName: "Frenly Pandas",
             communityImage: "https://pbs.twimg.com/profile_images/1599347398769143808/C6qG3RQv_400x400.jpg",
             imageUrl: "https://i.seadn.io/gae/K4_vmYtXAqU6LTnGDliLtJZc4UPmf9jUlk09_FDbXvSKKyUARyyV9RQEgXdb5bjje5OE9j9ZryC5pzcwBwH7TDOIl8oq7D2tSJ7p",
-            isLoading: false,
             backgroundColor: "",
             ownership: [
                 {
@@ -511,7 +498,6 @@ ListModel {
             communityName: "Frenly Pandas",
             communityImage: "https://pbs.twimg.com/profile_images/1599347398769143808/C6qG3RQv_400x400.jpg",
             imageUrl: "https://i.seadn.io/gae/cR-Bjmb6DsrywCJMOqEBPkkrMHjbTzeRSAKIvLpd7i8ss6raYZ3-doh8oF2z8bJsnmfC1oR3kllz6UxMfFaYAKdXYzXlhfVsDHo6bg",
-            isLoading: false,
             backgroundColor: "",
             ownership: [
                 {
@@ -538,7 +524,6 @@ ListModel {
             communityName: "Lonely Bearz Community 0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
             communityImage: "",
             imageUrl: "",
-            isLoading: false,
             backgroundColor: "pink",
             ownership: [
                 {
@@ -570,7 +555,6 @@ ListModel {
             communityName: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
             communityImage: "",
             imageUrl: "",
-            isLoading: false,
             backgroundColor: "pink",
             ownership: [
                 {

--- a/test/nim/collectibles_model_test.nim
+++ b/test/nim/collectibles_model_test.nim
@@ -1,11 +1,31 @@
 import unittest
 
-import stint, strutils, random
+import stint, strutils, random, options, sequtils
+import nimqml
 
 import backend/collectibles_types
 import app/modules/shared_models/collectibles_model
 import app/modules/shared_models/collectibles_entry
-    
+import app/modules/shared_models/collectible_ownership_model
+
+# Observes Model.itemsDataUpdated, the signal the views listen to in order to
+# re-read entries whose data changed in place.
+QtObject:
+  type ItemsDataUpdatedSpy = ref object of QObject
+    count: int
+
+  proc delete(self: ItemsDataUpdatedSpy)
+
+  proc onItemsDataUpdated*(self: ItemsDataUpdatedSpy) {.slot.} =
+    inc self.count
+
+  proc newItemsDataUpdatedSpy(): ItemsDataUpdatedSpy =
+    new(result, delete)
+    result.QObject.setup
+
+  proc delete(self: ItemsDataUpdatedSpy) =
+    self.QObject.delete
+
 proc createTestCollectible(seed: int): CollectiblesEntry =
     let data = Collectible(
         dataType: UniqueID,
@@ -28,6 +48,33 @@ proc createTestCollectibles(seed: int, count: int): seq[CollectiblesEntry] =
     result = @[]
     for i in 0..<count:
         result.add(createTestCollectible(seed + i))
+
+proc balances(entries: varargs[(string, int, int)]): seq[AccountBalance] =
+    result = @[]
+    for e in entries:
+        result.add(AccountBalance(address: e[0], balance: u256(e[1]), txTimestamp: e[2]))
+
+# Same shape as createTestCollectible, but with the ownership submodel data
+# (owning accounts + their balances) the backend refreshes independently of the
+# collectible metadata.
+proc createOwnedCollectible(seed: int, ownership: seq[AccountBalance]): CollectiblesEntry =
+    let data = Collectible(
+        dataType: UniqueID,
+        id: CollectibleUniqueID(
+            contractID: ContractID(
+                address: seed.toHex,
+                chainID: seed mod 4
+            ),
+            tokenID: u256(seed)
+        ),
+        ownership: some(ownership)
+    )
+    let extradata = ExtraData(
+        networkShortName: "Chain" & seed.toHex,
+        networkColor: "Color" & seed.toHex,
+        networkIconURL: "URL" & seed.toHex,
+    )
+    return newCollectibleDetailsFullEntry(data, extradata)
 
 suite "collectibles model":
   test "Collectible list set":
@@ -80,3 +127,80 @@ suite "collectibles model":
     
     model.updateItems(@[])
     check(model.getItems().len == 0)
+
+suite "collectibles model - ownership refresh of kept entries":
+  test "a kept entry exposes the refreshed ownership and announces it":
+    let model = newModel()
+    let spy = newItemsDataUpdatedSpy()
+    discard QObject.connect(model, itemsDataUpdated, spy, onItemsDataUpdated)
+
+    let original = createOwnedCollectible(1, balances(("0xAAA", 1, 100)))
+    model.updateItems(@[original])
+    check(model.getItems().len == 1)
+    # First population is an append, not an in-place data update.
+    check(spy.count == 0)
+
+    # Same collectible ID, but the backend now reports a bigger balance and a
+    # second owning account. Nothing else about the collectible changed.
+    let refreshed = createOwnedCollectible(1, balances(("0xAAA", 3, 200), ("0xBBB", 5, 300)))
+    model.updateItems(@[refreshed])
+
+    check(model.getItems().len == 1)
+    let kept = model.getItems()[0]
+    # The entry object itself is kept - no tile churn for an unchanged ID.
+    check(kept == original)
+
+    # ...but its ownership data must be the refreshed one, otherwise the UI
+    # keeps showing stale balance tags and picks the wrong account when sending.
+    let ownership = kept.getOwnership()
+    check(ownership.mapIt(it.address) == @["0xAAA", "0xBBB"])
+    check(ownership.mapIt(it.balance) == @[u256(3), u256(5)])
+    check(ownership.mapIt(it.txTimestamp) == @[200, 300])
+
+    # The submodel behind the Ownership role is what QML actually reads.
+    check(kept.getOwnershipModel().getBalance("0xAAA") == u256(3))
+    check(kept.getOwnershipModel().getBalance("0xBBB") == u256(5))
+
+    # The change has to be announced, or the views never re-read the entry.
+    check(spy.count == 1)
+
+  test "an identical refresh reports no change":
+    let model = newModel()
+    let spy = newItemsDataUpdatedSpy()
+    discard QObject.connect(model, itemsDataUpdated, spy, onItemsDataUpdated)
+
+    model.updateItems(@[createOwnedCollectible(2, balances(("0xAAA", 7, 111)))])
+    check(spy.count == 0)
+
+    # A poll carrying byte-identical data must not be reported as a change,
+    # otherwise the grid re-renders (flickers) on every refresh.
+    model.updateItems(@[createOwnedCollectible(2, balances(("0xAAA", 7, 111)))])
+    check(spy.count == 0)
+    check(model.getItems().len == 1)
+    check(model.getItems()[0].getOwnership()[0].balance == u256(7))
+
+  test "additions and removals still work around a refreshed kept entry":
+    let model = newModel()
+    let spy = newItemsDataUpdatedSpy()
+    discard QObject.connect(model, itemsDataUpdated, spy, onItemsDataUpdated)
+
+    let a = createOwnedCollectible(10, balances(("0xAAA", 1, 10)))
+    let b = createOwnedCollectible(11, balances(("0xAAA", 1, 10)))
+    model.updateItems(@[a, b])
+    check(model.getItems().len == 2)
+    check(spy.count == 0)
+
+    # b is gone, c is new, a is kept but its balance moved.
+    let aRefreshed = createOwnedCollectible(10, balances(("0xAAA", 9, 90)))
+    let c = createOwnedCollectible(12, balances(("0xBBB", 2, 20)))
+    model.updateItems(@[aRefreshed, c])
+
+    let ids = model.getItems().mapIt(it.getIDAsString())
+    check(ids.len == 2)
+    check(a.getIDAsString() in ids)
+    check(c.getIDAsString() in ids)
+    check(not (b.getIDAsString() in ids))
+
+    check(model.getItemById(a.getIDAsString()).getOwnership().mapIt(it.balance) == @[u256(9)])
+    check(model.getItemById(c.getIDAsString()).getOwnership().mapIt(it.address) == @["0xBBB"])
+    check(spy.count == 1)

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -35,9 +35,11 @@ ColumnLayout {
     required property string networkFilters
     property bool sendEnabled: true
     property bool filterVisible
-    property bool isFetching: false // Indicates if a collectibles page is being loaded from the backend
-    property bool isUpdating: false // Indicates if the collectibles list is being updated
-    property bool isError: false // Indicates an error occurred while updating/fetching the collectibles list
+    // Indicates that the list could not be read. Neither the ownership check nor
+    // the list read is surfaced here: the list read is fast and local, and the
+    // ownership check is indicated in the wallet tab header (see RightTabView),
+    // where it cannot shift or overlay the list.
+    property bool isError: false
     property alias bannerComponent: banner.sourceComponent
 
     // allows/disables choosing custom sort order from a sorter
@@ -88,10 +90,6 @@ ColumnLayout {
 
         readonly property var sourceModel: root.controller.sourceModel
 
-        // A load is in progress: either an ownership check is running in status-go
-        // (isUpdating) or a page of collectibles is being fetched (isFetching).
-        readonly property bool isLoading: root.isUpdating || root.isFetching
-
         function setSortByDateIsDisabled(disabled) {
             const orderByDateIndex =  cmbTokenOrder.indexOfValue(SortOrderComboBox.TokenOrderDateAdded)
 
@@ -128,11 +126,11 @@ ColumnLayout {
 
         readonly property bool isEmpty: !hasRegularCollectibles && !hasCommunityCollectibles
 
-        // Updates of an already populated list must be visually silent: the
-        // spinner/empty/error placeholders are only shown while there is nothing
-        // to display.
-        readonly property bool loadingPlaceholderVisible: isEmpty && isLoading
-        readonly property bool errorPlaceholderVisible: isEmpty && !isLoading && root.isError
+        // The empty state is never delayed by a running ownership check: an
+        // account with no known collectibles says so right away. Only the error
+        // state takes its place.
+        readonly property bool errorPlaceholderVisible: isEmpty && root.isError
+        readonly property bool emptyPlaceholderVisible: isEmpty && !root.isError
 
         readonly property var addrFilters: root.addressFilters.split(":")
 
@@ -375,34 +373,13 @@ ColumnLayout {
         Layout.fillWidth: true
     }
 
-    RowLayout {
-        objectName: "collectiblesLoadingIndicator"
-
-        Layout.alignment: Qt.AlignHCenter
-        Layout.topMargin: Theme.padding
-        spacing: Theme.halfPadding
-
-        visible: d.loadingPlaceholderVisible
-
-        StatusLoadingIndicator {
-            color: Theme.palette.directColor4
-        }
-
-        StatusBaseText {
-            color: Theme.palette.baseColor1
-            font.pixelSize: Theme.additionalTextSize
-            text: root.isUpdating ? qsTr("Checking collectibles ownership…")
-                                  : qsTr("Loading collectibles…")
-        }
-    }
-
     ShapeRectangle {
         objectName: "collectiblesEmptyPlaceholder"
 
         Layout.fillWidth: true
         Layout.preferredHeight: 44
         Layout.topMargin: Theme.padding
-        visible: d.isEmpty && !d.loadingPlaceholderVisible && !d.errorPlaceholderVisible
+        visible: d.emptyPlaceholderVisible
         text: qsTr("Collectibles will appear here")
     }
 
@@ -506,6 +483,11 @@ ColumnLayout {
             fallbackImageUrl: Utils.collectibleMediaSource(model.thumbnailUrl, model.imageUrl)
             allowAnimation: false
             backgroundColor: model.backgroundColor ? model.backgroundColor : Theme.palette.baseColor5
+            // The tile is listed before its metadata arrives; until then name and
+            // image would render as "#<tokenId>" and a blank square, so shimmer
+            // instead. Flips per tile as `wallet-collectibles-data-updated` fills
+            // the metadata in.
+            isLoading: !model.metadataAvailable
             privilegesLevel: model.communityPrivilegesLevel ?? Constants.TokenPrivilegesLevel.Community
             ornamentColor: model.communityColor ?? "transparent"
             communityId: model.communityId ?? ""

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -87,6 +87,9 @@ ColumnLayout {
         readonly property bool isCustomView: cmbTokenOrder.currentValue === SortOrderComboBox.TokenOrderCustom
 
         readonly property var sourceModel: root.controller.sourceModel
+
+        // A load is in progress: either an ownership check is running in status-go
+        // (isUpdating) or a page of collectibles is being fetched (isFetching).
         readonly property bool isLoading: root.isUpdating || root.isFetching
 
         function setSortByDateIsDisabled(disabled) {
@@ -96,68 +99,19 @@ ColumnLayout {
             cmbTokenOrder.modelChanged()
         }
 
-        onIsLoadingChanged: {
-            d.loadingItemsModel.refresh()
-        }
-
-        readonly property var loadingItemsModel: ListModel {
-            Component.onCompleted: {
-                refresh()
-            }
-
-            function refresh() {
-                clear()
-                if (d.isLoading) {
-                    for (let i = 0; i < 10; i++) {
-                        append({ isLoading: true, name: qsTr("Loading collectible...") })
-                    }
-                }
-            }
-        }
-
         readonly property var communityModel: CustomSFPM {
             isCommunity: true
-        }
-
-        readonly property var communityModelWithLoadingItems: ConcatModel {
-            sources: [
-                SourceModel {
-                    model: d.communityModel
-                    markerRoleValue: "communityModel"
-                },
-                SourceModel {
-                    model: d.loadingItemsModel
-                    markerRoleValue: "loadingItemsModel"
-                }
-            ]
-
-            markerRoleName: "sourceGroup"
         }
 
         readonly property var nonCommunityModel: CustomSFPM {
             isCommunity: false
         }
 
-        readonly property var nonCommunityModelWithLoadingItems: ConcatModel {
-            sources: [
-                SourceModel {
-                    model: d.nonCommunityModel
-                    markerRoleValue: "nonCommunityModel"
-                },
-                SourceModel {
-                    model: d.loadingItemsModel
-                    markerRoleValue: "loadingItemsModel"
-                }
-            ]
-
-            markerRoleName: "sourceGroup"
-        }
-
         readonly property var allCollectiblesModel: ConcatModel {
             sources: [
                 SourceModel {
                     model: d.communityModel
-                    markerRoleValue: "loadingItemsModel"
+                    markerRoleValue: "communityModel"
                 },
                 SourceModel {
                     model: d.nonCommunityModel
@@ -168,9 +122,17 @@ ColumnLayout {
         }
 
 
-        readonly property bool hasRegularCollectibles: d.nonCommunityModel.count || d.loadingItemsModel.count
-        readonly property bool hasCommunityCollectibles: d.communityModel.count || d.loadingItemsModel.count
+        readonly property bool hasRegularCollectibles: d.nonCommunityModel.count > 0
+        readonly property bool hasCommunityCollectibles: d.communityModel.count > 0
         readonly property bool onlyRegularCollectiblesType: hasRegularCollectibles && !hasCommunityCollectibles
+
+        readonly property bool isEmpty: !hasRegularCollectibles && !hasCommunityCollectibles
+
+        // Updates of an already populated list must be visually silent: the
+        // spinner/empty/error placeholders are only shown while there is nothing
+        // to display.
+        readonly property bool loadingPlaceholderVisible: isEmpty && isLoading
+        readonly property bool errorPlaceholderVisible: isEmpty && !isLoading && root.isError
 
         readonly property var addrFilters: root.addressFilters.split(":")
 
@@ -413,12 +375,47 @@ ColumnLayout {
         Layout.fillWidth: true
     }
 
+    RowLayout {
+        objectName: "collectiblesLoadingIndicator"
+
+        Layout.alignment: Qt.AlignHCenter
+        Layout.topMargin: Theme.padding
+        spacing: Theme.halfPadding
+
+        visible: d.loadingPlaceholderVisible
+
+        StatusLoadingIndicator {
+            color: Theme.palette.directColor4
+        }
+
+        StatusBaseText {
+            color: Theme.palette.baseColor1
+            font.pixelSize: Theme.additionalTextSize
+            text: root.isUpdating ? qsTr("Checking collectibles ownership…")
+                                  : qsTr("Loading collectibles…")
+        }
+    }
+
     ShapeRectangle {
+        objectName: "collectiblesEmptyPlaceholder"
+
         Layout.fillWidth: true
         Layout.preferredHeight: 44
         Layout.topMargin: Theme.padding
-        visible: !d.hasRegularCollectibles && !d.hasCommunityCollectibles
+        visible: d.isEmpty && !d.loadingPlaceholderVisible && !d.errorPlaceholderVisible
         text: qsTr("Collectibles will appear here")
+    }
+
+    ShapeRectangle {
+        objectName: "collectiblesErrorPlaceholder"
+
+        Layout.fillWidth: true
+        Layout.preferredHeight: 44
+        Layout.topMargin: Theme.padding
+        visible: d.errorPlaceholderVisible
+        icon: "warning"
+        textColor: Theme.palette.dangerColor1
+        text: qsTr("Collectibles could not be loaded")
     }
 
     DoubleFlickableWithFolding {
@@ -441,7 +438,7 @@ ColumnLayout {
             header: d.hasCommunityCollectibles ? communityHeaderComponent : null
             width: doubleFlickable.width
             cellHeight: d.communityCellHeight
-            model: d.communityModelWithLoadingItems
+            model: d.communityModel
 
             Component {
                 id: communityHeaderComponent
@@ -470,7 +467,7 @@ ColumnLayout {
             header: !d.hasRegularCollectibles || d.onlyRegularCollectiblesType ? null : regularHeaderComponent
             width: doubleFlickable.width
             cellHeight: d.cellHeight
-            model: d.nonCommunityModelWithLoadingItems
+            model: d.nonCommunityModel
 
             Component {
                 id: regularHeaderComponent
@@ -509,7 +506,6 @@ ColumnLayout {
             fallbackImageUrl: Utils.collectibleMediaSource(model.thumbnailUrl, model.imageUrl)
             allowAnimation: false
             backgroundColor: model.backgroundColor ? model.backgroundColor : Theme.palette.baseColor5
-            isLoading: !!model.isLoading
             privilegesLevel: model.communityPrivilegesLevel ?? Constants.TokenPrivilegesLevel.Community
             ornamentColor: model.communityColor ?? "transparent"
             communityId: model.communityId ?? ""

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -280,6 +280,33 @@ RightTabBaseView {
                         RootStore.setCurrentViewedHoldingType(walletTabBar.currentIndex === 1 ? Constants.TokenType.ERC721 : Constants.TokenType.ERC20)
                     }
                 }
+                // Ownership check running in the background. It lives in the tab
+                // header, next to the filter button, so that starting/finishing a
+                // check never shifts or overlays the list below: the row's height
+                // is set by the tab bar and the filter button, and the tab bar
+                // simply yields the few pixels it takes.
+                StatusLoadingIndicator {
+                    objectName: "collectiblesOwnershipCheckIndicator"
+
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.rightMargin: Theme.halfPadding
+                    Layout.preferredWidth: 16
+                    Layout.preferredHeight: 16
+
+                    color: Theme.palette.baseColor1
+                    visible: walletTabBar.currentIndex === RightTabView.TabIndex.Collectibles
+                             && RootStore.collectiblesStore.areCollectiblesUpdating
+
+                    StatusToolTip {
+                        visible: hoverHandler.hovered
+                        text: qsTr("Checking collectibles ownership…")
+                    }
+
+                    HoverHandler {
+                        id: hoverHandler
+                    }
+                }
+
                 StatusFlatButton {
                     id: filterButton
                     objectName: "filterButton"
@@ -518,8 +545,6 @@ RightTabBaseView {
                         onSwitchToCommunityRequested: (communityId) => Global.switchToCommunity(communityId)
                         onManageTokensRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.wallet,
                                                                                       Constants.walletSettingsSubsection.manageCollectibles)
-                        isFetching: RootStore.collectiblesStore.areCollectiblesFetching
-                        isUpdating: RootStore.collectiblesStore.areCollectiblesUpdating
                         isError: RootStore.collectiblesStore.areCollectiblesError
                     }
                 }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -3309,10 +3309,6 @@ file format</source>
 <context>
     <name>CollectiblesView</name>
     <message>
-        <source>Loading collectible...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sort by:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3346,6 +3342,10 @@ file format</source>
     </message>
     <message>
         <source>Collectibles will appear here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collectibles could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14610,6 +14610,10 @@ to load</source>
     </message>
     <message>
         <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checking collectibles ownership…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -3322,10 +3322,6 @@ formát souboru</translation>
 <context>
     <name>CollectiblesView</name>
     <message>
-        <source>Loading collectible...</source>
-        <translation>Načítání sběratelského předmětu...</translation>
-    </message>
-    <message>
         <source>Sort by:</source>
         <translation>Třídit podle:</translation>
     </message>
@@ -3360,6 +3356,10 @@ formát souboru</translation>
     <message>
         <source>Collectibles will appear here</source>
         <translation>Sběratelské předměty se zobrazí zde</translation>
+    </message>
+    <message>
+        <source>Collectibles could not be loaded</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Community minted</source>
@@ -14690,6 +14690,10 @@ selhalo</translation>
     </message>
     <message>
         <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checking collectibles ownership…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -3317,10 +3317,6 @@ no compatible</translation>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <source>Loading collectible...</source>
-        <translation>Cargando coleccionable...</translation>
-    </message>
-    <message>
         <source>Sort by:</source>
         <translation>Ordenar por:</translation>
     </message>
@@ -3355,6 +3351,10 @@ no compatible</translation>
     <message>
         <source>Collectibles will appear here</source>
         <translation>Los coleccionables aparecerán aquí</translation>
+    </message>
+    <message>
+        <source>Collectibles could not be loaded</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Community minted</source>
@@ -14625,6 +14625,10 @@ al cargar</translation>
     </message>
     <message>
         <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checking collectibles ownership…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -3301,10 +3301,6 @@ file format</source>
 <context>
     <name>CollectiblesView</name>
     <message>
-        <source>Loading collectible...</source>
-        <translation>콜렉터블 로딩 중...</translation>
-    </message>
-    <message>
         <source>Sort by:</source>
         <translation>정렬 기준:</translation>
     </message>
@@ -3339,6 +3335,10 @@ file format</source>
     <message>
         <source>Collectibles will appear here</source>
         <translation>수집품이 여기에 표시됩니다</translation>
+    </message>
+    <message>
+        <source>Collectibles could not be loaded</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Community minted</source>
@@ -14561,6 +14561,10 @@ to load</source>
     </message>
     <message>
         <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Checking collectibles ownership…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
### Collectibles workflow — what this pair of PRs touches

| # | Stage | Where | status-go PR | status-app PR |
|---|-------|-------|--------------|---------------|
| 1 | Ownership check (NFT providers + on-chain ERC1155 `balanceOf` fallback) | status-go `ownership/` | no 10s delay on first load; 1s debounce otherwise; `Delayed` state while waiting; cancellations ≠ errors; no loaders for unsupported chains | UI: thin indicator in tab header; error state no longer swallowed |
| 2 | List read (Nim reads NFT list from status-go local DB) | Nim `shared_modules/collectibles` | — | ist never cleared on background triggers; changes applied as diffs; update storms coalesced (1s); reset-during-fetch race fixed |
| 3 | Metadata fetch (from providers, cached in local DB) | status-go `manager.go` → Nim model | — | UI: per-tile shimmer until metadata arrives (`metadataAvailable` role); metadata-only updates now emit `dataChanged` |
| 4 | Image download (QML fetches media from CDN) | QML | — | — (covered by earlier PRs: size cap, thumbnails, HTTP cache) |



* Never clear the list on background triggers
* Apply ownership changes as incremental diffs
* Coalesce update storms, 1s debounce
* Skeleton removed; empty state shows instantly
* Thin ownership-check spinner in tab header
* Per-tile shimmer while metadata is missing
* Restore error state handling
* Refetching interval is still 10s

status-go: https://github.com/status-im/status-go/pull/7709


<table>
<tr>
<th width="50%">Before on old account</th>
<th width="50%">After on restored account</th>
</tr>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/eb915805-b45f-4d99-b07c-7eb0a46db538" controls muted width="100%"></video>
</td>
<td>
<video src="https://github.com/user-attachments/assets/ad1db224-a2ec-4202-8eb1-4dd7802eabb0" controls muted width="100%"></video>
</td>
</tr>
</table>

fixes #21793  
fixes #21732 