### PR TITLE
fix(@keycard): show Reading... state while Read Keycard metadata is being delivered

### DIFF
--- a/storybook/qmlTests/tests/tst_KeycardManagementPopup.qml
+++ b/storybook/qmlTests/tests/tst_KeycardManagementPopup.qml
@@ -175,6 +175,12 @@ Item {
             compare(call.args[1], "", "the first attempt must use the default pairing password")
         }
 
+        function test_readKeycardShowsReadingWhileMetadataIsInFlight() {
+            mockStore.keycardState = ""
+            launchReadKeycard()
+            compare(findChild(popup, "keycardProgressTitle").text, "Reading...")
+        }
+
         function test_pairingErrorShowsPasswordStep() {
             launchReadKeycard()
             mockStore.keycardGetMetadataError(pairingErrorText)

--- a/storybook/qmlTests/tests/tst_KeycardProgressState.qml
+++ b/storybook/qmlTests/tests/tst_KeycardProgressState.qml
@@ -90,5 +90,12 @@ Item {
             compare(findChild(progress, "keycardProgressTitle").text, data.expectedTitle)
             compare(findChild(progress, "keycardProgressMessage").text, data.expectedMessage)
         }
+
+        function test_emptyStateShowsProcessingNotWaitingForReader() {
+            const progress = createTemporaryObject(componentUnderTest, root, {processing: true})
+            verify(!!progress)
+            compare(progress.contentItem.state, "processing")
+            compare(findChild(progress, "keycardProgressTitle").text, "Reading...")
+        }
     }
 }

--- a/test/e2e/gui/keycard_simulator_controller.py
+++ b/test/e2e/gui/keycard_simulator_controller.py
@@ -6,6 +6,11 @@ from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.elements.window import Window
 from gui.objects_map import keycard_names
+from scripts.utils.wait_for_port import wait_for_port
+
+# Matches KEYCARD_SIMULATOR_DEFAULT_SIMULATOR_ADDRESS in keycardV2/test_controller.nim
+_KEYCARD_SIMULATOR_HOST = '127.0.0.1'
+_KEYCARD_SIMULATOR_PORT = 9025
 
 
 class KeycardSimulatorController(Window):
@@ -55,6 +60,7 @@ class KeycardSimulatorController(Window):
     def start_simulator(self):
         self._start_button.click()
         self._plug_reader_button.wait_until_enabled(configs.timeouts.KEYCARD_SIM_START_TIMEOUT_MSEC)
+        wait_for_port(_KEYCARD_SIMULATOR_HOST, _KEYCARD_SIMULATOR_PORT, timeout=1, retries=20)
         return self.background()
 
     @allure.step('Create empty keycard {card_id}')

--- a/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
+++ b/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
@@ -1489,8 +1489,7 @@ StatusDialog {
 
             keycardInteractionCompleted: d.keycardInteractionCompleted
 
-            processing: root.flow !== Constants.keycard.flow.readKeycard
-                        && d.processing
+            processing: d.processing
             processingImage: Assets.png("keycard/scanning/scanning")
             processingTitle: {
                 switch(root.flow) {

--- a/ui/imports/shared/popups/keycard_new/states/KeycardProgressState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/KeycardProgressState.qml
@@ -153,7 +153,7 @@ Control {
                           || root.keycardState === Constants.keycard.state.noReadersFound
                           || root.keycardState === Constants.keycard.state.unknownReaderState
                           || root.keycardState === Constants.keycard.state.pairingError
-                          || root.keycardState === "")
+                          || (root.keycardState === "" && !root.processing))
                 PropertyChanges {
                     target: image
                     source: Assets.png("keycard/wrong_card/something-went-wrong")


### PR DESCRIPTION
### What does the PR do

After PIN, Read Keycard sets processing but the progress step ignored it and treated an empty keycardState as “no reader”. The popup showed “Plug in Keycard reader...” even when the reader and card were already there, until GetMetadata returned. 
Use the processing UI for that state so  Reading... screen is shown instead of a false wait-for-reader one