### PR TITLE
StatusQ: compilation warnings (QQmlPropertyMap, QMouseEvent) fixed

### DIFF
--- a/ui/StatusQ/include/StatusQ/fastexpressionsorter.h
+++ b/ui/StatusQ/include/StatusQ/fastexpressionsorter.h
@@ -53,6 +53,6 @@ private:
 
     bool m_queuedInvalidate { false };
 
-    mutable QQmlPropertyMap m_modelLeftMap;
-    mutable QQmlPropertyMap m_modelRightMap;
+    QQmlPropertyMap* m_modelLeftMap = QQmlPropertyMap::create(this);
+    QQmlPropertyMap* m_modelRightMap = QQmlPropertyMap::create(this);
 };

--- a/ui/StatusQ/include/StatusQ/genericvalidator.h
+++ b/ui/StatusQ/include/StatusQ/genericvalidator.h
@@ -56,8 +56,8 @@ private:
     QQmlScriptString m_fixupScriptString;
     QQmlScriptString m_validateScriptString;
 
-    mutable QQmlPropertyMap m_fixupScope;
-    mutable QQmlPropertyMap m_validateScope;
+    QQmlPropertyMap* m_fixupScope = QQmlPropertyMap::create(this);
+    QQmlPropertyMap* m_validateScope = QQmlPropertyMap::create(this);
 
     std::unique_ptr<QQmlExpression> m_fixupExpression;
     std::unique_ptr<QQmlExpression> m_validateExpression;

--- a/ui/StatusQ/src/fastexpressionsorter.cpp
+++ b/ui/StatusQ/src/fastexpressionsorter.cpp
@@ -133,11 +133,11 @@ int FastExpressionSorter::compare(const QModelIndex& sourceLeft,
         if (!m_expectedRoles.contains(name))
             continue;
 
-        m_modelLeftMap.insert(name, proxyModel.sourceData(sourceLeft, role));
-        m_modelRightMap.insert(name, proxyModel.sourceData(sourceRight, role));
+        m_modelLeftMap->insert(name, proxyModel.sourceData(sourceLeft, role));
+        m_modelRightMap->insert(name, proxyModel.sourceData(sourceRight, role));
     }
-    m_modelLeftMap.insert(QStringLiteral("index"), sourceLeft.row());
-    m_modelRightMap.insert(QStringLiteral("index"), sourceRight.row());
+    m_modelLeftMap->insert(QStringLiteral("index"), sourceLeft.row());
+    m_modelRightMap->insert(QStringLiteral("index"), sourceRight.row());
 
     m_expression->setNotifyOnValueChanged(true);
 
@@ -159,14 +159,14 @@ void FastExpressionSorter::updateContext(const QQmlSortFilterProxyModel& proxyMo
         if (!m_expectedRoles.contains(name))
             continue;
 
-        m_modelLeftMap.insert(name, {});
-        m_modelRightMap.insert(name, {});
+        m_modelLeftMap->insert(name, {});
+        m_modelRightMap->insert(name, {});
     }
-    m_modelLeftMap.insert(QStringLiteral("index"), -1);
-    m_modelRightMap.insert(QStringLiteral("index"), -1);
+    m_modelLeftMap->insert(QStringLiteral("index"), -1);
+    m_modelRightMap->insert(QStringLiteral("index"), -1);
 
-    m_context->setContextProperty(QStringLiteral("modelLeft"), &m_modelLeftMap);
-    m_context->setContextProperty(QStringLiteral("modelRight"), &m_modelRightMap);
+    m_context->setContextProperty(QStringLiteral("modelLeft"), m_modelLeftMap);
+    m_context->setContextProperty(QStringLiteral("modelRight"), m_modelRightMap);
 
     m_expression->setNotifyOnValueChanged(true);
 }

--- a/ui/StatusQ/src/genericvalidator.cpp
+++ b/ui/StatusQ/src/genericvalidator.cpp
@@ -43,7 +43,7 @@ void GenericValidator::setFixupScriptString(
 
     m_fixupScriptString = scriptString;
     m_fixupExpression = std::make_unique<QQmlExpression>(
-                m_fixupScriptString, qmlContext(this), &m_fixupScope);
+                m_fixupScriptString, qmlContext(this), m_fixupScope);
 
     emit fixupScriptStringChanged();
 }
@@ -62,7 +62,7 @@ void GenericValidator::setValidateScriptString(
     m_validateScriptString = scriptString;
 
     m_validateExpression = std::make_unique<QQmlExpression>(
-                m_validateScriptString, qmlContext(this), &m_validateScope);
+                m_validateScriptString, qmlContext(this), m_validateScope);
     m_validateExpression->setNotifyOnValueChanged(true);
 
     connect(m_validateExpression.get(), &QQmlExpression::valueChanged, this,
@@ -77,7 +77,7 @@ void GenericValidator::fixup(QString& input) const
     if (!m_fixupExpression)
         return;
 
-    m_fixupScope.insert("input", input);
+    m_fixupScope->insert("input", input);
 
     m_fixupExpression->clearError();
     QVariant value = m_fixupExpression->evaluate();
@@ -106,8 +106,8 @@ QValidator::State GenericValidator::validate(QString& input, int& pos) const
                 &QValidator::changed);
     });
 
-    m_validateScope.insert("input", input);
-    m_validateScope.insert("pos", pos);
+    m_validateScope->insert("input", input);
+    m_validateScope->insert("pos", pos);
 
     m_validateExpression->clearError();
     QVariant value = m_validateExpression->evaluate();

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -460,15 +460,21 @@ void SystemUtilsInternal::openAccessibilitySettings()
 #endif
 }
 
-void SystemUtilsInternal::synthetizeRightClick(QQuickItem* item, qreal x, qreal y, Qt::KeyboardModifiers modifiers) const
+void SystemUtilsInternal::synthetizeRightClick(QQuickItem* item, qreal x, qreal y,
+                                               Qt::KeyboardModifiers modifiers) const
 {
     if (!item)
         return;
 
-    // Synthesize a right click event on the given item
-    auto leftClickRelease = new QMouseEvent(QEvent::MouseButtonRelease, {x, y}, Qt::LeftButton, Qt::NoButton, modifiers);
-    auto rightClickPress = new QMouseEvent(QEvent::MouseButtonPress, {x, y}, Qt::RightButton, Qt::NoButton, modifiers);
-    auto rightClickRelease = new QMouseEvent(QEvent::MouseButtonRelease, {x, y}, Qt::RightButton, Qt::NoButton, modifiers);
+    const QPointF localPos(x, y);
+    const QPointF globalPos = item->mapToGlobal(localPos);
+
+    auto leftClickRelease = new QMouseEvent(
+        QEvent::MouseButtonRelease, localPos, globalPos, Qt::LeftButton, Qt::NoButton, modifiers);
+    auto rightClickPress = new QMouseEvent(
+        QEvent::MouseButtonPress, localPos, globalPos, Qt::RightButton, Qt::NoButton, modifiers);
+    auto rightClickRelease = new QMouseEvent(
+        QEvent::MouseButtonRelease, localPos, globalPos, Qt::RightButton, Qt::NoButton, modifiers);
     
     QCoreApplication::postEvent(item, leftClickRelease);
     QCoreApplication::postEvent(item, rightClickPress);


### PR DESCRIPTION
### What does the PR do

Fixes compilation warnings caused by Qt API changes.

### Affected areas
`StatusQ` cpp components.

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications


### Impact on end user

-

### How to test

-

### Risk 

Low
