### PR TITLE
fix: the same address can not be simultaneously saved as watch only and saved address

### DIFF
--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -479,13 +479,13 @@ method destroyAddAccountPopup*(self: Module) =
 method runAddAccountPopup*(self: Module, addingWatchOnlyAccount: bool) =
   self.destroyAddAccountPopup()
   self.addAccountModule = add_account_module.newModule(self, self.events, self.accountsService,
-    self.walletAccountService, self.savedAddressService)
+    self.walletAccountService)
   self.addAccountModule.loadForAddingAccount(addingWatchOnlyAccount)
 
 method runEditAccountPopup*(self: Module, address: string) =
   self.destroyAddAccountPopup()
   self.addAccountModule = add_account_module.newModule(self, self.events, self.accountsService,
-    self.walletAccountService, self.savedAddressService)
+    self.walletAccountService)
   self.addAccountModule.loadForEditingAccount(address)
 
 method getAddAccountModule*(self: Module): QVariant =

--- a/src/app/modules/shared_modules/add_account/controller.nim
+++ b/src/app/modules/shared_modules/add_account/controller.nim
@@ -4,7 +4,6 @@ import io_interface
 
 import app_service/service/accounts/service as accounts_service
 import app_service/service/wallet_account/service as wallet_account_service
-import app_service/service/saved_address/service as saved_address_service
 
 import app/core/eventemitter
 
@@ -17,7 +16,6 @@ type
     events: EventEmitter
     accountsService: accounts_service.Service
     walletAccountService: wallet_account_service.Service
-    savedAddressService: saved_address_service.Service
     connectionIds: seq[UUID]
     tmpAuthenticatedKeyUid: string
     tmpPassword: string
@@ -28,15 +26,13 @@ type
 proc newController*(delegate: io_interface.AccessInterface,
   events: EventEmitter,
   accountsService: accounts_service.Service,
-  walletAccountService: wallet_account_service.Service,
-  savedAddressService: saved_address_service.Service):
+  walletAccountService: wallet_account_service.Service):
   Controller =
   result = Controller()
   result.delegate = delegate
   result.events = events
   result.accountsService = accountsService
   result.walletAccountService = walletAccountService
-  result.savedAddressService = savedAddressService
 
 proc disconnectAll*(self: Controller) =
   for id in self.connectionIds:
@@ -74,11 +70,6 @@ proc init*(self: Controller) =
     self.delegate.updateDerivedAddresses(args.derivedAddresses, args.error, false)
   self.connectionIds.add(handlerId)
 
-  handlerId = self.events.onWithUUID(SIGNAL_SAVED_ADDRESS_DELETED) do(e:Args):
-    let args = SavedAddressArgs(e)
-    self.delegate.savedAddressDeleted(args.address, args.errorMsg)
-  self.connectionIds.add(handlerId)
-
 proc setAuthenticatedKeyUid*(self: Controller, value: string) =
   self.tmpAuthenticatedKeyUid = value
 
@@ -108,12 +99,6 @@ proc getKeypairs*(self: Controller): seq[KeypairDto] =
 
 proc getKeypairByKeyUid*(self: Controller, keyUid: string): KeypairDto =
   return self.walletAccountService.getKeypairByKeyUid(keyUid)
-
-proc getSavedAddress*(self: Controller, address: string): SavedAddressDto =
-  return self.savedAddressService.getSavedAddress(address)
-
-proc deleteSavedAddress*(self: Controller, address: string) =
-  self.savedAddressService.deleteSavedAddress(address)
 
 proc finalizeAction*(self: Controller) =
   self.delegate.finalizeAction()

--- a/src/app/modules/shared_modules/add_account/io_interface.nim
+++ b/src/app/modules/shared_modules/add_account/io_interface.nim
@@ -96,12 +96,6 @@ method buildNewPrivateKeyKeypairAndAddItToOrigin*(self: AccessInterface) {.base.
 method buildNewSeedPhraseKeypairAndAddItToOrigin*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method removingSavedAddressConfirmed*(self: AccessInterface, address: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method savedAddressDeleted*(self: AccessInterface, address: string, errorMsg: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method isChecksumValidForAddress*(self: AccessInterface, address: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -16,7 +16,6 @@ const dummyUsage = account_constants.ZERO_ADDRESS # dummy usage to prevent false
 
 import app_service/service/accounts/service as accounts_service
 import app_service/service/wallet_account/service as wallet_account_service
-import app_service/service/saved_address/service as saved_address_service
 
 export io_interface
 
@@ -53,16 +52,14 @@ proc doAddAccount[T](self: Module[T])
 proc newModule*[T](delegate: T,
   events: EventEmitter,
   accountsService: accounts_service.Service,
-  walletAccountService: wallet_account_service.Service,
-  savedAddressService: saved_address_service.Service):
+  walletAccountService: wallet_account_service.Service):
   Module[T] =
   result = Module[T]()
   result.delegate = delegate
   result.events = events
   result.view = newView(result)
   result.viewVariant = newQVariant(result.view)
-  result.controller = controller.newController(result, events, accountsService, walletAccountService,
-    savedAddressService)
+  result.controller = controller.newController(result, events, accountsService, walletAccountService)
   result.authenticationReason = AuthenticationReason.AddingAccount
   result.fetchingAddressesIsInProgress = false
   result.addAccountRequested = false
@@ -635,11 +632,6 @@ proc doAddAccount[T](self: Module[T]) =
     publicKey = ""
     keyUid = ""
 
-  let savedAddressDto = self.controller.getSavedAddress(address)
-  if not savedAddressDto.isNil:
-    self.view.sendConfirmSavedAddressRemovalSignal(savedAddressDto.name, savedAddressDto.address)
-    return
-
   var success = false
   if addingNewKeyPair:
     if selectedOrigin.getPairType() == KeyPairType.PrivateKeyImport.int:
@@ -687,15 +679,6 @@ proc doAddAccount[T](self: Module[T]) =
       error "failed to store account", address=selectedAddrItem.getAddress()
 
   self.closeAddAccountPopup()
-
-method removingSavedAddressConfirmed[T](self: Module[T], address: string) =
-  self.controller.deleteSavedAddress(address)
-
-method savedAddressDeleted*[T](self: Module[T], address: string, errorMsg: string) =
-  if errorMsg.len > 0:
-    error "failed to delete saved address", address=address, err=errorMsg
-    return
-  self.doAddAccount()
 
 proc doEditAccount[T](self: Module[T]) =
   self.view.setDisablePopup(true)

--- a/src/app/modules/shared_modules/add_account/view.nim
+++ b/src/app/modules/shared_modules/add_account/view.nim
@@ -350,16 +350,6 @@ QtObject:
   proc startScanningForActivity*(self: View) {.slot.} =
     self.delegate.startScanningForActivity()
 
-  proc confirmSavedAddressRemoval*(self: View, name: string, address: string) {.signal.}
-  proc sendConfirmSavedAddressRemovalSignal*(self: View, name: string, address: string) =
-    self.confirmSavedAddressRemoval(name, address)
-
-  proc removingSavedAddressConfirmed*(self: View, address: string) {.slot.} =
-    self.delegate.removingSavedAddressConfirmed(address)
-
-  proc removingSavedAddressRejected*(self: View) {.slot.} =
-    self.setDisablePopup(false)
-
   proc isChecksumValidForAddress*(self: View, address: string): bool {.slot.} =
     return self.delegate.isChecksumValidForAddress(address)
 

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -714,22 +714,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Removing saved address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The account you&apos;re trying to add &lt;b&gt;%1&lt;/b&gt; is already saved under the name &lt;b&gt;%2&lt;/b&gt;.&lt;br/&gt;&lt;br/&gt;Do you want to remove it from saved addresses in favour of adding it to the Wallet?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save changes</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -714,22 +714,6 @@
         <translation type="unfinished">Zavřít</translation>
     </message>
     <message>
-        <source>Removing saved address</source>
-        <translation>Odstranění uložené adresy</translation>
-    </message>
-    <message>
-        <source>The account you&apos;re trying to add &lt;b&gt;%1&lt;/b&gt; is already saved under the name &lt;b&gt;%2&lt;/b&gt;.&lt;br/&gt;&lt;br/&gt;Do you want to remove it from saved addresses in favour of adding it to the Wallet?</source>
-        <translation>Účet, který se pokoušíte přidat &lt;b&gt;%1&lt;/b&gt;, je již uložen pod názvem &lt;b&gt;%2&lt;/b&gt;.&lt;br/&gt;&lt;br/&gt;Chcete jej odstranit z uložených adres a přidat do peněženky?</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation>Ano</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation>Ne</translation>
-    </message>
-    <message>
         <source>Save changes</source>
         <translation>Uložit změny</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -714,22 +714,6 @@
         <translation type="unfinished">Cerrar</translation>
     </message>
     <message>
-        <source>Removing saved address</source>
-        <translation>Eliminando dirección guardada</translation>
-    </message>
-    <message>
-        <source>The account you&apos;re trying to add &lt;b&gt;%1&lt;/b&gt; is already saved under the name &lt;b&gt;%2&lt;/b&gt;.&lt;br/&gt;&lt;br/&gt;Do you want to remove it from saved addresses in favour of adding it to the Wallet?</source>
-        <translation>La cuenta que intentas agregar &lt;b&gt;%1&lt;/b&gt; ya está guardada con el nombre &lt;b&gt;%2&lt;/b&gt;.&lt;br/&gt;&lt;br/&gt;¿Quieres eliminarla de las direcciones guardadas para agregarla a la Billetera?</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation>Sí</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation>No</translation>
-    </message>
-    <message>
         <source>Save changes</source>
         <translation>Guardar cambios</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -714,22 +714,6 @@
         <translation type="unfinished">닫기</translation>
     </message>
     <message>
-        <source>Removing saved address</source>
-        <translation>저장된 주소 제거 중</translation>
-    </message>
-    <message>
-        <source>The account you&apos;re trying to add &lt;b&gt;%1&lt;/b&gt; is already saved under the name &lt;b&gt;%2&lt;/b&gt;.&lt;br/&gt;&lt;br/&gt;Do you want to remove it from saved addresses in favour of adding it to the Wallet?</source>
-        <translation>추가하려는 계정 &lt;b&gt;%1&lt;/b&gt;은 이미 &lt;b&gt;%2&lt;/b&gt; 이름으로 저장되어 있습니다.&lt;br/&gt;&lt;br/&gt;저장된 주소에서 제거하고 지갑에 추가하시겠습니까?</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation>예</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation>아니오</translation>
-    </message>
-    <message>
         <source>Save changes</source>
         <translation>변경사항 저장</translation>
     </message>

--- a/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
+++ b/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
@@ -42,9 +42,6 @@ StatusModal {
 
     Connections {
         target: root.store.addAccountModule
-        function onConfirmSavedAddressRemoval(name, address) {
-            Global.openPopup(confirmSavedAddressRemoval, {address: address, name: name})
-        }
         function onXpubMissingForSelectedOrigin(keypairName) {
             Global.openPopup(reImportKeypairDialog, {keypairName: keypairName})
         }
@@ -202,35 +199,6 @@ StatusModal {
             }
         }
 
-        Component {
-            id: confirmSavedAddressRemoval
-
-            ConfirmationDialog {
-
-                property string name
-                property string address
-
-                closePolicy: Popup.NoAutoClose
-                headerSettings.title: qsTr("Removing saved address")
-                confirmationText: qsTr("The account you're trying to add <b>%1</b> is already saved under the name <b>%2</b>.<br/><br/>Do you want to remove it from saved addresses in favour of adding it to the Wallet?")
-                .arg(address)
-                .arg(name)
-                showCancelButton: true
-                cancelBtnType: ""
-                confirmButtonLabel: qsTr("Yes")
-                cancelButtonLabel: qsTr("No")
-
-                onConfirmButtonClicked: {
-                    root.store.addAccountModule.removingSavedAddressConfirmed(address)
-                    close()
-                }
-
-                onCancelButtonClicked: {
-                    root.store.addAccountModule.removingSavedAddressRejected()
-                    close()
-                }
-            }
-        }
     }
 
     leftButtons: [


### PR DESCRIPTION
Code that checks whether an address already exists among saved addresses has been removed and now the same address can be simultaneously saved as watch only and a saved address.

Fun fact is that when users were adding a new saved address the app was not checking if that address was already added to watch-only addresses, so in that regard, we didn't have anything to do/remove. :)

Fixes #20712