### PR TITLE
feat(ci): change S3 storage from DO to Hetzner

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 QT_VERSION = "6.11.0"
 

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 /* Object to store public URLs for description. */
 urls = [:]

--- a/ci/Jenkinsfile.fdroid
+++ b/ci/Jenkinsfile.fdroid
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.flatpak
+++ b/ci/Jenkinsfile.flatpak
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 QT_VERSION = "6.11.0"
 

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 QT_VERSION = "6.11.0"
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 QT_VERSION = "6.11.0"
 

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 QT_VERSION = "6.11.0"
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.46'
+library 'status-jenkins-lib@v1.9.48'
 
 QT_VERSION = "6.11.0"
 


### PR DESCRIPTION
Update status-jenkins-lib to newest tag which uses Hetzner object storage instead of Digital Ocean spaces.

Referenced issue:
* https://github.com/status-im/infra-ci/issues/282