### PR TITLE
fix: "login failed" instead of "password incorrect" when logging in with wrong password

### DIFF
--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -360,7 +360,9 @@ proc finishAppLoading2[T](self: Module[T]) =
 method onAccountLoginError*[T](self: Module[T], error: string) =
   # SQLITE_NOTADB: "file is not a database"
   var wrongPassword = false
-  if error.contains("file is not a database"):
+  if error.contains("file is not a database") or
+      error.contains("incorrect password provided") or
+      error.contains("envelope: invalid key-encryption key"):
     wrongPassword = true
   warn "failed to login", wrongPassword, error
   self.view.accountLoginError(error, wrongPassword)


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/7753

Wrong password on envelope-encrypted profiles now fails with "incorrect password provided" (or raw "envelope: invalid key-encryption key"), not only SQLCipher's "file is not a database".

Fixes: #22068