### PR TITLE
feat(settings): add a Storage stats section to Advanced

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -421,6 +421,7 @@ proc load(self: AppController) =
   self.gifService.init()
   self.networkConnectionService.init()
   self.marketService.init()
+  self.advancedService.init()
 
   # Accessible after user login
   singletonInstance.engine.setRootContextProperty("appSettings", self.appSettingsVariant)

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -77,6 +77,8 @@ type SignalType* {.pure.} = enum
   WCSessionDelete = "connector.wcSessionDelete"
   LocalMessageBackupDone = "local.message.backup.done"
   MediaServerStarted = "mediaserver.started"
+  StorageStatsProgress = "storage-stats.progress"
+  StorageStatsResult = "storage-stats.result"
   Unknown
 
 proc event*(self:SignalType):string =

--- a/src/app/core/signals/remote_signals/storage_stats.nim
+++ b/src/app/core/signals/remote_signals/storage_stats.nim
@@ -1,0 +1,36 @@
+import json
+
+import base
+import signal_type
+
+type StorageStatsProgressSignal* = ref object of Signal
+  ## Emitted once per collection step; `total` is known before the first one.
+  requestId*: string
+  step*: int
+  total*: int
+
+type StorageStatsResultSignal* = ref object of Signal
+  ## Emitted once per collection; `data` is the profile.
+  requestId*: string
+  error*: string
+  data*: JsonNode
+
+proc fromEvent*(T: type StorageStatsProgressSignal, jsonSignal: JsonNode): StorageStatsProgressSignal =
+  result = StorageStatsProgressSignal()
+  result.signalType = SignalType.StorageStatsProgress
+  if jsonSignal["event"].kind != JNull:
+    let event = jsonSignal["event"]
+    result.requestId = event{"requestId"}.getStr()
+    result.step = event{"step"}.getInt()
+    result.total = event{"total"}.getInt()
+
+proc fromEvent*(T: type StorageStatsResultSignal, jsonSignal: JsonNode): StorageStatsResultSignal =
+  result = StorageStatsResultSignal()
+  result.signalType = SignalType.StorageStatsResult
+  result.data = newJNull()
+  if jsonSignal["event"].kind != JNull:
+    let event = jsonSignal["event"]
+    result.requestId = event{"requestId"}.getStr()
+    result.error = event{"error"}.getStr()
+    if event.hasKey("data"):
+      result.data = event["data"]

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -107,6 +107,8 @@ QtObject:
       of SignalType.MailserverAvailable: MailserverAvailableSignal.fromEvent(jsonSignal)
       of SignalType.MailserverNotWorking: MailserverNotWorkingSignal.fromEvent(jsonSignal)
       of SignalType.MediaServerStarted: MediaServerStartedSignal.fromEvent(jsonSignal)
+      of SignalType.StorageStatsProgress: StorageStatsProgressSignal.fromEvent(jsonSignal)
+      of SignalType.StorageStatsResult: StorageStatsResultSignal.fromEvent(jsonSignal)
       of SignalType.HistoryArchivesProtocolEnabled: HistoryArchivesSignal.historyArchivesProtocolEnabledFromEvent(jsonSignal)
       of SignalType.HistoryArchivesProtocolDisabled: HistoryArchivesSignal.historyArchivesProtocolDisabledFromEvent(jsonSignal)
       of SignalType.CreatingHistoryArchives: HistoryArchivesSignal.creatingHistoryArchivesFromEvent(jsonSignal)

--- a/src/app/core/signals/types.nim
+++ b/src/app/core/signals/types.nim
@@ -1,9 +1,9 @@
 {.used.}
 
 import ./remote_signals/[base, community, connection_status_change, connector, discovery_summary, envelope, expired, mailserver, mediaserver, messages,
-  signal_type, wallet, whisper_filter, update_available, status_updates, backed_up_profile,
+  signal_type, storage_stats, wallet, whisper_filter, update_available, status_updates, backed_up_profile,
   backed_up_settings, pairing, node, networks, back_up_completed]
 
 export base, community, connection_status_change, connector, discovery_summary, envelope, expired, mailserver, mediaserver, messages,
-  signal_type, wallet, whisper_filter, update_available, status_updates, backed_up_profile,
+  signal_type, storage_stats, wallet, whisper_filter, update_available, status_updates, backed_up_profile,
   backed_up_settings, back_up_completed, pairing, node, networks

--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -52,6 +52,14 @@ proc init*(self: Controller) =
 
   self.advancedService.refreshLogsFolderSize()
 
+  self.events.on(advanced_service.SIGNAL_STORAGE_STATS_PROGRESS) do(e: Args):
+    let args = advanced_service.StorageStatsProgressArgs(e)
+    self.delegate.onStorageStatsProgress(args.step, args.total)
+
+  self.events.on(advanced_service.SIGNAL_STORAGE_STATS_FINISHED) do(e: Args):
+    let args = advanced_service.StorageStatsFinishedArgs(e)
+    self.delegate.onStorageStatsFinished(args.data, args.snapshotPath, args.error)
+
 proc getFleet*(self: Controller): string =
   return self.settingsService.getFleetAsString()
 
@@ -150,3 +158,25 @@ proc setCommunityHistoryArchiveProtocolMode*(self: Controller, mode: int): bool 
      return false
   let archiveProtocolMode = node_configuration_service.ArchiveProtocolMode(mode)
   self.nodeConfigurationService.setCommunityHistoryArchiveProtocolMode(archiveProtocolMode)
+
+proc getIsCollectingStorageStats*(self: Controller): bool =
+  return self.advancedService.isCollectingStorageStats()
+
+proc collectStorageStats*(self: Controller) =
+  if self.advancedService.collectStorageStats():
+    self.delegate.onStorageStatsCollectionStarted()
+
+proc getLastStorageStatsData*(self: Controller): string =
+  let last = self.advancedService.getLastStorageStats()
+  if last.isNil:
+    return ""
+  return last.data
+
+proc getLastStorageStatsSnapshotPath*(self: Controller): string =
+  let last = self.advancedService.getLastStorageStats()
+  if last.isNil:
+    return ""
+  return last.snapshotPath
+
+proc getLastStorageStatsAgeSeconds*(self: Controller): int =
+  return self.advancedService.lastStorageStatsAgeSeconds()

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -108,3 +108,28 @@ method onOldLogsCleanupFinished*(self: AccessInterface, deletedCount, failedCoun
 
 method onOldLogsCleanupStarted*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getIsCollectingStorageStats*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method collectStorageStats*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onStorageStatsCollectionStarted*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onStorageStatsProgress*(self: AccessInterface, step, total: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onStorageStatsFinished*(self: AccessInterface, data, snapshotPath,
+    error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getLastStorageStatsData*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getLastStorageStatsSnapshotPath*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getLastStorageStatsAgeSeconds*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -152,3 +152,29 @@ method onOldLogsCleanupFinished*(self: Module, deletedCount, failedCount: int,
     error: string) =
   self.view.isClearingOldLogsChanged()
   self.view.oldLogsCleanupFinished(deletedCount, failedCount, error)
+
+method getIsCollectingStorageStats*(self: Module): bool =
+  return self.controller.getIsCollectingStorageStats()
+
+method collectStorageStats*(self: Module) =
+  self.controller.collectStorageStats()
+
+method onStorageStatsCollectionStarted*(self: Module) =
+  self.view.isCollectingStorageStatsChanged()
+  self.view.storageStatsProgress(0, 0)
+
+method onStorageStatsProgress*(self: Module, step, total: int) =
+  self.view.storageStatsProgress(step, total)
+
+method onStorageStatsFinished*(self: Module, data, snapshotPath, error: string) =
+  self.view.isCollectingStorageStatsChanged()
+  self.view.storageStatsFinished(data, snapshotPath, error)
+
+method getLastStorageStatsData*(self: Module): string =
+  return self.controller.getLastStorageStatsData()
+
+method getLastStorageStatsSnapshotPath*(self: Module): string =
+  return self.controller.getLastStorageStatsSnapshotPath()
+
+method getLastStorageStatsAgeSeconds*(self: Module): int =
+  return self.controller.getLastStorageStatsAgeSeconds()

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -120,6 +120,31 @@ QtObject:
   proc clearOldLogs*(self: View) {.slot.} =
     self.delegate.clearOldLogs()
 
+  proc isCollectingStorageStatsChanged*(self: View) {.signal.}
+  proc getIsCollectingStorageStats*(self: View): bool {.slot.} =
+    return self.delegate.getIsCollectingStorageStats()
+  QtProperty[bool] isCollectingStorageStats:
+    read = getIsCollectingStorageStats
+    notify = isCollectingStorageStatsChanged
+
+  proc storageStatsProgress*(self: View, step: int, total: int) {.signal.}
+  proc storageStatsFinished*(self: View, data: string, snapshotPath: string,
+    error: string) {.signal.}
+
+  proc collectStorageStats*(self: View) {.slot.} =
+    self.delegate.collectStorageStats()
+
+  # Read from the module, not held here: a Loader rebuilds this view on every
+  # navigation.
+  proc lastStorageStatsData*(self: View): string {.slot.} =
+    return self.delegate.getLastStorageStatsData()
+
+  proc lastStorageStatsSnapshotPath*(self: View): string {.slot.} =
+    return self.delegate.getLastStorageStatsSnapshotPath()
+
+  proc lastStorageStatsAgeSeconds*(self: View): int {.slot.} =
+    return self.delegate.getLastStorageStatsAgeSeconds()
+
   proc delete*(self: View) =
     self.QObject.delete
 

--- a/src/app_service/service/advanced/service.nim
+++ b/src/app_service/service/advanced/service.nim
@@ -1,10 +1,12 @@
-import std/times
+import std/[times, os, strutils]
 
 import nimqml, json, chronicles
 
 import app/core/eventemitter
+import app/core/signals/types
 import app/core/tasks/threadpool
 import app/global/log_cleanup
+import backend/storage_stats as status_storage_stats
 import constants
 import ./async_tasks
 
@@ -13,11 +15,49 @@ logScope:
 
 const SIGNAL_ADVANCED_LOGS_CLEANUP_FINISHED* = "advancedLogsCleanupFinished"
 const SIGNAL_ADVANCED_LOGS_SIZE_UPDATED* = "advancedLogsSizeUpdated"
+const SIGNAL_STORAGE_STATS_PROGRESS* = "storageStatsProgress"
+const SIGNAL_STORAGE_STATS_FINISHED* = "storageStatsFinished"
+
+## The snapshot goes into LOGDIR so the existing "collect logs" flow bundles it.
+## Milliseconds in the name keep two collections in the same second apart.
+const STORAGE_STATS_FILE_PREFIX = "storage-stats-"
+const STORAGE_STATS_FILE_SUFFIX = ".json"
+const STORAGE_STATS_FILE_TIME_FORMAT = "yyyyMMdd-HHmmss'-'fff"
+
+## Result error meaning "aborted by Stop()", not a failure worth showing.
+## Mirrors storagestats.ErrCancelled in status-go.
+const STORAGE_STATS_CANCELLED = "cancelled"
 
 type AdvancedLogsCleanupFinishedArgs* = ref object of Args
   deletedCount*: int
   failedCount*: int
   error*: string
+
+type StorageStatsProgressArgs* = ref object of Args
+  step*: int
+  total*: int
+
+type StorageStatsFinishedArgs* = ref object of Args
+  ## `data` is the profile as pretty-printed JSON: parsed by the preview, copied
+  ## by the user, and written to `snapshotPath`. That path is empty if the file
+  ## could not be written, which is not a collection failure.
+  data*: string
+  snapshotPath*: string
+  error*: string
+
+## backend/core wraps a failed RPC into a multi-line
+## "status-go error [methodName:..., code:..., message:... ]" string; only the
+## message belongs in the UI.
+proc rpcErrorMessage(raw: string): string =
+  const marker = "message:"
+  let start = raw.find(marker)
+  if start < 0:
+    return raw.strip()
+
+  var message = raw[start + marker.len .. ^1].strip()
+  if message.endsWith("]"):
+    message = message[0 ..< message.high].strip()
+  return message
 
 QtObject:
   type Service* = ref object of QObject
@@ -26,6 +66,12 @@ QtObject:
     clearingOldLogs: bool
     refreshingLogsSize: bool
     logsFolderSizeBytesCached: float
+    collectingStorageStats: bool
+    storageStatsRequestId: string
+    # Kept for the session: the settings view is built by a Loader and loses its
+    # own state on navigation, and re-collecting costs minutes of table scans.
+    lastStorageStats: StorageStatsFinishedArgs
+    lastStorageStatsCollectedAt: int64
 
   proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
@@ -34,6 +80,7 @@ QtObject:
     result.events = events
     result.threadpool = threadpool
     result.clearingOldLogs = false
+    result.collectingStorageStats = false
 
   proc isClearingOldLogs*(self: Service): bool =
     return self.clearingOldLogs
@@ -105,6 +152,89 @@ QtObject:
     self.clearingOldLogs = false
     self.events.emit(SIGNAL_ADVANCED_LOGS_CLEANUP_FINISHED, result)
     self.refreshLogsFolderSize()
+
+  proc isCollectingStorageStats*(self: Service): bool =
+    return self.collectingStorageStats
+
+  proc getLastStorageStats*(self: Service): StorageStatsFinishedArgs =
+    return self.lastStorageStats
+
+  ## Seconds since the cached profile was collected, or -1 when there is none.
+  ## An age, not a timestamp: the artifact must carry no absolute dates.
+  proc lastStorageStatsAgeSeconds*(self: Service): int =
+    if self.lastStorageStats.isNil:
+      return -1
+    return int(getTime().toUnix - self.lastStorageStatsCollectedAt)
+
+  ## Returns the path written, or "" on failure.
+  proc writeStorageStatsSnapshot(self: Service, content: string): string =
+    if content.len == 0:
+      return ""
+    try:
+      let path = LOGDIR / (STORAGE_STATS_FILE_PREFIX &
+        now().format(STORAGE_STATS_FILE_TIME_FORMAT) & STORAGE_STATS_FILE_SUFFIX)
+      createDir(LOGDIR)
+      writeFile(path, content)
+      return path
+    except Exception as e:
+      error "failed to write the storage stats snapshot", error = e.msg
+      return ""
+
+  proc finishStorageStats(self: Service, args: StorageStatsFinishedArgs) =
+    self.collectingStorageStats = false
+    self.storageStatsRequestId = ""
+    if args.data.len > 0:
+      self.lastStorageStats = args
+      self.lastStorageStatsCollectedAt = getTime().toUnix
+    self.events.emit(SIGNAL_STORAGE_STATS_FINISHED, args)
+
+  ## Starts a collection in status-go; false if one is already running. The
+  ## result arrives through the signals below, never from this call.
+  proc collectStorageStats*(self: Service): bool =
+    if self.collectingStorageStats:
+      return false
+
+    self.collectingStorageStats = true
+    try:
+      # callPrivateRPC raises on backend errors instead of returning them, so
+      # every failure lands in the except branch below.
+      let requestId = status_storage_stats.collect().result.getStr()
+      if requestId.len == 0:
+        self.finishStorageStats(StorageStatsFinishedArgs(
+          error: "status-go did not return a request id"))
+        return false
+      # Signals are delivered on this thread, so no progress event can arrive
+      # before the id is assigned.
+      self.storageStatsRequestId = requestId
+    except Exception as e:
+      error "failed to start collecting storage stats", error = e.msg
+      self.finishStorageStats(StorageStatsFinishedArgs(error: rpcErrorMessage(e.msg)))
+      return false
+
+    return true
+
+  proc init*(self: Service) =
+    self.events.on(SignalType.StorageStatsProgress.event) do(e: Args):
+      let signal = StorageStatsProgressSignal(e)
+      if signal.requestId != self.storageStatsRequestId:
+        return
+      self.events.emit(SIGNAL_STORAGE_STATS_PROGRESS,
+        StorageStatsProgressArgs(step: signal.step, total: signal.total))
+
+    self.events.on(SignalType.StorageStatsResult.event) do(e: Args):
+      let signal = StorageStatsResultSignal(e)
+      if signal.requestId != self.storageStatsRequestId:
+        return
+
+      var args = StorageStatsFinishedArgs(error: signal.error)
+      if args.error == STORAGE_STATS_CANCELLED:
+        args.error = ""
+      elif signal.error.len == 0:
+        if not signal.data.isNil and signal.data.kind != JNull:
+          # Pretty-printed once; the preview, the clipboard and the file share it.
+          args.data = signal.data.pretty()
+        args.snapshotPath = self.writeStorageStatsSnapshot(args.data)
+      self.finishStorageStats(args)
 
   proc delete*(self: Service) =
     self.QObject.delete

--- a/src/backend/storage_stats.nim
+++ b/src/backend/storage_stats.nim
@@ -1,0 +1,16 @@
+## Thin wrapper around the status-go `storagestats` JSON-RPC namespace.
+## See vendor/status-go/services/storagestats/service.go for the server side.
+import json
+import core
+import response_type
+
+export response_type
+
+proc prefix*(methodName: string): string =
+  result = "storagestats_" & methodName
+
+## Returns the request id carried by the resulting `storage-stats.progress` /
+## `storage-stats.result` signals. Returns immediately; status-go does the walk
+## on its own goroutine.
+proc collect*(): RpcResponse[JsonNode] {.raises: [RpcException].} =
+  callPrivateRPC("collect".prefix)

--- a/test/nim/signals_manager_test.nim
+++ b/test/nim/signals_manager_test.nim
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 import app/core/eventemitter
@@ -5,6 +6,7 @@ import app/core/signals/signals_manager
 import app/core/signals/signal_type_scan
 import app/core/signals/remote_signals/signal_type
 import app/core/signals/remote_signals/mediaserver
+import app/core/signals/remote_signals/storage_stats
 
 # Exercises the real ManageSignals dispatch path (`processSignal`) to prove that
 # the cheap-triage guard skips unhandled types before parsing
@@ -98,3 +100,54 @@ suite "SignalsManager - unhandled signal-type skipping":
 
     check dispatched
     check unhandledSignalCount() == 0
+
+  test "storage-stats.progress carries a deterministic N of M":
+    # The Storage stats section shows a real "N of M" rather than a spinner, so
+    # both numbers have to survive the decode.
+    let emitter = createEventEmitter()
+    var step, total = -1
+    var requestId = ""
+    emitter.on(SignalType.StorageStatsProgress.event) do(a: Args):
+      let signal = StorageStatsProgressSignal(a)
+      requestId = signal.requestId
+      step = signal.step
+      total = signal.total
+
+    let manager = newSignalsManager(emitter)
+    manager.processSignal("""{"type":"storage-stats.progress","event":{"requestId":"abc","step":7,"total":160}}""")
+
+    check requestId == "abc"
+    check step == 7
+    check total == 160
+
+  test "storage-stats.result carries the profile":
+    # The profile is what the preview renders and what the user copies, so it
+    # has to survive the decode intact.
+    let emitter = createEventEmitter()
+    var profileVersion = 0
+    var messagesTotal = 0
+    emitter.on(SignalType.StorageStatsResult.event) do(a: Args):
+      let signal = StorageStatsResultSignal(a)
+      profileVersion = signal.data{"profileVersion"}.getInt()
+      messagesTotal = signal.data{"messaging"}{"messagesTotal"}.getInt()
+
+    let manager = newSignalsManager(emitter)
+    manager.processSignal("""{"type":"storage-stats.result","event":{"requestId":"abc","data":{"profileVersion":1,"messaging":{"messagesTotal":100000}}}}""")
+
+    check profileVersion == 1
+    check messagesTotal == 100000
+
+  test "a failed storage-stats.result reports the error and leaves data null":
+    let emitter = createEventEmitter()
+    var error = ""
+    var dataIsNull = false
+    emitter.on(SignalType.StorageStatsResult.event) do(a: Args):
+      let signal = StorageStatsResultSignal(a)
+      error = signal.error
+      dataIsNull = signal.data.kind == JNull
+
+    let manager = newSignalsManager(emitter)
+    manager.processSignal("""{"type":"storage-stats.result","event":{"requestId":"abc","error":"no account is logged in"}}""")
+
+    check error == "no account is logged in"
+    check dataIsNull

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -83,6 +83,12 @@ QtObject {
         return num.toLocaleString(locale, 'f', precision)
     }
 
+    function formattedDataSize(bytes, precision = 2, locale = null) {
+        locale = locale || Qt.locale()
+
+        return locale.formattedDataSize(bytes || 0, precision, Locale.DataSizeTraditionalFormat)
+    }
+
     function currencyNumberToLocaleString(num, symbol = "", locale = null) {
         locale = locale || Qt.locale()
 

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -23,6 +23,7 @@ QtObject {
     property real logsFolderSizeBytes: advancedModule ? advancedModule.logsFolderSizeBytes : 0
     property bool isRuntimeLogLevelSet: advancedModule ? advancedModule.isRuntimeLogLevelSet: false
     property bool isClearingOldLogs: advancedModule ? advancedModule.isClearingOldLogs : false
+    property bool isCollectingStorageStats: advancedModule ? advancedModule.isCollectingStorageStats : false
     readonly property int archiveProtocolMode: advancedModule ? advancedModule.archiveProtocolMode : AdvancedStore.ArchiveProtocolMode.Disabled
     readonly property string archiveProtocolModeLabel: {
         switch (root.archiveProtocolMode) {
@@ -51,6 +52,23 @@ QtObject {
         }
     }
 
+    // `data` is the profile as pretty-printed JSON; `snapshotPath` is the copy
+    // already written next to the application logs.
+    signal storageStatsProgress(int step, int total)
+    signal storageStatsFinished(string data, string snapshotPath, string error)
+
+    readonly property Connections storageStatsConnection: Connections {
+        target: root.advancedModule
+
+        function onStorageStatsProgress(step, total) {
+            root.storageStatsProgress(step, total)
+        }
+
+        function onStorageStatsFinished(data, snapshotPath, error) {
+            root.storageStatsFinished(data, snapshotPath, error)
+        }
+    }
+
     readonly property QtObject experimentalFeatures: QtObject {
         readonly property string browser: "browser"
         readonly property string communities: "communities"
@@ -66,6 +84,30 @@ QtObject {
     readonly property real scrollDeceleration: localAppSettings.scrollDeceleration
 
     readonly property bool refreshTokenEnabled: localAppSettings.refreshTokenEnabled ?? false
+
+    function collectStorageStats() {
+        if(!root.advancedModule)
+            return
+
+        root.advancedModule.collectStorageStats()
+    }
+
+    // Last profile, held by the Nim service so navigating away does not discard
+    // it. Null when nothing has been collected this session.
+    function lastStorageStats() {
+        if(!root.advancedModule)
+            return null
+
+        const ageSeconds = root.advancedModule.lastStorageStatsAgeSeconds()
+        if(ageSeconds < 0)
+            return null
+
+        return {
+            data: root.advancedModule.lastStorageStatsData(),
+            snapshotPath: root.advancedModule.lastStorageStatsSnapshotPath(),
+            ageSeconds: ageSeconds
+        }
+    }
 
     function logDir() {
         if(!root.advancedModule)

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -71,6 +71,100 @@ SettingsContentBase {
                             deletedCount > 0 ? qsTr("%n old log file(s) cleared", "", deletedCount) : qsTr("No old log files to clear"),
                             "", "checkmark-circle", false, Constants.ephemeralNotificationType.success, "")
             }
+
+            // --- Storage stats ---------------------------------------------
+            // Presentation state only; the artifact itself lives in the service.
+            property int storageStatsStep: 0
+            property int storageStatsTotal: 0
+            property var storageStatsData: null
+            // Pretty-printed JSON: parsed for the preview, copied verbatim.
+            property string storageStatsJson: ""
+            property string storageStatsSnapshotPath: ""
+            property string storageStatsError: ""
+            // Age of the profile on screen; -1 when there is none, 0 when fresh.
+            property int storageStatsAgeSeconds: -1
+
+            // A Loader rebuilds this page, so `d` starts empty on every visit;
+            // the service still holds the profile.
+            function restoreStorageStats() {
+                const last = root.advancedStore.lastStorageStats()
+                if (!last)
+                    return
+
+                d.storageStatsJson = last.data
+                d.storageStatsSnapshotPath = last.snapshotPath
+                d.storageStatsAgeSeconds = last.ageSeconds
+                d.setStorageStatsData(last.data)
+            }
+
+            function setStorageStatsData(data) {
+                d.storageStatsData = null
+                if (data === "")
+                    return
+                try {
+                    d.storageStatsData = JSON.parse(data)
+                } catch (e) {
+                    d.storageStatsError = qsTr("The collected profile could not be read: %1").arg(e.message)
+                }
+            }
+
+            function formatAge(seconds) {
+                if (seconds < 60)
+                    return qsTr("just now")
+                if (seconds < 3600)
+                    return qsTr("%n minute(s) ago", "", Math.floor(seconds / 60))
+                if (seconds < 86400)
+                    return qsTr("%n hour(s) ago", "", Math.floor(seconds / 3600))
+                return qsTr("%n day(s) ago", "", Math.floor(seconds / 86400))
+            }
+
+            // Clears progress and error only. The previous profile stays on
+            // screen until a new one replaces it.
+            function beginStorageStatsCollection() {
+                d.storageStatsStep = 0
+                d.storageStatsTotal = 0
+                d.storageStatsError = ""
+            }
+
+            readonly property var storageStatsHistogram:
+                !!d.storageStatsData && !!d.storageStatsData.messaging
+                    ? (d.storageStatsData.messaging.perChatHistogram || []) : []
+
+            // Bars are scaled against the fullest bucket.
+            readonly property int storageStatsHistogramPeak: {
+                let peak = 0
+                for (let i = 0; i < d.storageStatsHistogram.length; i++)
+                    peak = Math.max(peak, d.storageStatsHistogram[i].chats)
+                return peak
+            }
+
+            // Headline numbers only; the full profile is in the copied artifact.
+            readonly property var storageStatsSummary: {
+                const profile = d.storageStatsData
+                if (!profile)
+                    return []
+
+                const messaging = profile.messaging || {}
+                const chats = messaging.chats || {}
+                const sync = profile.sync || {}
+                const wallet = profile.wallet || {}
+                const db = profile.db || {}
+
+                const chatsTotal = (chats.oneToOne || 0) + (chats["public"] || 0)
+                                 + (chats.group || 0) + (chats.communityChannels || 0)
+                                 + (chats.other || 0)
+
+                return [
+                    { label: qsTr("Messages"), value: LocaleUtils.numberToLocaleString(messaging.messagesTotal || 0) },
+                    { label: qsTr("Chats"), value: LocaleUtils.numberToLocaleString(chatsTotal) },
+                    { label: qsTr("Communities"), value: LocaleUtils.numberToLocaleString(messaging.communities || 0) },
+                    { label: qsTr("Oldest message"), value: qsTr("%n day(s) ago", "", messaging.oldestMessageDays || 0) },
+                    { label: qsTr("Max sync gap"), value: qsTr("%n day(s)", "", sync.maxSyncGapDays || 0) },
+                    { label: qsTr("Collectibles"), value: LocaleUtils.numberToLocaleString(wallet.collectibles || 0) },
+                    { label: qsTr("App database"), value: LocaleUtils.formattedDataSize(db.appDbBytes) },
+                    { label: qsTr("Wallet database"), value: LocaleUtils.formattedDataSize(db.walletDbBytes) }
+                ]
+            }
         }
 
         Connections {
@@ -78,6 +172,22 @@ SettingsContentBase {
 
             function onOldLogsCleanupFinished(deletedCount, failedCount, error) {
                 d.showOldLogsCleanupResult(deletedCount, failedCount, error)
+            }
+
+            function onStorageStatsProgress(step, total) {
+                d.storageStatsStep = step
+                d.storageStatsTotal = total
+            }
+
+            function onStorageStatsFinished(data, snapshotPath, error) {
+                d.storageStatsError = error
+                if (data === "")
+                    return
+
+                d.storageStatsJson = data
+                d.storageStatsSnapshotPath = snapshotPath
+                d.storageStatsAgeSeconds = 0
+                d.setStorageStatsData(data)
             }
         }
 
@@ -436,6 +546,179 @@ SettingsContentBase {
                 id: httpStatsButton
                 text: qsTr("HTTP statistics")
                 onClicked: httpStatsModal.open()
+            }
+
+            Separator {
+                width: parent.width
+                visible: storageStatsSection.visible
+            }
+
+            StatusSectionHeadline {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: Theme.padding
+                anchors.rightMargin: Theme.padding
+                text: qsTr("Storage stats")
+                topPadding: Theme.bigPadding
+                bottomPadding: Theme.padding
+                visible: storageStatsSection.visible
+            }
+
+            ColumnLayout {
+                id: storageStatsSection
+                objectName: "storageStatsSection"
+
+                Component.onCompleted: if (visible) d.restoreStorageStats()
+                onVisibleChanged: if (visible) d.restoreStorageStats()
+
+                // Non-production and CI builds; in release only behind Debug.
+                visible: !production || TestConfig.testMode || root.advancedStore.isDebugEnabled
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: Theme.padding
+                anchors.rightMargin: Theme.padding
+                spacing: Theme.padding
+
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    wrapMode: Text.Wrap
+                    color: Theme.palette.baseColor1
+                    font.pixelSize: Theme.tertiaryTextFontSize
+                    text: qsTr("Describes the shape of this account's databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.")
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.padding
+
+                    StatusButton {
+                        objectName: "collectStorageStatsButton"
+                        text: root.advancedStore.isCollectingStorageStats
+                              ? qsTr("Collecting...") : qsTr("Collect data")
+                        enabled: !root.advancedStore.isCollectingStorageStats
+                        onClicked: {
+                            d.beginStorageStatsCollection()
+                            root.advancedStore.collectStorageStats()
+                        }
+                    }
+
+                    CopyToClipBoardButton {
+                        objectName: "copyStorageStatsButton"
+                        visible: d.storageStatsJson !== ""
+                        textToCopy: d.storageStatsJson
+                        onCopyClicked: ClipboardUtils.setText(textToCopy)
+                    }
+
+                    StatusBaseText {
+                        objectName: "storageStatsStatusText"
+                        Layout.fillWidth: true
+                        elide: Text.ElideMiddle
+                        font.pixelSize: Theme.tertiaryTextFontSize
+                        color: d.storageStatsError !== ""
+                               ? Theme.palette.dangerColor1 : Theme.palette.baseColor1
+                        text: {
+                            if (d.storageStatsError !== "")
+                                return d.storageStatsError
+                            if (root.advancedStore.isCollectingStorageStats)
+                                return d.storageStatsTotal > 0
+                                        ? qsTr("%1 of %2").arg(d.storageStatsStep).arg(d.storageStatsTotal)
+                                        : qsTr("Starting...")
+                            if (d.storageStatsSnapshotPath !== "")
+                                return qsTr("Collected %1, saved to %2 and picked up by Application Logs")
+                                        .arg(d.formatAge(d.storageStatsAgeSeconds))
+                                        .arg(d.storageStatsSnapshotPath)
+                            if (d.storageStatsAgeSeconds >= 0)
+                                return qsTr("Collected %1").arg(d.formatAge(d.storageStatsAgeSeconds))
+                            return ""
+                        }
+                    }
+                }
+
+                StatusProgressBar {
+                    Layout.fillWidth: true
+                    visible: root.advancedStore.isCollectingStorageStats
+                    from: 0
+                    // Total is 0 until status-go reports the table count.
+                    to: Math.max(1, d.storageStatsTotal)
+                    value: d.storageStatsStep
+                    fillColor: Theme.palette.primaryColor1
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    Layout.topMargin: Theme.halfPadding
+                    spacing: Theme.halfPadding
+                    visible: !!d.storageStatsData
+
+                    StatusBaseText {
+                        text: qsTr("Chats by message count")
+                        font.pixelSize: Theme.tertiaryTextFontSize
+                        color: Theme.palette.baseColor1
+                    }
+
+                    Repeater {
+                        model: d.storageStatsHistogram
+
+                        delegate: RowLayout {
+                            required property var modelData
+
+                            Layout.fillWidth: true
+                            spacing: Theme.halfPadding
+
+                            StatusBaseText {
+                                Layout.preferredWidth: 64
+                                text: modelData.bucket
+                                font.pixelSize: Theme.tertiaryTextFontSize
+                            }
+
+                            Rectangle {
+                                Layout.preferredHeight: 10
+                                Layout.preferredWidth: d.storageStatsHistogramPeak > 0
+                                    ? Math.max(2, 220 * modelData.chats / d.storageStatsHistogramPeak) : 2
+                                radius: 2
+                                color: Theme.palette.primaryColor1
+                            }
+
+                            StatusBaseText {
+                                Layout.fillWidth: true
+                                text: modelData.chats
+                                font.pixelSize: Theme.tertiaryTextFontSize
+                                color: Theme.palette.baseColor1
+                            }
+                        }
+                    }
+
+                    Repeater {
+                        model: d.storageStatsSummary
+
+                        delegate: RowLayout {
+                            required property var modelData
+
+                            Layout.fillWidth: true
+                            spacing: Theme.halfPadding
+
+                            StatusBaseText {
+                                Layout.preferredWidth: 160
+                                text: modelData.label
+                                font.pixelSize: Theme.tertiaryTextFontSize
+                                color: Theme.palette.baseColor1
+                            }
+
+                            StatusBaseText {
+                                Layout.fillWidth: true
+                                text: modelData.value
+                                font.pixelSize: Theme.tertiaryTextFontSize
+                                elide: Text.ElideRight
+                            }
+                        }
+                    }
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: Theme.bigPadding
+                }
             }
         }
 

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1038,6 +1038,74 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>The collected profile could not be read: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>just now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s) ago</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) ago</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Communities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Oldest message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max sync gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wallet database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Fleet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1107,6 +1175,42 @@
     </message>
     <message>
         <source>Developer features</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Storage stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collect data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1, saved to %2 and picked up by Application Logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chats by message count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1041,6 +1041,78 @@
         <translation>Tato funkce je experimentální a je určena pro testovací účely hlavními přispěvateli a komunitou. Není určena pro reálné použití a neposkytuje žádné záruky bezpečnosti nebo integrity finančních prostředků nebo dat. Použití je na vlastní nebezpečí.</translation>
     </message>
     <message>
+        <source>The collected profile could not be read: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>just now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s) ago</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>před %n hodinou</numerusform>
+            <numerusform>před %n hodinami</numerusform>
+            <numerusform>před %n hodinami</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>před %n dnem</numerusform>
+            <numerusform>před %n dny</numerusform>
+            <numerusform>před %n dny</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">Zprávy</translation>
+    </message>
+    <message>
+        <source>Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Communities</source>
+        <translation type="unfinished">Komunity</translation>
+    </message>
+    <message>
+        <source>Oldest message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max sync gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">Sbírky</translation>
+    </message>
+    <message>
+        <source>App database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wallet database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Fleet</source>
         <translation>Fleet</translation>
     </message>
@@ -1111,6 +1183,42 @@
     <message>
         <source>Developer features</source>
         <translation>Vývojářské funkce</translation>
+    </message>
+    <message>
+        <source>Storage stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collect data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <translation type="unfinished">%1 z %2</translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1, saved to %2 and picked up by Application Logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chats by message count</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The app will restart if you confirm.</source>

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -35,6 +35,34 @@
             <numerusform>%n old log files cleared</numerusform>
         </translation>
     </message>
+    <message numerus="yes">
+        <source>%n minute(s) ago</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n hour ago</numerusform>
+            <numerusform>%n hours ago</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n day ago</numerusform>
+            <numerusform>%n days ago</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
 </context>
 <context>
     <name>AirdropRecipientsSelector</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1038,6 +1038,74 @@
         <translation>Esta función es experimental y está destinada para propósitos de prueba por contribuidores principales y la comunidad. No está destinada para uso real y no garantiza la seguridad o integridad de fondos o datos. Úsala bajo tu propio riesgo.</translation>
     </message>
     <message>
+        <source>The collected profile could not be read: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>just now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s) ago</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>Hace %n hora</numerusform>
+            <numerusform>Hace %n horas</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>Hace %n día</numerusform>
+            <numerusform>Hace %n días</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">Mensajes</translation>
+    </message>
+    <message>
+        <source>Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Communities</source>
+        <translation type="unfinished">Comunidades</translation>
+    </message>
+    <message>
+        <source>Oldest message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max sync gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">Coleccionables</translation>
+    </message>
+    <message>
+        <source>App database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wallet database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Fleet</source>
         <translation>Fleet</translation>
     </message>
@@ -1108,6 +1176,42 @@
     <message>
         <source>Developer features</source>
         <translation>Funciones para desarrolladores</translation>
+    </message>
+    <message>
+        <source>Storage stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collect data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <translation type="unfinished">%1 de %2</translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1, saved to %2 and picked up by Application Logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chats by message count</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The app will restart if you confirm.</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -1038,6 +1038,74 @@
         <translation>Cette fonctionnalité est expérimentale et destinée à être testée par les contributeurs principaux et la communauté. Elle n’est pas conçue pour une utilisation réelle et ne garantit ni la sécurité, ni l’intégrité des fonds ou des données. Utilisez-la à vos propres risques.</translation>
     </message>
     <message>
+        <source>The collected profile could not be read: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>just now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s) ago</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>Il y a %n heure</numerusform>
+            <numerusform>Il y a %n heures</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>Il y a %n jour</numerusform>
+            <numerusform>Il y a %n jours</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">Messages</translation>
+    </message>
+    <message>
+        <source>Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Communities</source>
+        <translation type="unfinished">Communautés</translation>
+    </message>
+    <message>
+        <source>Oldest message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max sync gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">Collectibles</translation>
+    </message>
+    <message>
+        <source>App database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wallet database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Fleet</source>
         <translation>Flotte</translation>
     </message>
@@ -1108,6 +1176,42 @@
     <message>
         <source>Developer features</source>
         <translation>Fonctionnalités pour développeurs</translation>
+    </message>
+    <message>
+        <source>Storage stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collect data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <translation type="unfinished">%1 sur %2</translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1, saved to %2 and picked up by Application Logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chats by message count</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The app will restart if you confirm.</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1035,6 +1035,70 @@
         <translation>이 기능은 실험적이며 핵심 기여자와 커뮤니티의 테스트 목적으로 제공됩니다. 실제 사용을 위한 것이 아니며 자금이나 데이터의 보안 또는 무결성을 보장하지 않습니다. 본인 책임하에 사용하세요.</translation>
     </message>
     <message>
+        <source>The collected profile could not be read: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>just now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s) ago</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n시간 전</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s) ago</source>
+        <translation type="unfinished">
+            <numerusform>%n일 전</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Messages</source>
+        <translation type="unfinished">메시지</translation>
+    </message>
+    <message>
+        <source>Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Communities</source>
+        <translation type="unfinished">커뮤니티</translation>
+    </message>
+    <message>
+        <source>Oldest message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max sync gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Collectibles</source>
+        <translation type="unfinished">수집품</translation>
+    </message>
+    <message>
+        <source>App database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wallet database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Fleet</source>
         <translation>플릿</translation>
     </message>
@@ -1105,6 +1169,42 @@
     <message>
         <source>Developer features</source>
         <translation>개발자 기능</translation>
+    </message>
+    <message>
+        <source>Storage stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collect data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <translation type="unfinished">%2 중 %1</translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1, saved to %2 and picked up by Application Logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Collected %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chats by message count</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The app will restart if you confirm.</source>


### PR DESCRIPTION
* add Storage stats section to Advanced
* non-production builds only
* collect exact database counters on demand
* progress shown as "N of M"
* copy JSON to clipboard, histogram preview
* snapshot saved next to application logs
* profile cached for the session
* bumps status-go submodule


https://github.com/user-attachments/assets/48a84317-b115-4366-a7ef-93e08f3ccf0a



status-go PR: https://github.com/status-im/status-go/pull/7722

Fixes #21605