### PR TITLE
chore(android): drop unused permissions, widen the device catalog

### DIFF
--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -16,8 +16,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.NFC"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -31,7 +29,6 @@
 
     <!-- dangerous permissions -->
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <supports-screens


### PR DESCRIPTION
Closes #21742

Audited every permission in the Android manifest against a real consumer:

| Permission | Consumer | Verdict |
|---|---|---|
| `INTERNET` | everything | keep |
| `NFC` | keycard (`libQt6Nfc` bundled, `FLAG_KEYCARD_ENABLED ?= 1`) | keep |
| `ACCESS_NETWORK_STATE` | `StatusGoService` ConnectivityManager callbacks | keep |
| `VIBRATE` | `NotificationBuilder` channel vibration | keep |
| `USE_BIOMETRIC` | `SecureAndroidAuthentication` | keep |
| `FOREGROUND_SERVICE(_SPECIAL_USE)` | `StatusGoService` | keep |
| `CAMERA` | `StatusQrCodeCapture` / QtMultimedia | keep |
| `POST_NOTIFICATIONS` | `StatusNotificationManager` | keep |
| `*.permission.STATUSGO_SERVICE` | Binder IPC | keep |
| `ACCESS_WIFI_STATE` | none | **dropped** |
| `ACCESS_FINE_LOCATION` | none | **dropped** |
| `RECEIVE_BOOT_COMPLETED` | no receiver declared | **dropped** |
