### PR TITLE
Fix plain text emoji conversion

### DIFF
--- a/storybook/pages/ChatTextAreaPage.qml
+++ b/storybook/pages/ChatTextAreaPage.qml
@@ -464,6 +464,7 @@ unclosed fence here (no closing triple-tick)
                             codeBackground: Theme.palette.baseColor4
                             quoteBarVisible: quoteBarSwitch.checked
                             imageEmojis: true
+                            asciiEmojiConversion: asciiEmojiSwitch.checked
 
                             characterLimit: limitSpinBox.value
                             onAttemptToExceedHardLimit: limitInfo.hitCount++
@@ -794,6 +795,12 @@ unclosed fence here (no closing triple-tick)
                     text: "Image emojis (Twemoji)"
                     checked: textArea.imageEmojis
                     onToggled: textArea.imageEmojis = checked
+                }
+                Switch {
+                    id: asciiEmojiSwitch
+
+                    text: "Convert ASCII emoticons"
+                    checked: true
                 }
                 Switch {
                     id: flushOnEnterSwitch

--- a/storybook/qmlTests/tests/tst_ChatTextArea.qml
+++ b/storybook/qmlTests/tests/tst_ChatTextArea.qml
@@ -957,6 +957,124 @@ Item {
             compare(control.textWithMentions(), emoji + emoji)
         }
 
+        // ── ASCII emoticon conversion ───────────────────────────────────────────
+
+        readonly property string slightlySmiling: "\u{1F642}" // :)
+        readonly property string smilingDevil: "\u{1F608}"    // >:)
+
+        // Completing an emoticon with a space converts it; the space still types.
+        function test_asciiEmoji_convertsOnSpace() {
+            control.asciiEmojiConversion = true
+            control.text = "hello :)"
+            control.cursorPosition = control.length
+            control.forceActiveFocus()
+
+            keyClick(Qt.Key_Space)
+
+            compare(control.textWithMentions(), "hello " + slightlySmiling + " ")
+        }
+
+        // Enter converts too, so "hi :)" + newline doesn't leave the emoticon behind.
+        function test_asciiEmoji_convertsOnEnter() {
+            control.asciiEmojiConversion = true
+            control.text = "hi :)"
+            control.cursorPosition = control.length
+            control.forceActiveFocus()
+
+            keyClick(Qt.Key_Return)
+
+            compare(control.textWithMentions(), "hi " + slightlySmiling + "\n")
+        }
+
+        // The longest emoticon wins: ">:)" must not be matched as ":)".
+        function test_asciiEmoji_longestMatchWins() {
+            control.asciiEmojiConversion = true
+            control.text = "hey >:)"
+            control.cursorPosition = control.length
+            control.forceActiveFocus()
+
+            keyClick(Qt.Key_Space)
+
+            compare(control.textWithMentions(), "hey " + smilingDevil + " ")
+        }
+
+        // Opt-in: nothing happens while the property is off (the default).
+        function test_asciiEmoji_disabledByDefault() {
+            compare(control.asciiEmojiConversion, false)
+            control.text = "hello :)"
+            control.cursorPosition = control.length
+            control.forceActiveFocus()
+
+            keyClick(Qt.Key_Space)
+
+            compare(control.textWithMentions(), "hello :) ")
+        }
+
+        // The emoticon must be a whole word — "hello:)" is left alone.
+        function test_asciiEmoji_requiresWordStart() {
+            control.asciiEmojiConversion = true
+            control.text = "hello:)"
+            control.cursorPosition = control.length
+            control.forceActiveFocus()
+
+            keyClick(Qt.Key_Space)
+
+            compare(control.textWithMentions(), "hello:) ")
+        }
+
+        // Emoticons inside a code span/block stay verbatim.
+        function test_asciiEmoji_notInsideCode() {
+            control.asciiEmojiConversion = true
+            control.text = "`:)`"
+            control.cursorPosition = 3 // between ":)" and the closing backtick
+            control.forceActiveFocus()
+
+            keyClick(Qt.Key_Space)
+
+            compare(control.textWithMentions(), "`:) `")
+        }
+
+        // convertAsciiEmoji() lets the host force the conversion (e.g. right before sending)
+        // without a completing keystroke.
+        function test_asciiEmoji_forcedConversion() {
+            control.asciiEmojiConversion = true
+            control.text = "hello :)"
+            control.cursorPosition = control.length
+
+            control.convertAsciiEmoji()
+
+            compare(control.textWithMentions(), "hello " + slightlySmiling)
+        }
+
+        // In image mode the emoji lands as an inline image object right away (no raw-Unicode step).
+        function test_asciiEmoji_imageMode() {
+            control.asciiEmojiConversion = true
+            control.imageEmojis = true
+            control.text = ":)"
+            control.cursorPosition = control.length
+
+            control.convertAsciiEmoji()
+
+            compare(control.length, 1) // single image ORC
+            compare(control.getText(0, 1).charCodeAt(0), 0xFFFC)
+            compare(control.textWithMentions(), slightlySmiling)
+        }
+
+        // Remove + insert form a single undo step, so one Ctrl+Z brings the emoticon back.
+        function test_asciiEmoji_undoIsOneStep() {
+            control.asciiEmojiConversion = true
+            control.text = "hello :)"
+            control.cursorPosition = control.length
+            control.forceActiveFocus()
+
+            control.convertAsciiEmoji()
+            compare(control.textWithMentions(), "hello " + slightlySmiling)
+
+            keyClick(Qt.Key_Z, Qt.ControlModifier)
+
+            compare(control.textWithMentions(), "hello :)")
+        }
+
         // ── nodeAt: AST-based caret formatting (delimiters belong to their node) ──────
 
         // Each sample is the document text with "|" marking the caret; "flags" lists exactly the

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -479,6 +479,32 @@ Item {
             compare(signalSpy.count, 1)
         }
 
+        // ── ASCII emoticon conversion
+        //
+        // A trailing emoticon is converted on send, even though no space completed it.
+        function test_asciiEmoticon_convertedOnSend() {
+            signalSpy.setup(controlUnderTest, "sendMessageRequested")
+
+            controlUnderTest.textInput.forceActiveFocus()
+            typeText("hello :)")
+            waitForRendering(controlUnderTest)
+
+            keyClick(Qt.Key_Return) // send (NoModifier maps to send on desktop/offscreen)
+            waitForRendering(controlUnderTest)
+
+            compare(controlUnderTest.getPlainText(), "hello \u{1F642}")
+            compare(signalSpy.count, 1)
+        }
+
+        // Typing a space after an emoticon converts it in place.
+        function test_asciiEmoticon_convertedOnSpace() {
+            controlUnderTest.textInput.forceActiveFocus()
+            typeText("hello :) ")
+            waitForRendering(controlUnderTest)
+
+            compare(controlUnderTest.getPlainText(), "hello \u{1F642} ")
+        }
+
         function test_selectStickerForTest_emits_stickerSelected() {
             signalSpy.setup(controlUnderTest, "stickerSelected")
 

--- a/ui/StatusQ/include/StatusQ/chatinputhighlighter.h
+++ b/ui/StatusQ/include/StatusQ/chatinputhighlighter.h
@@ -124,6 +124,10 @@ public:
     // In font mode it is a plain text insert. Used by paste/suggestion insertion paths.
     Q_INVOKABLE void insertTextWithEmojis(int position, const QString& text);
 
+    // Same as insertTextWithEmojis, but first removes `[start, end)`; both edits form a single
+    // undo step.
+    Q_INVOKABLE void replaceTextWithEmojis(int start, int end, const QString& text);
+
     // Number of inline emoji image objects in the document, counted by fragment — i.e. the number
     // of separately-rendered images. Adjacent identical emoji are kept in distinct fragments (via a
     // unique id) so each is counted/rendered; without that they would merge into one.

--- a/ui/StatusQ/include/StatusQ/statusemojimodel.h
+++ b/ui/StatusQ/include/StatusQ/statusemojimodel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <QHash>
 #include <QJsonArray>
 
 class StatusEmojiModel : public QAbstractListModel
@@ -38,6 +39,8 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     Q_INVOKABLE QString getEmojiUnicodeFromShortname(const QString &shortname) const;
+    Q_INVOKABLE QString getEmojiFromAsciiAlias(const QString &alias) const;
+    Q_INVOKABLE int maxAsciiEmojiAliasLength() const;
     Q_INVOKABLE int getCategoryOffset(int categoryIndex) const;
 
     Q_INVOKABLE void addRecentEmoji(const QString &hexcode);
@@ -51,6 +54,7 @@ private:
     QJsonArray emojiJson() const;
     void setEmojiJson(const QJsonArray &newEmojiJson);
     QJsonArray m_emojiJson;
+    mutable int m_maxAsciiEmojiAliasLength = -1;
 
     QStringList categories() const;
     QStringList categoryIcons() const;

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
@@ -140,41 +140,13 @@ QtObject {
         })
     }
 
-    // ASCII emoticon (":)", ";P", "<3"…) table, built on first use.
-    readonly property QtObject d: QtObject {
-        property var asciiEmojis: null // alias -> emoji character
-        property int maxAsciiEmojiLength: 0
-
-        function ensureAsciiEmojis() {
-            if (asciiEmojis)
-                return asciiEmojis
-
-            const map = {}
-            let max = 0
-            // The first entry declaring an alias wins, so base emojis take precedence over
-            // their skin-tone variants.
-            EmojiJSON.emoji_json.forEach(emoji => {
-                emoji.aliases_ascii.forEach(alias => {
-                    if (map[alias] === undefined) {
-                        map[alias] = emoji.emoji
-                        max = Math.max(max, alias.length)
-                    }
-                })
-            })
-            maxAsciiEmojiLength = max
-            asciiEmojis = map
-            return map
-        }
-    }
-
     // Length of the longest ASCII emoticon, to bound the look-back when matching one.
     function maxAsciiEmojiLength(): int {
-        d.ensureAsciiEmojis()
-        return d.maxAsciiEmojiLength
+        return emojiModel.maxAsciiEmojiAliasLength()
     }
 
     // Returns the emoji character for an ASCII emoticon, or "" when it isn't one.
     function getAsciiEmoji(text: string): string {
-        return d.ensureAsciiEmojis()[text] || ""
+        return emojiModel.getEmojiFromAsciiAlias(text)
     }
 }

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
@@ -139,4 +139,42 @@ QtObject {
                     emoji.keywords.some(k => k.includes(input))
         })
     }
+
+    // ASCII emoticon (":)", ";P", "<3"…) table, built on first use.
+    readonly property QtObject d: QtObject {
+        property var asciiEmojis: null // alias -> emoji character
+        property int maxAsciiEmojiLength: 0
+
+        function ensureAsciiEmojis() {
+            if (asciiEmojis)
+                return asciiEmojis
+
+            const map = {}
+            let max = 0
+            // The first entry declaring an alias wins, so base emojis take precedence over
+            // their skin-tone variants.
+            EmojiJSON.emoji_json.forEach(emoji => {
+                emoji.aliases_ascii.forEach(alias => {
+                    if (map[alias] === undefined) {
+                        map[alias] = emoji.emoji
+                        max = Math.max(max, alias.length)
+                    }
+                })
+            })
+            maxAsciiEmojiLength = max
+            asciiEmojis = map
+            return map
+        }
+    }
+
+    // Length of the longest ASCII emoticon, to bound the look-back when matching one.
+    function maxAsciiEmojiLength(): int {
+        d.ensureAsciiEmojis()
+        return d.maxAsciiEmojiLength
+    }
+
+    // Returns the emoji character for an ASCII emoticon, or "" when it isn't one.
+    function getAsciiEmoji(text: string): string {
+        return d.ensureAsciiEmojis()[text] || ""
+    }
 }

--- a/ui/StatusQ/src/StatusQ/Core/Utils/StringUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/StringUtils.qml
@@ -39,7 +39,7 @@ QtObject {
     // kaomoji, returning any other text unchanged.
     function expandAsciiEmoticonShortcuts(text) {
         if (text.startsWith("/shrug"))
-            return text.replace("/shrug", "") + " ¯\\\\\\_(ツ)\\_/¯"
+            return text.replace("/shrug", "") + " ¯\\_(ツ)_/¯"
 
         if (text.startsWith("/tableflip"))
             return text.replace("/tableflip", "") + " (╯°□°）╯︵ ┻━┻"

--- a/ui/StatusQ/src/chatinputhighlighter.cpp
+++ b/ui/StatusQ/src/chatinputhighlighter.cpp
@@ -1237,6 +1237,23 @@ void ChatInputHighlighter::insertTextWithEmojis(int position, const QString& tex
     cursor.endEditBlock();
 }
 
+void ChatInputHighlighter::replaceTextWithEmojis(int start, int end, const QString& text)
+{
+    if (!document())
+        return;
+    const int last = document()->characterCount() - 1;
+    const int from = qBound(0, qMin(start, end), last);
+    const int to = qBound(0, qMax(start, end), last);
+    QTextCursor cursor(document());
+    cursor.setPosition(from);
+    cursor.setPosition(to, QTextCursor::KeepAnchor);
+    cursor.beginEditBlock();
+    if (cursor.hasSelection())
+        cursor.removeSelectedText();
+    insertEmojiAwareText(cursor, text);
+    cursor.endEditBlock();
+}
+
 int ChatInputHighlighter::emojiImageCount() const
 {
     const QTextDocument* doc = document();

--- a/ui/StatusQ/src/statusemojimodel.cpp
+++ b/ui/StatusQ/src/statusemojimodel.cpp
@@ -118,6 +118,7 @@ void StatusEmojiModel::setEmojiJson(const QJsonArray &newEmojiJson)
 
     beginResetModel();
     m_emojiJson = newEmojiJson;
+    m_maxAsciiEmojiAliasLength = -1;
     emit emojiJsonChanged();
     endResetModel();
 }
@@ -134,6 +135,43 @@ QString StatusEmojiModel::getEmojiUnicodeFromShortname(const QString &shortname)
     if (it != m_emojiJson.cend())
         return it->toObject().value(kUnicode).toString();
     return {};
+}
+
+QString StatusEmojiModel::getEmojiFromAsciiAlias(const QString &alias) const
+{
+    const auto it = std::find_if(m_emojiJson.cbegin(),
+                                 m_emojiJson.cend(),
+                                 [&alias](const auto &emojiValue) {
+                                     if (!emojiValue.isObject())
+                                         return false;
+
+                                     const auto aliases = emojiValue.toObject()
+                                                              .value(kAliasesAscii)
+                                                              .toArray();
+                                     return std::any_of(aliases.cbegin(),
+                                                        aliases.cend(),
+                                                        [&alias](const auto &aliasValue) {
+                                                            return aliasValue.toString() == alias;
+                                                        });
+                                 });
+    return it == m_emojiJson.cend() ? QString() : it->toObject().value(kEmoji).toString();
+}
+
+int StatusEmojiModel::maxAsciiEmojiAliasLength() const
+{
+    if (m_maxAsciiEmojiAliasLength >= 0)
+        return m_maxAsciiEmojiAliasLength;
+
+    m_maxAsciiEmojiAliasLength = 0;
+    for (const auto &emojiValue : m_emojiJson) {
+        if (!emojiValue.isObject())
+            continue;
+
+        for (const auto &aliasValue : emojiValue.toObject().value(kAliasesAscii).toArray())
+            m_maxAsciiEmojiAliasLength = qMax(m_maxAsciiEmojiAliasLength,
+                                              aliasValue.toString().size());
+    }
+    return m_maxAsciiEmojiAliasLength;
 }
 
 int StatusEmojiModel::getCategoryOffset(int categoryIndex) const {

--- a/ui/StatusQ/tests/TestCore/TestUtils/tst_Emoji.qml
+++ b/ui/StatusQ/tests/TestCore/TestUtils/tst_Emoji.qml
@@ -24,5 +24,12 @@ TestCase {
         }
         compare(Emoji.lastFlagIndex, lastIndex, "Last flag index is still valid")
     }
+
+    function test_ascii_emoticons_are_resolved() {
+        compare(Emoji.getAsciiEmoji(":)"), "\u{1F642}")
+        compare(Emoji.getAsciiEmoji(">:)"), "\u{1F608}")
+        compare(Emoji.getAsciiEmoji("not-an-emoticon"), "")
+        compare(Emoji.maxAsciiEmojiLength(), 3)
+    }
 }
 

--- a/ui/imports/shared/status/ChatTextArea.qml
+++ b/ui/imports/shared/status/ChatTextArea.qml
@@ -64,6 +64,20 @@ StatusTextArea {
     // The partial shortcode typed after that ":" (up to the caret); "" when not entering one.
     readonly property string emojiFilter: d.emojiContext.filter
 
+    // When true, an ASCII emoticon (":)", ";P", "<3"…) typed as a whole word is replaced by the
+    // corresponding emoji once the word is completed with a space or a newline. The host can also
+    // force it (e.g. right before sending) via convertAsciiEmoji().
+    property bool asciiEmojiConversion: false
+
+    // Replaces the ASCII emoticon ending at the caret, if any, with its emoji. No-op when
+    // asciiEmojiConversion is off, when there is a selection, or when the word isn't an emoticon.
+    function convertAsciiEmoji() {
+        const match = d.asciiEmojiBeforeCaret()
+        if (!match)
+            return
+        highlighter.replaceTextWithEmojis(match.start, root.cursorPosition, match.emoji)
+    }
+
     function insertMention(pos, name, pubKey) {
         highlighter.insertMention(pos, name, pubKey)
     }
@@ -227,6 +241,8 @@ StatusTextArea {
     InputMethodEventFilter {
         target: root
         onInputMethodEventReceived: (imeEvent) => {
+            if (imeEvent.commitString === " " || imeEvent.commitString === "\n")
+                root.convertAsciiEmoji()
             if (imeEvent.commitString === "\n" && d.continueQuoteBlock())
                 imeEvent.accept()
         }
@@ -353,6 +369,35 @@ StatusTextArea {
             return { entering: true, filter: filter }
         }
 
+        // { start, emoji } for the ASCII emoticon ending at the caret, or null. The emoticon must
+        // be a whole word (text/line start or right after whitespace) and outside code.
+        function asciiEmojiBeforeCaret() {
+            if (!root.asciiEmojiConversion
+                    || root.selectionStart !== root.selectionEnd
+                    || root.preeditText.length > 0)
+                return null
+
+            const caret = root.cursorPosition
+            const from = Math.max(0, caret - Emoji.maxAsciiEmojiLength())
+            const chunk = root.getText(from, caret)
+
+            // Longest match first, so ">:)" wins over ":)".
+            for (let start = 0; start < chunk.length; ++start) {
+                if (start > 0 && !/\s/.test(chunk.charAt(start - 1)))
+                    continue
+                if (start === 0 && from > 0 && !/\s/.test(root.getText(from - 1, from)))
+                    continue
+
+                const emoji = Emoji.getAsciiEmoji(chunk.substring(start))
+                if (!emoji)
+                    continue
+
+                const pos = from + start
+                return highlighter.isInsideCode(pos) ? null : { start: pos, emoji: emoji }
+            }
+            return null
+        }
+
         // Triggers repainting the caret at the right place after an out-of-band
         // document edit (paste, or removing formatting). The highlighter mutates
         // the document and re-applies char formats as part of the same change —
@@ -471,6 +516,12 @@ StatusTextArea {
                 return
             }
         }
+
+        // Convert the ASCII emoticon completed by this key before its own insertion happens, so
+        // the caret still sits right at the end of the word. The key then types as usual.
+        if (event.key === Qt.Key_Space || event.key === Qt.Key_Return
+                || event.key === Qt.Key_Enter)
+            root.convertAsciiEmoji()
 
         // Intercept the 3rd backtick typed right after "``" and perform
         // the "``" -> "```" replacement ourselves, as a single joinable

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -357,6 +357,9 @@ Control {
         - hides extended area
       */
     function tryFinalizeMessage() {
+        // Convert a trailing ASCII emoticon ("hello :)") that was never completed with a space.
+        messageInputField.convertAsciiEmoji()
+
         // Count against the wire text (mentions expanded to @0xpubkey), not the pill-placeholder text.
         const messageLength = messageInputField.textWithMentions().length
         const wasEdit = root.isEdit
@@ -370,7 +373,6 @@ Control {
             return
         }
 
-        // Emojis are already plain unicode (no ":)" conversion needed).
         root.sendMessageRequested()
         if (!wasEdit)
             root.hideExtendedArea()
@@ -816,6 +818,7 @@ Control {
 
                         characterLimit: root.messageLimitHard
                         imageEmojis: true
+                        asciiEmojiConversion: true
 
                         // Paddings are used only for left/right sides because
                         // when used nn top/bottom they cause artificial cut-off


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-app/issues/22037

The StatusChatInput refactor dropped the ASCII emoticon conversion that
used to run off the old text area's onTextChanged handler, so typing
":)" stayed ":)" instead of becoming 🙂.

Restore it at the layer that owns caret and text structure. ChatTextArea
gains an opt-in asciiEmojiConversion property and a convertAsciiEmoji()
function: it matches the word ending at the caret against the emoticon
table, longest alias first, and requires a whole word at text/line start
or after whitespace. Conversion is triggered from Keys.onPressed on
space and enter, before the key's own insertion, and from the existing
InputMethodEventFilter for on-screen keyboard commits.

Emoji gains a lazily-built alias_ascii lookup, replacing the old linear
scan over the whole emoji list on every keystroke, and the highlighter
gains replaceTextWithEmojis() so a conversion is a single undo step.
StatusChatInput enables the property and force-converts in
tryFinalizeMessage(), so "hello :)" sent without a trailing space is
converted too.

Unlike the previous implementation, emoticons inside code spans and code
blocks are now left verbatim.

Also fixes the issue with the shrug command having too many backslahes.

### Affected areas

- chatintputhighligher
- Emoji.qml
- ChatTextArea.qml
- StatusChatInput.qml
- New tests

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction

### Screencapture of the functionality

[emojis-fix.webm](https://github.com/user-attachments/assets/f38f6c4d-d378-4efa-8485-73c2564dfd28)

### Impact on end user

Fixes the issue

### How to test

Type ascii emojis

### Risk 

Low
