### PR TITLE
fix: logs scattered across the local data folder and never cleaned up

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -44,6 +44,8 @@ import app/modules/keycard_channel/module as keycard_channel_module
 import app/core/notifications/notifications_manager
 import app/global/global_singleton
 import app/global/app_signals
+import app/global/log_cleanup
+import app/global/log_cleanup_tasks
 import app/core/[main]
 
 import constants as main_constants
@@ -140,6 +142,7 @@ proc connect(self: AppController) =
         setLogLevel(chronicles.LogLevel.DEBUG)
       elif defined(production):
         setLogLevel(chronicles.LogLevel.INFO)
+
 
 proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result = AppController()
@@ -433,6 +436,15 @@ proc load(self: AppController) =
   if not main_constants.runtimeLogLevelSet():
     if self.nodeConfigurationService.isDebugEnabled():
       setLogLevel(chronicles.LogLevel.DEBUG)
+
+  # Apply the user's per-family cap
+  scheduleLogFamilyCleanup(
+    self.statusFoundation.threadpool,
+    main_constants.LOGDIR,
+    main_constants.STATUSGODIR,
+    logCleanupProcessStartedAt(),
+    self.nodeConfigurationService.getLogMaxBackups()
+  )
 
   # load main module
   self.mainModule.load(

--- a/src/app/global/log_cleanup.nim
+++ b/src/app/global/log_cleanup.nim
@@ -1,6 +1,11 @@
-import std/[locks, os, strutils, times]
+import std/[algorithm, locks, os, strutils, tables, times]
 
-const LogRetentionDays* = 14
+const
+  DefaultLogFamilyMaxFiles* = 10
+  MaxLogFamilyMaxFiles* = 50
+
+  # Only Android runs status-go in a separate long-lived process (StatusGoService)
+  StatusGoRunsOutOfProcess* = defined(android)
 
 type
   LogCleanupMode* = enum
@@ -11,6 +16,15 @@ type
     deletedCount*: int
     failedCount*: int
     skippedCount*: int
+
+  LogMigrationResult* = object
+    movedCount*: int
+    failedCount*: int
+    skippedCount*: int
+
+  LogFileEntry = object
+    path: string
+    lastWriteTime: Time
 
 var cleanupLock: Lock
 var logCleanupStartedAt = getTime()
@@ -24,38 +38,80 @@ proc logCleanupProcessStartedAt*(): Time =
   logCleanupStartedAt
 
 proc isDataLogFile(path: string): bool =
-  path.toLowerAscii().endsWith(".log")
+  let lower = path.toLowerAscii()
+  lower.endsWith(".log") or lower.endsWith(".log.gz")
 
-proc shouldRemove(fileTime, processStartedAt, currentTime: Time,
-    mode: LogCleanupMode): bool =
-  if fileTime >= processStartedAt:
+func isDigits(s: string, first, last: int): bool =
+  for i in first .. last:
+    if s[i] notin {'0'..'9'}:
+      return false
+  true
+
+# Check if a string is a valid session timestamp in the format "YYYY-MM-DDTHH-MM-SS" followed by "Z" or ".mmm"
+func isSessionTimestamp(s: string): bool =
+  if s.len != 20 and s.len != 23:
     return false
+  if not (s.isDigits(0, 3) and s[4] == '-' and s.isDigits(5, 6) and s[7] == '-' and
+      s.isDigits(8, 9) and s[10] == 'T' and s.isDigits(11, 12) and s[13] == '-' and
+      s.isDigits(14, 15) and s[16] == '-' and s.isDigits(17, 18)):
+    return false
+  if s.len == 20:
+    return s[19] == 'Z'
+  return s[19] == '.' and s.isDigits(20, 22)
 
-  return mode == ClearClosedLogs or
-    fileTime < currentTime - initDuration(days = LogRetentionDays)
+# Splits a log file name into its stem and extension (".log" or ".log.gz")
+func splitLogName(fileName: string): tuple[stem, ext: string] =
+  var name = extractFilename(fileName)
+  var ext = ""
+  if name.toLowerAscii().endsWith(".gz"):
+    ext = name[^3..^1]
+    name.setLen(name.len - 3)
+  if name.toLowerAscii().endsWith(".log"):
+    ext = name[^4..^1] & ext
+    name.setLen(name.len - 4)
+  (name, ext)
 
-proc cleanupFile(path: string, processStartedAt, currentTime: Time,
-    mode: LogCleanupMode, result: var LogCleanupResult) =
-  try:
-    let fileInfo = getFileInfo(path, followSymlink = false)
-    if fileInfo.kind != pcFile:
-      inc result.skippedCount
-      return
+func isAppLogStem(stem: string): bool =
+  stem.len == 19 and stem.startsWith("app_") and stem[12] == '_' and
+    stem.isDigits(4, 11) and stem.isDigits(13, 18)
 
-    if not shouldRemove(fileInfo.lastWriteTime, processStartedAt, currentTime, mode):
-      inc result.skippedCount
-      return
+func sessionTimestampSuffixLen(stem: string): int =
+  for tsLen in [20, 23]:
+    if stem.len > tsLen + 1 and stem[stem.len - tsLen - 1] == '-' and
+        isSessionTimestamp(stem[stem.len - tsLen .. ^1]):
+      return tsLen
+  return 0
 
-    if tryRemoveFile(path):
-      inc result.deletedCount
-    elif fileExists(path):
-      inc result.failedCount
-  except OSError:
-    if fileExists(path):
-      inc result.failedCount
+# Detemines the log family of a log file (pre_login, 0x12..cdef, api, app...  anything else is its own single-file family)
+proc logFamily*(fileName: string): string =
+  let (stem, _) = splitLogName(fileName)
+  let tsLen = sessionTimestampSuffixLen(stem)
+  if tsLen > 0:
+    return stem[0 .. stem.len - tsLen - 2]
+  if isAppLogStem(stem):
+    return "app"
+  return stem
 
-proc cleanupDataDirectory(directory: string, processStartedAt, currentTime: Time,
-    mode: LogCleanupMode, result: var LogCleanupResult) =
+# Canonical names (pre_login.log, 0x….log, keycard.log, ...) are the live logs, differ from timestamped archives
+# and per-start app_* client logs.
+proc isCanonicalLogName*(fileName: string): bool =
+  let (stem, _) = splitLogName(fileName)
+  sessionTimestampSuffixLen(stem) == 0 and not isAppLogStem(stem)
+
+func isStatusGoOwnedLogStem(stem: string): bool =
+  # pre_login/api/geth plus the per-profile truncated keyUID ("0x12..3456")
+  stem in ["pre_login", "api", "geth"] or
+    (stem.startsWith("0x") and stem.contains(".."))
+
+# Canonical log files written by status-go. When status-go runs in a separate long-lived process (Android),
+# these can be actively written even though their mtime predates this (UI) process' start, so the mtime guard is not a valid
+# liveness test for them. All other log files are owned by this process, where the mtime guard is sufficient.
+proc isStatusGoOwnedCanonicalLogName*(fileName: string): bool =
+  let (stem, _) = splitLogName(fileName)
+  sessionTimestampSuffixLen(stem) == 0 and isStatusGoOwnedLogStem(stem)
+
+proc collectLogFiles(directory: string, recursive: bool,
+    entries: var seq[LogFileEntry], result: var LogCleanupResult) =
   if not dirExists(directory):
     return
 
@@ -64,26 +120,142 @@ proc cleanupDataDirectory(directory: string, processStartedAt, currentTime: Time
       case kind
       of pcFile:
         if isDataLogFile(path):
-          cleanupFile(path, processStartedAt, currentTime, mode, result)
+          try:
+            let fileInfo = getFileInfo(path, followSymlink = false)
+            if fileInfo.kind == pcFile:
+              entries.add(LogFileEntry(path: path, lastWriteTime: fileInfo.lastWriteTime))
+            else:
+              inc result.skippedCount
+          except OSError:
+            inc result.failedCount
       of pcDir:
-        cleanupDataDirectory(path, processStartedAt, currentTime, mode, result)
+        if recursive:
+          collectLogFiles(path, recursive, entries, result)
       else:
         discard
   except OSError:
     inc result.failedCount
 
-proc cleanupLogFiles*(logsDir, dataDir: string, processStartedAt, currentTime: Time,
-    mode: LogCleanupMode): LogCleanupResult =
+proc removeLogFile(path: string, result: var LogCleanupResult) =
+  try:
+    if tryRemoveFile(path):
+      inc result.deletedCount
+    elif fileExists(path):
+      inc result.failedCount
+  except OSError:
+    if fileExists(path):
+      inc result.failedCount
+
+# Clears log files from the logs dir and data dir, based on the mode and maxFilesPerFamily.
+# Files written since process start are always kept and don't count against the cap;
+# when status-go runs out of process (Android), its canonical (live-name) files are
+# kept too, since their mtime says nothing about whether they are still in use.
+proc cleanupLogFiles*(logsDir, dataDir: string, processStartedAt: Time, mode: LogCleanupMode,
+  maxFilesPerFamily: int = DefaultLogFamilyMaxFiles,
+  protectStatusGoCanonical: bool = StatusGoRunsOutOfProcess): LogCleanupResult =
   acquire(cleanupLock)
   defer:
     release(cleanupLock)
 
-  if dirExists(logsDir):
-    try:
-      for kind, path in walkDir(logsDir):
-        if kind == pcFile:
-          cleanupFile(path, processStartedAt, currentTime, mode, result)
-    except OSError:
-      inc result.failedCount
+  let cap = clamp(maxFilesPerFamily, 1, MaxLogFamilyMaxFiles)
 
-  cleanupDataDirectory(dataDir, processStartedAt, currentTime, mode, result)
+  var entries: seq[LogFileEntry]
+  collectLogFiles(logsDir, recursive = false, entries, result)
+  collectLogFiles(dataDir, recursive = true, entries, result)
+
+  var closed: seq[LogFileEntry]
+  for entry in entries:
+    if entry.lastWriteTime >= processStartedAt or
+        (protectStatusGoCanonical and isStatusGoOwnedCanonicalLogName(entry.path)):
+      inc result.skippedCount
+    else:
+      closed.add(entry)
+
+  if mode == ClearClosedLogs:
+    for entry in closed:
+      removeLogFile(entry.path, result)
+    return
+
+  closed.sort(proc(a, b: LogFileEntry): int =
+    cmp(b.lastWriteTime, a.lastWriteTime))
+
+  var familyCounts = initCountTable[string]()
+  for entry in closed:
+    let family = logFamily(entry.path)
+    if familyCounts.getOrDefault(family) < cap:
+      familyCounts.inc(family)
+      inc result.skippedCount
+    else:
+      removeLogFile(entry.path, result)
+
+# Calculates the total size of log files in the logs dir and data dir.
+proc logsTotalSizeBytes*(logsDir, dataDir: string): int64 =
+  var collectResult: LogCleanupResult
+  var entries: seq[LogFileEntry]
+  collectLogFiles(logsDir, recursive = false, entries, collectResult)
+  collectLogFiles(dataDir, recursive = true, entries, collectResult)
+  for entry in entries:
+    try:
+      result += getFileSize(entry.path)
+    except OSError, IOError:
+      discard
+
+# Matches status-go's session-archive (= lumberjack backup) suffix so that the renamed files keep grouping into
+# the right retention family.
+proc archiveTimestamp(t: Time): string =
+  t.utc.format("yyyy-MM-dd'T'HH-mm-ss") & "." &
+    align($(t.nanosecond div 1_000_000), 3, '0')
+
+proc collisionFreeArchivePath(targetDir, family, ext: string, mtime: Time): string =
+  for offsetMs in 0 ..< 1000:
+    let ts = archiveTimestamp(mtime + initDuration(milliseconds = offsetMs))
+    let candidate = joinPath(targetDir, family & "-" & ts & ext)
+    if not fileExists(candidate):
+      return candidate
+  ""
+
+# Moves closed log files from the status-go data dir into the logs dir.
+# status-go-owned canonical (live-name) files are moved only when `migrateStatusGoCanonicalNames` is set - i.e. when status-go
+# runs inside this process and provably hasn't started yet (desktop, iOS);
+# On Android the status-go service outlives the UI process and may still be writing them.
+# Canonical files are renamed to a timestamped archive name so they can't collide with the new live file;
+# name collisions likewise get a collision-free archive name so nothing is left behind.
+# Moving preserves modification times, so per-family retention ordering survives the move.
+proc migrateLegacyLogFiles*(dataDir, logsDir: string, processStartedAt: Time,
+    migrateStatusGoCanonicalNames: bool = not StatusGoRunsOutOfProcess): LogMigrationResult =
+  acquire(cleanupLock)
+  defer:
+    release(cleanupLock)
+
+  if not dirExists(dataDir):
+    return
+
+  var collectResult: LogCleanupResult
+  var entries: seq[LogFileEntry]
+  collectLogFiles(dataDir, recursive = true, entries, collectResult)
+  result.failedCount = collectResult.failedCount
+  result.skippedCount = collectResult.skippedCount
+
+  for entry in entries:
+    if entry.lastWriteTime >= processStartedAt:
+      inc result.skippedCount
+      continue
+    let name = extractFilename(entry.path)
+    let canonical = isCanonicalLogName(name)
+    if canonical and not migrateStatusGoCanonicalNames and
+        isStatusGoOwnedCanonicalLogName(name):
+      inc result.skippedCount
+      continue
+    var target = joinPath(logsDir, name)
+    if canonical or fileExists(target):
+      let (_, ext) = splitLogName(name)
+      target = collisionFreeArchivePath(logsDir, logFamily(name), ext,
+        entry.lastWriteTime)
+      if target == "":
+        inc result.failedCount
+        continue
+    try:
+      moveFile(entry.path, target)
+      inc result.movedCount
+    except OSError, IOError:
+      inc result.failedCount

--- a/src/app/global/log_cleanup_tasks.nim
+++ b/src/app/global/log_cleanup_tasks.nim
@@ -12,6 +12,7 @@ type StartupLogCleanupTaskArg = ref object of TaskArg
   logsDir: string
   dataDir: string
   processStartedAtUnix: int64
+  maxFilesPerFamily: int
 
 proc startupLogCleanupTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[StartupLogCleanupTaskArg](argEncoded)
@@ -19,8 +20,9 @@ proc startupLogCleanupTask(argEncoded: string) {.gcsafe, nimcall.} =
     arg.logsDir,
     arg.dataDir,
     fromUnix(arg.processStartedAtUnix),
-    getTime(),
-    RemoveExpiredLogs)
+    RemoveExpiredLogs,
+    arg.maxFilesPerFamily
+  )
 
   if result.failedCount > 0:
     warn "failed to remove some expired log files", deletedCount = result.deletedCount,
@@ -28,11 +30,17 @@ proc startupLogCleanupTask(argEncoded: string) {.gcsafe, nimcall.} =
   else:
     debug "removed expired log files", deletedCount = result.deletedCount
 
-proc scheduleStartupLogCleanup*(threadpool: ThreadPool, logsDir, dataDir: string,
-    processStartedAt: Time) =
+proc scheduleLogFamilyCleanup*(threadpool: ThreadPool, logsDir, dataDir: string, processStartedAt: Time,
+  maxFilesPerFamily: int) =
   let arg = StartupLogCleanupTaskArg(
     tptr: startupLogCleanupTask,
     logsDir: logsDir,
     dataDir: dataDir,
-    processStartedAtUnix: processStartedAt.toUnix)
+    processStartedAtUnix: processStartedAt.toUnix,
+    maxFilesPerFamily: maxFilesPerFamily
+  )
   threadpool.start(arg)
+
+proc scheduleStartupLogCleanup*(threadpool: ThreadPool, logsDir, dataDir: string, processStartedAt: Time) =
+  # MaxLogFamilyMaxFiles is used on the app start, later updated to the user's per-family setting when DB is ready
+  scheduleLogFamilyCleanup(threadpool, logsDir, dataDir, processStartedAt, MaxLogFamilyMaxFiles)

--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -43,6 +43,15 @@ proc init*(self: Controller) =
     let args = advanced_service.AdvancedLogsCleanupFinishedArgs(e)
     self.onOldLogsCleanupFinished(args.deletedCount, args.failedCount, args.error)
 
+  self.events.on(node_configuration_service.SIGNAL_NODE_LOG_MAX_BACKUPS_UPDATE) do(e: Args):
+    let args = node_configuration_service.NodeLogMaxBackupsUpdatedArgs(e)
+    self.advancedService.cleanupLogFamilies(args.maxBackups)
+
+  self.events.on(advanced_service.SIGNAL_ADVANCED_LOGS_SIZE_UPDATED) do(e: Args):
+    self.delegate.onLogsFolderSizeChanged()
+
+  self.advancedService.refreshLogsFolderSize()
+
 proc getFleet*(self: Controller): string =
   return self.settingsService.getFleetAsString()
 
@@ -67,6 +76,12 @@ proc setMaxLogBackups*(self: Controller, value: int) =
 
 proc getIsClearingOldLogs*(self: Controller): bool =
   return self.advancedService.isClearingOldLogs()
+
+proc getLogsFolderSizeBytes*(self: Controller): float =
+  return self.advancedService.logsFolderSizeBytes()
+
+proc refreshLogsFolderSize*(self: Controller) =
+  self.advancedService.refreshLogsFolderSize()
 
 proc clearOldLogs*(self: Controller) =
   if self.advancedService.clearOldLogs():

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -90,6 +90,15 @@ method onLogMaxBackupsChanged*(self: AccessInterface) {.base.} =
 method getIsClearingOldLogs*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getLogsFolderSizeBytes*(self: AccessInterface): float {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onLogsFolderSizeChanged*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method refreshLogsFolderSize*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method clearOldLogs*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -133,6 +133,15 @@ method onLogMaxBackupsChanged*(self: Module) =
 method getIsClearingOldLogs*(self: Module): bool =
   return self.controller.getIsClearingOldLogs()
 
+method getLogsFolderSizeBytes*(self: Module): float =
+  return self.controller.getLogsFolderSizeBytes()
+
+method onLogsFolderSizeChanged*(self: Module) =
+  self.view.logsFolderSizeBytesChanged()
+
+method refreshLogsFolderSize*(self: Module) =
+  self.controller.refreshLogsFolderSize()
+
 method clearOldLogs*(self: Module) =
   self.controller.clearOldLogs()
 

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -106,6 +106,16 @@ QtObject:
     read = getIsClearingOldLogs
     notify = isClearingOldLogsChanged
 
+  proc logsFolderSizeBytesChanged*(self: View) {.signal.}
+  proc getLogsFolderSizeBytes*(self: View): float {.slot.} =
+    return self.delegate.getLogsFolderSizeBytes()
+  QtProperty[float] logsFolderSizeBytes:
+    read = getLogsFolderSizeBytes
+    notify = logsFolderSizeBytesChanged
+
+  proc refreshLogsFolderSize*(self: View) {.slot.} =
+    self.delegate.refreshLogsFolderSize()
+
   proc oldLogsCleanupFinished*(self: View, deletedCount: int, failedCount: int, error: string) {.signal.}
   proc clearOldLogs*(self: View) {.slot.} =
     self.delegate.clearOldLogs()

--- a/src/app_service/service/accounts/dto/login_request.nim
+++ b/src/app_service/service/accounts/dto/login_request.nim
@@ -22,6 +22,7 @@ type
     walletConfig*: WalletConfig
     apiConfig*: APIConfig
     walletConnectProjectID*: string
+    logFilePath*: string
 
 proc toJson*(self: LoginAccountRequest): JsonNode =
   result = %* {
@@ -36,6 +37,7 @@ proc toJson*(self: LoginAccountRequest): JsonNode =
     "mnemonic": self.mnemonic,
     "apiConfig": self.apiConfig,
     "walletConnectProjectID": self.walletConnectProjectID,
+    "logFilePath": self.logFilePath,
   }
   for key, value in self.walletSecretsConfig.toJson().pairs():
     result[key] = value

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -188,6 +188,7 @@ QtObject:
         kdfIterations: KDF_ITERATIONS,
         customizationColor: DEFAULT_CUSTOMIZATION_COLOR,
         logLevel: some(main_constants.getStatusGoLogLevel()),
+        logFilePath: main_constants.LOGDIR,
         wakuV2LightClient: main_constants.IS_MOBILE,
         wakuV2Nameserver: if main_constants.IS_MOBILE: some(MOBILE_WAKU_V2_NAMESERVER) else: none(string),
         wakuV2EnableMissingMessageVerification: true,
@@ -437,6 +438,7 @@ QtObject:
       apiConfig: defaultApiConfig(),
       walletConnectProjectID: main_constants.WALLET_CONNECT_PROJECT_ID,
       wakuV2Nameserver: if main_constants.IS_MOBILE: MOBILE_WAKU_V2_NAMESERVER else: "",
+      logFilePath: main_constants.LOGDIR,
     )
 
     if main_constants.runtimeLogLevelSet():

--- a/src/app_service/service/advanced/async_tasks.nim
+++ b/src/app_service/service/advanced/async_tasks.nim
@@ -20,7 +20,6 @@ proc clearOldLogsTask*(argEncoded: string) {.gcsafe, nimcall.} =
       arg.logsDir,
       arg.dataDir,
       fromUnix(arg.processStartedAtUnix),
-      getTime(),
       ClearClosedLogs)
     arg.finish(%* {
       "deletedCount": result.deletedCount,
@@ -29,6 +28,50 @@ proc clearOldLogsTask*(argEncoded: string) {.gcsafe, nimcall.} =
     })
   except Exception as e:
     error "failed to clear old log files", error = e.msg
+    arg.finish(%* {
+      "deletedCount": 0,
+      "failedCount": 0,
+      "error": e.msg,
+    })
+
+type LogsSizeTaskArg* = ref object of QObjectTaskArg
+  logsDir*: string
+  dataDir*: string
+
+proc computeLogsSizeTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[LogsSizeTaskArg](argEncoded)
+  try:
+    arg.finish(%* {
+      "sizeBytes": logsTotalSizeBytes(arg.logsDir, arg.dataDir),
+    })
+  except Exception as e:
+    error "failed to compute logs size", error = e.msg
+    arg.finish(%* {
+      "sizeBytes": 0,
+    })
+
+type LogFamilyCleanupTaskArg* = ref object of QObjectTaskArg
+  logsDir*: string
+  dataDir*: string
+  processStartedAtUnix*: int64
+  maxFilesPerFamily*: int
+
+proc logFamilyCleanupTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[LogFamilyCleanupTaskArg](argEncoded)
+  try:
+    let result = cleanupLogFiles(
+      arg.logsDir,
+      arg.dataDir,
+      fromUnix(arg.processStartedAtUnix),
+      RemoveExpiredLogs,
+      arg.maxFilesPerFamily)
+    arg.finish(%* {
+      "deletedCount": result.deletedCount,
+      "failedCount": result.failedCount,
+      "error": "",
+    })
+  except Exception as e:
+    error "failed to apply log family cap", error = e.msg
     arg.finish(%* {
       "deletedCount": 0,
       "failedCount": 0,

--- a/src/app_service/service/advanced/service.nim
+++ b/src/app_service/service/advanced/service.nim
@@ -12,6 +12,7 @@ logScope:
   topics = "advanced-app-service"
 
 const SIGNAL_ADVANCED_LOGS_CLEANUP_FINISHED* = "advancedLogsCleanupFinished"
+const SIGNAL_ADVANCED_LOGS_SIZE_UPDATED* = "advancedLogsSizeUpdated"
 
 type AdvancedLogsCleanupFinishedArgs* = ref object of Args
   deletedCount*: int
@@ -23,6 +24,8 @@ QtObject:
     events: EventEmitter
     threadpool: ThreadPool
     clearingOldLogs: bool
+    refreshingLogsSize: bool
+    logsFolderSizeBytesCached: float
 
   proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
@@ -34,6 +37,31 @@ QtObject:
 
   proc isClearingOldLogs*(self: Service): bool =
     return self.clearingOldLogs
+
+  proc logsFolderSizeBytes*(self: Service): float =
+    return self.logsFolderSizeBytesCached
+
+  proc refreshLogsFolderSize*(self: Service) =
+    if self.refreshingLogsSize:
+      return
+
+    self.refreshingLogsSize = true
+    let arg = LogsSizeTaskArg(
+      tptr: computeLogsSizeTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onLogsSizeComputed",
+      logsDir: LOGDIR,
+      dataDir: STATUSGODIR)
+    self.threadpool.start(arg)
+
+  proc onLogsSizeComputed*(self: Service, response: string) {.slot.} =
+    self.refreshingLogsSize = false
+    try:
+      let responseObj = response.parseJson
+      self.logsFolderSizeBytesCached = responseObj{"sizeBytes"}.getBiggestInt().float
+    except Exception as e:
+      error "failed to parse logs size response", error = e.msg
+    self.events.emit(SIGNAL_ADVANCED_LOGS_SIZE_UPDATED, Args())
 
   proc clearOldLogs*(self: Service): bool =
     if self.clearingOldLogs:
@@ -50,6 +78,20 @@ QtObject:
     self.threadpool.start(arg)
     return true
 
+  proc cleanupLogFamilies*(self: Service, maxFilesPerFamily: int) =
+    let arg = LogFamilyCleanupTaskArg(
+      tptr: logFamilyCleanupTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onLogFamilyCleanupFinished",
+      logsDir: LOGDIR,
+      dataDir: STATUSGODIR,
+      processStartedAtUnix: logCleanupProcessStartedAt().toUnix,
+      maxFilesPerFamily: maxFilesPerFamily)
+    self.threadpool.start(arg)
+
+  proc onLogFamilyCleanupFinished*(self: Service, response: string) {.slot.} =
+    self.refreshLogsFolderSize()
+
   proc onOldLogsCleanupFinished*(self: Service, response: string) {.slot.} =
     var result = AdvancedLogsCleanupFinishedArgs()
     try:
@@ -62,6 +104,7 @@ QtObject:
 
     self.clearingOldLogs = false
     self.events.emit(SIGNAL_ADVANCED_LOGS_CLEANUP_FINISHED, result)
+    self.refreshLogsFolderSize()
 
   proc delete*(self: Service) =
     self.QObject.delete

--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -1,7 +1,9 @@
+import std/json
 import chronicles, json_serialization
 
 import ./dto/node_config
 import ../../../app/core/eventemitter
+import ../../../app/global/log_cleanup
 import ../../../backend/node_config as status_node_config
 import ../../../constants as main_constants
 import ../../../app/core/signals/types
@@ -16,11 +18,16 @@ const WAKU_VERSION_2* = 2
 
 const
   SIGNAL_NODE_LOG_LEVEL_UPDATE* = "nodeLogLevelUpdated"
+  SIGNAL_NODE_LOG_MAX_BACKUPS_UPDATE* = "nodeLogMaxBackupsUpdated"
   DEBUG_LOG_LEVELS = @["DEBUG", "TRACE"]
 
 type
   NodeLogLevelUpdatedArgs* = ref object of Args
     logLevel*: LogLevel
+
+type
+  NodeLogMaxBackupsUpdatedArgs* = ref object of Args
+    maxBackups*: int
 
 type
   ArchiveProtocolMode* {.pure.} = enum
@@ -200,17 +207,21 @@ proc isFullNode*(self: Service): bool =
    return self.configuration.WakuConfig.FullNode
 
 proc getLogMaxBackups*(self: Service): int =
-  return self.configuration.LogMaxBackups
+  if self.configuration.LogMaxBackups <= 0:
+    return DefaultLogFamilyMaxFiles
+  return min(self.configuration.LogMaxBackups, MaxLogFamilyMaxFiles)
 
 proc setMaxLogBackups*(self: Service, value: int): bool =
+  let clamped = clamp(value, 1, MaxLogFamilyMaxFiles)
   try:
-    let response = status_node_config.setMaxLogBackups(value)
+    let response = status_node_config.setMaxLogBackups(clamped)
 
-    if response.error != nil:
-      let error = Json.decode($response.error, RpcError)
-      raise newException(RpcException, error.message)
+    let responseError = response.result{"error"}.getStr
+    if responseError != "":
+      raise newException(RpcException, responseError)
 
-    self.configuration.LogMaxBackups = value
+    self.configuration.LogMaxBackups = clamped
+    self.events.emit(SIGNAL_NODE_LOG_MAX_BACKUPS_UPDATE, NodeLogMaxBackupsUpdatedArgs(maxBackups: clamped))
     return true
   except Exception as e:
     error "failed to set max log backups", errDescription = e.msg

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -289,7 +289,7 @@ proc openedAccounts*(path: string): RpcResponse[JsonNode] =
       "mixpanelToken": MIXPANEL_TOKEN,
       "sentryDSN": SENTRY_DSN_STATUS_GO,
       "logEnabled": true,
-      "logDir": "", # Empty value defaults to `dataDir`
+      "logDir": status_const.LOGDIR,
       "logLevel": status_const.getStatusGoLogLevel(),
       "apiLoggingEnabled": status_const.API_LOGGING,
       "metricsEnabled": status_const.METRICS_ENABLED,

--- a/src/backend/node_config.nim
+++ b/src/backend/node_config.nim
@@ -36,10 +36,15 @@ proc setLogLevel*(logLevel: LogLevel): RpcResponse[JsonNode] =
   result = core.callPrivateRPC("setLogLevel".prefix, payload)
 
 proc setMaxLogBackups*(maxLogBackups: int): RpcResponse[JsonNode] =
-  let payload = %*[{
+  let payload = %* {
     "maxLogBackups": maxLogBackups
-  }]
-  return core.callPrivateRPC("setMaxLogBackups".prefix, payload)
+  }
+  try:
+    let response = status_go.setProfileLogMaxBackups($payload)
+    result.result = response.parseJSON()
+  except Exception as e:
+    error "error doing rpc request", methodName = "setProfileLogMaxBackups", exception=e.msg
+    raise newException(RpcException, e.msg)
 
 proc setLightClient*(enabled: bool): RpcResponse[JsonNode] =
   let payload = %*[{

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -59,7 +59,7 @@ let
   TMPDIR* = joinPath(baseDir, "tmp") & sep
   LOGDIR* = joinPath(baseDir, "logs") & sep
   KEYCARD_DATA_DIR* = joinPath(baseDir, "data", "keycard")
-  KEYCARD_LOG_FILE_PATH* = joinPath(KEYCARD_DATA_DIR, "keycard.log")
+  KEYCARD_LOG_FILE_PATH* = joinPath(LOGDIR, "keycard.log")
   KEYCARDPAIRINGDATAFILE* = joinPath(KEYCARD_DATA_DIR, "pairings.json")
 
   # runtime variables

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -239,6 +239,12 @@ proc mainProc() =
   let logCleanupProcessStartedAt = getTime()
   initializeLogCleanup(logCleanupProcessStartedAt)
 
+  # Move log files from the status-go data dir to the logs dir, before status-go opens any of
+  # them. On Android status-go runs in a separate long-lived process that may still be writing
+  # its live (canonical-named) log files, so those are left in place there (handled by the
+  # StatusGoRunsOutOfProcess-based default).
+  discard migrateLegacyLogFiles(STATUSGODIR, LOGDIR, logCleanupProcessStartedAt)
+
   # Open the log file and set the log level before any subsystem starts logging.
   # On iOS the stdout sink is disabled (no valid stdout FILE*), so logs go to the
   # file sink only; opening it here guarantees every startup log has a valid sink

--- a/src/status_go.nim
+++ b/src/status_go.nim
@@ -380,6 +380,11 @@ proc loginAccount*(requestJson: string): string =
   defer: go_shim.free(funcOut)
   return $funcOut
 
+proc setProfileLogMaxBackups*(requestJson: string): string =
+  var funcOut = go_shim.setProfileLogMaxBackups(requestJson.cstring)
+  defer: go_shim.free(funcOut)
+  return $funcOut
+
 proc createAccountAndLogin*(requestJSON: string): string =
   var funcOut = go_shim.createAccountAndLogin(requestJSON.cstring)
   defer: go_shim.free(funcOut)

--- a/src/status_go/impl.nim
+++ b/src/status_go/impl.nim
@@ -162,6 +162,8 @@ proc inputConnectionStringForImportingKeypairsKeystores*(connectionString: cstri
 
 proc loginAccount*(requestJSON: cstring): cstring {.importc: "LoginAccount".}
 
+proc setProfileLogMaxBackups*(requestJSON: cstring): cstring {.importc: "SetProfileLogMaxBackups".}
+
 proc createAccountAndLogin*(requestJSON: cstring): cstring {.importc: "CreateAccountAndLogin".}
 
 proc restoreAccountAndLogin*(requestJSON: cstring): cstring {.importc: "RestoreAccountAndLogin".}

--- a/test/nim/log_cleanup_test.nim
+++ b/test/nim/log_cleanup_test.nim
@@ -1,4 +1,4 @@
-import std/[os, times, unittest]
+import std/[os, strutils, times, unittest]
 
 import app/core/tasks/threadpool
 import app/global/log_cleanup
@@ -21,6 +21,11 @@ proc writeLog(path: string, modifiedAt: Time) =
   writeFile(path, "log")
   setLastModificationTime(path, modifiedAt)
 
+proc countLogs(dir, prefix: string): int =
+  for kind, path in walkDir(dir):
+    if kind == pcFile and extractFilename(path).startsWith(prefix):
+      inc result
+
 suite "log cleanup":
   var tempDir: string
   var logsDir: string
@@ -36,83 +41,273 @@ suite "log cleanup":
   teardown:
     removeTree(tempDir)
 
-  test "clear closed logs removes logs and preserves active files":
+  test "log family derivation":
+    check logFamily("app_20260814_083321.log") == "app"
+    check logFamily("app_20260815_121212.log") == "app"
+    check logFamily("pre_login.log") == "pre_login"
+    check logFamily("pre_login-2026-08-14T11-08-48Z.log") == "pre_login"
+    check logFamily("pre_login-2026-08-14T11-08-48.123.log") == "pre_login"
+    check logFamily("0x4d..2f40.log") == "0x4d..2f40"
+    check logFamily("0x4d..2f40-2026-08-14T13-37-56Z.log") == "0x4d..2f40"
+    check logFamily("0x4d..2f40-2026-08-14T13-37-56.000.log") == "0x4d..2f40"
+    check logFamily("api-2026-08-14T13-37-56.000.log.gz") == "api"
+    check logFamily("geth-2026-08-14T13-37-56Z.log") == "geth"
+    check logFamily("keycard.log") == "keycard"
+    check logFamily("some_random.log") == "some_random"
+    # not a session timestamp: stays its own family
+    check logFamily("backup-2026-08-14.log") == "backup-2026-08-14"
+
+  test "canonical log name detection":
+    # live-file names a writer keeps open
+    check isCanonicalLogName("pre_login.log")
+    check isCanonicalLogName("0x4d..2f40.log")
+    check isCanonicalLogName("keycard.log")
+    check isCanonicalLogName("some_random.log")
+    # archives and per-start client logs are not canonical
+    check not isCanonicalLogName("pre_login-2026-08-14T11-08-48Z.log")
+    check not isCanonicalLogName("0x4d..2f40-2026-08-14T13-37-56.000.log")
+    check not isCanonicalLogName("api-2026-08-14T13-37-56.000.log.gz")
+    check not isCanonicalLogName("app_20260814_083321.log")
+    # only status-go's own live files can be held by an out-of-process writer
+    check isStatusGoOwnedCanonicalLogName("pre_login.log")
+    check isStatusGoOwnedCanonicalLogName("0x4d..2f40.log")
+    check isStatusGoOwnedCanonicalLogName("api.log")
+    check isStatusGoOwnedCanonicalLogName("geth.log")
+    check not isStatusGoOwnedCanonicalLogName("keycard.log")
+    check not isStatusGoOwnedCanonicalLogName("some_random.log")
+    check not isStatusGoOwnedCanonicalLogName("pre_login-2026-08-14T11-08-48Z.log")
+    check not isStatusGoOwnedCanonicalLogName("app_20260814_083321.log")
+
+  test "clear closed logs removes closed files and preserves active ones":
     let processStartedAt = getTime()
     let closedTime = processStartedAt - initDuration(hours = 1)
     let activeTime = processStartedAt + initDuration(seconds = 1)
-    let closedAppLog = logsDir / "app-old.log"
-    let closedArchive = logsDir / "app-old.log.gz"
-    let activeAppLog = logsDir / "app-current.log"
-    let closedDataLog = dataDir / "geth.log"
-    let nestedClosedDataLog = dataDir / "keycard" / "keycard.log"
-    let activeDataLog = dataDir / "pre_login.log"
+    let closedAppLog = logsDir / "app_20260101_000000.log"
+    let closedArchive = logsDir / "pre_login-2026-08-14T11-08-48Z.log"
+    let closedArchiveGz = logsDir / "api-2026-08-14T13-37-56.000.log.gz"
+    let activeAppLog = logsDir / "app_20260102_000000.log"
+    let closedDataArchive = dataDir / "0x4d..2f40-2026-08-14T13-37-56.000.log"
+    # in-process status-go (desktop/iOS): mtime is a valid liveness test, so
+    # closed canonical files are deletable and active ones are kept
+    let closedCanonicalLog = dataDir / "geth.log"
+    let closedNestedLog = dataDir / "keycard" / "keycard.log"
+    let activeCanonicalLog = dataDir / "pre_login.log"
     let dataFile = dataDir / "node-config.json"
 
     writeLog(closedAppLog, closedTime)
     writeLog(closedArchive, closedTime)
+    writeLog(closedArchiveGz, closedTime)
     writeLog(activeAppLog, activeTime)
-    writeLog(closedDataLog, closedTime)
-    writeLog(nestedClosedDataLog, closedTime)
-    writeLog(activeDataLog, activeTime)
+    writeLog(closedDataArchive, closedTime)
+    writeLog(closedCanonicalLog, closedTime)
+    writeLog(closedNestedLog, closedTime)
+    writeLog(activeCanonicalLog, activeTime)
     writeFile(dataFile, "config")
 
-    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt, processStartedAt,
-      ClearClosedLogs)
+    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt, ClearClosedLogs,
+      protectStatusGoCanonical = false)
 
-    check result.deletedCount == 4
+    check result.deletedCount == 6
     check result.failedCount == 0
     check not fileExists(closedAppLog)
     check not fileExists(closedArchive)
-    check not fileExists(closedDataLog)
-    check not fileExists(nestedClosedDataLog)
+    check not fileExists(closedArchiveGz)
+    check not fileExists(closedDataArchive)
+    check not fileExists(closedCanonicalLog)
+    check not fileExists(closedNestedLog)
     check fileExists(activeAppLog)
-    check fileExists(activeDataLog)
+    check fileExists(activeCanonicalLog)
     check fileExists(dataFile)
 
-  test "retention removes only closed logs older than two weeks":
+  test "clear closed logs protects status-go canonical files when out of process":
+    # Android: the status-go service outlives the UI process, so its canonical
+    # files may be live even with an old mtime. UI-owned files (keycard.log)
+    # still follow the mtime test.
     let processStartedAt = getTime()
-    let expiredTime = processStartedAt - initDuration(days = LogRetentionDays + 1)
-    let recentTime = processStartedAt - initDuration(days = LogRetentionDays - 1)
+    let closedTime = processStartedAt - initDuration(hours = 1)
+    let statusGoLiveLog = dataDir / "pre_login.log"
+    let statusGoProfileLog = dataDir / "0x4d..2f40.log"
+    let statusGoArchive = dataDir / "pre_login-2026-08-14T11-08-48Z.log"
+    let uiOwnedLog = dataDir / "keycard" / "keycard.log"
+
+    writeLog(statusGoLiveLog, closedTime)
+    writeLog(statusGoProfileLog, closedTime)
+    writeLog(statusGoArchive, closedTime)
+    writeLog(uiOwnedLog, closedTime)
+
+    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt, ClearClosedLogs,
+      protectStatusGoCanonical = true)
+
+    check result.deletedCount == 2
+    check fileExists(statusGoLiveLog)
+    check fileExists(statusGoProfileLog)
+    # archives are closed by definition (status-go renamed them)
+    check not fileExists(statusGoArchive)
+    check not fileExists(uiOwnedLog)
+
+  test "retention keeps the newest files per family":
+    let processStartedAt = getTime()
     let activeTime = processStartedAt + initDuration(seconds = 1)
-    let expiredAppLog = logsDir / "app-expired.log"
-    let recentAppLog = logsDir / "app-recent.log"
-    let expiredDataLog = dataDir / "geth.log"
-    let recentDataLog = dataDir / "nested" / "keycard.log"
-    let activeDataLog = dataDir / "pre_login.log"
 
-    writeLog(expiredAppLog, expiredTime)
-    writeLog(recentAppLog, recentTime)
-    writeLog(expiredDataLog, expiredTime)
-    writeLog(recentDataLog, recentTime)
-    writeLog(activeDataLog, activeTime)
+    # 5 closed app logs, newest first should survive with cap 3
+    for i in 1 .. 5:
+      writeLog(logsDir / ("app_2026081" & $i & "_083321.log"),
+        processStartedAt - initDuration(days = 10 - i))
 
-    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt, processStartedAt,
-      RemoveExpiredLogs)
+    # another family should not be affected by the app family's overflow
+    writeLog(logsDir / "pre_login-2026-08-14T11-08-48Z.log",
+      processStartedAt - initDuration(days = 9))
+    writeLog(logsDir / "pre_login-2026-08-15T11-08-48Z.log",
+      processStartedAt - initDuration(days = 8))
+
+    # active file is kept and does not count against the cap
+    writeLog(logsDir / "app_20260816_083321.log", activeTime)
+
+    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt,
+      RemoveExpiredLogs, maxFilesPerFamily = 3)
 
     check result.deletedCount == 2
     check result.failedCount == 0
-    check not fileExists(expiredAppLog)
-    check not fileExists(expiredDataLog)
-    check fileExists(recentAppLog)
-    check fileExists(recentDataLog)
-    check fileExists(activeDataLog)
+    # oldest two app logs removed
+    check not fileExists(logsDir / "app_20260811_083321.log")
+    check not fileExists(logsDir / "app_20260812_083321.log")
+    check fileExists(logsDir / "app_20260813_083321.log")
+    check fileExists(logsDir / "app_20260814_083321.log")
+    check fileExists(logsDir / "app_20260815_083321.log")
+    check fileExists(logsDir / "pre_login-2026-08-14T11-08-48Z.log")
+    check fileExists(logsDir / "pre_login-2026-08-15T11-08-48Z.log")
+    check fileExists(logsDir / "app_20260816_083321.log")
+
+  test "retention counts family members across both directories":
+    let processStartedAt = getTime()
+
+    writeLog(logsDir / "pre_login-2026-08-15T11-08-48Z.log",
+      processStartedAt - initDuration(days = 1))
+    writeLog(dataDir / "pre_login-2026-08-14T11-08-48Z.log",
+      processStartedAt - initDuration(days = 2))
+    writeLog(dataDir / "pre_login-2026-08-13T11-08-48Z.log",
+      processStartedAt - initDuration(days = 3))
+
+    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt,
+      RemoveExpiredLogs, maxFilesPerFamily = 2)
+
+    check result.deletedCount == 1
+    check fileExists(logsDir / "pre_login-2026-08-15T11-08-48Z.log")
+    check fileExists(dataDir / "pre_login-2026-08-14T11-08-48Z.log")
+    check not fileExists(dataDir / "pre_login-2026-08-13T11-08-48Z.log")
+
+  test "retention clamps the cap to the allowed range":
+    let processStartedAt = getTime()
+    writeLog(logsDir / "app_20260814_083321.log",
+      processStartedAt - initDuration(days = 1))
+    writeLog(logsDir / "app_20260815_083321.log",
+      processStartedAt - initDuration(days = 2))
+
+    let result = cleanupLogFiles(logsDir, dataDir, processStartedAt,
+      RemoveExpiredLogs, maxFilesPerFamily = 0)
+
+    # cap 0 clamps to 1: newest survives
+    check result.deletedCount == 1
+    check fileExists(logsDir / "app_20260814_083321.log")
+    check not fileExists(logsDir / "app_20260815_083321.log")
 
   test "missing log directories are ignored":
     let currentTime = getTime()
     let missingLogsDir = tempDir / "missing-logs"
     let missingDataDir = tempDir / "missing-data"
-    let result = cleanupLogFiles(missingLogsDir, missingDataDir, currentTime, currentTime, ClearClosedLogs)
+    let result = cleanupLogFiles(missingLogsDir, missingDataDir, currentTime, ClearClosedLogs)
 
     check result.deletedCount == 0
     check result.failedCount == 0
 
-  test "startup retention runs on the shared thread pool":
+  test "migration moves closed logs from data dir into logs dir":
     let processStartedAt = getTime()
-    let expiredLog = logsDir / "app-expired.log"
-    writeLog(expiredLog, processStartedAt - initDuration(days = LogRetentionDays + 1))
+    let closedTime = processStartedAt - initDuration(hours = 1)
+    let activeTime = processStartedAt + initDuration(seconds = 1)
+
+    writeLog(dataDir / "pre_login.log", closedTime)
+    writeLog(dataDir / "pre_login-2026-08-14T11-08-48Z.log", closedTime)
+    writeLog(dataDir / "keycard" / "keycard.log", closedTime)
+    writeLog(dataDir / "0x4d..2f40.log", activeTime) # active: stays
+    writeLog(logsDir / "pre_login-2026-08-14T11-08-48Z.log", closedTime) # collision
+    writeFile(dataDir / "node-config.json", "config")
+
+    let result = migrateLegacyLogFiles(dataDir, logsDir, processStartedAt,
+      migrateStatusGoCanonicalNames = true)
+
+    check result.movedCount == 3
+    check result.failedCount == 0
+    # canonical files are moved under a timestamped archive name so they can't
+    # collide with the new live file at the destination
+    check not fileExists(logsDir / "pre_login.log")
+    check not fileExists(logsDir / "keycard.log")
+    check not fileExists(dataDir / "pre_login.log")
+    check not fileExists(dataDir / "keycard" / "keycard.log")
+    check countLogs(logsDir, "keycard-") == 1
+    # the archive rename must keep the file in its original retention family
+    for kind, path in walkDir(logsDir):
+      if kind == pcFile and extractFilename(path).startsWith("keycard-"):
+        check logFamily(path) == "keycard"
+    # the canonical pre_login.log and the colliding archive both got fresh
+    # archive names next to the pre-existing one
+    check countLogs(logsDir, "pre_login-") == 3
+    check not fileExists(dataDir / "pre_login-2026-08-14T11-08-48Z.log")
+    # active file untouched
+    check fileExists(dataDir / "0x4d..2f40.log")
+    check fileExists(dataDir / "node-config.json")
+
+  test "migration leaves status-go canonical names in place when not permitted":
+    # On Android the status-go service may still be writing pre_login.log /
+    # 0x….log even though this (UI) process just started. UI-owned canonical
+    # files (keycard.log) are still migrated.
+    let processStartedAt = getTime()
+    let closedTime = processStartedAt - initDuration(hours = 1)
+
+    writeLog(dataDir / "pre_login.log", closedTime)
+    writeLog(dataDir / "0x4d..2f40.log", closedTime)
+    writeLog(dataDir / "pre_login-2026-08-14T11-08-48Z.log", closedTime)
+    writeLog(dataDir / "keycard" / "keycard.log", closedTime)
+
+    let result = migrateLegacyLogFiles(dataDir, logsDir, processStartedAt,
+      migrateStatusGoCanonicalNames = false)
+
+    check result.movedCount == 2
+    check fileExists(dataDir / "pre_login.log")
+    check fileExists(dataDir / "0x4d..2f40.log")
+    check fileExists(logsDir / "pre_login-2026-08-14T11-08-48Z.log")
+    check not fileExists(dataDir / "keycard" / "keycard.log")
+    check countLogs(logsDir, "keycard-") == 1
+
+  test "migration preserves modification times":
+    let processStartedAt = getTime()
+    let closedTime = processStartedAt - initDuration(hours = 5)
+    writeLog(dataDir / "pre_login-2026-08-14T11-08-48Z.log", closedTime)
+
+    discard migrateLegacyLogFiles(dataDir, logsDir, processStartedAt,
+      migrateStatusGoCanonicalNames = true)
+
+    let movedInfo = getFileInfo(logsDir / "pre_login-2026-08-14T11-08-48Z.log")
+    check abs(inSeconds(movedInfo.lastWriteTime - closedTime)) <= 1
+
+  test "logs total size covers both directories":
+    let processStartedAt = getTime()
+    writeLog(logsDir / "app_20260814_083321.log", processStartedAt)
+    writeLog(dataDir / "pre_login.log", processStartedAt)
+    writeFile(dataDir / "node-config.json", "not counted")
+
+    check logsTotalSizeBytes(logsDir, dataDir) == 2 * len("log")
+
+  test "startup cleanup task runs on the shared thread pool":
+    let processStartedAt = getTime()
+    writeLog(logsDir / "app_20260814_083321.log",
+      processStartedAt - initDuration(days = 1))
+    writeLog(logsDir / "app_20260815_083321.log",
+      processStartedAt - initDuration(days = 2))
     let threadpool = newThreadPool()
 
-    scheduleStartupLogCleanup(threadpool, logsDir, dataDir, processStartedAt)
+    scheduleLogFamilyCleanup(threadpool, logsDir, dataDir, processStartedAt,
+      maxFilesPerFamily = 1)
     threadpool.teardown()
 
-    check not fileExists(expiredLog)
+    check fileExists(logsDir / "app_20260814_083321.log")
+    check not fileExists(logsDir / "app_20260815_083321.log")

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -20,6 +20,7 @@ QtObject {
     property bool isNimbusProxyEnabled: advancedModule? advancedModule.isNimbusProxyEnabled : false
     property bool isDebugEnabled: advancedModule? advancedModule.isDebugEnabled : false
     property int logMaxBackups: advancedModule ? advancedModule.logMaxBackups : 1
+    property real logsFolderSizeBytes: advancedModule ? advancedModule.logsFolderSizeBytes : 0
     property bool isRuntimeLogLevelSet: advancedModule ? advancedModule.isRuntimeLogLevelSet: false
     property bool isClearingOldLogs: advancedModule ? advancedModule.isClearingOldLogs : false
     readonly property int archiveProtocolMode: advancedModule ? advancedModule.archiveProtocolMode : AdvancedStore.ArchiveProtocolMode.Disabled
@@ -120,6 +121,13 @@ QtObject {
             return
 
         root.advancedModule.clearOldLogs()
+    }
+
+    function refreshLogsFolderSize() {
+        if(!root.advancedModule)
+            return
+
+        root.advancedModule.refreshLogsFolderSize()
     }
 
     function toggleExperimentalFeature(feature) {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -42,10 +42,11 @@ SettingsContentBase {
     property bool minimizeOnCloseOptionVisible
     property bool refetchTxHistoryClicked: false
     onVisibleChanged: {
-        // Reset the refetchTx button state when the user leaves the screen
         if (visible) {
+            root.advancedStore.refreshLogsFolderSize()
             return
         }
+        // Reset the refetchTx button state when the user leaves the screen
         root.refetchTxHistoryClicked = false
     }
 
@@ -173,15 +174,41 @@ SettingsContentBase {
                 spacing: Theme.padding
 
                 StatusBaseText {
-                    Layout.fillWidth: true
-                    text: qsTr("Old logs")
+                    text: qsTr("Logs (%1)").arg(Qt.locale().formattedDataSize(root.advancedStore.logsFolderSizeBytes, 2, Locale.DataSizeTraditionalFormat))
                     elide: Text.ElideRight
+                }
+
+                StatusButton {
+                    objectName: "refreshLogsFolderSizeButton"
+                    Layout.preferredWidth: 24
+                    Layout.preferredHeight: 24
+                    Layout.alignment: Qt.AlignVCenter
+                    size: StatusBaseButton.Size.Tiny
+                    icon.name: "refresh"
+                    icon.width: 16
+                    icon.height: 16
+                    Accessible.name: qsTr("Refresh logs size")
+                    tooltip.text: qsTr("Refresh logs size")
+                    onClicked: root.advancedStore.refreshLogsFolderSize()
+                }
+
+                Item {
+                    Layout.fillWidth: true
                 }
 
                 StatusButton {
                     text: root.advancedStore.isClearingOldLogs ? qsTr("Clearing...") : qsTr("Clear old logs")
                     enabled: !root.advancedStore.isClearingOldLogs
                     onClicked: clearOldLogsConfirmation.open()
+                }
+            }
+
+            StatusSettingsLineButton {
+                width: parent.width
+                text: qsTr("How many log files to keep archived")
+                currentValue: LocaleUtils.numberToLocaleString(root.advancedStore.logMaxBackups)
+                onClicked: {
+                    Global.openPopup(changeNumberOfLogsArchived)
                 }
             }
 
@@ -399,15 +426,6 @@ SettingsContentBase {
 
             StatusSettingsLineButton {
                 width: parent.width
-                text: qsTr("How many log files to keep archived")
-                currentValue: root.advancedStore.logMaxBackups.toString()
-                onClicked: {
-                    Global.openPopup(changeNumberOfLogsArchived)
-                }
-            }
-
-            StatusSettingsLineButton {
-                width: parent.width
                 id: rpcStatsButton
                 text: qsTr("RPC statistics")
                 onClicked: rpcStatsModal.open()
@@ -464,7 +482,7 @@ SettingsContentBase {
                         width: parent.width
                         padding: 15
                         wrapMode: Text.WordWrap
-                        text: qsTr("Choose a number between 1 and 100")
+                        text: qsTr("Choose a number between 1 and 50")
                     }
 
                     StatusAmountInput {
@@ -473,24 +491,17 @@ SettingsContentBase {
                         anchors.right: parent.right
                         anchors.leftMargin: Theme.padding
                         anchors.rightMargin: Theme.padding
-                        label: qsTr("Number of archives files")
+                        label: qsTr("Number of archive files per group")
                         input.text: root.advancedStore.logMaxBackups
-                        placeholderText: qsTr("Number between 1 and 100")
+                        placeholderText: qsTr("Number between 1 and 50")
                         validators: [
                             StatusIntValidator {
                                 bottom: 1
-                                top: 100
-                                errorMessage: qsTr("Number needs to be between 1 and 100")
+                                top: 50
+                                errorMessage: qsTr("Number needs to be between 1 and 50")
                                 locale: LocaleUtils.userInputLocale
                             }
                         ]
-                    }
-
-                    StatusBaseText {
-                        width: parent.width
-                        padding: 15
-                        wrapMode: Text.WordWrap
-                        text: qsTr("This change will only come into action after a restart")
                     }
                 }
 
@@ -505,6 +516,7 @@ SettingsContentBase {
                         id: banButton
                         text: qsTr("Change")
                         type: StatusBaseButton.Type.Normal
+                        enabled: numberInput.valid
                         onClicked: {
                             root.advancedStore.setMaxLogBackups(numberInput.input.text)
                             logChangerModal.close()

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1062,6 +1062,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Logs (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refresh logs size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Experimental features</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1106,6 +1114,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Choose a number between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number needs to be between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1123,10 +1143,6 @@
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
-    </message>
-    <message>
-        <source>Old logs</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clearing...</source>
@@ -1181,23 +1197,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Choose a number between 1 and 100</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of archives files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number between 1 and 100</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number needs to be between 1 and 100</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>This change will only come into action after a restart</source>
+        <source>Number of archive files per group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1065,6 +1065,14 @@
         <translation>Logy aplikace</translation>
     </message>
     <message>
+        <source>Logs (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refresh logs size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Experimental features</source>
         <translation>Experimentální funkce</translation>
     </message>
@@ -1109,6 +1117,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Choose a number between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number needs to be between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Debug</source>
         <translation>Ladění</translation>
     </message>
@@ -1127,10 +1147,6 @@
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
-    </message>
-    <message>
-        <source>Old logs</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clearing...</source>
@@ -1185,24 +1201,8 @@
         <translation>Kolik souborů logů chcete uchovávat archivovaných?</translation>
     </message>
     <message>
-        <source>Choose a number between 1 and 100</source>
-        <translation>Vyberte číslo mezi 1 a 100</translation>
-    </message>
-    <message>
-        <source>Number of archives files</source>
-        <translation>Počet archivních souborů</translation>
-    </message>
-    <message>
-        <source>Number between 1 and 100</source>
-        <translation>Číslo mezi 1 a 100</translation>
-    </message>
-    <message>
-        <source>Number needs to be between 1 and 100</source>
-        <translation>Číslo musí být mezi 1 a 100</translation>
-    </message>
-    <message>
-        <source>This change will only come into action after a restart</source>
-        <translation>Tato změna se projeví až po restartu</translation>
+        <source>Number of archive files per group</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1062,6 +1062,14 @@
         <translation>Registros de la aplicación</translation>
     </message>
     <message>
+        <source>Logs (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refresh logs size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Experimental features</source>
         <translation>Funciones experimentales</translation>
     </message>
@@ -1106,6 +1114,18 @@
         <translation>La aplicación se reiniciará si lo confirma.</translation>
     </message>
     <message>
+        <source>Choose a number between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number needs to be between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Debug</source>
         <translation>Depuración</translation>
     </message>
@@ -1123,10 +1143,6 @@
             <numerusform>Se borró %n archivo de registro antiguo</numerusform>
             <numerusform>Se borraron %n archivos de registro antiguos</numerusform>
         </translation>
-    </message>
-    <message>
-        <source>Old logs</source>
-        <translation>Registros antiguos</translation>
     </message>
     <message>
         <source>Clearing...</source>
@@ -1181,24 +1197,8 @@
         <translation>¿Cuántos archivos de registro quieres mantener archivados?</translation>
     </message>
     <message>
-        <source>Choose a number between 1 and 100</source>
-        <translation>Elige un número entre 1 y 100</translation>
-    </message>
-    <message>
-        <source>Number of archives files</source>
-        <translation>Número de archivos archivados</translation>
-    </message>
-    <message>
-        <source>Number between 1 and 100</source>
-        <translation>Número entre 1 y 100</translation>
-    </message>
-    <message>
-        <source>Number needs to be between 1 and 100</source>
-        <translation>El número debe estar entre 1 y 100</translation>
-    </message>
-    <message>
-        <source>This change will only come into action after a restart</source>
-        <translation>Este cambio solo entrará en acción después de un reinicio</translation>
+        <source>Number of archive files per group</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1059,6 +1059,14 @@
         <translation>애플리케이션 로그</translation>
     </message>
     <message>
+        <source>Logs (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refresh logs size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Experimental features</source>
         <translation>실험적 기능</translation>
     </message>
@@ -1103,6 +1111,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Choose a number between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number needs to be between 1 and 50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Debug</source>
         <translation>디버그</translation>
     </message>
@@ -1119,10 +1139,6 @@
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
-    </message>
-    <message>
-        <source>Old logs</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clearing...</source>
@@ -1177,24 +1193,8 @@
         <translation>보관할 로그 파일을 몇 개로 유지할까요?</translation>
     </message>
     <message>
-        <source>Choose a number between 1 and 100</source>
-        <translation>1부터 100 사이의 숫자를 선택하세요</translation>
-    </message>
-    <message>
-        <source>Number of archives files</source>
-        <translation>아카이브 파일 개수</translation>
-    </message>
-    <message>
-        <source>Number between 1 and 100</source>
-        <translation>1에서 100 사이의 숫자</translation>
-    </message>
-    <message>
-        <source>Number needs to be between 1 and 100</source>
-        <translation>숫자는 1과 100 사이여야 합니다</translation>
-    </message>
-    <message>
-        <source>This change will only come into action after a restart</source>
-        <translation>이 변경 사항은 재시작 후에만 적용됩니다</translation>
+        <source>Number of archive files per group</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -576,7 +576,7 @@ Window {
                             try {
                                 const json = globalUtils.collectLogFilesJson()
                                 const paths = JSON.parse(json)
-                                if (!paths || paths.length === 1) {
+                                if (!paths || paths.length === 0) {
                                     exportLogFilesButton.enabled = false
                                     exportLogFilesButton.text = qsTr("No log files found")
                                     return


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/7717

Changes:
- redirect all logs into logs/ dir
- pass logDir (InitializeApplication), logFilePath (CreateAccount) and the new Login.logFilePath to status-go, so pre_login.log, api.log and the per-profile 0x….log land in logs/
- one-time startup migration moves closed log files from data/ into logs/ dir
- make the Advanced setting default 10, range 1..50
- "Old logs" shows the total log size in MB with a refresh button

Fixes #22016


https://github.com/user-attachments/assets/623ebb32-5cb9-4f46-94a9-1b314812f538

