### PR TITLE
test(e2e_appium): dismiss introduce-yourself sheet

### DIFF
--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -152,6 +152,17 @@ class App(BasePage):
         if self.is_element_visible(self.locators.LEFT_NAV_SETTINGS, timeout=2):
             return True
 
+        from utils.screen_identity import dismiss_introduce_yourself
+
+        # Nav not immediately visible: the introduce-yourself sheet is one
+        # cause, and while it is up every a11y lookup below finds nothing.
+        if dismiss_introduce_yourself(self, timeout=1):
+            self.logger.warning(
+                "_ensure_main_nav_visible: dismissed introduce-yourself sheet"
+            )
+            if self.is_element_visible(self.locators.LEFT_NAV_SETTINGS, timeout=2):
+                return True
+
         if self.is_element_visible(self.locators.LEFT_NAV_ANY, timeout=1):
             return self.is_element_visible(self.locators.LEFT_NAV_SETTINGS, timeout=5)
 

--- a/test/e2e_appium/utils/screen_identity.py
+++ b/test/e2e_appium/utils/screen_identity.py
@@ -34,6 +34,8 @@ SCREEN_ANCHORS = {
 BACKUP_MODAL = BaseLocators.tid("EnableMessageBackupPopup")
 BACKUP_MODAL_SKIP = BaseLocators.tid("backupMessageSkipStatusFlatButton")
 
+INTRODUCE_MODAL_SKIP = BaseLocators.tid("introduceSkipStatusFlatButton")
+
 
 def dismiss_backup_modal(page, timeout: int = 2) -> bool:
     """Tap Skip on the on-device-backup popup if it is up. Returns True if a
@@ -49,6 +51,26 @@ def dismiss_backup_modal(page, timeout: int = 2) -> bool:
         return page.wait_for_invisibility(BACKUP_MODAL, timeout=5)
     except Exception as exc:
         page.logger.warning("Backup modal present but dismissal failed: %s", exc)
+        return False
+
+
+def dismiss_introduce_yourself(page, timeout: int = 2) -> bool:
+    """Tap Skip on the introduce-yourself sheet if it is up. Returns True if a
+    sheet was dismissed. It opens on the first entry to a messaging section
+    when the profile has no display name — which e2e profiles never set — and
+    while up it replaces the whole a11y tree, so nav lookups find nothing until
+    it is cleared. The app persists the seen-flag on close, so one dismissal
+    per profile suffices. Never raises: same guard-in-loop contract as
+    ``dismiss_backup_modal``."""
+    if not page.is_element_visible(INTRODUCE_MODAL_SKIP, timeout=timeout):
+        return False
+    try:
+        page.safe_click(INTRODUCE_MODAL_SKIP, timeout=5)
+        return page.wait_for_invisibility(INTRODUCE_MODAL_SKIP, timeout=5)
+    except Exception as exc:
+        page.logger.warning(
+            "Introduce-yourself sheet present but dismissal failed: %s", exc
+        )
         return False
 
 

--- a/test/e2e_appium/utils/screen_identity.py
+++ b/test/e2e_appium/utils/screen_identity.py
@@ -32,9 +32,9 @@ SCREEN_ANCHORS = {
 }
 
 BACKUP_MODAL = BaseLocators.tid("EnableMessageBackupPopup")
-BACKUP_MODAL_SKIP = BaseLocators.tid("backupMessageSkipStatusFlatButton")
+BACKUP_MODAL_SKIP = ChatLocators.BACKUP_SKIP_BUTTON
 
-INTRODUCE_MODAL_SKIP = BaseLocators.tid("introduceSkipStatusFlatButton")
+INTRODUCE_MODAL_SKIP = ChatLocators.INTRODUCE_SKIP_BUTTON
 
 
 def dismiss_backup_modal(page, timeout: int = 2) -> bool:


### PR DESCRIPTION
### What does the PR do

Since #21947 the "Introduce yourself" sheet opens the first time a profile with no display name enters Messages. E2e profiles never set a display name, so the sheet blocks navigation in every nightly module (16/24 failures on #224–#227).

- Add a `dismiss_introduce_yourself` guard in the nav rescue path, same pattern as the existing backup-modal guard
- Verified on device: navigation returns in ~66 s on a fresh profile vs a 15.5-minute timeout before; the guard fires once per profile and does not fire again

Not verified: the 2-device contact fixture end-to-end (device contention during the verification run); both single-device halves are verified.