### PR TITLE
Chat input: inserting mentions improvements

### DIFF
--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -280,6 +280,29 @@ Item {
             compare(controlUnderTest.getPlainText(), "hello@ world")
         }
 
+        // Pressing "@" while the caret is inside a code span must not latch the mention
+        // button highlighted: mentions are disabled in code, so the button must stay
+        // unchecked and must not get stuck checked when the caret later moves elsewhere.
+        function test_editMode_mentionButton_notCheckedInsideCode() {
+            const toolBar = getToolBar()
+            verify(!!toolBar)
+
+            openFormattingToolbar(toolBar)
+
+            controlUnderTest.textInput.forceActiveFocus()
+            toolBar.codeButton.click() // empty caret → inserts a code span, caret inside it
+            waitForRendering(controlUnderTest)
+            verify(toolBar.codeButton.checked)
+
+            toolBar.mentionButton.click()
+            waitForRendering(controlUnderTest)
+            verify(!toolBar.mentionButton.checked)
+
+            controlUnderTest.textInput.cursorPosition = 0
+            waitForRendering(controlUnderTest)
+            verify(!toolBar.mentionButton.checked)
+        }
+
         function test_editMode_emojiButton_opensPopupAndSelectsEmoji() {
             const toolBar = getToolBar()
             verify(!!toolBar)

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -261,6 +261,25 @@ Item {
             verify(controlUnderTest.getPlainText().includes("@"))
         }
 
+        // Clicking the mention button inserts the "@" at the caret, not appended to the
+        // end of the input. Regression: with the caret moved off the end (e.g. before a
+        // code block) the "@" used to land at the very end of the text.
+        function test_editMode_mentionButton_insertsAtCaretNotEnd() {
+            const toolBar = getToolBar()
+            verify(!!toolBar)
+
+            controlUnderTest.textInput.forceActiveFocus()
+            typeText("hello world")
+            waitForRendering(controlUnderTest)
+
+            controlUnderTest.textInput.cursorPosition = 5 // just after "hello"
+
+            mouseClick(toolBar.mentionButton)
+            waitForRendering(controlUnderTest)
+
+            compare(controlUnderTest.getPlainText(), "hello@ world")
+        }
+
         function test_editMode_emojiButton_opensPopupAndSelectsEmoji() {
             const toolBar = getToolBar()
             verify(!!toolBar)

--- a/ui/imports/shared/status/ChatTextArea.qml
+++ b/ui/imports/shared/status/ChatTextArea.qml
@@ -262,18 +262,34 @@ StatusTextArea {
         readonly property var mentionContext: {
             root.text
             root.cursorPosition
+            root.preeditText
             return d.computeMentionContext()
         }
 
-        function computeMentionContext() {
-            const text = root.text
+        // Splices the IME preedit (composition) text into the committed text at the caret so
+        // filtering sees what the user visually typed. Returns { text, caret, cursor } where
+        // `cursor` is the committed caret (preedit sits there) — used to map effective-text
+        // indices back to the committed document for highlighter.isInsideCode. preeditText is
+        // "" when no IME composition is active, leaving text/caret equal to the committed ones.
+        function composeWithPreedit() {
+            const committed = root.text
             const cursor = root.cursorPosition
+            const preedit = root.preeditText
+            return {
+                text: committed.substring(0, cursor) + preedit + committed.substring(cursor),
+                caret: cursor + preedit.length,
+                cursor: cursor
+            }
+        }
+
+        function computeMentionContext() {
+            const { text, caret, cursor } = d.composeWithPreedit()
             const none = { entering: false, filter: "" }
 
             // Walk back from the caret: only non-whitespace may precede it, and we must
             // reach an "@". Whitespace before any "@" means no mention in progress.
             let at = -1
-            for (let i = cursor; i > 0; --i) {
+            for (let i = caret; i > 0; --i) {
                 const ch = text.charAt(i - 1)
                 if (ch === "@") { at = i - 1; break }
                 if (/\s/.test(ch)) return none
@@ -285,11 +301,13 @@ StatusTextArea {
             if (at > 0 && !/\s/.test(text.charAt(at - 1)))
                 return none
 
-            // Mentions are not allowed inside code spans/blocks.
-            if (highlighter.isInsideCode(at))
+            // Mentions are not allowed inside code spans/blocks. isInsideCode indexes the
+            // committed document; the preedit block sits at `cursor`, so map any index
+            // inside/after it back to the committed caret.
+            if (highlighter.isInsideCode(at <= cursor ? at : cursor))
                 return none
 
-            return { entering: true, filter: text.substring(at + 1, cursor) }
+            return { entering: true, filter: text.substring(at + 1, caret) }
         }
 
         // {entering, filter} for the emoji shortcode being typed at the caret. Recomputed on
@@ -297,18 +315,18 @@ StatusTextArea {
         readonly property var emojiContext: {
             root.text
             root.cursorPosition
+            root.preeditText
             return d.computeEmojiContext()
         }
 
         function computeEmojiContext() {
-            const text = root.text
-            const cursor = root.cursorPosition
+            const { text, caret, cursor } = d.composeWithPreedit()
             const none = { entering: false, filter: "" }
 
             // Walk back from the caret: only shortcode chars ([a-zA-Z0-9_]) may precede it, and
             // we must reach a ":". Any other char before a ":" means no emoji in progress.
             let colon = -1
-            for (let i = cursor; i > 0; --i) {
+            for (let i = caret; i > 0; --i) {
                 const ch = text.charAt(i - 1)
                 if (ch === ":") { colon = i - 1; break }
                 if (!/[a-zA-Z0-9_]/.test(ch)) return none
@@ -320,11 +338,13 @@ StatusTextArea {
             if (colon > 0 && !/\s/.test(text.charAt(colon - 1)))
                 return none
 
-            // Emoji shortcodes are not allowed inside code spans/blocks.
-            if (highlighter.isInsideCode(colon))
+            // Emoji shortcodes are not allowed inside code spans/blocks. isInsideCode indexes
+            // the committed document; the preedit block sits at `cursor`, so map any index
+            // inside/after it back to the committed caret.
+            if (highlighter.isInsideCode(colon <= cursor ? colon : cursor))
                 return none
 
-            const filter = text.substring(colon + 1, cursor)
+            const filter = text.substring(colon + 1, caret)
 
             // Trigger only after at least two shortcode chars have been typed.
             if (filter.length < 2)

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1103,16 +1103,18 @@ Control {
                 }
             }
 
+            mentionButton.checkable: false
             mentionButton.checked: !suggestionsBox.shouldHide && messageInputField.enteringSuggestion
 
             mentionButton.onClicked: {
                 if (mentionButton.checked) {
+                    // A mention is in progress and its suggestions are shown → dismiss them.
+                    suggestionsBox.shouldHide = true
+                } else {
                     suggestionsBox.shouldHide = false
 
                     if (!messageInputField.enteringSuggestion)
                         messageInputField.insert(messageInputField.cursorPosition, "@")
-                } else {
-                    suggestionsBox.shouldHide = true
                 }
             }
         }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1110,7 +1110,7 @@ Control {
                     suggestionsBox.shouldHide = false
 
                     if (!messageInputField.enteringSuggestion)
-                        messageInputField.insert(messageInputField.length, "@")
+                        messageInputField.insert(messageInputField.cursorPosition, "@")
                 } else {
                     suggestionsBox.shouldHide = true
                 }


### PR DESCRIPTION
### What does the PR do

- fixes mention suggestion list handling when preedit text is involved (e.g. on some Androids). Now preedit text is correctly used for filtering as well.
- fixes inserting mention by the `@` button when cursor is not at the end. Now insertion always follows the cursor.
- fixes `@` button highlight when used inside code block/span. Now when used there the button stays not highlighted.

Closes: #21988
Closes: #21996

### Affected areas
`ChatTextArea`, `StatusChatInput`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/41dcc1dc-9c23-45b5-8e04-a6347259c60e



<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

It makes possible to filter mentions easily on some Android devices

### How to test

Android with temporary preedit text composition needed
- go to chat
- hit `@` button
- type sth to start filtering

### Risk 
Low
