### PR TITLE
chore(Profile): speed up initial creation

### DIFF
--- a/storybook/pages/SettingsLeftTabViewPage.qml
+++ b/storybook/pages/SettingsLeftTabViewPage.qml
@@ -29,7 +29,11 @@ SplitView {
             messagingBadgeCount: ctrlMessagingBadgeCount.value
             localBackupEnabled: ctrlLocalBackupEnabled.checked
         }
-        onMenuItemClicked: (event) => logs.logEvent("onMenuItemClicked", ["event"], [event])
+        onMenuItemClicked: function(subsection) {
+            settingsSubsection = subsection
+            logs.logEvent("onMenuItemClicked", ["subsection"], [subsection])
+        }
+
     }
 
     LogsAndControlsPanel {

--- a/storybook/src/Models/SectionsModel.qml
+++ b/storybook/src/Models/SectionsModel.qml
@@ -127,7 +127,7 @@ ListModel {
         description: "",
         allMembers: [],
         activeMembersCount: 0,
-        enabled: true,
+        enabled: false,
         hasNotification: false,
         notificationsCount: 0,
         active: false

--- a/test/e2e/gui/objects_map/settings_names.py
+++ b/test/e2e/gui/objects_map/settings_names.py
@@ -26,7 +26,7 @@ settingsWalletOption = {"container": mainWindow_settingsList_SettingsList, "obje
 settingsSignOutQuitOption = {"container": LeftTabProfileMenu, "objectName": "17-ExtraMenuItem", "type": "StatusNavigationListItem", "visible": True}
 
 # Communities View
-mainWindow_CommunitiesView = {"container": statusDesktop_mainWindow, "id": "communitiesView", "type": "Loader", "unnamed": 1}
+mainWindow_CommunitiesView = {"container": statusDesktop_mainWindow, "type": "CommunitiesView", "unnamed": 1, "visible": True}
 mainWindow_settingsContentBaseScrollView_StatusScrollView = {"container": statusDesktop_mainWindow, "objectName": "settingsContentBaseScrollView", "type": "StatusScrollView", "visible": True}
 settingsContentBaseScrollView_listItem_StatusListItem = {"container": mainWindow_settingsContentBaseScrollView_StatusScrollView, "id": "listItem", "type": "StatusListItem", "unnamed": 1, "visible": True}
 
@@ -47,7 +47,7 @@ always_show_radioButton_StatusRadioButton = {"container": settingsContentBase_Sc
 never_show_radioButton_StatusRadioButton = {"container": settingsContentBase_ScrollView, "objectName": "MessagingView_NeverShow_RadioButton", "type": "SettingsRadioButton", "visible": True}
 
 # Contacts View
-mainWindow_ContactsView = {"container": statusDesktop_mainWindow, "id": "contactsView", "type": "Loader", "unnamed": 1, "visible": True}
+mainWindow_ContactsView = {"container": statusDesktop_mainWindow, "type": "ContactsView", "unnamed": 1, "visible": True}
 mainWindow_Send_contact_request_to_chat_key_StatusButton = {"checkable": False, "container": mainWindow_ContactsView, "objectName": "ContactsView_ContactRequest_Button", "type": "StatusButton", "visible": True}
 contactsTabBar_Pending_Requests_StatusTabButton = {"container": mainWindow_ContactsView, "objectName": "ContactsView_PendingRequest_Button", "type": "StatusTabButton", "visible": True}
 settingsContentBaseScrollView_ContactListPanel = {"container": settingsContentBase_ScrollView, "objectName": "ContactListPanel_ListView", "type": "ContactsListPanel", "visible": True}
@@ -71,7 +71,6 @@ unblock_user_StatusMenuItem = {"container": statusDesktop_mainWindow_overlay, "e
 block_user_StatusMenuItem = {"container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": "blockUser_StatusItem", "type": "StatusMenuItem", "visible": True}
 
 # Wallet Settings View
-mainWindow_WalletView = {"container": statusDesktop_mainWindow, "id": "walletView", "type": "Loader", "unnamed": 1, "visible": True}
 settingsWallet_View = {"container": statusDesktop_mainWindow, "type": "WalletView", "unnamed": 1, "visible": True}
 settings_Wallet_MainView_Networks = {"container": statusDesktop_mainWindow, "objectName": "networksItem", "type": "StatusListItem"}
 settings_Wallet_MainView_Manage_Tokens = {"container": settingsContentBase_ScrollView, "objectName": "manageTokensItem", "type": "StatusListItem", "visible": True}

--- a/test/e2e/gui/screens/settings_wallet.py
+++ b/test/e2e/gui/screens/settings_wallet.py
@@ -29,7 +29,7 @@ from gui.objects_map import settings_names, wallet_names
 class WalletSettingsView(QObject):
 
     def __init__(self):
-        super().__init__(settings_names.mainWindow_WalletView)
+        super().__init__(settings_names.settingsWallet_View)
         self.scroll = Scroll(settings_names.settingsContentBase_ScrollView)
         self.wallet_settings_add_new_account_button = Button(
             settings_names.settings_Wallet_MainView_AddNewAccountButton)

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -257,6 +257,8 @@ LayoutChooser {
         landscapeView
     ]
 
+    readonly property bool isPortrait: chosenLayout === portraitView
+
     StatusSectionLayoutLandscape {
         id: landscapeView
         anchors.fill: parent

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -39,8 +39,8 @@ StatusSectionLayout {
     required property bool isProduction
     required property string userUID
 
-    property alias settingsSubsection: leftPanel.settingsSubsection
-    property int settingsSubSubsection
+    property int settingsSubsection: -1
+    property int settingsSubSubsection: -1
 
     objectName: "profileStatusSectionLayout"
 
@@ -92,7 +92,9 @@ StatusSectionLayout {
     required property real nativeWindowDpr // baseline/native DPR of the respective Screen
 
     required property var whitelistedDomainsModel
- 
+
+    required property int syncingBadgeCount
+
     signal addressWasShownRequested(string address)
     signal connectUsernameRequested(string ensName, string ownerAddress)
     signal registerUsernameRequested(string ensName, int chainId)
@@ -118,13 +120,13 @@ StatusSectionLayout {
             Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.about)
             break;
         case Constants.settingsSubsection.wallet:
-            walletView.item.goBack()
+            profileContainer.currentItem.goBack()
             break;
         case Constants.settingsSubsection.privacyAndSecurity:
-            privacyAndSecurityView.item.resetStack()
+            profileContainer.currentItem.resetStack()
             break;
         case Constants.settingsSubsection.keycardNew:
-            keycardViewNew.item.handleBackAction()
+            profileContainer.currentItem.handleBackAction()
             break;
         }
 
@@ -135,20 +137,13 @@ StatusSectionLayout {
         root.goToNextPanel()
     }
 
-    Component.onCompleted: {
-        Qt.callLater(() => {
-                         profileContainer.currentIndexChanged()
-                         root.devicesStore.loadDevices() // Load devices to get non-paired number for badge
-                     })
-    }
-
     QtObject {
         id: d
 
         readonly property int contentWidth: Math.min(root.centerPanel.width, 560)
         readonly property int rightPanelWidth: Math.min(root.centerPanel.height, 768)
 
-        readonly property bool isProfilePanelActive: profileContainer.currentIndex === Constants.settingsSubsection.profile
+        readonly property bool isProfilePanelActive: root.settingsSubsection === Constants.settingsSubsection.profile
         readonly property bool sideBySidePreviewAvailable: root.Window.width >= 1840 // design
 
         // Used to alternatively add an error message to the dirty bubble if ephemeral notification
@@ -168,7 +163,7 @@ StatusSectionLayout {
         isKeycardEnabled: root.isKeycardEnabled
         localBackupEnabled: root.devicesStore.localBackupEnabled
 
-        syncingBadgeCount: root.devicesStore.totalDevicesCount - root.devicesStore.pairedDevicesCount
+        syncingBadgeCount: root.syncingBadgeCount
         messagingBadgeCount: root.pendingReceivedContactsCount
     }
 
@@ -176,59 +171,127 @@ StatusSectionLayout {
     subsectionHistory: SQUtils.SubsectionNavigationHistory {
         currentKey: root.settingsSubsection
         validateFn: (key) => SQUtils.ModelUtils.indexOf(settingsEntriesModel, "subsection", parseInt(key)) >= 0
-        onNavigateRequested: (key) => root.settingsSubsection = parseInt(key)
+        onNavigateRequested: (key) => {
+                                 Global.changeAppSectionBySectionType(Constants.appSection.profile, parseInt(key))
+                                 root.goToNextPanel()
+                             }
     }
 
     leftPanel: SettingsLeftTabView {
         id: leftPanel
         anchors.fill: parent
 
+        settingsSubsection: root.settingsSubsection
         model: settingsEntriesModel
 
-        onMenuItemClicked: function(event) {
-            if (profileContainer.currentItem.dirty && !profileContainer.currentItem.ignoreDirty) {
-                event.accepted = true;
+        onMenuItemClicked: function(subsection) {
+            if (profileContainer.currentItem?.dirty && !profileContainer.currentItem?.ignoreDirty) {
                 profileContainer.currentItem.notifyDirty();
+                return
             }
+            Global.changeAppSectionBySectionType(Constants.appSection.profile, subsection)
             root.goToNextPanel();
         }
     }
 
-    centerPanel: StackLayout {
-        id: profileContainer
+    function loadSection(section: int): void {
+        d.backButtonName = ""
+        if (section === -1) {
+            profileContainer.clear()
+            return
+        }
+        var componentToLoad = null
+        switch (section) {
+        case Constants.settingsSubsection.profile:
+            componentToLoad = myProfileViewComp
+            break
+        case Constants.settingsSubsection.password:
+            componentToLoad = changePasswordViewComp
+            break
+        case Constants.settingsSubsection.contacts:
+            d.backButtonName = settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.messaging)
+            componentToLoad = contactsViewComp
+            break
+        case Constants.settingsSubsection.ensUsernames:
+            componentToLoad = ensViewComp
+            break
+        case Constants.settingsSubsection.messaging:
+            componentToLoad = messagingViewComp
+            break
+        case Constants.settingsSubsection.wallet:
+            componentToLoad = walletViewComp
+            break
+        case Constants.settingsSubsection.appearance:
+            componentToLoad = appearanceViewComp
+            break
+        case Constants.settingsSubsection.language:
+            componentToLoad = languageViewComp
+            break
+        case Constants.settingsSubsection.notifications:
+            componentToLoad = notificationsViewComp
+            break
+        case Constants.settingsSubsection.syncingSettings:
+            componentToLoad = syncingViewComp
+            break
+        case Constants.settingsSubsection.browserSettings:
+            componentToLoad = browserViewComp
+            break
+        case Constants.settingsSubsection.advanced:
+            componentToLoad = advancedViewComp
+            break
+        case Constants.settingsSubsection.about:
+            componentToLoad = aboutViewComp
+            break
+        case Constants.settingsSubsection.communitiesSettings:
+            componentToLoad = communitiesViewComp
+            break
+        case Constants.settingsSubsection.keycardNew:
+            componentToLoad = keycardViewNewComp
+            break
+        case Constants.settingsSubsection.about_terms:
+            d.backButtonName = settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.about)
+            componentToLoad = termsOfUseComp
+            break
+        case Constants.settingsSubsection.about_privacy:
+            d.backButtonName = settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.about)
+            componentToLoad = privacyPolicyComp
+            break
+        case Constants.settingsSubsection.privacyAndSecurity:
+            componentToLoad = privacyAndSecurityViewComp
+            break
+        case Constants.settingsSubsection.backupSettings:
+            componentToLoad = backupViewComp
+            break
+        case Constants.settingsSubsection.logosNetworkSettings:
+            componentToLoad = logosNetworkViewComp
+            break
+        default:
+            console.warn("ProfileLayout.loadSection: unhandled settings subsection:", section)
+            break
+        }
+        if (!!componentToLoad) {
+            profileContainer.replaceCurrentItem(componentToLoad, {}, StackView.Immediate)
+        }
+    }
 
-        readonly property var currentItem: (currentIndex >= 0 && currentIndex < children.length) ? children[currentIndex].item : null
+    Connections {
+        target: root
+        function onSettingsSubsectionChanged(): void {
+            root.loadSection(root.settingsSubsection)
+        }
+    }
+
+    centerPanel: StackView {
+        id: profileContainer
 
         anchors.fill: parent
         anchors.leftMargin: root.Theme.xlPadding * 2
         anchors.rightMargin: root.Theme.xlPadding * 2
 
-        currentIndex: leftPanel.settingsSubsection
-        onCurrentIndexChanged: {
-            if (!!children[currentIndex] && !children[currentIndex].active)
-                children[currentIndex].active = true
-
-            d.backButtonName = ""
-
-            if (currentIndex === Constants.settingsSubsection.contacts) {
-                d.backButtonName = settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.messaging)
-            } else if (currentIndex === Constants.settingsSubsection.about_privacy || currentIndex === Constants.settingsSubsection.about_terms) {
-                d.backButtonName = settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.about)
-            } else if (currentIndex === Constants.settingsSubsection.wallet) {
-                walletView.item.initStack()
-            } else if (currentIndex === Constants.settingsSubsection.privacyAndSecurity) {
-                privacyAndSecurityView.item.resetStack()
-            } else if (currentIndex === Constants.settingsSubsection.keycardNew) {
-                keycardViewNew.item.handleBackAction()
-            }
-        }
-
-        Loader {
-            active: false
-            sourceComponent: MyProfileView {
-                id: myProfileView
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: myProfileViewComp
+            MyProfileView {
+                ignoreDirty: root.isPortrait
 
                 profileStore: root.profileStore
                 contactsStore: root.contactsStore
@@ -272,11 +335,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: ChangePasswordView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: changePasswordViewComp
+            ChangePasswordView {
                 privacyStore: root.privacyStore
                 keychain: root.keychain
                 passwordStrengthScoreFunction: root.sharedRootStore.getPasswordStrengthScore
@@ -285,13 +346,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            id: contactsView
-
-            active: false
-            sourceComponent: ContactsView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: contactsViewComp
+            ContactsView {
                 contactsStore: root.contactsStore
                 utilsStore: root.utilsStore
                 sectionTitle: qsTr("Contacts")
@@ -305,16 +362,13 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            id: ensContainer
-            active: false
-            sourceComponent: EnsView {
+        Component {
+            id: ensViewComp
+            EnsView {
                 // TODO: we need to align structure for the entire this part using `SettingsContentBase` as root component
                 // TODO: handle structure for this subsection to match style used in onther sections
                 // using `SettingsContentBase` component as base.
 
-                implicitWidth: parent.width
-                implicitHeight: parent.height
                 ensUsernamesStore: root.ensUsernamesStore
                 walletAssetsStore: root.walletAssetsStore
                 networkConnectionStore: root.networkConnectionStore
@@ -325,11 +379,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: MessagingView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: messagingViewComp
+            MessagingView {
                 contentWidth: d.contentWidth
 
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.messaging)
@@ -338,12 +390,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            id: walletView
-            active: false
-            sourceComponent: WalletView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: walletViewComp
+            WalletView {
                 contentWidth: d.contentWidth
 
                 settingsSubSubsection: root.settingsSubSubsection
@@ -366,15 +415,14 @@ StatusSectionLayout {
                 onAddressWasShownRequested: (address) => root.addressWasShownRequested(address)
 
                 onBackButtonNameChanged: d.backButtonName = backButtonName
+
+                Component.onCompleted: initStack()
             }
-            onLoaded: d.backButtonName = ""
         }
 
-        Loader {
-            active: false
-            sourceComponent: AppearanceView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: appearanceViewComp
+            AppearanceView {
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.appearance)
                 contentWidth: d.contentWidth
                 nativeWindowDpr: root.nativeWindowDpr
@@ -385,12 +433,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: LanguageView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
-
+        Component {
+            id: languageViewComp
+            LanguageView {
                 currentLanguage: root.languageStore.currentLanguage
                 availableLanguages: root.languageStore.availableLanguages
                 currentCurrency: root.currencyStore.currentCurrency
@@ -408,12 +453,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: NotificationsView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
-
+        Component {
+            id: notificationsViewComp
+            NotificationsView {
                 privacyStore: root.privacyStore
                 notificationsStore: root.notificationsStore
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.notifications)
@@ -421,13 +463,10 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: SyncingView {
+        Component {
+            id: syncingViewComp
+            SyncingView {
                 id: syncingView
-                implicitWidth: parent.width
-                implicitHeight: parent.height
-
                 profileStore: root.profileStore
                 devicesStore: root.devicesStore
                 privacyStore: root.privacyStore
@@ -443,12 +482,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: BrowserView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
-
+        Component {
+            id: browserViewComp
+            BrowserView {
                 userUID: root.userUID
                 accountSettings: localAccountSensitiveSettings
                 browserPreferencesStore: root.browserPreferencesStore
@@ -457,14 +493,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            id: advancedView
-
-            active: false
-            sourceComponent: AdvancedView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
-
+        Component {
+            id: advancedViewComp
+            AdvancedView {
                 messagingSettingsStore: root.messagingSettingsStore
                 advancedStore: root.advancedStore
                 walletStore: root.walletStore
@@ -477,11 +508,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: AboutView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: aboutViewComp
+            AboutView {
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.about)
                 contentWidth: d.contentWidth
                 isProduction: root.isProduction
@@ -495,21 +524,13 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            id: communitiesView
-            
-            active: false
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            sourceComponent: CommunitiesView {
-
+        Component {
+            id: communitiesViewComp
+            CommunitiesView {
                 function getSpecificCommunityAccessStore(communityId: string) {
                     const communityRootStore = root.messagingRootStore.createCommunityRootStore(this, communityId)
                     return communityRootStore ? communityRootStore.communityAccessStore : null
                 }
-
-                implicitWidth: parent.width
-                implicitHeight: parent.height
 
                 rootStore: root.globalStore
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.communitiesSettings)
@@ -535,13 +556,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            id: keycardViewNew
-            active: false
-            sourceComponent: KeycardViewNew {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
-
+        Component {
+            id: keycardViewNewComp
+            KeycardViewNew {
                 keycardNewStore: root.keycardNewStore
                 areTestNetworksEnabled: root.networksStore.areTestNetworksEnabled
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.keycardNew)
@@ -551,16 +568,14 @@ StatusSectionLayout {
                 onBackButtonNameRequested: function(name) {
                     d.backButtonName = name
                 }
+
+                Component.onCompleted: handleBackAction()
             }
         }
 
-        Loader {
-            active: false
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            sourceComponent: SettingsContentBase {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: termsOfUseComp
+            SettingsContentBase {
                 sectionTitle: "Status Software - Terms of Use"
                 contentWidth: d.contentWidth
 
@@ -574,13 +589,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            sourceComponent: SettingsContentBase {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: privacyPolicyComp
+            SettingsContentBase {
                 sectionTitle: "Status Software - Privacy Policy"
                 contentWidth: d.contentWidth
 
@@ -594,17 +605,13 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            id: privacyAndSecurityView
-
-            active: false
-            sourceComponent: PrivacyAndSecurityView {
+        Component {
+            id: privacyAndSecurityViewComp
+            PrivacyAndSecurityView {
                 whitelistedDomainsModel: root.whitelistedDomainsModel
                 isStatusNewsViaRSSEnabled: root.privacyStore.isStatusNewsViaRSSEnabled
                 thirdpartyServicesEnabled: root.privacyStore.thirdpartyServicesEnabled
                 privacyModeFeatureEnabled: root.privacyModeFeatureEnabled
-                implicitWidth: parent.width
-                implicitHeight: parent.height
 
                 privacySectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.privacyAndSecurity)
                 contentWidth: d.contentWidth
@@ -617,14 +624,14 @@ StatusSectionLayout {
 
                 onBackButtonTextChanged: d.backButtonName = backButtonText
                 onRemoveWhitelistedDomain: index => root.removeWhitelistedDomain(index)
+
+                Component.onCompleted: resetStack()
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: BackupView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: backupViewComp
+            BackupView {
                 contentWidth: d.contentWidth
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.backupSettings)
 
@@ -643,11 +650,9 @@ StatusSectionLayout {
             }
         }
 
-        Loader {
-            active: false
-            sourceComponent: LogosNetworkView {
-                implicitWidth: parent.width
-                implicitHeight: parent.height
+        Component {
+            id: logosNetworkViewComp
+            LogosNetworkView {
                 contentWidth: d.contentWidth
                 sectionTitle: qsTr("Logos Network")
                 peerCount: root.logosNetworkStore.peerCount
@@ -663,6 +668,6 @@ StatusSectionLayout {
     rightPanelWidth: d.rightPanelWidth
     rightPanel: Loader {
         active: root.showRightPanel
-        sourceComponent: profileContainer.currentItem.sideBySidePreviewComponent
+        sourceComponent: profileContainer.currentItem?.sideBySidePreviewComponent
     }
 }

--- a/ui/app/AppLayouts/Profile/controls/SettingsList.qml
+++ b/ui/app/AppLayouts/Profile/controls/SettingsList.qml
@@ -24,7 +24,7 @@ import StatusQ.Core.Utils
 StatusListView {
     id: root
 
-    property int currenctSubsection
+    property int currenctSubsection: -1
 
     signal clicked(int subsection)
 

--- a/ui/app/AppLayouts/Profile/helpers/SettingsEntriesModel.qml
+++ b/ui/app/AppLayouts/Profile/helpers/SettingsEntriesModel.qml
@@ -191,19 +191,6 @@ SortFilterProxyModel {
         }
     ]
 
-    // Update model after retranslation
-    onEntriesChanged: {
-        if (baseModel.count === 0)
-            return
-
-        entries.forEach((elem, index) => {
-            baseModel.setProperty(index, "text", elem.text)
-
-            if (elem.group)
-                baseModel.setProperty(index, "group", elem.group)
-        })
-    }
-
     function getNameForSubsection(subsection) {
         const entry = root.entries.find(entry => entry.subsection === subsection)
         return entry ? entry.text : ""
@@ -217,9 +204,10 @@ SortFilterProxyModel {
         }
 
         delegate: QtObject {
-            readonly property string objectName: "settingsNav_" + model.subsection
+            readonly property int subsection: model.subsection
+            readonly property string objectName: "settingsNav_" + subsection
             readonly property bool visible: {
-                switch (model.subsection) {
+                switch (subsection) {
                     case Constants.settingsSubsection.ensUsernames:
                     case Constants.settingsSubsection.wallet:
                         return root.showWalletEntries
@@ -239,7 +227,7 @@ SortFilterProxyModel {
             }
 
             readonly property int badgeCount: {
-                switch (model.subsection) {
+                switch (subsection) {
                     case Constants.settingsSubsection.backUpSeed:
                         return root.backUpSeedBadgeCount
                     case Constants.settingsSubsection.syncingSettings:

--- a/ui/app/AppLayouts/Profile/views/LogosNetworkView.qml
+++ b/ui/app/AppLayouts/Profile/views/LogosNetworkView.qml
@@ -65,10 +65,13 @@ SettingsContentBase {
                   .arg(Utils.getStyledLink(qsTr("Learn more"),
                                            d.logosMessagingDocsUrl,
                                            hoveredLink,
-                                           Theme.palette.isDark ? Theme.palette.directColor1 : Theme.palette.primaryColor1,
-                                           Theme.palette.isDark ? Theme.palette.directColor1 : Theme.palette.hoverColor(Theme.palette.primaryColor1)))
+                                           Theme.palette.primaryColor1,
+                                           Theme.palette.hoverColor(Theme.palette.primaryColor1), hoveredLink))
             textFormat: Text.RichText
             onLinkActivated: (link) => Global.requestOpenLink(link)
+            HoverHandler {
+                cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : undefined
+            }
         }
 
         Separator {
@@ -95,7 +98,9 @@ SettingsContentBase {
                 color: Theme.palette.primaryColor3
 
                 StatusBaseText {
-                    anchors.centerIn: parent
+                    anchors.fill: parent
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
                     text: root.peerCountLoading || root.peerCount < 0 ?
                               "..." :
                               root.peerCount
@@ -180,6 +185,7 @@ SettingsContentBase {
                 anchors.leftMargin: d.spacing
                 anchors.rightMargin: d.spacing
                 anchors.topMargin: Theme.padding
+                anchors.bottomMargin: Theme.padding
                 spacing: Theme.padding
 
                 StatusBaseText {

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -117,8 +117,8 @@ SettingsContentBase {
         }
     }
 
-    onVisibleChanged: if (visible) profileStore.requestProfileShowcasePreferences()
-    Component.onCompleted: profileStore.requestProfileShowcasePreferences()
+    onVisibleChanged: if (visible) Qt.callLater(() => profileStore.requestProfileShowcasePreferences())
+    Component.onCompleted: Qt.callLater(() => profileStore.requestProfileShowcasePreferences())
 
     property QObject priv: QObject {
         id: priv

--- a/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
+++ b/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
@@ -28,7 +28,7 @@ SettingsContentBase {
     signal removeWhitelistedDomain(int index)
 
     function resetStack() {
-            stackContainer.currentIndex = 0
+        stackContainer.currentIndex = 0
     }
 
     StackLayout {

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -184,6 +184,7 @@ FocusScope {
 
     Connections {
         target: scrollView.flickable
+        enabled: SQUtils.Utils.isMobile
 
         function scrollToFocusedItem() {
             const focusedItem = root.Window.activeFocusItem

--- a/ui/app/AppLayouts/Profile/views/SettingsLeftTabView.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsLeftTabView.qml
@@ -13,9 +13,9 @@ Item {
 
     property alias model: settingsList.model
 
-    signal menuItemClicked(var event)
+    signal menuItemClicked(string subsection)
 
-    property alias settingsSubsection: settingsList.currenctSubsection
+    property int settingsSubsection: -1
 
     StatusNavigationPanelHeadline {
         id: title
@@ -28,6 +28,8 @@ Item {
 
     SettingsList {
         id: settingsList
+
+        currenctSubsection: root.settingsSubsection
 
         anchors.right: parent.right
         anchors.left: parent.left
@@ -48,14 +50,7 @@ Item {
                 return
             }
 
-            const event = { accepted: false, item: subsection }
-
-            root.menuItemClicked(event)
-
-            if (event.accepted)
-                return
-
-            root.settingsSubsection = subsection
+            root.menuItemClicked(subsection)
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -405,6 +405,7 @@ SettingsContentBase {
             implicitHeight: root.availableHeight
             Layout.fillWidth: true
 
+            currentIndex: root.settingsSubSubsection - 2 // manageNetworks, manageAccounts
             tokensStore: root.tokensStore
             thirdpartyServicesEnabled: root.thirdpartyServicesEnabled
             tokenListUpdatedAt: tokensStore.tokenListUpdatedAt

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDKBase.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDKBase.qml
@@ -3,7 +3,7 @@ import QtQuick
 /// Abstract base for WC/BC SDK implementations (ConnectorWCSDK, DappsConnectorSDK)
 Item {
     required property string projectId
-    property bool enabled: true
+    enabled: true
 
     signal statusChanged(string message)
     signal sdkInit(bool success, var result)

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -83,6 +83,7 @@ QtObject {
             localBackupEnabled: root.localBackupEnabled
             palette: root.palette
         }
+        onLoaded: Qt.callLater(() => item.devicesStore.loadDevices())
     }
 
     readonly property var contactsStoreLoader: Loader {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2340,6 +2340,7 @@ Item {
                         keychain: appMain.keychain
 
                         isProduction: appMain.rootStore.isProduction
+                        isPortraitMode: appMain.isPortraitMode
                         systemTrayIconAvailable: appMain.systemTrayIconAvailable
                         theme: appMainLocalSettings.theme
                         nativeWindowDpr: d.nativeWindowDpr

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1293,8 +1293,8 @@ Item {
             }
 
             if (sectionType === Constants.appSection.profile) {
-                profileLoader.settingsSubsection = subsection || Constants.settingsSubsection.profile
                 profileLoader.settingsSubSubsection = subSubsection
+                profileLoader.settingsSubsection = subsection || Constants.settingsSubsection.profile
                 profileLoader.forceSubsectionNavigation()
             } else if (sectionType === Constants.appSection.wallet) {
                 appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(subsection, subSubsection, data)
@@ -2339,11 +2339,13 @@ Item {
                         emojiPopupLoader: statusEmojiPopup
                         keychain: appMain.keychain
 
+                        userUID: d.myPublicKey
                         isProduction: appMain.rootStore.isProduction
                         isPortraitMode: appMain.isPortraitMode
                         systemTrayIconAvailable: appMain.systemTrayIconAvailable
                         theme: appMainLocalSettings.theme
                         nativeWindowDpr: d.nativeWindowDpr
+                        syncingBadgeCount: d.syncingBadgeCount
                         whitelistedDomainsModel: appMainLocalSettings.whitelistedUnfurledDomains
                         leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -301,6 +301,9 @@ Control {
             color: d.containerBgColor
             radius: d.containerBgRadius
 
+            // prevent badge peeking out when we're fully hidden
+            clip: root.position === 0
+
             PrimaryNavSidebarButton {
                 anchors.fill: parent
                 bgRadius: parent.radius

--- a/ui/app/mainui/sectionLoaders/HomePageLoader.qml
+++ b/ui/app/mainui/sectionLoaders/HomePageLoader.qml
@@ -40,8 +40,6 @@ Loader {
         id: adaptor
         active: root.active
         sourceComponent: HomePageAdaptor {
-            id: homePageAdaptor
-
             readonly property bool sectionsLoaded: root.rootStore.sectionsLoaded
 
             sectionsBaseModel: sectionsLoaded ? root.rootStore.sectionsModel : null
@@ -102,7 +100,7 @@ Loader {
         target: root.item
         ignoreUnknownSignals: true
 
-        function onItemActivated(key, sectionType, itemId) {
+        function onItemActivated(key: string, sectionType: int, itemId: string): void {
             adaptor.item.setTimestamp(key, new Date().valueOf())
 
             if (sectionType === -1) { // search
@@ -135,13 +133,13 @@ Loader {
             root.appSectionRequested(sectionType, subsection, subSubsection, data)
         }
 
-        function onItemPinRequested(key, pin) {
+        function onItemPinRequested(key: string, pin: bool): void {
             adaptor.item.setPinned(key, pin)
             if (pin)
                 adaptor.item.setTimestamp(key, new Date().valueOf())
         }
 
-        function onDappDisconnectRequested(dappUrl) {
+        function onDappDisconnectRequested(dappUrl: string): void {
             root.dappsServiceLoader.dappDisconnectRequested(dappUrl)
         }
     }

--- a/ui/app/mainui/sectionLoaders/ProfileLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ProfileLoader.qml
@@ -55,12 +55,13 @@ Loader {
 
     // Inputs
     required property bool isProduction
+    required property bool isPortraitMode
     required property bool systemTrayIconAvailable
     required property int theme
     required property var whitelistedDomainsModel
     required property real nativeWindowDpr // baseline/native DPR of the respective Screen
 
-    property int settingsSubsection: -1
+    property int settingsSubsection: isPortraitMode ? -1 : Constants.settingsSubsection.profile // load and select Profile on desktop; nothing on mobile
     property int settingsSubSubsection: -1
     property real leftPanelWidthOverride: 0
 

--- a/ui/app/mainui/sectionLoaders/ProfileLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ProfileLoader.qml
@@ -54,14 +54,16 @@ Loader {
     required property Keychain keychain
 
     // Inputs
+    required property string userUID
     required property bool isProduction
     required property bool isPortraitMode
     required property bool systemTrayIconAvailable
     required property int theme
     required property var whitelistedDomainsModel
     required property real nativeWindowDpr // baseline/native DPR of the respective Screen
+    required property int syncingBadgeCount
 
-    property int settingsSubsection: isPortraitMode ? -1 : Constants.settingsSubsection.profile // load and select Profile on desktop; nothing on mobile
+    property int settingsSubsection: isPortraitMode ? -1 : Constants.settingsSubsection.profile // load and select Profile on desktop; nothing on mobile, just the left panel list
     property int settingsSubSubsection: -1
     property real leftPanelWidthOverride: 0
 
@@ -69,24 +71,6 @@ Loader {
         if (root.item && root.item.forceSubsectionNavigation) {
             root.item.forceSubsectionNavigation()
         }
-    }
-
-    onSettingsSubsectionChanged: {
-        if (root.item && root.item.settingsSubsection !== root.settingsSubsection) {
-            root.item.settingsSubsection = root.settingsSubsection
-        }
-    }
-
-    onSettingsSubSubsectionChanged: {
-        if (root.item && root.item.settingsSubSubsection !== root.settingsSubSubsection) {
-            root.item.settingsSubSubsection = root.settingsSubSubsection
-        }
-    }
-
-    Binding {
-        when: !!root.item
-        root.settingsSubsection: root.item.settingsSubsection
-        root.settingsSubSubsection: root.item.settingsSubSubsection
     }
 
     // Signals re-emitted so AppMain can mutate appMainLocalSettings / Theme outside the loader
@@ -103,12 +87,14 @@ Loader {
     function loadSection() {
         if (!root.active)
             return
+        if (!!root.item)
+            return
         if (root.source === QmlCompiler.profileUrl)
             return
         setSource(QmlCompiler.profileUrl, {
             visible:                                false,
-            isProduction:                           Qt.binding(() => root.isProduction),
-            userUID:                                Qt.binding(() => root.profileStore.pubKey),
+            isProduction:                           root.isProduction,
+            userUID:                                root.userUID,
             sharedRootStore:                        Qt.binding(() => root.sharedRootStore),
             utilsStore:                             Qt.binding(() => root.utilsStore),
             aboutStore:                             Qt.binding(() => root.aboutStore),
@@ -134,13 +120,13 @@ Loader {
             currencyStore:                          Qt.binding(() => root.currencyStore),
             networksStore:                          Qt.binding(() => root.networksStore),
             messagingRootStore:                     Qt.binding(() => root.messagingRootStore),
-            keychain:                               Qt.binding(() => root.keychain),
-            emojiPopup:                             Qt.binding(() => root.emojiPopupLoader.item),
-            mutualContactsModel:                    Qt.binding(() => root.contactsAdaptor.mutualContacts),
-            blockedContactsModel:                   Qt.binding(() => root.contactsAdaptor.blockedContacts),
-            pendingContactsModel:                   Qt.binding(() => root.contactsAdaptor.pendingContacts),
+            keychain:                               root.keychain,
+            emojiPopup:                             root.emojiPopupLoader.item,
+            mutualContactsModel:                    root.contactsAdaptor.mutualContacts,
+            blockedContactsModel:                   root.contactsAdaptor.blockedContacts,
+            pendingContactsModel:                   root.contactsAdaptor.pendingContacts,
             pendingReceivedContactsCount:           Qt.binding(() => root.contactsAdaptor.pendingReceivedRequestContacts.count),
-            dismissedReceivedRequestContactsModel:  Qt.binding(() => root.contactsAdaptor.dismissedReceivedRequestContacts),
+            dismissedReceivedRequestContactsModel:  root.contactsAdaptor.dismissedReceivedRequestContacts,
             isKeycardEnabled:                       Qt.binding(() => root.featureFlagsStore.keycardEnabled),
             isBrowserEnabled:                       Qt.binding(() => root.featureFlagsStore.browserEnabled),
             messageLinkSharingFeatureEnabled:       Qt.binding(() => root.featureFlagsStore.messageLinkSharingEnabled),
@@ -148,15 +134,25 @@ Loader {
             minimizeOnCloseOptionVisible:           Qt.binding(() => root.systemTrayIconAvailable),
             theme:                                  Qt.binding(() => root.theme),
             nativeWindowDpr:                        Qt.binding(() => root.nativeWindowDpr),
+            syncingBadgeCount:                      Qt.binding(() => root.syncingBadgeCount),
             whitelistedDomainsModel:                Qt.binding(() => root.whitelistedDomainsModel),
             leftPanelWidthOverride:                 Qt.binding(() => root.leftPanelWidthOverride),
-            settingsSubsection:                     Qt.binding(() => root.settingsSubsection),
-            settingsSubSubsection:                  Qt.binding(() => root.settingsSubSubsection)
         })
     }
 
-    onActiveChanged: loadSection()
+    onActiveChanged: {
+        if (active)
+            loadSection()
+        else {
+            // reinit the bindings from scratch when unloading
+            root.settingsSubsection = Qt.binding(() => root.isPortraitMode ? -1 : Constants.settingsSubsection.profile)
+            root.settingsSubSubsection = -1
+        }
+    }
     onLoaded: {
+        // late bindings in order to re-eval when invoking Settings from outside
+        item.settingsSubsection = Qt.binding(() => root.settingsSubsection)
+        item.settingsSubSubsection = Qt.binding(() => root.settingsSubSubsection)
         item.visible = true
     }
 
@@ -164,9 +160,6 @@ Loader {
         target: root.item
         ignoreUnknownSignals: true
 
-        function onSettingsSubsectionChanged() {
-            root.settingsSubsection = root.item.settingsSubsection
-        }
         function onAddressWasShownRequested(address) {
             WalletStores.RootStore.addressWasShown(address)
         }

--- a/ui/app/mainui/sectionLoaders/QmlCompiler.qml
+++ b/ui/app/mainui/sectionLoaders/QmlCompiler.qml
@@ -21,11 +21,10 @@ QtObject {
     readonly property QtObject _d: QtObject {
         id: d
         property var precompiledUrls: new Set()
-        property var pinned: []
+        property var pinned: [] // prevent GC of the `precompiledUrls`
     }
 
     signal precompileFinished(url componentUrl, bool success)
-
 
     function precompile(componentUrl, async = true) {
         if (d.precompiledUrls.has(componentUrl))

--- a/ui/imports/shared/panels/RoundedIcon.qml
+++ b/ui/imports/shared/panels/RoundedIcon.qml
@@ -18,7 +18,6 @@ Rectangle {
     height: 36
     property alias iconWidth: roundedIconImage.width
     property alias iconHeight: roundedIconImage.height
-    property alias rotation: roundedIconImage.rotation
     property color iconColor: StatusColors.transparent
 
     color: Theme.palette.primaryColor1
@@ -37,6 +36,7 @@ Rectangle {
             height: 12
             fillMode: Image.PreserveAspectFit
             source: Assets.svg("new_chat")
+            rotation: root.rotation
         }
         ColorOverlay {
             anchors.fill: roundedIconImage

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -23,6 +23,6 @@ QtObject {
     }
 
     function getPasswordStrengthScore(password) {
-        return root.privacyModule.getPasswordStrengthScore(password, "");
+        return root.privacyModule.getPasswordStrengthScore(password)
     }
 }

--- a/ui/imports/utils/ProfileUtils.qml
+++ b/ui/imports/utils/ProfileUtils.qml
@@ -8,24 +8,24 @@ QtObject {
 
     readonly property int defaultDelegateHeight: 76
 
-    function displayName(nickName, ensName, displayName, aliasName)
+    function displayName(nickName: string, ensName: string, displayName: string, aliasName: string) : string
     {
         return nickName || ensName || displayName || aliasName
     }
 
     // social links utils
-    function addSocialLinkPrefix(link, type) {
+    function addSocialLinkPrefix(link: string, type: int) : string {
         const prefix = Constants.socialLinkPrefixesByType[type]
         if (link.startsWith(prefix))
             return link
         return prefix + link
     }
 
-    function stripSocialLinkPrefix(link, type) {
+    function stripSocialLinkPrefix(link: string, type: int) : string {
         return link.replace(Constants.socialLinkPrefixesByType[type], "")
     }
 
-    function linkTypeToText(linkType) {
+    function linkTypeToText(linkType: int) : string {
         if (linkType === Constants.socialLinkType.twitter) return qsTr("X (Twitter)")
         if (linkType === Constants.socialLinkType.personalSite) return qsTr("Personal site")
         if (linkType === Constants.socialLinkType.github) return qsTr("Github")
@@ -35,7 +35,7 @@ QtObject {
         return "" // "custom" link type allows for user defined text
     }
 
-    function linkTypeToShortText(linkType) {
+    function linkTypeToShortText(linkType: int) : string {
         if (linkType === Constants.socialLinkType.twitter) return qsTr("X (Twitter)")
         if (linkType === Constants.socialLinkType.personalSite) return qsTr("Personal")
         if (linkType === Constants.socialLinkType.github) return qsTr("Github")
@@ -45,7 +45,7 @@ QtObject {
         return "" // "custom" link type allows for user defined text
     }
 
-    function linkTypeColor(linkType: int, palette: ThemePalette) : color {
+    function linkTypeColor(linkType: int, palette: ThemePalette) : string {
         if (linkType === Constants.socialLinkType.twitter) return "#000000"
         if (linkType === Constants.socialLinkType.github) return "#000000"
         if (linkType === Constants.socialLinkType.youtube) return "#FF3000"
@@ -54,11 +54,11 @@ QtObject {
         return palette.primaryColor1
     }
 
-    function linkTypeBgColor(linkType:int, palette: ThemePalette) : color {
+    function linkTypeBgColor(linkType:int, palette: ThemePalette) : string {
         return StatusColors.getColor(linkTypeColor(linkType, palette), 0.1)
     }
 
-    function linkTypeToDescription(linkType) {
+    function linkTypeToDescription(linkType: int) : string {
         if (linkType === Constants.socialLinkType.twitter) return qsTr("Twitter username")
         if (linkType === Constants.socialLinkType.personalSite) return qsTr("Personal site")
         if (linkType === Constants.socialLinkType.github) return qsTr("Github")
@@ -68,7 +68,7 @@ QtObject {
         return ""
     }
 
-    function linkTextToType(text) {
+    function linkTextToType(text: string): int {
         if (text === "__twitter") return Constants.socialLinkType.twitter
         if (text === "__personal_site") return Constants.socialLinkType.personalSite
         if (text === "__github") return Constants.socialLinkType.github
@@ -78,7 +78,7 @@ QtObject {
         return Constants.socialLinkType.custom
     }
 
-    function linkTypeToIcon(linkType) {
+    function linkTypeToIcon(linkType: int) : string {
         if (linkType === Constants.socialLinkType.twitter) return "xtwitter"
         if (linkType === Constants.socialLinkType.personalSite) return "language"
         if (linkType === Constants.socialLinkType.github) return "github"
@@ -89,7 +89,7 @@ QtObject {
     }
 
     // showcase
-    function visibilityIcon(showcaseVisibility) {
+    function visibilityIcon(showcaseVisibility: int) : string {
         switch (showcaseVisibility) {
         case Constants.ShowcaseVisibility.IdVerifiedContacts:
             return "checkmark-circle"
@@ -104,7 +104,7 @@ QtObject {
     }
 
     // Member role names:
-    function getMemberRoleText(memberRole) {
+    function getMemberRoleText(memberRole: int) : string {
         switch(memberRole) {
         case Constants.memberRole.owner:
             return qsTr("Owner")


### PR DESCRIPTION
### What does the PR do

> [!NOTE]
> Best review commit by commit 

- bunch of improvements to speed up initial Settings loading time
- couple of fixes spotted

Fixes https://github.com/status-im/status-app/issues/21960

### Affected areas

Settings

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/4f9c2271-b046-4591-81c1-43d0747457d0

### Impact on end user

- faster startup time, esp. on mobile

### How to test

- launch Status
- click the Settings icon in the left nav bar

### Risk 

low
