### PR TITLE
fix(main): show loading section while restoring chat/community

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -728,7 +728,7 @@ method load*[T](
       color = "",
       hasNotification = false,
       notificationsCount = 0,
-      active = true,
+      active = activeSectionId == HOMEPAGE_SECTION_ID,
       enabled = true,
     )
     self.view.model().addItem(homePageSectionItem)
@@ -913,10 +913,10 @@ method load*[T](
   #if homePageEnabled:
   #  activeSection = homePageSectionItem
 
-  # Set active section on app start
-  # If section is empty wait until chats are loaded
   if not activeSection.isEmpty():
     self.setActiveSection(activeSection)
+  else:
+    self.setActiveSection(loadingSectionItem, skipSavingInSettings = true)
 
 proc isEverythingLoaded[T](self: Module[T]): bool =
   return self.communityDataLoaded and self.chatsLoaded and self.contactsLoaded
@@ -943,8 +943,6 @@ method onChatsLoaded*[T](
   let myPubKey = singletonInstance.userProfile.getPubKey()
   var activeSection: SectionItem
   var activeSectionId = singletonInstance.localAccountSensitiveSettings.getActiveSection()
-
-  self.view.model().removeItem(LOADING_SECTION_ID)
 
   # Create personal chat section
   self.chatSectionModules[myPubKey] = chat_section_module.newModule(
@@ -1029,6 +1027,10 @@ method onChatsLoaded*[T](
   # Set active section if it is one of the channel sections
   if not activeSection.isEmpty():
     self.setActiveSection(activeSection)
+  elif self.getActiveSectionId() == LOADING_SECTION_ID:
+    self.setActiveSection(personalChatSectionItem)
+
+  self.view.model().removeItem(LOADING_SECTION_ID)
 
   self.view.sectionsLoaded()
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2133,6 +2133,8 @@ Item {
                         switch (d.activeSectionType) {
                         case Constants.appSection.homePage:
                             return Constants.appViewStackIndex.homePage
+                        case Constants.appSection.loadingSection:
+                            return -1
                         case Constants.appSection.chat:
                             return Constants.appViewStackIndex.chat
                         case Constants.appSection.community:
@@ -2439,7 +2441,8 @@ Item {
                     active: !appMain.mainReady
                             && (d.activeSectionType === Constants.appSection.chat
                                 || d.activeSectionType === Constants.appSection.community
-                                || d.activeSectionType === Constants.appSection.communitiesPortal)
+                                || d.activeSectionType === Constants.appSection.communitiesPortal
+                                || d.activeSectionType === Constants.appSection.loadingSection)
                     sourceComponent: d.activeSectionType === Constants.appSection.communitiesPortal
                                      ? communitiesPortalLoading
                                      : chatLayoutLoading


### PR DESCRIPTION
### What does the PR do

Fixes #21965

Activate the existing loading section when the persisted active section is not available until chats and communities finish loading. This prevents the HomePage from briefly rendering after startup.

Keep the loading item active until the restored section is resolved, fall back to Messages if it no longer exists, and avoid persisting the temporary loading section. Map the loading type to the startup chat skeleton in QML.

### Affected areas

- main module
- AppMain

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring

### Screencapture of the functionality

Community loading:

[community-load.webm](https://github.com/user-attachments/assets/aaf2c6db-bae9-4d11-be81-6e30fd5838ac)

Chat Loading:

[messages-loading.webm](https://github.com/user-attachments/assets/57f4f744-b148-451a-b8de-81c146552567)

Wallet loading:

[wallet-loading.webm](https://github.com/user-attachments/assets/1fb4a198-9081-435d-b882-9b1a74cf2c6c)

### Impact on end user

Better UX when opening the app in a chat section

### How to test

Close the app on a section and restart

### Risk 

Low
