### PR TITLE
test: guards for the critical findings of the perf stack review

### DIFF
--- a/storybook/qmlTests/tests/tst_CollapsedCategoryVirtualization.qml
+++ b/storybook/qmlTests/tests/tst_CollapsedCategoryVirtualization.qml
@@ -1,0 +1,102 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Components
+
+// Guard (stack PR #21943): chats hidden by a collapsed category must be
+// filtered out of the view via the model-computed "hidden" role — a
+// zero-height delegate would still be instantiated by the ListView (with
+// spacing 0 a zero-height item never advances the fill cursor, so one pass
+// would synchronously instantiate every hidden row of the category).
+Item {
+    id: root
+
+    width: 400
+    height: 600
+
+    ListModel { id: chatsModel }
+
+    StatusChatList {
+        id: chatList
+        anchors.fill: parent
+        model: chatsModel
+    }
+
+    TestCase {
+        name: "CollapsedCategoryVirtualization"
+        when: windowShown
+
+        function test_collapsedCategoryStaysVirtualized() {
+            chatsModel.append({
+                itemId: "cat-0",
+                categoryId: "cat-0",
+                name: "Collapsed category",
+                type: 0,
+                muted: false,
+                active: false,
+                blocked: false,
+                hasUnreadMessages: false,
+                notificationsCount: 0,
+                highlight: false,
+                icon: "",
+                emoji: "",
+                color: "",
+                colorId: 0,
+                categoryOpened: false,
+                hidden: false,
+                usesDefaultName: false,
+                onlineStatus: 1,
+                requiresPermissions: false,
+                locked: false,
+                isCategory: true,
+                position: 0,
+                categoryPosition: 0,
+                lastMessageTimestamp: 0
+            })
+
+            // 500 channels of that category: not active, not unread, not
+            // mentioned — the backend computes hidden == true for every one
+            for (let i = 0; i < 500; ++i) {
+                chatsModel.append({
+                    itemId: "chat-" + i,
+                    categoryId: "cat-0",
+                    name: "Channel " + i,
+                    type: 1,
+                    muted: false,
+                    active: false,
+                    blocked: false,
+                    hasUnreadMessages: false,
+                    notificationsCount: 0,
+                    highlight: false,
+                    icon: "",
+                    emoji: "",
+                    color: "",
+                    colorId: i % 10,
+                    categoryOpened: false,
+                    hidden: true,
+                    usesDefaultName: false,
+                    onlineStatus: 1,
+                    requiresPermissions: false,
+                    locked: false,
+                    isCategory: false,
+                    position: i,
+                    categoryPosition: 0,
+                    lastMessageTimestamp: 1000000 - i
+                })
+            }
+
+            // hidden rows are filtered out of the view model entirely
+            const lv = chatList.statusChatListItems
+            tryCompare(lv, "count", 1)
+            waitForRendering(lv)
+
+            // geometry contract: the collapsed category is the only visible row
+            compare(lv.contentHeight, chatList.categoryRowHeight)
+
+            const created = lv.contentItem.children.length
+            verify(created < 60,
+                   "expected the hidden rows to stay virtualized, got "
+                   + created + " instantiated delegates")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_WalletLoaderDeepLink.qml
+++ b/storybook/qmlTests/tests/tst_WalletLoaderDeepLink.qml
@@ -1,0 +1,66 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.stores as AppStores
+
+import mainui.sectionLoaders
+
+// RED (stack PR #21918): WalletLoader became asynchronous, but the wallet
+// deep-link entry point (AppMain.qml, onAppSectionBySectionTypeChanged) still
+// dereferences the loaded item in the same tick as the section activation:
+// `appView.children[...wallet].item.openDesiredView(subsection, ...)`. With
+// async incubation `item` is null at that point, so activity-center and toast
+// redirects to a transaction throw a TypeError and the txHash payload is
+// dropped. The loader must expose a queuing openDesiredView forwarder (the
+// pattern ProfileLoader.forceSubsectionNavigation already uses) that replays
+// the navigation once the section finishes incubating.
+Item {
+    id: root
+
+    width: 800
+    height: 600
+
+    AppStores.RootStore { id: appRootStore }
+    AppStores.ContactsStore { id: appContactsStore }
+    AppStores.FeatureFlagsStore { id: appFeatureFlagsStore }
+
+    Loader { id: dummyLoader }
+
+    WalletLoader {
+        id: walletLoader
+        anchors.fill: parent
+
+        // never load the real section in the test harness
+        active: false
+
+        rootStore: appRootStore
+        contactsStore: appContactsStore
+        featureFlagsStore: appFeatureFlagsStore
+        sharedRootStore: null
+        networkConnectionStore: null
+        networksStore: null
+        communitiesStore: null
+        transactionStore: null
+        popupHandler: null
+        dappsServiceLoader: dummyLoader
+        emojiPopupLoader: dummyLoader
+    }
+
+    TestCase {
+        name: "WalletLoaderDeepLink"
+        when: windowShown
+
+        function test_deepLinkSurvivesAsyncIncubation() {
+            verify(walletLoader.asynchronous,
+                   "precondition: the wallet section loads asynchronously")
+
+            // AppMain fires the deep link in the same tick as the section
+            // activation, when `item` does not exist yet — the loader itself
+            // must accept and queue the navigation.
+            verify(typeof walletLoader.openDesiredView === "function",
+                   "WalletLoader must expose openDesiredView and queue it until "
+                   + "the section item exists; today AppMain dereferences "
+                   + "`.item.openDesiredView(...)` and throws while incubating")
+        }
+    }
+}

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -80,3 +80,7 @@ add_test(NAME TestHttpStats COMMAND TestHttpStats)
 add_executable(TestNetworkAccessFactory src/tst_networkaccessfactory.cpp)
 target_link_libraries(TestNetworkAccessFactory PRIVATE Qt::Test Qt::Network Qt::Qml StatusQ)
 add_test(NAME TestNetworkAccessFactory COMMAND TestNetworkAccessFactory)
+
+add_executable(TestIncubationController src/tst_incubationcontroller.cpp)
+target_link_libraries(TestIncubationController PRIVATE Qt::Test Qt::Gui Qt::Qml Qt::Quick StatusQ)
+add_test(NAME TestIncubationController COMMAND TestIncubationController)

--- a/ui/StatusQ/tests/src/tst_incubationcontroller.cpp
+++ b/ui/StatusQ/tests/src/tst_incubationcontroller.cpp
@@ -1,0 +1,187 @@
+// RED (stack PR #21921): once the gentle window of the boosted incubation
+// controller expires, the controller re-arms itself with a zero-interval
+// timer and calls incubateFor(msPerTick) on every event-loop pass. A zero
+// timer never lets the dispatcher sleep, so the GUI thread runs a
+// back-to-back block/incubate duty cycle for the remainder of the burst:
+// one core is pinned and every posted event (input, UpdateRequest) waits up
+// to a full tick (20 ms in the shipped configuration). The boosted phase
+// must be paced with a non-zero interval so the event loop breathes between
+// ticks.
+
+#include <QtTest>
+
+#include <QAbstractEventDispatcher>
+#include <QElapsedTimer>
+#include <QGuiApplication>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQmlIncubator>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+extern "C" void statusq_installBoostedIncubationController(void* engine, int msPerTick,
+                                                           int gentlePeriodMs);
+
+namespace {
+
+// Enough plain Items that a single asynchronous incubation spans several
+// controller ticks
+QByteArray largeComponentQml()
+{
+    QByteArray qml = "import QtQuick\nItem{";
+    for (int i = 0; i < 30000; ++i)
+        qml += "Item{}";
+    qml += "}";
+    return qml;
+}
+
+int minRegisteredTimerIntervalMs(QObject* object)
+{
+    int minInterval = std::numeric_limits<int>::max();
+    auto* dispatcher = QAbstractEventDispatcher::instance();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    const auto timers = dispatcher->timersForObject(object);
+    for (const auto& info : timers) {
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(info.interval);
+        minInterval = std::min(minInterval, int(ms.count()));
+    }
+#else
+    const auto timers = dispatcher->registeredTimers(object);
+    for (const auto& info : timers)
+        minInterval = std::min(minInterval, info.interval);
+#endif
+    return minInterval;
+}
+
+QObject* installController(QQmlEngine& engine, int msPerTick, int gentlePeriodMs)
+{
+    const QObjectList childrenBefore = engine.children();
+    statusq_installBoostedIncubationController(&engine, msPerTick, gentlePeriodMs);
+
+    QObject* controller = nullptr;
+    for (QObject* child : engine.children()) {
+        if (!childrenBefore.contains(child))
+            controller = child;
+    }
+    return controller;
+}
+
+} // namespace
+
+class TestIncubationController : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // With the gentle phase disabled the controller is in the boosted phase
+    // from its very first tick. A small per-tick budget stretches one
+    // incubation over many ticks, so the pacing interval the controller
+    // re-arms itself with is observable from the outside.
+    void boostedPhaseMustNotUseAZeroIntervalTimer()
+    {
+        QQmlEngine engine;
+        QObject* controller = installController(engine, 1, 0);
+        QVERIFY2(controller, "the installed controller must be a child of the engine");
+
+        QQmlComponent component(&engine);
+        component.setData(largeComponentQml(), QUrl(QStringLiteral("inline://large.qml")));
+        QTRY_VERIFY_WITH_TIMEOUT(component.status() != QQmlComponent::Loading, 30000);
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+
+        QQmlIncubator incubator(QQmlIncubator::Asynchronous);
+        component.create(incubator);
+
+        bool zeroIntervalSeen = false;
+        int samples = 0;
+        QElapsedTimer wall;
+        wall.start();
+
+        while (incubator.isLoading() && wall.elapsed() < 15000) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 5);
+            if (!incubator.isLoading())
+                break;
+            ++samples;
+            if (minRegisteredTimerIntervalMs(controller) == 0)
+                zeroIntervalSeen = true;
+        }
+
+        QVERIFY2(incubator.isReady(), "incubation must finish");
+        delete incubator.object();
+
+        QVERIFY2(samples > 0, "the incubation window must be long enough to observe the timer");
+        QVERIFY2(!zeroIntervalSeen,
+                 "the boosted phase re-armed with a zero-interval timer: the event "
+                 "loop never sleeps and incubateFor() blocks the GUI thread "
+                 "back-to-back for the whole burst");
+    }
+
+    // Shipped configuration (20 ms budget, 300 ms gentle window): once a
+    // burst outlives the gentle window the throttle opens. Chained
+    // incubations keep the burst alive past the window, exactly like a
+    // stream of async delegates during a section load.
+    void shippedConfigMustStayPacedAfterGentleWindow()
+    {
+        QQmlEngine engine;
+        QObject* controller = installController(engine, 20, 300);
+        QVERIFY2(controller, "the installed controller must be a child of the engine");
+
+        QQmlComponent component(&engine);
+        component.setData(largeComponentQml(), QUrl(QStringLiteral("inline://large2.qml")));
+        QTRY_VERIFY_WITH_TIMEOUT(component.status() != QQmlComponent::Loading, 30000);
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+
+        // A pool of overlapping incubators keeps incubatingObjectCount() above
+        // zero for the whole window, so the controller sees one long burst.
+        std::vector<std::unique_ptr<QQmlIncubator>> pool;
+        const auto topUpPool = [&] {
+            pool.erase(std::remove_if(pool.begin(), pool.end(), [](const auto& inc) {
+                if (inc->isLoading())
+                    return false;
+                delete inc->object();
+                return true;
+            }), pool.end());
+            while (pool.size() < 2) {
+                pool.push_back(std::make_unique<QQmlIncubator>(QQmlIncubator::Asynchronous));
+                component.create(*pool.back());
+            }
+        };
+        topUpPool();
+
+        bool zeroIntervalSeen = false;
+        int samplesPastGentle = 0;
+        QElapsedTimer wall;
+        wall.start();
+
+        while (wall.elapsed() < 1200) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 5);
+            topUpPool();
+
+            if (wall.elapsed() > 500) {
+                ++samplesPastGentle;
+                if (minRegisteredTimerIntervalMs(controller) == 0)
+                    zeroIntervalSeen = true;
+            }
+        }
+
+        for (const auto& inc : pool)
+            inc->clear();
+
+        QVERIFY2(samplesPastGentle > 0, "must sample the controller after the gentle window");
+        QVERIFY2(!zeroIntervalSeen,
+                 "after the 300 ms gentle window the shipped configuration re-armed "
+                 "with a zero-interval timer: ~100% CPU and up to 20 ms of added "
+                 "input/frame latency for the rest of the load");
+    }
+};
+
+int main(int argc, char** argv)
+{
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QGuiApplication app(argc, argv);
+    TestIncubationController test;
+    return QTest::qExec(&test, argc, argv);
+}
+
+#include "tst_incubationcontroller.moc"


### PR DESCRIPTION
Three tests locking in the fixes for the critical defects found while reviewing the perf/loading-skeletons..perf/mobile-section-extras stack (originally filed as RED tests; the underlying fixes have since landed on their PRs and these now pass):

- tst_WalletLoaderDeepLink (PR #21918): WalletLoader is asynchronous — activity-center/toast deep-link redirects that arrive while the loader is still incubating must be queued by the loader-level `openDesiredView` forwarder and replayed on load, not dropped with the txHash payload.

- tst_incubationcontroller (PR #21921): after the gentle window the boosted incubation controller must keep a non-zero gap between incubation bursts (shipped config: 12 ms budget / 2 ms gap) so input and rendering stay responsive during long incubation runs — a zero-interval re-arm would pin a core and add up to a full budget of latency per burst.

- tst_CollapsedCategoryVirtualization (PR #21943): rows hidden by a collapsed category are filtered out of the chat list view via the backend-computed `hidden` role; zero-height delegates would all be instantiated synchronously by the ListView (measured 502 delegates for one collapsed 500-channel category before the fix).

A fourth finding (LoadingSkeletonGroup shimmer intensity in the dark theme) was reviewed on-device and rejected — the shipped shimmer is visible as designed, so no test guards it.
