### PR TITLE
feat: display restart prompt when the base screen DPR changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ nim_status_client.log
 *.csv
 .flatpak-builder
 /ui/StatusQ/sandbox/android/.gradle/
+mobile/android/qt6/.gradle/
 .qmake_previous
 # Used to track the simulated keycard mode changes via the USE_SIMULATED_KEYCARD build flag
 .use_simulated_keycard_previous
@@ -69,6 +70,8 @@ _deps
 build-*/
 # CMake default build directory
 build/
+# Zed default build directory
+builds/
 
 # https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore
 # Prerequisites

--- a/mobile/android/qt6/src/app/status/mobile/DensityListener.java
+++ b/mobile/android/qt6/src/app/status/mobile/DensityListener.java
@@ -1,0 +1,65 @@
+package app.status.mobile;
+
+import android.app.Activity;
+import android.content.ComponentCallbacks;
+import android.content.res.Configuration;
+import android.util.DisplayMetrics;
+import android.util.Log;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class DensityListener {
+    private static final String TAG = "StatusDensityListener";
+    private static final AtomicBoolean started = new AtomicBoolean(false);
+    private static float lastDensity = -1.0f;
+
+    private DensityListener() {}
+
+    public static void start(Activity activity) {
+        if (activity == null) return;
+
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            DisplayMetrics initialMetrics = activity.getResources().getDisplayMetrics();
+            if (initialMetrics != null) {
+                lastDensity = initialMetrics.density;
+            }
+        } catch (Throwable t) {
+            Log.w(TAG, "Failed to get initial display metrics", t);
+        }
+
+        final android.content.res.Resources resources = activity.getApplication().getResources();
+        activity.getApplication().registerComponentCallbacks(new ComponentCallbacks() {
+            @Override
+            public void onConfigurationChanged(Configuration newConfig) {
+                try {
+                    DisplayMetrics metrics = resources.getDisplayMetrics();
+                    if (metrics != null) {
+                        float currentDensity = metrics.density;
+                        if (lastDensity < 0 || Math.abs(currentDensity - lastDensity) > 0.0001f) {
+                            lastDensity = currentDensity;
+                            Log.i(TAG, "onConfigurationChanged: density changed to " + currentDensity);
+                            try {
+                                nativeOnDensityChanged(currentDensity);
+                            } catch (UnsatisfiedLinkError e) {
+                                Log.w(TAG, "nativeOnDensityChanged not yet registered", e);
+                            }
+                        }
+                    }
+                } catch (Throwable t) {
+                    Log.w(TAG, "Error handling onConfigurationChanged", t);
+                }
+            }
+
+            @Override
+            public void onLowMemory() {
+                // no-op
+            }
+        });
+    }
+
+    private static native void nativeOnDensityChanged(float density);
+}

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -45,13 +45,15 @@ public class StatusQtActivity extends QtActivity {
         // onboarding resume check queries the service immediately on startup.
         super.onCreate(savedInstanceState);
         sInstance = this;
-        
+
         if (Build.VERSION.SDK_INT >= 31) { // Android 12+
             SplashScreen splashScreen = SplashScreen.installSplashScreen(this);
             splashScreen.setKeepOnScreenCondition(() -> !splashShouldHide.get());
         }
         // Set up shake detection (used for share-on-shake)
         ShakeDetector.start(this);
+        // Set up density change detection
+        DensityListener.start(this);
 
         handleDeepLink(getIntent());
     }

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -190,8 +190,6 @@ proc enableHDPI(uiScaleFilePath: string) =
     echo "[Warning] ", scaleEnvVar, " already set, will NOT enable custom Status scaling"
     return
 
-  QGuiApplication.setHighDpiScaleFactorRoundingPolicy(HighDpiScaleFactorRoundingPolicyEnum.PassThrough)
-
   if fileExists(uiScaleFilePath):
     # Reads the file and strips any trailing/leading whitespace (like newlines)
     let scaleStr = readFile(uiScaleFilePath).strip()

--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -39,7 +39,6 @@ int main(int argc, char *argv[])
     QtWebView::initialize();
 
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 
     QGuiApplication app(argc, argv);
     QGuiApplication::setOrganizationName(u"Status"_s);

--- a/storybook/pages/AppearanceViewPage.qml
+++ b/storybook/pages/AppearanceViewPage.qml
@@ -1,7 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Layouts
-import QtQml
 
 import StatusQ
 import StatusQ.Core
@@ -9,16 +7,75 @@ import StatusQ.Core.Utils
 import StatusQ.Controls
 import StatusQ.Components
 import StatusQ.Core.Theme
+import StatusQ.Core.Backpressure
 
 import AppLayouts.Profile.views
 
+import AppLayouts.stores as AppLayoutStores
+import shared.stores as SharedStores
+import mainui.sectionLoaders
+
 Item {
     id: root
+
+    QtObject {
+        id: d
+
+        // not bindings intentionally
+        property real nativeWindowDpr // baseline/native DPR of the respective Screen
+        property string screen
+
+        // refresh values when either the Window changes Screen, or the Screen OS settings have changed
+        readonly property var nativeWindowDprConn: Connections {
+            enabled: false
+            target: root.Window.window
+            function onDevicePixelRatioChanged() {
+                console.warn("!!! DPR CHANGED")
+                Backpressure.debounce(root, 1000, function() {
+                    const window = root.Window.window
+                    const currentScreen = window.screen.name
+                    const newDpr = SystemUtils.nativeDpr(window)
+                    console.warn("!!! DPR CHANGED; OLD/NEW :", d.nativeWindowDpr, newDpr)
+                    console.warn("!!! SCREENS:", d.screen, currentScreen)
+                    if (!SystemUtils.fuzzyCompare(d.nativeWindowDpr, newDpr) && d.screen === currentScreen) {
+                        console.warn("!!! RESTART POPUP")
+                        popups.openDprChangedConfirmationPopup()
+                    }
+                    d.nativeWindowDpr = newDpr
+                    d.screen = currentScreen
+                })()
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        Backpressure.debounce(root, 50, function() {
+            d.screen = root.Window.window.screen.name
+            console.warn("!!! INITIAL SCREEN:", d.screen)
+            d.nativeWindowDpr = SystemUtils.nativeDpr(root.Window.window)
+            console.warn("!!! INITIAL DPR:", d.nativeWindowDpr)
+            d.nativeWindowDprConn.enabled = true
+        })()
+    }
+
+    PopupsLoader {
+        id: popups
+        keychain: Keychain {}
+        popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
+        rootStore: AppLayoutStores.RootStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
+        networksStore: SharedStores.NetworksStore {}
+
+        onRestartRequested: console.info("PopupsLoader.onRestartRequested")
+    }
 
     AppearanceView {
         anchors.fill: parent
         anchors.topMargin: 80
         contentWidth: root.width * 4 / 5
+
+        nativeWindowDpr: d.nativeWindowDpr
 
         theme: ThemeUtils.Style.System
         onThemeChangeRequested: function(theme) {

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -80,6 +80,9 @@ public:
 
     Q_INVOKABLE void tryCloseActivePopups();
 
+    // exposes qFuzzyCompare(double, double) to QML
+    Q_INVOKABLE bool fuzzyCompare(const QJSValue &lhs, const QJSValue &rhs) const;
+
 signals:
     // Emitted when event of type QEvent::Quit is detected by event filter on
     // QGuiApplication. It's helpful to handle close requests on mac coming from
@@ -94,6 +97,7 @@ signals:
     void shakeDetected();
     void imageSavedToGallery(const QString& destination);
     void imageSaveToGalleryFailed();
+    void nativeDprChanged(qreal value);
 
 private:
     int m_androidKeyboardHeight = 0;

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -63,6 +63,7 @@ static void handleIOSFilePickerRejected();
 #ifdef Q_OS_ANDROID
 extern "C" {
 static void jni_nativeShakeDetected(JNIEnv*, jclass);
+static void jni_nativeDensityChanged(JNIEnv*, jclass, jfloat density);
 }
 #endif
 
@@ -77,6 +78,35 @@ SystemUtilsInternal::SystemUtilsInternal(QObject *parent)
     QObject::connect(filter, &QuitFilter::quit, this, &SystemUtilsInternal::quit);
 
 #ifdef Q_OS_ANDROID
+    // Register native methods for density listener and start listening
+    static std::once_flag densityRegOnce;
+    std::call_once(densityRegOnce, []{
+        QJniEnvironment env;
+        jclass clazz = env->FindClass("app/status/mobile/DensityListener");
+        if (clazz) {
+            const JNINativeMethod methods[] = {
+                { const_cast<char*>("nativeOnDensityChanged"),
+                  const_cast<char*>("(F)V"),
+                  reinterpret_cast<void*>(jni_nativeDensityChanged) },
+            };
+            jint rc = env->RegisterNatives(clazz, methods, jint(std::size(methods)));
+            env->DeleteLocalRef(clazz);
+            if (rc != 0) {
+                qWarning() << "[Android Density] RegisterNatives failed:" << rc;
+            }
+        }
+
+        QJniObject activity = QNativeInterface::QAndroidApplication::context();
+        if (activity.isValid()) {
+            QJniObject::callStaticMethod<void>(
+                "app/status/mobile/DensityListener",
+                "start",
+                "(Landroid/app/Activity;)V",
+                activity.object<jobject>()
+            );
+        }
+    });
+
     // Poll keyboard state on Android and emit property change signals
     auto keyboardTimer = new QTimer(this);
     keyboardTimer->setInterval(50); // 20 FPS polling rate
@@ -793,7 +823,6 @@ qreal SystemUtilsInternal::nativeDpr(QQuickWindow *window) const
 
 void SystemUtilsInternal::tryCloseActivePopups()
 {
-    qWarning() << "!!!" << Q_FUNC_INFO;
     const auto windows = qGuiApp->topLevelWindows();
     for (auto window: windows) {
         const auto childrenList = window->findChildren<QObject *>();
@@ -805,13 +834,21 @@ void SystemUtilsInternal::tryCloseActivePopups()
                     const auto opened = popupObject->property("opened").toBool();
                     const auto closeable = popupObject->property("closePolicy").toInt() > 0; // Popup::NoAutoClose = 0x00
                     if (opened && closeable) {
-                        qWarning() << "!!! CLOSING CHILD POPUP:" << child << child->property("title").toString();
                         QMetaObject::invokeMethod(popupObject, "close");
                     }
                 }
             }
         }
     }
+}
+
+bool SystemUtilsInternal::fuzzyCompare(const QJSValue &lhs, const QJSValue &rhs) const
+{
+    if (!lhs.isNumber() || !rhs.isNumber()) {
+        qWarning() << Q_FUNC_INFO << ": param is not a JS Number";
+        return false;
+    }
+    return qFuzzyCompare(lhs.toNumber(), rhs.toNumber());
 }
 
 #ifdef Q_OS_IOS
@@ -854,6 +891,21 @@ static void jni_nativeShakeDetected(JNIEnv*, jclass)
         qInfo() << "[Android Shake] SystemUtilsInternal: shakeDetected signal emitted";
 #endif
         emit s_systemUtilsInternal->shakeDetected();
+    }, Qt::QueuedConnection);
+}
+
+static void jni_nativeDensityChanged(JNIEnv*, jclass, jfloat density)
+{
+    if (!s_systemUtilsInternal)
+        return;
+    QPointer<SystemUtilsInternal> weak(s_systemUtilsInternal);
+    QMetaObject::invokeMethod(s_systemUtilsInternal, [weak, density]() {
+        if (!weak)
+            return;
+#ifdef QT_DEBUG
+        qInfo() << "[Android Density] SystemUtilsInternal: nativeDprChanged signal emitted with" << density;
+#endif
+        emit weak->nativeDprChanged(static_cast<qreal>(density));
     }, Qt::QueuedConnection);
 }
 #endif

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -89,6 +89,7 @@ StatusSectionLayout {
     property var dismissedReceivedRequestContactsModel
 
     required property int theme // ThemeUtils.Style.xxx
+    required property real nativeWindowDpr // baseline/native DPR of the respective Screen
 
     required property var whitelistedDomainsModel
  
@@ -376,6 +377,7 @@ StatusSectionLayout {
                 implicitHeight: parent.height
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.appearance)
                 contentWidth: d.contentWidth
+                nativeWindowDpr: root.nativeWindowDpr
                 theme: root.theme
                 uiScaleFile: uiScaleFilePath
                 onThemeChangeRequested: (theme) => root.themeChangeRequested(theme)

--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -18,6 +18,7 @@ SettingsContentBase {
     id: root
 
     required property int theme // ThemeUtils.Style.xxx
+    required property real nativeWindowDpr // baseline/native DPR of the respective Screen
     property string uiScaleFile: StandardPaths.writableLocation(StandardPaths.AppLocalDataLocation) + "/ui-scale"
 
     signal themeChangeRequested(int theme)
@@ -30,7 +31,6 @@ SettingsContentBase {
         property bool dirty
 
         property real windowDpr: root.Window.window?.screen.devicePixelRatio ?? root.Screen.devicePixelRatio // current DPR, based on the Screen where the Window currently is
-        property real nativeWindowDpr: SystemUtils.nativeDpr(root.Window.window) // baseline/native DPR of the respective Screen
 
         // refresh values when either the Window changes Screen, or the Screen OS settings have changed
         readonly property var _conn: Connections {
@@ -38,7 +38,6 @@ SettingsContentBase {
             function onDevicePixelRatioChanged() {
                 Backpressure.debounce(root, 1000, function() {
                     d.windowDpr = root.Window.window?.screen.devicePixelRatio ?? root.Screen.devicePixelRatio
-                    d.nativeWindowDpr = SystemUtils.nativeDpr(root.Window.window)
                 })()
             }
         }
@@ -77,7 +76,11 @@ SettingsContentBase {
         }
     }
 
-    Component.onCompleted: d.prevValue = slider.value
+    Component.onCompleted: {
+        Backpressure.debounce(root, 100, function() {
+            d.prevValue = slider.value
+        })()
+    }
 
     content: ColumnLayout {
         width: root.contentWidth - 2 * Theme.padding
@@ -185,7 +188,7 @@ SettingsContentBase {
                 id: slider
                 from: 0.75 // 3/4 of the baseline
                 to: 1.5 // 1.5x the baseline
-                value: d.windowDpr/d.nativeWindowDpr
+                value: d.windowDpr/root.nativeWindowDpr
                 stepSize: 0.05 // steps of 5%
                 snapMode: Slider.SnapAlways
                 onMoved: d.dirty = true

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -932,6 +932,37 @@ Item {
         property string skipNextSectionHistoryRecordFor: ""
         property bool closeActivityCenterOnNextBack: false
 
+        // not bindings intentionally
+        property real nativeWindowDpr // baseline/native DPR of the respective Screen
+        property string screen
+
+        // refresh values when either the Window changes Screen, or the Screen OS settings have changed
+        readonly property var nativeWindowDprConn: Connections {
+            enabled: false
+            target: appMain.Window.window
+            function onDevicePixelRatioChanged() {
+                Backpressure.debounce(appMain, 1000, function() {
+                    const window = appMain.Window.window
+                    const currentScreen = window.screen.name
+                    const newDpr = SystemUtils.nativeDpr(window)
+                    if (!SystemUtils.fuzzyCompare(d.nativeWindowDpr, newDpr) && d.screen === currentScreen) {
+                        popups.openDprChangedConfirmationPopup()
+                    }
+                    d.nativeWindowDpr = newDpr
+                    d.screen = currentScreen
+                })()
+            }
+        }
+
+        readonly property var androidWindowDprConn: Connections {
+            enabled: false
+            target: SystemUtils
+            function onNativeDprChanged(value) {
+                popups.openDprChangedConfirmationPopup()
+                d.nativeWindowDpr = value
+            }
+        }
+
         function recordActivityCenterHistory() {
             d.skipNextSectionHistoryRecordFor = appMain.rootStore.activeSectionId
             sectionNavigationHistory.record(appMain.rootStore.activeSectionId)
@@ -1084,9 +1115,10 @@ Item {
         }
 
         Component.onCompleted: {
-            ThemeUtils.setTheme(appMain.Window.window, appMainLocalSettings.theme)
-            ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.fontSize)
-            ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.paddingFactor)
+            const window = appMain.Window.window
+            ThemeUtils.setTheme(window, appMainLocalSettings.theme)
+            ThemeUtils.setFontSize(window, appMainLocalSettings.fontSize)
+            ThemeUtils.setPaddingFactor(window, appMainLocalSettings.paddingFactor)
 
             // Show the navigation education dialog the first time the app
             // is opened after the new menu is introduce, if the nav bar is in collapsed mode
@@ -1096,8 +1128,9 @@ Item {
         readonly property var _conn: Connections {
             target: appMain
             function onIsPortraitModeChanged() {
-                ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.fontSize)
-                ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.paddingFactor)
+                const window = appMain.Window.window
+                ThemeUtils.setFontSize(window, appMainLocalSettings.fontSize)
+                ThemeUtils.setPaddingFactor(window, appMainLocalSettings.paddingFactor)
             }
         }
     }
@@ -1146,6 +1179,7 @@ Item {
         onTransferOwnershipRequested: (tokenId, senderAddress, tokenName, tokenImage) => popupRequestsHandler.transferOwnership(tokenId, senderAddress, tokenName, tokenImage)
         onWcUriScanned: uri => d.pairWalletConnectUri(uri)
         onNavigationEducationDialogSeenRequested: appMainGlobalSettings.newMenuEducationPopupSeen = true
+        onRestartRequested: SystemUtils.restartApplication()
     }
 
     HandlersManagerLoader {
@@ -1179,13 +1213,21 @@ Item {
             if (appMain.mainReady)
                 Qt.callLater(() => popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup())
         }
+    }
 
-        Connections {
-            target: appMain
+    Connections {
+        target: appMain
 
-            function onMainReadyChanged() {
-                if (appMain.mainReady)
-                    popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup()
+        function onMainReadyChanged() {
+            if (appMain.mainReady) {
+                popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup()
+
+                Backpressure.debounce(appMain, 50, function() {
+                    d.screen = appMain.Window.window.screen.name
+                    d.nativeWindowDpr = SystemUtils.nativeDpr(appMain.Window.window)
+                    d.nativeWindowDprConn.enabled = true
+                    d.androidWindowDprConn.enabled = true
+                })()
             }
         }
     }
@@ -2298,6 +2340,7 @@ Item {
                         isProduction: appMain.rootStore.isProduction
                         systemTrayIconAvailable: appMain.systemTrayIconAvailable
                         theme: appMainLocalSettings.theme
+                        nativeWindowDpr: d.nativeWindowDpr
                         whitelistedDomainsModel: appMainLocalSettings.whitelistedUnfurledDomains
                         leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -98,6 +98,7 @@ QtObject {
     signal transferOwnershipRequested(string tokenId, string senderAddress, string tokenName, string tokenImage)
     signal wcUriScanned(string uri)
     signal navigationEducationDialogSeenRequested()
+    signal restartRequested()
 
     readonly property Connections imageSaveConnections: Connections {
         target: SystemUtils
@@ -626,6 +627,10 @@ QtObject {
 
     function openQRScannerPopup() {
         openPopup(qrCodeScannerDialogComponent)
+    }
+
+    function openDprChangedConfirmationPopup() {
+        openPopup(dprChangedConfirmationComponent)
     }
 
     readonly property list<Component> _components: [
@@ -1755,6 +1760,24 @@ QtObject {
                 standardButtons: Dialog.Ok
 
                 onClosed: destroy()
+            }
+        },
+
+        Component {
+            id: dprChangedConfirmationComponent
+            ConfirmationDialog {
+                title: qsTr("Display zoom changed")
+                destroyOnClose: true
+                confirmButtonLabel: qsTr("Restart")
+                cancelButtonLabel: qsTr("Not Now")
+                cancelBtnType: ""
+                showCancelButton: true
+                confirmationText: qsTr("Restart Status to apply your new display zoom")
+                onCancelButtonClicked: close()
+                onConfirmButtonClicked: {
+                    close()
+                    root.restartRequested()
+                }
             }
         }
     ]

--- a/ui/app/mainui/sectionLoaders/PopupsLoader.qml
+++ b/ui/app/mainui/sectionLoaders/PopupsLoader.qml
@@ -53,6 +53,7 @@ Loader {
     signal transferOwnershipRequested(string tokenId, string senderAddress, string tokenName, string tokenImage)
     signal wcUriScanned(string uri)
     signal navigationEducationDialogSeenRequested()
+    signal restartRequested()
 
     asynchronous: true
     active: false
@@ -118,7 +119,7 @@ Loader {
             callable()
             return
         }
-        if (root.active == false) {
+        if (!root.active) {
             root.active = true
         }
         d.pending.push(callable)
@@ -159,6 +160,9 @@ Loader {
     }
     function openLeaveCommunityPopup(community, communityId, outroMessage) {
         invoke(() => root.item.openLeaveCommunityPopup(community, communityId, outroMessage))
+    }
+    function openDprChangedConfirmationPopup() {
+        invoke(() => root.item.openDprChangedConfirmationPopup())
     }
 
     Connections {
@@ -339,5 +343,6 @@ Loader {
         }
         function onWcUriScanned(uri) { root.wcUriScanned(uri) }
         function onNavigationEducationDialogSeenRequested() { root.navigationEducationDialogSeenRequested() }
+        function onRestartRequested() { root.restartRequested() }
     }
 }

--- a/ui/app/mainui/sectionLoaders/ProfileLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ProfileLoader.qml
@@ -58,6 +58,7 @@ Loader {
     required property bool systemTrayIconAvailable
     required property int theme
     required property var whitelistedDomainsModel
+    required property real nativeWindowDpr // baseline/native DPR of the respective Screen
 
     property int settingsSubsection: -1
     property int settingsSubSubsection: -1
@@ -145,6 +146,7 @@ Loader {
             privacyModeFeatureEnabled:              Qt.binding(() => root.featureFlagsStore.privacyModeFeatureEnabled),
             minimizeOnCloseOptionVisible:           Qt.binding(() => root.systemTrayIconAvailable),
             theme:                                  Qt.binding(() => root.theme),
+            nativeWindowDpr:                        Qt.binding(() => root.nativeWindowDpr),
             whitelistedDomainsModel:                Qt.binding(() => root.whitelistedDomainsModel),
             leftPanelWidthOverride:                 Qt.binding(() => root.leftPanelWidthOverride),
             settingsSubsection:                     Qt.binding(() => root.settingsSubsection),

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -13387,6 +13387,22 @@ to load</source>
         <source>Sign out &amp; Quit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Display zoom changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart Status to apply your new display zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PrimaryNavSidebar</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -13464,6 +13464,22 @@ selhalo</translation>
         <source>Sign out &amp; Quit</source>
         <translation type="unfinished">Odhlásit se a ukončit</translation>
     </message>
+    <message>
+        <source>Display zoom changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished">Restartovat</translation>
+    </message>
+    <message>
+        <source>Not Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart Status to apply your new display zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PrimaryNavSidebar</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -13402,6 +13402,22 @@ al cargar</translation>
         <source>Sign out &amp; Quit</source>
         <translation>Cerrar sesión y salir</translation>
     </message>
+    <message>
+        <source>Display zoom changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished">Reiniciar</translation>
+    </message>
+    <message>
+        <source>Not Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart Status to apply your new display zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PrimaryNavSidebar</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -13341,6 +13341,22 @@ to load</source>
         <source>Sign out &amp; Quit</source>
         <translation type="unfinished">로그아웃 및 종료</translation>
     </message>
+    <message>
+        <source>Display zoom changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation type="unfinished">다시 시작</translation>
+    </message>
+    <message>
+        <source>Not Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart Status to apply your new display zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PrimaryNavSidebar</name>


### PR DESCRIPTION
### What does the PR do

- move the `nativeWindowDpr` handling up to AppMain, initialize it with a small delay when the appMain is ready; also track the current `screen` in order not to restart when the user just moves the window between screens
- on Android, add a dedicated `DensityListener` to emit the needed signal for us; the Android `QPlatformScreen/QPlatformWindow` doesn't (re)implement the needed `devicePixelRatio()` methods
- add a simple ConfirmationDialog (with bottom sheet) asking for restart when the native/base DPR changes
- adjust SB page, update TS files

Fixes #21915

### Affected areas

AppMain

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality
Desktop:
<img width="2488" height="2072" alt="Snímek obrazovky z 2026-08-15 14-03-04" src="https://github.com/user-attachments/assets/71418225-240a-4916-a4b4-76eb93bcbdcd" />

Mobile:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/4d6d7fc1-d043-4710-abcd-f60ff4f92420" />


### Impact on end user

Better screen zoom UX

### How to test

- change the OS settings' zoom level
- get the prompt to restart popup in Status

### Risk 

low
