### PR TITLE
chore: reduce account and keypair name minimum length to 1 char

### DIFF
--- a/storybook/qmlTests/tests/tst_AccountAndKeypairNameValidators.qml
+++ b/storybook/qmlTests/tests/tst_AccountAndKeypairNameValidators.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Profile.popups
+import shared.popups.keycard_new.states
+
+import utils
+
+Item {
+    id: root
+
+    width: 600
+    height: 700
+
+    Component {
+        id: renameAccountModalComponent
+
+        RenameAccountModal {
+            accountName: "Sample Account"
+            accountColorId: Constants.walletAccountColors.orange
+            destroyOnClose: false
+        }
+    }
+
+    Component {
+        id: enterKeyPairNameStateComponent
+
+        EnterKeyPairNameState {
+            width: 400
+        }
+    }
+
+    TestCase {
+        name: "AccountAndKeypairNameValidators"
+        when: windowShown
+
+        function setAndValidate(input, text) {
+            input.text = text
+            input.validate(true)
+        }
+
+        function test_minLengthConstants() {
+            compare(Constants.addAccountPopup.keyPairAccountNameMinLength, 1)
+            compare(Constants.keypair.nameLengthMin, 1)
+            compare(Constants.displayName.nameLengthMin, 5)
+        }
+
+        function test_accountName_emptyIsInvalidOneCharIsValid() {
+            const popup = createTemporaryObject(renameAccountModalComponent, root)
+            verify(!!popup)
+            popup.open()
+            tryCompare(popup, "opened", true)
+
+            const input = popup.contentItem.accountNameInput
+            verify(!!input)
+
+            setAndValidate(input, "")
+            verify(!input.valid, "empty account name must be invalid")
+            compare(input.errorMessageCmp.text,
+                    qsTr("Account name must be at least %n character(s)", "",
+                         Constants.addAccountPopup.keyPairAccountNameMinLength))
+
+            setAndValidate(input, "a")
+            verify(input.valid, "a 1-character account name must be valid")
+
+            popup.close()
+        }
+
+        function test_keypairName_emptyIsInvalidOneCharIsValid() {
+            const state = createTemporaryObject(enterKeyPairNameStateComponent, root)
+            verify(!!state)
+            waitForRendering(state)
+
+            const input = findChild(state, "keycardKeyPairNameInput")
+            verify(!!input)
+
+            setAndValidate(input, "")
+            verify(!input.valid, "empty key pair name must be invalid")
+            compare(input.errorMessageCmp.text,
+                    qsTr("Key pair must be at least %n character(s)", "",
+                         Constants.keypair.nameLengthMin))
+
+            setAndValidate(input, "a")
+            verify(input.valid, "a 1-character key pair name must be valid")
+        }
+    }
+}

--- a/test/e2e/constants/wallet.py
+++ b/test/e2e/constants/wallet.py
@@ -162,9 +162,9 @@ class WalletSeedPhrase(Enum):
 
 
 class WalletAccountPopup(Enum):
-    WALLET_ACCOUNT_NAME_MIN = 'Account name must be at least 5 characters'
-    WALLET_KEYPAIR_NAME_MIN = 'Key pair name must be at least 5 characters'
-    WALLET_KEYPAIR_MIN = 'Key pair must be at least 5 character(s)'
+    WALLET_ACCOUNT_NAME_MIN = 'Account name must be at least 1 character'
+    WALLET_KEYPAIR_NAME_MIN = 'Key pair name must be at least 1 character'
+    WALLET_KEYPAIR_MIN = 'Key pair must be at least 1 character(s)'
 
 E2E_NETWORK_CHAIN_IDS: dict[str, int] = {
     "Hoodi": WalletNetworkNaming.HOODI_NETWORK_ID.value,

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_rename_keypair.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_rename_keypair.py
@@ -32,13 +32,13 @@ def test_rename_keypair_test(main_screen: MainWindow, user_account, emoji: str, 
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(random_wallet_acc_keypair_name()).set_emoji(emoji)
 
-    with step('Enter private key name less than 5 characters and verify that error appears'):
-        pk_name_short = ''.join(random.choices(string.ascii_letters + string.digits, k=4))
+    with step('Enter empty private key name and verify that error appears'):
         new_account_popup = account_popup.open_add_new_account_popup()
-        new_account_popup.import_and_enter_private_key(address_pair.private_key).enter_private_key_name(pk_name_short)
+        new_account_popup.import_and_enter_private_key(address_pair.private_key).enter_private_key_name('a')
+        new_account_popup.enter_private_key_name('')
         assert new_account_popup.get_private_key_error_message() == WalletAccountPopup.WALLET_KEYPAIR_NAME_MIN.value
 
-    with step('Enter private key name more than 5 characters and continue creating of import private key account'):
+    with step('Enter private key name and continue creating of import private key account'):
         pk_name = ''.join(random.choices(string.ascii_letters + string.digits, k=5))
         new_account_popup.enter_private_key_name(pk_name).click_continue()
         account_popup.save_changes()

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -31,9 +31,12 @@ def test_add_new_account_from_wallet_settings(
 
     with step('Add a new generated account from wallet settings screen'):
 
-        with step('Verify that error appears when name consists of less then 5 characters'):
-            add_account_popup.set_name(''.join(random.choices(string.ascii_letters +
-                                                              string.digits, k=4)))
+        with step('Verify that a one character name is accepted'):
+            add_account_popup.set_name(''.join(random.choices(string.ascii_letters + string.digits, k=1)))
+            assert add_account_popup.get_error_message() == ''
+
+        with step('Verify that error appears when name is empty'):
+            add_account_popup.set_name('')
             assert add_account_popup.get_error_message() == WalletAccountPopup.WALLET_ACCOUNT_NAME_MIN.value
 
         add_account_popup.set_name(wallet_account.name).save_changes()

--- a/ui/imports/shared/popups/NicknamePopup.qml
+++ b/ui/imports/shared/popups/NicknamePopup.qml
@@ -37,7 +37,7 @@ CommonContactDialog {
         label: qsTr("Nickname")
         input.clearable: true
         text: root.nickname
-        charLimit: Constants.keypair.nameLengthMax
+        charLimit: Constants.displayName.nameLengthMax
         validators: [
             StatusValidator {
                 validatorObj: RXValidator { regularExpression: /^[\w\d_ -\.]*$/u }
@@ -45,7 +45,7 @@ CommonContactDialog {
                 errorMessage: qsTr("Invalid characters (use A-Z and 0-9, hyphens and underscores only)")
             },
             StatusMinLengthValidator {
-                minLength: Constants.keypair.nameLengthMin
+                minLength: Constants.displayName.nameLengthMin
                 errorMessage: qsTr("Nicknames must be at least %n character(s) long", "", minLength)
             },
             StatusValidator {

--- a/ui/imports/shared/validators/DisplayNameValidators.qml
+++ b/ui/imports/shared/validators/DisplayNameValidators.qml
@@ -28,16 +28,16 @@ QtObject {
             errorMessage: qsTr("Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)")
         },
         StatusMinLengthValidator {
-            minLength: Constants.keypair.nameLengthMin
+            minLength: Constants.displayName.nameLengthMin
             errorMessage: qsTr("Display Names must be at least %n character(s) long",
-                               "", Constants.keypair.nameLengthMin)
+                               "", Constants.displayName.nameLengthMin)
         },
         // TODO: Create `StatusMaxLengthValidator` in StatusQ
         StatusValidator {
             name: "maxLengthValidator"
-            validate: t => t.length <= Constants.keypair.nameLengthMax
+            validate: t => t.length <= Constants.displayName.nameLengthMax
             errorMessage: qsTr("Display Names can’t be longer than %n character(s)",
-                               "", Constants.keypair.nameLengthMax)
+                               "", Constants.displayName.nameLengthMax)
         },
         StatusValidator {
             name: "endsWith-ethValidator"

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -377,9 +377,14 @@ QtObject {
         readonly property int rejectedReceivedContactRequest: 3
     }
 
-    readonly property QtObject keypair: QtObject {
+    readonly property QtObject displayName: QtObject {
         readonly property int nameLengthMax: 20
         readonly property int nameLengthMin: 5
+    }
+
+    readonly property QtObject keypair: QtObject {
+        readonly property int nameLengthMax: 20
+        readonly property int nameLengthMin: 1
 
         readonly property QtObject type: QtObject {
             readonly property int unknown: -1
@@ -620,7 +625,7 @@ QtObject {
         readonly property int importPrivateKeyWarningHeight: 86
         readonly property int footerButtonsHeight: 44
         readonly property int keyPairNameMaxLength: 20
-        readonly property int keyPairAccountNameMinLength: 5
+        readonly property int keyPairAccountNameMinLength: 1
         readonly property int stepperWidth: 242
 
         readonly property QtObject keyPairType: QtObject {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -412,13 +412,13 @@ QtObject {
                 validate: function (t) { return !t.startsWith(" ") }
                 errorMessage: qsTr("Key pair starting with whitespace are not allowed")
             },
-            StatusRegularExpressionValidator {
-                regularExpression: /^[a-zA-Z0-9\-_ ]+$/
-                errorMessage: errorMessages.alphanumericalExpandedRegExp
-            },
             StatusMinLengthValidator {
                 minLength: keypair.nameLengthMin
                 errorMessage: qsTr("Key pair must be at least %n character(s)", "", keypair.nameLengthMin)
+            },
+            StatusRegularExpressionValidator {
+                regularExpression: /^[a-zA-Z0-9\-_ ]+$/
+                errorMessage: errorMessages.alphanumericalExpandedRegExp
             }
         ]
     }


### PR DESCRIPTION
The minimum length for account names and key pair names has been reduced to 1 character.

Closes #20715