### PR TITLE
Two fixes to the CreateChatView

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -154,7 +154,7 @@ QtObject {
         }
 
         exposedRoles: ["key", "symbol", "shortName", "name", "category"]
-        expectedRoles: ["symbol", "collectionName", "collectionUid"]
+        expectedRoles: ["collectionName", "collectionUid"]
     }
 
     readonly property var walletCollectiblesGroupingModel: GroupingModel {

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -37,7 +37,7 @@ Page {
         id: d
 
         function createChat() {
-            root.createChatPropertiesStore.createChatInitMessage = chatInput.textInput.text
+            root.createChatPropertiesStore.createChatInitMessage = chatInput.getTextWithPublicKeys()
             root.createChatPropertiesStore.createChatFileUrls = chatInput.fileUrlsAndSources
             membersSelector.createChat()
 
@@ -171,11 +171,11 @@ Page {
 
                 Layout.alignment: Qt.AlignBottom
                 Layout.fillWidth: true
-                visible: membersSelector.model.count > 0
+                visible: !membersSelector.model.ModelCount.empty
                 emojiPopup: root.emojiPopup
                 stickersPopup: root.stickersPopup
                 closeGifPopupAfterSelection: true
-                usersModel: membersSelector.model
+                usersModel: membersSelector.selectedContactsModel
                 paymentRequestFeatureEnabled: false
                 onStickerSelected: (hashId, packId, url) => {
                     root.createChatPropertiesStore.createChatStickerHashId = hashId;
@@ -184,7 +184,8 @@ Page {
                     membersSelector.createChat();
                 }
 
-                onOpenGifPopupRequest: root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
+                onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) =>
+                    root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
                 onSendMessageRequested: { d.createChat() }
             }
         }

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -28,6 +28,8 @@ Page {
     property var mutualContactsModel
     property var allContactsModel
 
+    signal openGifPopupRequest(var params, var cbOnGifSelected, var cbOnClose)
+
     property var emojiPopup: null
     property var stickersPopup: null
 
@@ -182,6 +184,7 @@ Page {
                     membersSelector.createChat();
                 }
 
+                onOpenGifPopupRequest: root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
                 onSendMessageRequested: { d.createChat() }
             }
         }

--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -2,8 +2,10 @@ import QtQuick
 import QtQuick.Controls
 import QtQml.Models
 
+import StatusQ
 import StatusQ.Controls
 import StatusQ.Components
+import StatusQ.Core.Utils
 
 import AppLayouts.Profile.helpers
 
@@ -12,11 +14,17 @@ import "private"
 import shared.stores
 import utils
 
+import QtModelsToolkit
+import SortFilterProxyModel
+
 MembersSelectorBase {
     id: root
 
     property UtilsStore utilsStore
     property var allContactsModel
+
+    // Selected members carrying the full contact role set (unlike the plain `model`)
+    readonly property alias selectedContactsModel: selectedContacts
 
     signal resolveENS(string address)
     signal populateContactDetails(string pubkey)
@@ -73,6 +81,28 @@ MembersSelectorBase {
         elideMode: Text.ElideMiddle
 
         onClosed: root.entryRemoved(this)
+    }
+
+    SortFilterProxyModel {
+        id: selectedContacts
+
+        sourceModel: root.contactsModel
+
+        // Kept out of the expression below; singletons and attached types are not
+        // resolvable in its context
+        readonly property int selectedCount: root.model.ModelCount.count
+
+        function isMemberPredicate(pubKey) {
+            return ModelUtils.contains(root.model, "pubKey", pubKey)
+        }
+
+        filters: FastExpressionFilter {
+            expression: {
+                selectedContacts.selectedCount // ensure expression is reevaluated when members model changes
+                return selectedContacts.isMemberPredicate(model.pubKey)
+            }
+            expectedRoles: ["pubKey"]
+        }
     }
 
     QtObject {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2450,7 +2450,8 @@ Item {
                         emojiPopup: statusEmojiPopup.item
                         stickersPopup: statusStickersPopupLoader.item
 
-                        onOpenGifPopupRequest: popupRequestsHandler.openGifs(params, cbOnGifSelected, cbOnClose)
+                        onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) =>
+                            popupRequestsHandler.openGifs(params, cbOnGifSelected, cbOnClose)
                     }
                 }
             }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2449,6 +2449,8 @@ Item {
 
                         emojiPopup: statusEmojiPopup.item
                         stickersPopup: statusStickersPopupLoader.item
+
+                        onOpenGifPopupRequest: popupRequestsHandler.openGifs(params, cbOnGifSelected, cbOnClose)
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

Fixes #21814

- Fix gif popup not being wires
- Fix mentions showing as undefined

### Affected areas

- CreateChatView
- MemberSelectorView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction

### Screencapture of the functionality

Gif fix:

[gif-sending.webm](https://github.com/user-attachments/assets/3b7cd0e0-d0f9-4ec7-88e7-bd2a33aa0b95)

Mentions fix:

[fix-mentions.webm](https://github.com/user-attachments/assets/01360485-5792-4544-b0c1-37226e10a949)

### Impact on end user

makes the CreateChatView better

### How to test

- have contacts
- open create chat view
- select members
- try to send a gif
- try to send mentions

### Risk 

Low
