### PR TITLE
fix(biometrics): make biometrics work for keycard profiles

### DIFF
--- a/storybook/qmlTests/tests/tst_AuthSignPopupBase.qml
+++ b/storybook/qmlTests/tests/tst_AuthSignPopupBase.qml
@@ -1,0 +1,172 @@
+import QtQuick
+import QtQuick.Controls
+
+import QtTest
+
+import StatusQ
+
+import shared.popups.auth_sign_base 1.0
+
+import utils
+
+Item {
+    id: root
+
+    width: 480
+    height: 520
+
+    Component {
+        id: componentUnderTest
+
+        PopupBase {
+            reason: "testing"
+            keyUid: "key-uid-1"
+
+            keychain: Keychain {}
+
+            keycardState: Constants.keycard.state.ready
+            keycardUid: "keycard-uid-1"
+            remainingPinAttempts: 3
+            userProfileKeyUid: "key-uid-1"
+            userProfilePublicKey: "0xpub"
+            userProfileMigratedToColdWallet: true
+            isKeycardKeyPair: true
+
+            btnActionName: "Authenticate"
+            btnPasswordActionAndUpdateName: "Update password & authenticate"
+            btnPinActionAndUpdateName: "Update PIN & authenticate"
+
+            closePolicy: Popup.NoAutoClose
+        }
+    }
+
+    Component {
+        id: mockedKeychainComponent
+
+        // Shadows the C++ members so no real OS keychain/biometrics is touched
+        Keychain {
+            property int requestCount: 0
+            readonly property bool available: true
+            function hasCredential(account) {
+                return account === "key-uid-1" ? Keychain.StatusSuccess
+                                               : Keychain.StatusNotFound
+            }
+            function requestGetCredential(reason, account) {
+                requestCount++
+                return Keychain.StatusSuccess
+            }
+        }
+    }
+
+    TestCase {
+        name: "AuthSignPopupBase_biometricsAutoStart"
+        when: windowShown
+
+        property var popup: null
+        property var mockKeychain: null
+
+        function init() {
+            mockKeychain = createTemporaryObject(mockedKeychainComponent, root)
+            verify(!!mockKeychain)
+        }
+
+        function cleanup() {
+            if (popup) {
+                popup.destroy()
+                popup = null
+            }
+        }
+
+        function test_autoStartsForProfileKeycardKeyPair() {
+            popup = createTemporaryObject(componentUnderTest, root, { keychain: mockKeychain })
+            verify(!!popup)
+            popup.open()
+
+            tryCompare(mockKeychain, "requestCount", 1)
+        }
+
+        // SignPopup's externalAuthorization can only settle to its final value after the store
+        // gets ready — the gate turning on late must still auto-start biometrics.
+        function test_autoStartsWhenGateTurnsOnLate() {
+            popup = createTemporaryObject(componentUnderTest, root, {
+                                              keychain: mockKeychain,
+                                              externalAuthorization: true
+                                          })
+            verify(!!popup)
+            popup.open()
+
+            waitForRendering(popup.contentItem)
+            compare(mockKeychain.requestCount, 0)
+
+            popup.externalAuthorization = false
+            tryCompare(mockKeychain, "requestCount", 1)
+        }
+
+        // Biometrics holds the profile credential only: signing with a non-profile keycard
+        // keypair must go through its own keycard, never through biometrics.
+        function test_neverStartsForNonProfileKeycardKeyPair() {
+            popup = createTemporaryObject(componentUnderTest, root, {
+                                              keychain: mockKeychain,
+                                              keyUid: "other-keypair-uid",
+                                              externalAuthorization: true
+                                          })
+            verify(!!popup)
+            popup.open()
+
+            waitForRendering(popup.contentItem)
+
+            // mimic the store-ready flip that re-resolves externalAuthorization for keycard keypairs
+            popup.externalAuthorization = false
+            waitForRendering(popup.contentItem)
+
+            compare(mockKeychain.requestCount, 0)
+
+            const bioButton = findChild(popup, "useBiometricsButton")
+            verify(!!bioButton)
+            verify(!bioButton.visible)
+        }
+    }
+
+    TestCase {
+        name: "AuthSignPopupBase_keycardPin"
+        when: windowShown
+
+        property var popup: null
+
+        function cleanup() {
+            if (popup) {
+                popup.destroy()
+                popup = null
+            }
+        }
+
+        // The PIN used for the keycard action must be exposed via lastUsedPin, so that
+        // concrete popups (AuthenticationPopup) can propagate it on success and the
+        // enable-biometrics handlers store the PIN (not the encryption public key).
+        function test_lastUsedPinExposesEnteredPin() {
+            let capturedKeyUid = ""
+            let capturedPin = ""
+
+            popup = createTemporaryObject(componentUnderTest, root)
+            verify(!!popup)
+            popup.performKeycardAction = (keyUid, pin, pairingPassword) => {
+                capturedKeyUid = keyUid
+                capturedPin = pin
+            }
+            popup.open()
+
+            compare(popup.lastUsedPin, "")
+
+            tryVerify(() => !!findChild(popup, "keycardAuthPinInput"))
+            const pinInput = findChild(popup, "keycardAuthPinInput")
+            pinInput.setPin("123456") // completing the PIN auto-submits the keycard action
+
+            compare(capturedKeyUid, "key-uid-1")
+            compare(capturedPin, "123456")
+            compare(popup.lastUsedPin, "123456")
+
+            popup.handleKeycardSuccess()
+            compare(popup.lastUsedPin, "123456")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -645,7 +645,7 @@ Item {
                 verify(!!keycardBox)
 
                 if (data.biometrics) { // biometrics + PIN
-                    mockDriver.keycardState = Onboarding.KeycardState.NotEmpty // triggers biometrics request
+                    mockDriver.keycardState = Onboarding.KeycardState.NotEmpty // shows PIN input, biometrics is requested on profile selection
                     waitForRendering(keycardBox)
                     waitForItemPolished(keycardBox)
 

--- a/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
@@ -157,17 +157,6 @@ OnboardingPage {
         }
     }
 
-    onKeycardStateChanged: {
-        Qt.callLater(() => {
-            if (!isBiometricsLogin || !d.currentProfileIsKeycard
-                || root.keycardState !== Onboarding.KeycardState.NotEmpty)
-                return
-
-            root.biometricsRequested(loginUserSelector.selectedProfileKeyId)
-        })
-    }
-
-
     // login errors reporting
     function setAccountLoginError(error: string, wrongPassword: bool) : void {
         if (!error && !wrongPassword) {
@@ -264,9 +253,6 @@ OnboardingPage {
 
                     Qt.callLater(() => {
                         if (!root || !root.isBiometricsLogin)
-                            return
-
-                        if (d.currentProfileIsKeycard && root.keycardState !== Onboarding.KeycardState.NotEmpty)
                             return
 
                         root.biometricsRequested(loginUserSelector.selectedProfileKeyId)

--- a/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
+++ b/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
@@ -135,7 +135,7 @@ SettingsContentBase {
                 default:
                     Global.displayToastMessage(
                                 qsTr("Failed to disable biometric login and transaction authentication for this device"),
-                                errorDescription, "warning", false, Constants.ephemeralNotificationType.danger, "")
+                                "", "warning", false, Constants.ephemeralNotificationType.danger, "")
                 }
                 d.reevaluateHasCredential()
             }

--- a/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
+++ b/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
@@ -127,6 +127,7 @@ StatusDialog {
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
             StatusFlatButton {
+                objectName: "useBiometricsButton"
                 visible: d.usingBiometrics && !d.biometricsInProgress && !d.verifying
                 text: qsTr("Use biometrics")
                 onClicked: d.startBiometrics()
@@ -216,8 +217,22 @@ StatusDialog {
 
         readonly property bool usingBiometrics: root.keychain.available
                                                 && !root.externalAuthorization // the authentication popup runs its own biometrics
-                                                && root.useKeyUid === root.userProfileKeyUid
+                                                && (!root.isKeycardKeyPair || root.keyUid === root.userProfileKeyUid)
                                                 && keychain.hasCredential(root.useKeyUid) === Keychain.StatusSuccess
+
+        onUsingBiometricsChanged: d.tryAutoStartBiometrics()
+
+        property bool constructionDone: false
+        property bool autoBiometricsAttempted: false
+
+        function tryAutoStartBiometrics() {
+            if (!d.constructionDone || !d.usingBiometrics || d.autoBiometricsAttempted)
+                return
+            d.autoBiometricsAttempted = true
+            if (d.biometricsInProgress || d.verifying || d.success)
+                return
+            d.startBiometrics()
+        }
 
         property bool biometricsInProgress: false
         property bool credentialMismatchAfterBiometrics: false
@@ -381,6 +396,8 @@ StatusDialog {
         errorText: d.error
     }
 
+    readonly property string lastUsedPin: d.lastPin
+
     // Public API for concrete popups to drive state
     function handleKeycardSuccess() {
         d.handleKeycardSuccess()
@@ -395,9 +412,8 @@ StatusDialog {
     }
 
     Component.onCompleted: {
-        if (d.usingBiometrics) {
-            d.startBiometrics()
-        }
+        d.constructionDone = true
+        d.tryAutoStartBiometrics()
     }
 
     onClosed: {

--- a/ui/imports/shared/popups/authentication/AuthenticationPopup.qml
+++ b/ui/imports/shared/popups/authentication/AuthenticationPopup.qml
@@ -54,7 +54,7 @@ PopupBase {
 
         function onKeycardAuthSuccess(encryptionPublicKey, chatPrivateKey) {
             root.handleKeycardSuccess()
-            root.authenticationSuccess(root.reason, encryptionPublicKey, "", root.keyUid, chatPrivateKey)
+            root.authenticationSuccess(root.reason, encryptionPublicKey, root.lastUsedPin, root.keyUid, chatPrivateKey)
             root.close()
         }
 


### PR DESCRIPTION
What's done:
- store the keycard pin in the keychain instead of the encryption public key (expose lastUsedPin from PopupBase, pass it through authenticationSuccess), this way, we're aligned with what we have in the release
- login screen - request biometrics on profile selection (same as for password profiles)
- sign popup - auto-start biometrics when the profile is keycard migrated