### PR TITLE
avoid linking `pcre`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -131,7 +131,7 @@ npm install -g npm@latest
 Install required packages:
 
 ```bash
-sudo dnf install pcsc-lite-devel pcre-devel openssl-devel protobuf-devel protobuf-compiler
+sudo dnf install pcsc-lite-devel openssl-devel protobuf-devel protobuf-compiler
 ```
 
 Install **nvm** and Node.js as per the [Ubuntu instructions above](#ubuntu).

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SHELL := bash # the shell used internally by Make
 BUILD_SYSTEM_DIR := vendor/nimbus-build-system
 
 GIT_ROOT ?= $(shell git rev-parse --show-toplevel 2>/dev/null || echo .)
-
+LINK_PCRE=0 # nimbus-build-system links `pcre` by default which is not needed
 # we don't want an error here, so we can handle things later, in the ".DEFAULT" target
 -include $(BUILD_SYSTEM_DIR)/makefiles/variables.mk
 


### PR DESCRIPTION
### What does the PR do

removes `-lpcre` from the linking command line (pcre2 remains a dep via qt) - pcre is obsolete

### Affected areas

`std/re` module in nim should not be used - instead, use [nim-regex](https://github.com/nitely/nim-regex)