### PR TITLE
feat(gifs): hide GIF-only message URLs when previewing

### DIFF
--- a/storybook/qmlTests/tests/tst_LinkPreviewGifDelegate.qml
+++ b/storybook/qmlTests/tests/tst_LinkPreviewGifDelegate.qml
@@ -1,0 +1,29 @@
+import QtQuick
+import QtTest
+
+import shared.controls.delegates
+
+Item {
+    id: root
+
+    Component {
+        id: componentUnderTest
+
+        LinkPreviewGifDelegate {
+            link: "https://media.example.com/animation.gif"
+            playAnimation: false
+            isOnline: false
+        }
+    }
+
+    TestCase {
+        name: "LinkPreviewGifDelegate"
+
+        function test_accessibleLabel() {
+            const control = createTemporaryObject(componentUnderTest, root)
+            verify(control)
+            compare(control.Accessible.role, Accessible.StaticText)
+            compare(control.Accessible.name, "Animated GIF")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_Utils.qml
+++ b/storybook/qmlTests/tests/tst_Utils.qml
@@ -93,4 +93,55 @@ Item {
             compare(Utils.collectibleMediaSource(thumbnail, image), thumbnail)
         }
     }
+
+    TestCase {
+        name: "Utils_gifLinks"
+
+        function test_isGifLink_data() {
+            return [
+                {tag: "Klipy", url: "https://static.klipy.com/ii/935d7ab9d8c6202580a668421940ec81/23/12/Baqa16H5.gif", expected: true},
+                {tag: "uppercase extension", url: "https://media.example.com/animation.GIF", expected: true},
+                {tag: "query string", url: "https://media.example.com/animation.gif?width=320", expected: true},
+                {tag: "fragment", url: "https://media.example.com/animation.gif#preview", expected: true},
+                {tag: "other image", url: "https://media.example.com/image.webp", expected: false},
+                {tag: "suffix only", url: "https://media.example.com/animation.gifx", expected: false},
+                {tag: "bare filename", url: "animation.gif", expected: false}
+            ]
+        }
+
+        function test_isGifLink(data) {
+            compare(Utils.isGifLink(data.url), data.expected)
+        }
+
+        function test_gifLinks_data() {
+            return [
+                {tag: "single GIF", text: "https://media.example.com/animation.gif", expected: 1},
+                {tag: "spaces", text: "https://media.example.com/one.gif  https://media.example.com/two.gif", expected: 2},
+                {tag: "newlines", text: "https://media.example.com/one.gif\nhttps://media.example.com/two.gif", expected: 2},
+                {tag: "mixed whitespace", text: "\thttps://media.example.com/one.gif\r\n https://media.example.com/two.gif ", expected: 2},
+                {tag: "non-GIF", text: "https://media.example.com/image.png", expected: 0},
+                {tag: "missing", text: undefined, expected: 0}
+            ]
+        }
+
+        function test_gifLinks(data) {
+            compare(Utils.gifLinks(data.text).length, data.expected)
+        }
+
+        function test_isGifOnlyText_data() {
+            return [
+                {tag: "single GIF", text: "https://media.example.com/animation.gif", expected: true},
+                {tag: "multiple GIFs", text: "https://media.example.com/one.gif\nhttps://media.example.com/two.gif", expected: true},
+                {tag: "surrounding whitespace", text: "  https://media.example.com/animation.gif  ", expected: true},
+                {tag: "text and GIF", text: "look at this https://media.example.com/animation.gif", expected: false},
+                {tag: "empty", text: "", expected: false},
+                {tag: "missing", text: undefined, expected: false},
+                {tag: "non-GIF", text: "https://media.example.com/image.png", expected: false}
+            ]
+        }
+
+        function test_isGifOnlyText(data) {
+            compare(Utils.isGifOnlyText(data.text), data.expected)
+        }
+    }
 }

--- a/ui/app/AppLayouts/ActivityCenter/adaptors/NotificationAdaptorMessenger.qml
+++ b/ui/app/AppLayouts/ActivityCenter/adaptors/NotificationAdaptorMessenger.qml
@@ -42,7 +42,12 @@ NotificationAdaptorSender {
     // Content block related
     // -------------------------
 
-    content: notification && notification.message ? notification.message.messageText : ""
+    content: {
+        const message = notification?.message
+        if (!message)
+            return ""
+        return Utils.isGifOnlyText(message.unparsedText) ? qsTr("GIF") : message.messageText
+    }
     attachments: {
         const msg = notification && notification.message
         const images = msg && msg.albumMessageImages

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -10070,6 +10070,13 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>LinkPreviewGifDelegate</name>
+    <message>
+        <source>Animated GIF</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LinkPreviewMiniCard</name>
     <message>
         <source>Generating preview...</source>
@@ -11301,6 +11308,10 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>GIF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Reply</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12164,6 +12175,13 @@ to load</source>
     </message>
     <message>
         <source>Contact request declined</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NotificationAdaptorMessenger</name>
+    <message>
+        <source>GIF</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -10122,6 +10122,13 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>LinkPreviewGifDelegate</name>
+    <message>
+        <source>Animated GIF</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LinkPreviewMiniCard</name>
     <message>
         <source>Generating preview...</source>
@@ -11367,6 +11374,10 @@ selhalo</translation>
         <translation>Smazaná zpráva</translation>
     </message>
     <message>
+        <source>GIF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Reply</source>
         <translation>Odpovědět</translation>
     </message>
@@ -12234,6 +12245,13 @@ selhalo</translation>
     </message>
     <message>
         <source>Contact request declined</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NotificationAdaptorMessenger</name>
+    <message>
+        <source>GIF</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -10082,6 +10082,13 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>LinkPreviewGifDelegate</name>
+    <message>
+        <source>Animated GIF</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LinkPreviewMiniCard</name>
     <message>
         <source>Generating preview...</source>
@@ -11314,6 +11321,10 @@ al cargar</translation>
         <translation>Mensaje eliminado</translation>
     </message>
     <message>
+        <source>GIF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Reply</source>
         <translation>Responder</translation>
     </message>
@@ -12178,6 +12189,13 @@ al cargar</translation>
     <message>
         <source>Contact request declined</source>
         <translation>Solicitud de contacto rechazada</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationAdaptorMessenger</name>
+    <message>
+        <source>GIF</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -10079,6 +10079,13 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>LinkPreviewGifDelegate</name>
+    <message>
+        <source>Animated GIF</source>
+        <translation>GIF animé</translation>
+    </message>
+</context>
+<context>
     <name>LinkPreviewMiniCard</name>
     <message>
         <source>Generating preview...</source>
@@ -11311,6 +11318,10 @@ chargement</translation>
         <translation>Message supprimé</translation>
     </message>
     <message>
+        <source>GIF</source>
+        <translation>GIF</translation>
+    </message>
+    <message>
         <source>Reply</source>
         <translation>Répondre</translation>
     </message>
@@ -12175,6 +12186,13 @@ chargement</translation>
     <message>
         <source>Contact request declined</source>
         <translation>Demande de contact refusée</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationAdaptorMessenger</name>
+    <message>
+        <source>GIF</source>
+        <translation>GIF</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -10043,6 +10043,13 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>LinkPreviewGifDelegate</name>
+    <message>
+        <source>Animated GIF</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LinkPreviewMiniCard</name>
     <message>
         <source>Generating preview...</source>
@@ -11262,6 +11269,10 @@ to load</source>
         <translation>메시지 삭제됨</translation>
     </message>
     <message>
+        <source>GIF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Reply</source>
         <translation>답장</translation>
     </message>
@@ -12121,6 +12132,13 @@ to load</source>
     </message>
     <message>
         <source>Contact request declined</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NotificationAdaptorMessenger</name>
+    <message>
+        <source>GIF</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/imports/shared/controls/delegates/LinkPreviewGifDelegate.qml
+++ b/ui/imports/shared/controls/delegates/LinkPreviewGifDelegate.qml
@@ -15,6 +15,9 @@ CalloutCard {
     required property bool playAnimation
     required property bool isOnline
 
+    Accessible.role: Accessible.StaticText
+    Accessible.name: qsTr("Animated GIF")
+
     property int imageWidth: 300
 
     readonly property bool isPlaying: linkImage.playing

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -93,12 +93,7 @@ Loader {
 
     // These 2 properties can be dropped when the new unfurling flow supports GIFs
     property var links
-    readonly property var gifLinks: {
-        if (!links)
-            return []
-        const arr = links.split(" ")
-        return arr.filter(value => value.toLowerCase().endsWith('.gif'))
-    }
+    readonly property var gifLinks: Utils.gifLinks(links)
 
     property string responseToMessageWithId: ""
     property string quotedMessageText: ""
@@ -387,6 +382,9 @@ Loader {
         id: d
 
         readonly property int chatButtonSize: 32
+        readonly property bool gifOnlyMessage: root.gifUnfurlingEnabled
+                                               && root.gifLinks.length > 0
+                                               && Utils.isGifOnlyText(root.unparsedText)
         property bool hideMessage: false
         property bool emojiPopupOpened: false
 
@@ -955,8 +953,8 @@ Loader {
                         }
                         return ""
                     }
-                    messageText: root.messageText
-                    unparsedText: root.unparsedText
+                    messageText: d.gifOnlyMessage ? "" : root.messageText
+                    unparsedText: d.gifOnlyMessage ? "" : root.unparsedText
                     mentionsMap: root.mentionsMap
                     messageContent: {
                         switch (delegate.contentType)
@@ -1023,6 +1021,8 @@ Loader {
                             return qsTr("Message deleted")
                         if (!root.quotedMessageText && !root.quotedMessageFrom)
                             return qsTr("Unknown message. Trying to recover it")
+                        if (Utils.isGifOnlyText(root.quotedMessageUnparsedText))
+                            return qsTr("GIF")
                         return root.quotedMessageText
                     }
                     unparsedText: {
@@ -1030,6 +1030,8 @@ Loader {
                             return qsTr("Message deleted")
                         if (!root.quotedMessageUnparsedText && !root.quotedMessageFrom)
                             return qsTr("Unknown message. Trying to recover it")
+                        if (Utils.isGifOnlyText(root.quotedMessageUnparsedText))
+                            return qsTr("GIF")
                         return root.quotedMessageUnparsedText
                     }
                     mentionsMap: root.mentionsMap

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -233,6 +233,28 @@ QtObject {
         return (/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}(\.[a-zA-Z0-9()]{1,6})?\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/.test(text))
     }
 
+    function isGifLink(url) {
+        if (typeof url !== "string" || !/^https?:\/\/\S+$/i.test(url))
+            return false
+        const suffixStart = url.search(/[?#]/)
+        const path = suffixStart === -1 ? url : url.slice(0, suffixStart)
+        return path.toLowerCase().endsWith(".gif")
+    }
+
+    function gifLinks(text) {
+        if (typeof text !== "string")
+            return []
+        const tokens = text.trim().split(/\s+/)
+        return tokens[0] === "" ? [] : tokens.filter(isGifLink)
+    }
+
+    function isGifOnlyText(text) {
+        if (text === null || text === undefined)
+            return false
+        const tokens = text.toString().trim().split(/\s+/)
+        return tokens.length > 0 && tokens[0] !== "" && tokens.every(isGifLink)
+    }
+
     function isURLWithOptionalProtocol(text) {
         return (/^(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/.test(text))
     }


### PR DESCRIPTION
### What does the PR do

Fixes #21990

- detect direct HTTP(S) `.gif` URLs generically, including query/fragment variants
- hide the text bubble only when a message contains GIF URLs and nothing else
- retain raw URLs in mixed messages, copy, and edit flows
- show `GIF` for GIF-only reply and Activity Center text previews
- add QML utility coverage for GIF link and GIF-only message detection

### Affected areas

- MessageView
- Utils

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction

### Screencapture of the functionality

<img width="681" height="862" alt="image" src="https://github.com/user-attachments/assets/33a5b9f5-0482-4010-bdf0-43db38b5621d" />

### Impact on end user

Makes viewing gifs nicer

### How to test

Send gifs and reply to them

### Risk 

Low
