### PR TITLE
fix(AppMain): unbreak section kbd shortcuts

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2675,9 +2675,11 @@ Item {
     Instantiator {
         model: 9
         delegate: Action {
+            id: delegateAction
+            required property int index
             shortcut: "Ctrl+" + (index + 1)
-            onTriggered: index => {
-                Global.setNthEnabledSectionActive(index)
+            onTriggered: {
+                Global.setNthEnabledSectionActive(delegateAction.index)
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

- the `index` capture was wrong here; the signal signature is `triggered(QtObject source)`, we need the `index` from the parent Repeater's delegate

Fixes #22008

### Affected areas

AppMain

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/eb6657b0-22da-4b74-96a7-06c386ef12f7

### Impact on end user

- working kbd shortcuts

### How to test

- press `Ctrl+0..9` to switch sections

### Risk 

low
