### PR TITLE
chore: bump status-go, upgrade protoc to v36 and drop protoc-gen-go installs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -85,7 +85,7 @@ Install [scoop](https://scoop.sh/) if you don't have it already. Then run:
 
 ```
 scoop bucket add extras
-scoop install --global protobuf@3.20.1
+scoop install --global protobuf@36.0
 ```
 
 > ⚠️ Note: There is a script `scripts/windows_build_setup.ps1`, which is used to install dependencies on CI machines. Feel free to use it as inspiration for the needed versions.
@@ -98,8 +98,10 @@ Install required packages:
 
 ```bash
 sudo apt update
-sudo apt install libpcsclite-dev build-essential mesa-common-dev libglu1-mesa-dev libssl-dev cmake jq libxcb-xinerama0 protobuf-compiler
+sudo apt install libpcsclite-dev build-essential mesa-common-dev libglu1-mesa-dev libssl-dev cmake jq libxcb-xinerama0
 ```
+
+> ⚠️ Note: `status-go` needs protoc 36 or newer, which is newer than `protobuf-compiler` in apt. `scripts/ubuntu_build_setup.sh` installs it from the upstream release.
 
 Install **Go 1.26**:
 
@@ -290,16 +292,6 @@ git clone https://github.com/status-im/status-app.git
 cd status-desktop
 ```
 
-Install some `status-go` dependencies:
-
-```bash
-make status-go-deps
-```
-
-Make sure you have `~/go/bin` in your `PATH`:
-```bash
-echo "export PATH=\"$HOME/go/bin:\$PATH\"" >> ~/.zshrc
-```
 
 Update all submodules and build the dependencies:
 

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ $(BOTTLES):
 bottles: $(BOTTLES)
 endif
 
-deps: | check-qt-dir deps-common status-go-deps bottles
+deps: | check-qt-dir deps-common bottles
 
 update: | check-qt-dir update-common
 # Build the pkg-config wrapper (and generate this kit's Qt .pc if missing)
@@ -505,7 +505,7 @@ $(NIMSDS_LIBFILE): | platform-cleanup
 	echo -e $(BUILD_MSG) "nim-sds"
 	$(STATUSGO_MAKE_PARAMS) $(MAKE) -C vendor/status-go build-libsds SHELL=/bin/sh $(HANDLE_OUTPUT)
 
-$(STATUSGO): | deps status-go-deps $(NIMSDS_LIBFILE) platform-cleanup
+$(STATUSGO): | deps $(NIMSDS_LIBFILE) platform-cleanup
 	echo -e $(BUILD_MSG) "status-go"
 	# FIXME: Nix shell usage breaks builds due to Glibc mismatch.
 	$(STATUSGO_MAKE_PARAMS) $(MAKE) -C vendor/status-go statusgo-shared-library SHELL=/bin/sh \
@@ -514,10 +514,6 @@ $(STATUSGO): | deps status-go-deps $(NIMSDS_LIBFILE) platform-cleanup
 		 $(HANDLE_OUTPUT)
 
 status-go: $(STATUSGO)
-
-status-go-deps: export GOPROXY ?= https://proxy.golang.org|direct
-status-go-deps:
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 
 status-go-clean:
 	echo -e "\033[92mCleaning:\033[39m status-go"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -138,9 +138,9 @@ RUN GOLANG_SHA256="da18191ddb7db8a9339816f3e2b54bdded8047cdc2a5d67059478f8d1595c
  && sudo ln -s /usr/local/go/bin/go /usr/local/bin
 
 # Install Protoc
-RUN PROTOC_SHA256="75d8a9d7a2c42566e46411750d589c51276242d8b6247a5724bac0f9283e05a8" \
- && PROTOC_TARBALL="protoc-3.20.0-linux-x86_64.zip" \
- && wget -q -L  "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/${PROTOC_TARBALL}" \
+RUN PROTOC_SHA256="bc8211ce760bd43ee21ddc145d6d9dbaeeabae205267a79d9054a240e367d4b4" \
+ && PROTOC_TARBALL="protoc-36.0-linux-x86_64.zip" \
+ && wget -q -L  "https://github.com/protocolbuffers/protobuf/releases/download/v36.0/${PROTOC_TARBALL}" \
  && echo "${PROTOC_SHA256} ${PROTOC_TARBALL}" | sha256sum -c \
  && sudo unzip -d /usr/local "${PROTOC_TARBALL}" \
  && rm "${PROTOC_TARBALL}"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -145,14 +145,6 @@ RUN PROTOC_SHA256="bc8211ce760bd43ee21ddc145d6d9dbaeeabae205267a79d9054a240e367d
  && sudo unzip -d /usr/local "${PROTOC_TARBALL}" \
  && rm "${PROTOC_TARBALL}"
 
-# Install Protoc-deg-go
-RUN PROTOC_GEN_SHA256="0b2c257938a8cd9ba3506bbdbbaad45e51245b6f9e0743035ade7acf746c6be7" \
- && PROTOC_GEN_TARBALL="protoc-gen-go.v1.34.1.linux.amd64.tar.gz" \
- && wget -q -L "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.34.1/${PROTOC_GEN_TARBALL}" \
- && echo "${PROTOC_GEN_SHA256} ${PROTOC_GEN_TARBALL}" | sha256sum -c \
- && sudo tar -C /usr/local/bin -xzf "${PROTOC_GEN_TARBALL}" \
- && rm "${PROTOC_GEN_TARBALL}"
-
 # Create Nix directory as root.
 RUN mkdir /nix && chown 1001:1001 /nix
 

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -14,7 +14,7 @@ pipeline {
     /* Image with Ubuntu 22.04, QT ${QT_VERSION}, Android SDK/NDK, Go, and Nim */
     docker {
       label 'linuxcontainer'
-      image "harbor.status.im/status-im/status-desktop-build:1.0.1-qt${QT_VERSION}-android"
+      image "harbor.status.im/status-im/status-desktop-build:1.0.3-qt${QT_VERSION}-android"
       alwaysPull true
       args '--entrypoint="" ' +
            '--volume=/nix:/nix ' +

--- a/ci/Jenkinsfile.flatpak
+++ b/ci/Jenkinsfile.flatpak
@@ -12,7 +12,7 @@ pipeline {
     /* Image with Ubuntu 22.04 and QT ${QT_VERSION} */
     docker {
       label 'linuxcontainer'
-      image "harbor.status.im/status-im/status-desktop-build:1.0.10-qt${QT_VERSION}"
+      image "harbor.status.im/status-im/status-desktop-build:1.0.13-qt${QT_VERSION}"
       /* --privileged is required because flatpak-builder uses bubblewrap (bwrap) which needs
        * the pivot_root syscall. */
       args '--entrypoint="" ' +

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -8,7 +8,7 @@ def isPRBuild = utils.isPRBuild()
 
 pipeline {
 
-  agent { label "macos && arm64 && nix-2.24 && xcode-26.4 && qt-${QT_VERSION}" }
+  agent { label "macos && arm64 && nix-2.33 && xcode-26.4 && qt-${QT_VERSION}" }
 
   parameters {
     booleanParam(

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -12,7 +12,7 @@ pipeline {
     /* Image with Ubuntu 22.04 and QT ${QT_VERSION} */
     docker {
       label 'linuxcontainer'
-      image "harbor.status.im/status-im/status-desktop-build:1.0.8-qt${QT_VERSION}"
+      image "harbor.status.im/status-im/status-desktop-build:1.0.13-qt${QT_VERSION}"
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" ' +
            '--cap-add=SYS_ADMIN ' +

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -10,7 +10,7 @@ pipeline {
   agent {
     docker {
       label 'linuxcontainer'
-      image "harbor.status.im/status-im/status-desktop-build:1.0.8-qt${QT_VERSION}"
+      image "harbor.status.im/status-im/status-desktop-build:1.0.13-qt${QT_VERSION}"
     }
   }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -222,7 +222,7 @@ def assembePath(List<String> extraPaths) {
       'C:/ProgramData/scoop/apps/llvm/22.1.8/bin',
       'C:/ProgramData/scoop/apps/vcredist2022/14.44.35211.0',
       'C:/ProgramData/scoop/apps/openssl-lts/3.0.19/bin',
-      'C:/ProgramData/scoop/apps/protobuf/3.20.1/bin',
+      'C:/ProgramData/scoop/apps/protobuf/36.0/bin',
       'C:/ProgramData/scoop/apps/inno-setup/6.7.0',
       'C:/ProgramData/scoop/apps/openjdk25/25.0.2-10/bin',
       'C:/ProgramData/scoop/apps/git/current/bin',

--- a/ci/tests.Dockerfile
+++ b/ci/tests.Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.status.im/status-im/status-desktop-build:1.0.8-qt6.11.0
+FROM harbor.status.im/status-im/status-desktop-build:1.0.13-qt6.11.0
 
 USER root
 

--- a/fdroid/build-app.sh
+++ b/fdroid/build-app.sh
@@ -28,8 +28,6 @@ export PATH="$QT_BASE/gcc_64/bin:$QT_BASE/android_arm64_v8a/bin:$NDK_TOOLCHAIN/b
 
 cd "$BUILD_DIR"
 
-go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
-
 ulimit -n 65536 || true
 export USE_SYSTEM_NIM=1
 export NIM_SDS_SOURCE_DIR="$BUILD_DIR/vendor/nim-sds"

--- a/mobile/ContainerBuilds.mk
+++ b/mobile/ContainerBuilds.mk
@@ -12,7 +12,7 @@ QT_MAJOR=$(shell echo $(QT_VERSION) | cut -d. -f1)
 ARCH?=arm64
 
 # Use the same pre-built Docker image as CI (see ci/Jenkinsfile.android)
-DOCKER_IMAGE := harbor.status.im/status-im/status-desktop-build:1.0.0-qt$(QT_VERSION)-android
+DOCKER_IMAGE := harbor.status.im/status-im/status-desktop-build:1.0.3-qt$(QT_VERSION)-android
 
 # Map architecture to Android ABI
 ifeq ($(ARCH), arm64)

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -67,7 +67,7 @@ make -f mobile/ContainerBuilds.mk run
 ```
 
 ### What Happens Behind the Scenes
-- The build process uses the same pre-built Docker image as the CI pipeline (`harbor.status.im/status-im/status-desktop-build:1.0.0-qt6.11.0-android`)
+- The build process uses the same pre-built Docker image as the CI pipeline (`harbor.status.im/status-im/status-desktop-build:1.0.3-qt6.11.0-android`)
 - All required tools and dependencies (Qt 6.11.0, Android SDK/NDK, Go, Nim) are provided by the container
 - The container runs on linux/amd64 platform for consistency, even on ARM macOS machines
 - The built APK/AAB is available in the `mobile/bin/android/qt6/` directory

--- a/mobile/docker/Dockerfile
+++ b/mobile/docker/Dockerfile
@@ -164,7 +164,6 @@ RUN GOLANG_SHA256="da18191ddb7db8a9339816f3e2b54bdded8047cdc2a5d67059478f8d1595c
 # Install Go tools and clean up Go module cache to save space
 RUN /usr/local/go/bin/go install github.com/go-bindata/go-bindata/v3/go-bindata@latest \
  && /usr/local/go/bin/go install go.uber.org/mock/mockgen@v0.4.0 \
- && /usr/local/go/bin/go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1 \
  && cp /root/go/bin/* /usr/local/bin/ \
  && rm -rf /root/go /root/.cache/go-build
 

--- a/mobile/docker/Dockerfile
+++ b/mobile/docker/Dockerfile
@@ -171,9 +171,9 @@ RUN /usr/local/go/bin/go install github.com/go-bindata/go-bindata/v3/go-bindata@
 # =============================================================================
 # Install Protoc (from GitHub releases, includes well-known types)
 # =============================================================================
-RUN PROTOC_SHA256="75d8a9d7a2c42566e46411750d589c51276242d8b6247a5724bac0f9283e05a8" \
- && PROTOC_TARBALL="protoc-3.20.0-linux-x86_64.zip" \
- && wget -q -L "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/${PROTOC_TARBALL}" \
+RUN PROTOC_SHA256="bc8211ce760bd43ee21ddc145d6d9dbaeeabae205267a79d9054a240e367d4b4" \
+ && PROTOC_TARBALL="protoc-36.0-linux-x86_64.zip" \
+ && wget -q -L "https://github.com/protocolbuffers/protobuf/releases/download/v36.0/${PROTOC_TARBALL}" \
  && echo "${PROTOC_SHA256} ${PROTOC_TARBALL}" | sha256sum -c \
  && unzip -d /usr/local "${PROTOC_TARBALL}" \
  && rm "${PROTOC_TARBALL}"

--- a/scripts/macos_build_setup.sh
+++ b/scripts/macos_build_setup.sh
@@ -24,7 +24,7 @@ function check_version {
 
 function install_build_dependencies {
   echo "Install build dependencies"
-  brew install pkg-config libtool jq node@22 yarn protoc-gen-go aqtinstall xcbeautify nim
+  brew install pkg-config libtool jq node@22 yarn protobuf aqtinstall xcbeautify nim
 }
 
 function install_qt {

--- a/scripts/ubuntu_build_setup.sh
+++ b/scripts/ubuntu_build_setup.sh
@@ -5,6 +5,7 @@ GO_VERSION="1.24.7"
 GO_INSTALL_DIR="/usr/local/go"
 QT_VERSION="6.11.0"
 QT_INSTALL_DIR="/opt/qt"
+PROTOC_VERSION="36.0"
 
 function check_version {
   source /etc/os-release
@@ -16,9 +17,21 @@ function install_build_dependencies {
   echo "Install build dependencies"
   apt update
   apt install -yq git wget build-essential \
-    cmake extra-cmake-modules pkg-config protoc-gen-go \
+    cmake extra-cmake-modules pkg-config unzip \
     mesa-common-dev unixodbc-dev libpq-dev libglu1-mesa-dev libpcsclite-dev \
     libssl-dev libpulse-mainloop-glib0 libxkbcommon-x11-dev
+}
+
+function install_protoc {
+  if [[ "$(protoc --version 2>/dev/null)" == "libprotoc ${PROTOC_VERSION}" ]]; then
+    echo "Already present: $(protoc --version)"
+    return
+  fi
+  echo "Install protoc ${PROTOC_VERSION}"
+  PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+  wget -q -L "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
+  unzip -o -q -d /usr/local "${PROTOC_ZIP}" 'bin/protoc' 'include/*'
+  rm "${PROTOC_ZIP}"
 }
 
 function install_release_dependencies {
@@ -108,6 +121,7 @@ export PATH=\$QTDIR:\$QTDIR/bin:\$(go env GOPATH)\bin:$PATH
 if [ "$0" = "$BASH_SOURCE" ]; then
     check_version
     install_build_dependencies
+    install_protoc
     install_release_dependencies
     install_flatpak_dependencies
     install_runtime_dependencies

--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -72,7 +72,7 @@ function Install-Dependencies {
     Scoop-Install 'status/python'        '3.13.5'
     Scoop-Install 'status/mingw-winlibs' '15.2.0-13.0.0-r5'
     Scoop-Install 'status/vcredist2022'  '14.44.35211.0'
-    Scoop-Install 'status/protobuf'      '3.20.1'
+    Scoop-Install 'status/protobuf'      '36.0'
     Scoop-Install 'status/openssl-lts'   '3.0.19'
     Scoop-Install 'status/inno-setup'    '6.7.0'
     Scoop-Install 'status/msys2'         '2025-12-13'

--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -23,20 +23,6 @@ function run {
     }
 }
 
-# Install Protobuf tool necessary to generate status-go files.
-function Install-Protobuf-Go {
-    $ProtocGenVersion = "v1.34.1"
-    $ProtocGenZIP = "protoc-gen-go.$ProtocGenVersion.windows.amd64.zip"
-    $ProtocGenURL = "https://github.com/protocolbuffers/protobuf-go/releases/download/$ProtocGenVersion/$ProtocGenZIP"
-    $ProtocGenSHA256 = "403a619c4698fe5c4162c7f855803de3e8d8e0c187d7d51cbeb8d599f7a5a073"
-    (New-Object System.Net.WebClient).DownloadFile($ProtocGenURL, "$env:USERPROFILE\$ProtocGenZIP")
-    $ProtocGenRealSHA256 = (Get-Filehash -algorithm SHA256 "$env:USERPROFILE\$ProtocGenZIP").Hash
-    if ($ProtocGenRealSHA256 -ne $ProtocGenSHA256) {
-        throw "SHA256 hash does not match for $ProtocGenZIP !"
-    }
-    New-Item "$env:USERPROFILE\go\bin" -ItemType Directory -ea 0
-    run 7z x "-o$env:USERPROFILE\go\bin" -y "$env:USERPROFILE\$ProtocGenZIP"
-}
 
 function Scoop-Install([string]$package, [string]$version) {
     $appName = ($package -split '/')[-1]
@@ -169,7 +155,6 @@ If ($MyInvocation.InvocationName -ne ".") {
     Install-Scoop
     Install-Dependencies
     Install-MSYS2-Packages
-    Install-Protobuf-Go
     Install-Qt-SDK
     Install-VC-BuildTools
     Show-Success-Message


### PR DESCRIPTION
### What does the PR do

1. Bumps the `vendor/status-go` pin the top of the stack:
    - status-im/status-go#7746
    - status-im/status-go#7738
    - status-im/status-go#7739
3. Upgrades protoc to v36 in every environment that builds status-go: both build images, the Windows scoop pin, and the Ubuntu setup script. status-go now passes `--go_prefix`, which protoc only understands from v36, and status-app builds status-go against the host toolchain rather than its Nix shell.
4. Moves the pipelines onto the build images that ship protoc 36 — Linux `1.0.13`, Android `1.0.3`.
5. Stopped installing `protoc-gen-go` anywhere. status-go declares it in `go.mod` and runs it as `go tool protoc-gen-go`, so protoc no longer resolves it from `PATH`. Removes the `status-go-deps` target with it, which existed only to run that install.

<details>
<summary>AI-made decisions</summary>

- Every `protoc-gen-go` install here was for status-go's benefit — status-app has no protos of its own — so all five went (`Makefile`, `fdroid/build-app.sh`, both Dockerfiles, `windows_build_setup.ps1`).
- Ubuntu was getting protoc transitively from apt's `protoc-gen-go` (3.12 on 22.04), so it now installs the release build into `/usr/local` like Go and linuxdeployqt already are, and `BUILDING.md` notes that apt's `protobuf-compiler` is too old.
- macOS keeps getting protoc from brew, via `protobuf` (36.0 in homebrew/core today) instead of `protoc-gen-go`. Left unpinned rather than `protobuf@36`, so it tracks the default formula.
- The Linux tag had drifted apart across pipelines (1.0.8 in linux and tests-nim, 1.0.10 in flatpak); all three now point at 1.0.13.
- Kept the Dockerfile changes even though the pipelines pull prebuilt images: `master` still pins protoc 3.20.0, so without them the next image build would regress.
- Pinned the top of the status-go stack, so one build covers all three PRs.
- The status-go stack was rebased onto current `develop` first. Without that the pin would move status-go backwards past the DEK envelope work, failing the commit-recency check and breaking the companion build against `mobile/status.go`.
- The "status-go must point to a commit on develop" check will fail while this points at an unmerged branch. Expected for a preview pin.

</details>

### Follow-ups

- macOS and Windows agents are provisioned by `infra-ci` from `scripts/macos_build_setup.sh` / `scripts/windows_build_setup.ps1`, pinned by commit **and** script sha256 in `ansible/roles/status-desktop-setup/vars/`. Both need bumping once this merges. Note `brew install protobuf` will not upgrade an existing older install.
- Windows needs scoop `protobuf` 36.0 published — status-im/infra-scoop-bucket#2.
