### PR TITLE
feat(@ci): extend Windows benchmarks job to support PR and releases

### DIFF
--- a/ci/Jenkinsfile.tests-e2e.windows-benchmark
+++ b/ci/Jenkinsfile.tests-e2e.windows-benchmark
@@ -1,7 +1,15 @@
 #!/usr/bin/env groovy
 library 'status-jenkins-lib@v1.9.46'
 
+/* Windows benchmarks for nightly, pull requests, and release candidates.
+ *
+ * Two Jenkins jobs share this file:
+ *   - nightly-benchmark-windows-master — cron; empty CHANGE_ID/RELEASE_VERSION
+ *   - status-app/e2e/manual-benchmark-windows — parameterized PR/RC runs
+ */
+
 QT_VERSION = "6.11.0"
+NIGHTLY_BUILD_SOURCE = 'status-app/systems/windows/x86_64/package'
 
 pipeline {
   agent {
@@ -18,6 +26,16 @@ pipeline {
       name: 'BUILD_SOURCE',
       description: 'URL to tar.gz file OR path to Jenkins build.',
       defaultValue: 'status-app/systems/windows/x86_64/package'
+    )
+    string(
+      name: 'CHANGE_ID',
+      description: 'PR number. Set this for a pull-request run.',
+      defaultValue: ''
+    )
+    string(
+      name: 'RELEASE_VERSION',
+      description: 'Release or RC version, for example 2.39.0-rc.1. Set this for a release run.',
+      defaultValue: ''
     )
     string(
       name: 'TEST_NAME',
@@ -39,12 +57,17 @@ pipeline {
       description: 'Log level for pytest.',
       choices: ['INFO', 'DEBUG', 'TRACE', 'WARNING', 'CRITICAL']
     )
+    booleanParam(
+      name: 'PUBLISH_RESULTS',
+      description: 'Publish CSV/dashboard for PR/release runs. Nightly always publishes. Off by default for dry-runs.',
+      defaultValue: false
+    )
   }
 
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 30, unit: 'MINUTES')
+    timeout(time: 120, unit: 'MINUTES')
     disableConcurrentBuilds()
     disableRestartFromStage()
     /* manage how many builds we keep */
@@ -56,7 +79,10 @@ pipeline {
   }
 
   environment {
-    PLATFORM = 'tests/e2e-windows'
+    // ghcmgr platform max length is 20 characters
+    PLATFORM = 'tests/win-benchmark'
+    CHANGE_ID = "${params.CHANGE_ID}"
+    RELEASE_VERSION = "${params.RELEASE_VERSION}"
 
     SQUISH_DIR = 'C:\\squish-runner-9.2.2-qt-6.11'
     PYTHONPATH = "${SQUISH_DIR}\\lib;${SQUISH_DIR}\\bin;${SQUISH_DIR}\\lib\\python;${PYTHONPATH}"
@@ -71,6 +97,7 @@ pipeline {
 
     /* To store user configuratiin files in temp dir */
     XDG_CONFIG_HOME = "${WORKSPACE_TMP}/config"
+    BENCHMARK_RESULTS_DIR = "${WORKSPACE}\\test\\e2e\\benchmark-results"
 
     TESTRAIL_URL = 'https://ethstatus.testrail.net'
     TESTRAIL_PROJECT_ID = 18
@@ -94,6 +121,41 @@ pipeline {
 
 
   stages {
+    stage('Validate Parameters') {
+      steps {
+        script {
+          def hasPr = params.CHANGE_ID?.trim() as boolean
+          def hasRelease = params.RELEASE_VERSION?.trim() as boolean
+          def isManualJob = env.JOB_NAME.toLowerCase().contains('manual-benchmark')
+
+          if (hasPr && hasRelease) {
+            error('Set CHANGE_ID or RELEASE_VERSION, not both')
+          }
+          if (hasPr && !(params.CHANGE_ID ==~ /^[0-9]+$/)) {
+            error('CHANGE_ID must be the PR number')
+          }
+          if (isManualJob && !hasPr && !hasRelease) {
+            error('Manual benchmarks job requires CHANGE_ID for a PR run, or RELEASE_VERSION for a release run')
+          }
+          if (hasPr || hasRelease) {
+            def buildSource = params.BUILD_SOURCE?.trim()
+            if (!buildSource || buildSource == NIGHTLY_BUILD_SOURCE) {
+              error('For PR/release runs, set BUILD_SOURCE to the package URL or Jenkins project for that build')
+            }
+          }
+
+          if (hasPr) {
+            env.CHANNEL = 'pr'
+          } else if (hasRelease) {
+            env.CHANNEL = 'release'
+          } else {
+            env.CHANNEL = 'nightly'
+          }
+          echo "Benchmark channel: ${env.CHANNEL}"
+        }
+      }
+    }
+
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'
@@ -120,6 +182,8 @@ pipeline {
             url:            params.BUILD_SOURCE,
             targetFileName: 'StatusIm-Desktop.7z',
             targetLocation: './pkg/',
+            userName:       '',
+            password:       '',
           )
         ])
       } } } }
@@ -187,34 +251,63 @@ pipeline {
       script {
         dir('test/e2e') {
           archiveArtifacts(
-            artifacts: 'local_run_results/*.log',
+            artifacts: 'local_run_results/*.log,benchmark-results/*.json',
             allowEmptyArchive: true,
           )
 
-          sh 'cp ext/allure_files/categories.json allure-results'
-          sh 'cp ext/allure_files/environment.properties allure-results'
+          if (fileExists('allure-results')) {
+            sh 'cp ext/allure_files/categories.json allure-results'
+            sh 'cp ext/allure_files/environment.properties allure-results'
 
-          allure([
-            results: [[path: 'allure-results']],
-            reportBuildPolicy: 'ALWAYS',
-            properties: [],
-            jdk: '',
-          ])
-        }
-      }
-      script {
-        withCredentials([sshUserPrivateKey(
-          credentialsId: 'status-app-benchmarks-deploy-key',
-          keyFileVariable: 'SSH_KEY_FILE'
-        )]) {
-          sh '''
-              eval $(ssh-agent -s)
-              ssh-add $SSH_KEY_FILE
-              ./scripts/push_benchmark.sh
-            '''
+            allure([
+              results: [[path: 'allure-results']],
+              reportBuildPolicy: 'ALWAYS',
+              properties: [],
+              jdk: '',
+            ])
+          } else {
+            echo 'No allure-results directory; skipping Allure report'
+          }
         }
       }
     }
+    success { script {
+      def publishResults = params.PUBLISH_RESULTS == true || "${params.PUBLISH_RESULTS}" == 'true'
+      def shouldPublish = (env.CHANNEL == 'nightly') || publishResults
+      if (!shouldPublish) {
+        echo 'PUBLISH_RESULTS=false; benchmark artifacts will not be committed'
+      } else {
+        /* Serialize publish across nightly + manual jobs (disableConcurrentBuilds is per-job). */
+        lock(resource: 'status-app-benchmarks-publish') {
+          withCredentials([sshUserPrivateKey(
+            credentialsId: 'status-app-benchmarks-deploy-key',
+            keyFileVariable: 'SSH_KEY_FILE'
+          )]) {
+            sh '''
+                eval $(ssh-agent -s)
+                ssh-add $SSH_KEY_FILE
+                ./scripts/push_benchmark.sh
+              '''
+          }
+        }
+      }
+      if (params.CHANGE_ID ==~ /^[0-9]+$/) {
+        env.CHANGE_ID = params.CHANGE_ID
+        env.PKG_URL = shouldPublish
+          ? "https://status-im.github.io/status-app-benchmarks/desktop/pr/${params.CHANGE_ID}/"
+          : "${env.BUILD_URL}consoleText"
+        echo "Notifying PR ${env.CHANGE_ID}: PLATFORM=${env.PLATFORM} PKG_URL=${env.PKG_URL}"
+        github.notifyPR(true)
+      }
+    } }
+    failure { script {
+      if (params.CHANGE_ID ==~ /^[0-9]+$/) {
+        env.CHANGE_ID = params.CHANGE_ID
+        env.PKG_URL = "${env.BUILD_URL}consoleText"
+        echo "Notifying PR ${env.CHANGE_ID} of failure: PLATFORM=${env.PLATFORM} PKG_URL=${env.PKG_URL}"
+        github.notifyPR(false)
+      }
+    } }
     cleanup {
       script {
         powershell '''
@@ -240,6 +333,9 @@ def setBuildDescFromFile(fileNameOrPath) {
     currentBuild.description = utils.baseName(fileNameOrPath)
     return
   }
+  if (tokens.commit) {
+    env.SOURCE_COMMIT = tokens.commit
+  }
   if (tokens.build && tokens.build.startsWith('pr')) {
     currentBuild.displayName = tokens.build.replace(/^pr/, 'PR-')
   }
@@ -249,4 +345,10 @@ def setBuildDescFromFile(fileNameOrPath) {
     Commit: tokens.commit,
     Version: (tokens.tstamp ?: tokens.version),
   ])
+}
+
+def formatMap(Map data=[:]) {
+  def text = ''
+  data.each { key, val -> text += "<b>${key}</b>: ${val}</a><br>\n" }
+  return text
 }

--- a/scripts/push_benchmark.sh
+++ b/scripts/push_benchmark.sh
@@ -21,13 +21,75 @@ GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 echo -e "${GRN}Pushing benchmark results${RST}"
 
 cd "${GIT_ROOT}"
-# Get the commit SHA from the status-app repo BEFORE cloning benchmarks-repo
-commit_sha=$(git rev-parse --short HEAD)
+# GIT_REF selects test code; SOURCE_COMMIT identifies the binary under test.
+pr_number="${PR_NUMBER:-${CHANGE_ID:-}}"
+release_version="${RELEASE_VERSION:-}"
+if [[ -z "${SOURCE_COMMIT:-}" && ( -n "${pr_number}" || -n "${release_version}" ) ]]; then
+  echo "Cannot derive the binary commit from BUILD_SOURCE"
+  exit 2
+fi
+commit_sha="${SOURCE_COMMIT:-$(git rev-parse --short HEAD)}"
+source_ref="${GIT_REF:-$(git rev-parse --abbrev-ref HEAD)}"
+build_source="${BUILD_SOURCE:-}"
+
+if [[ -n "${pr_number}" && -n "${release_version}" ]]; then
+  echo "Set CHANGE_ID or RELEASE_VERSION, not both"
+  exit 2
+fi
+
+if [[ -n "${pr_number}" ]]; then
+  channel=pr
+elif [[ -n "${release_version}" ]]; then
+  channel=release
+else
+  channel="${CHANNEL:-nightly}"
+fi
+
+if [[ "${channel}" == "release" ]]; then
+  if [[ "${release_version}" =~ ^([0-9]+\.[0-9]+) ]]; then
+    release_series="${BASH_REMATCH[1]}"
+  else
+    echo "Cannot derive release series from ${release_version}"
+    exit 2
+  fi
+else
+  release_series=""
+fi
 
 git clone "${REPO_URL}" benchmarks-repo
 cd benchmarks-repo
 
 date_time=$(date -u '+%Y-%m-%dT%H:%M:%S')
+date_compact=$(date -u '+%Y%m%dT%H%M%S')
+build_number="${BUILD_NUMBER:-${date_compact}}"
+
+case "${channel}" in
+  nightly)
+    data_dir="./data"
+    output_dir="./docs/desktop/nightly"
+    build_label="${date_time}|${commit_sha}"
+    run_id="nightly-${commit_sha}-${build_number}"
+    ;;
+  pr)
+    [[ "${pr_number}" =~ ^[0-9]+$ ]] || { echo "CHANGE_ID is required for PR benchmarks"; exit 2; }
+    data_dir="./data/desktop/pr/${pr_number}"
+    output_dir="./docs/desktop/pr/${pr_number}"
+    build_label="PR ${pr_number}"
+    run_id="pr-${pr_number}-${commit_sha}-${build_number}"
+    ;;
+  release)
+    [[ -n "${release_version}" ]] \
+      || { echo "RELEASE_VERSION is required for release benchmarks"; exit 2; }
+    data_dir="./data/desktop/releases/${release_series}"
+    output_dir="./docs/desktop/releases/${release_series}"
+    build_label="${release_version}"
+    run_id="release-${release_version}-${commit_sha}-${build_number}"
+    ;;
+  *)
+    echo "Unsupported benchmark channel: ${channel}"
+    exit 2
+    ;;
+esac
 
 echo -e "${GRN}Creating virtual environment${RST}"
 python3 -m venv .venv
@@ -46,15 +108,39 @@ machine_info_args=()
 [[ -s machine_info.json ]] && machine_info_args=(--machine-info machine_info.json)
 
 echo -e "${GRN}Updating data in repo${RST}"
-${PYTHON_CMD} scripts/benchmark.py --config ./scripts/tests_config.toml parse ../test/e2e/allure-report/ --data-dir ./data --commit-hash "${commit_sha}" --date "${date_time}" "${machine_info_args[@]}"
+results_dir="../test/e2e/benchmark-results"
+if [[ ! -d "${results_dir}" ]]; then
+  echo -e "${YLW}Structured benchmark results not found; falling back to Allure${RST}"
+  results_dir="../test/e2e/allure-report"
+fi
+parse_args=(
+  --config ./scripts/tests_config.toml
+  parse "${results_dir}"
+  --data-dir ./data
+  --run-id "${run_id}"
+  --channel "${channel}"
+  --commit-hash "${commit_sha}"
+  --date "${date_time}"
+  --build-label "${build_label}"
+  --source-ref "${source_ref}"
+  --build-source "${build_source}"
+)
+[[ -n "${pr_number}" ]] && parse_args+=(--pr-number "${pr_number}")
+[[ -n "${release_version}" ]] && parse_args+=(--release-version "${release_version}")
+parse_args+=("${machine_info_args[@]}")
+${PYTHON_CMD} scripts/benchmark.py "${parse_args[@]}"
 
 echo -e "${GRN}Generating new visualizations from data${RST}"
-${PYTHON_CMD} scripts/benchmark.py --config ./scripts/tests_config.toml graphs
+${PYTHON_CMD} scripts/benchmark.py --config ./scripts/tests_config.toml graphs \
+  --data-dir "${data_dir}" \
+  --output-dir "${output_dir}" \
+  --channel "${channel}" \
+  --baseline-dir ./data/desktop/baselines
 
 echo -e "${GRN}Committing changes${RST}"
 rm -f machine_info.json
 git add .
-git commit -m "Add benchmark results for commit ${commit_sha}"
+git commit -m "Add ${channel} benchmark results for ${build_label}"
 
 echo -e "${GRN}Pushing changes${RST}"
 git push "${REPO_URL}"

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -10,6 +10,7 @@ import subprocess
 from tests import test_data
 from configs.system import get_platform
 from fixtures.path import generate_test_info
+from scripts.utils.benchmark_report import finalize_structured_benchmark_result
 from scripts.utils.failure_screenshot import attach_failure_screenshot
 from scripts.utils.system_path import SystemPath
 
@@ -165,6 +166,14 @@ def pytest_runtest_makereport(item, call):
                 rep.longrepr = error_text
     elif rep.failed:
         test_data.error = rep.longreprtext
+
+    if rep.when == 'call' and item.get_closest_marker('benchmark') is not None:
+        finalize_structured_benchmark_result(
+            item.nodeid,
+            item.name,
+            status='passed' if rep.outcome == 'passed' else 'failed',
+            duration_seconds=rep.duration,
+        )
 
 
 def pytest_exception_interact(node, call, report):

--- a/test/e2e/scripts/utils/benchmark_report.py
+++ b/test/e2e/scripts/utils/benchmark_report.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import logging
 import os
 import time
@@ -15,6 +17,8 @@ from scripts.utils.process_metrics import ProcessSampleStats, ProcessMonitor, re
 LOG = logging.getLogger(__name__)
 
 T = TypeVar('T')
+BENCHMARK_RESULTS_ENV = 'BENCHMARK_RESULTS_DIR'
+BENCHMARK_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -67,10 +71,89 @@ def attach_metric_report(
 
 
 def attach_benchmark_metrics(tmp_path: Path, metrics: list[BenchmarkMetricReport]) -> None:
+    record_structured_benchmark_metrics(metrics)
     for metric in metrics:
         report_lines = build_metric_report_lines(metric.line_subject, metric.unit, metric.values)
         with step(f'Attach {metric.attachment_prefix} to Allure'):
             attach_metric_report(tmp_path, report_lines, metric.attachment_prefix, metric.filename)
+
+
+def _current_test_identity() -> tuple[str, str]:
+    nodeid = os.environ.get('PYTEST_CURRENT_TEST', '').split(' (', 1)[0]
+    test_name = nodeid.rsplit('::', 1)[-1] if nodeid else 'unknown'
+    return nodeid, test_name
+
+
+def _result_path(nodeid: str) -> Path | None:
+    results_dir = os.environ.get(BENCHMARK_RESULTS_ENV, '').strip()
+    if not results_dir:
+        return None
+    digest = hashlib.sha256(nodeid.encode('utf-8')).hexdigest()[:16]
+    path = Path(results_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    return path / f'{digest}.json'
+
+
+def _load_result(path: Path, nodeid: str, test_name: str) -> dict:
+    if path.exists():
+        return json.loads(path.read_text(encoding='utf-8'))
+    return {
+        'schema_version': BENCHMARK_SCHEMA_VERSION,
+        'nodeid': nodeid,
+        'test_name': test_name,
+        'status': 'unknown',
+        'duration_ms': 0,
+        'retries_count': 0,
+        'flaky': False,
+        'attempts': 0,
+        'metrics': [],
+    }
+
+
+def _write_result(path: Path, result: dict) -> None:
+    path.write_text(json.dumps(result, indent=2, sort_keys=True), encoding='utf-8')
+
+
+def record_structured_benchmark_metrics(metrics: list[BenchmarkMetricReport]) -> None:
+    """Write versioned raw samples independently of the Allure report."""
+    nodeid, test_name = _current_test_identity()
+    path = _result_path(nodeid)
+    if path is None:
+        return
+    result = _load_result(path, nodeid, test_name)
+    by_name = {metric['name']: metric for metric in result.get('metrics', [])}
+    for metric in metrics:
+        by_name[metric.attachment_prefix] = {
+            'name': metric.attachment_prefix,
+            'unit': metric.unit,
+            'values': metric.values,
+        }
+    result['metrics'] = list(by_name.values())
+    _write_result(path, result)
+
+
+def finalize_structured_benchmark_result(
+    nodeid: str,
+    test_name: str,
+    *,
+    status: str,
+    duration_seconds: float,
+) -> None:
+    """Record final pytest status and retries for a benchmark test attempt."""
+    path = _result_path(nodeid)
+    if path is None:
+        return
+    result = _load_result(path, nodeid, test_name)
+    previous_status = result.get('status', 'unknown')
+    attempts = int(result.get('attempts', 0)) + 1
+    result.update({
+        'status': status,
+        'duration_ms': round(float(result.get('duration_ms', 0)) + duration_seconds * 1000),
+        'attempts': attempts,
+        'retries_count': max(0, attempts - 1),
+        'flaky': status == 'passed' and previous_status in {'failed', 'broken'},
+    })
+    _write_result(path, result)
 
 
 def enable_benchmark_mode() -> None:


### PR DESCRIPTION
### What does the PR do

- Extend `ci/Jenkinsfile.tests-e2e.windows-benchmark` so one pipeline covers nightly, PR, and release runs. Two Jenkins jobs share this file:
  - `nightly-benchmark-windows-master` — cron, empty `CHANGE_ID`/`RELEASE_VERSION`, always publishes
  - `status-app/e2e/manual-benchmarks-job` — set `CHANGE_ID` **or** `RELEASE_VERSION`, plus `GIT_REF`, `BUILD_SOURCE`, `TEST_NAME`, `PUBLISH_RESULTS` (default false)
- Channel, series, label, run id, and binary commit are derived. PR/RC runs reject the nightly default `BUILD_SOURCE`.
- `push_benchmark.sh` publishes into isolated datasets (`data/`, `data/desktop/pr/<n>/`, `data/desktop/releases/<series>/`) and prefers pytest JSON over Allure.
- Benchmark tests emit versioned JSON when `BENCHMARK_RESULTS_DIR` is set.

Depends on https://github.com/status-im/status-app-benchmarks/pull/27
Causes https://github.com/status-im/github-comment-manager/pull/29
