### PR TITLE
fix(AdvancedView): hide dev options

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -20,7 +20,6 @@ when defined(ios):
 import seaqt/qguiapplication
 import seaqt/qsslconfiguration
 import seaqt/qsslcertificate
-import seaqt/QtCore/gen_qnamespace
 
 when defined(qmldebug):
   import seaqt/qqmldebuggingenabler

--- a/storybook/pages/AboutViewPage.qml
+++ b/storybook/pages/AboutViewPage.qml
@@ -38,19 +38,21 @@ SplitView {
             SplitView.preferredHeight: 200
 
             logsView.logText: logs.logText
-        }
-    }
 
-    Switch {
-        id: ctrlProduction
-        SplitView.minimumWidth: 300
-        SplitView.preferredWidth: 300
-        text: "Production"
-        checked: true
+            ColumnLayout {
+                anchors.fill: parent
+
+                Switch {
+                    id: ctrlProduction
+                    text: "Production"
+                    checked: true
+                }
+            }
+        }
     }
 }
 
-// category: Views
+// category: Settings
 // status: good
 // https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=1159%3A114479
 // https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=1684%3A127762

--- a/storybook/pages/AdvancedViewPage.qml
+++ b/storybook/pages/AdvancedViewPage.qml
@@ -1,0 +1,185 @@
+import QtCore
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQml
+
+import StatusQ
+import StatusQ.Core
+import StatusQ.Core.Utils
+import StatusQ.Controls
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+import Models
+import Storybook
+
+import utils
+
+import mainui.sectionLoaders
+
+import AppLayouts.Profile.views
+import AppLayouts.Profile.stores
+
+import shared.stores as SharedStores
+import AppLayouts.stores as AppLayoutStores
+import AppLayouts.Profile.helpers
+import AppLayouts.Wallet.stores as WalletStores
+
+
+SplitView {
+    id: root
+    Logs { id: logs }
+
+    PopupsLoader {
+        keychain: Keychain {}
+        popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
+        rootStore: AppLayoutStores.RootStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
+        networksStore: SharedStores.NetworksStore {}
+        utilsStore: SharedStores.UtilsStore {}
+        profileStore: ProfileStore {}
+    }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        AdvancedView {
+            id: advancedView
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+            contentWidth: parent.width
+
+            isProduction: ctrlProduction.checked
+            isFleetSelectionEnabled: ctrlIsFleetSelectionEnabled.checked
+            isBrowserEnabled: ctrlIsBrowserEnabled.checked
+            messageLinkSharingFeatureEnabled: ctrlMessageLinkSharingFeatureEnabled.checked
+            minimizeOnCloseOptionVisible: ctrlMinimizeOnCloseOptionVisible.checked
+
+            walletStore: WalletStore {
+                function getRpcStats() {}
+                function resetRpcStats() {}
+            }
+            advancedStore: AdvancedStore {
+                enum ArchiveProtocolMode {
+                    Disabled,
+                    LogosStorage,
+                    Torrent
+                }
+                property string archiveProtocolModeLabel: "Torrent"
+                property int archiveProtocolMode: AdvancedStore.ArchiveProtocolMode.Torrent
+
+                property string fleet: "fleet-123"
+                function setFleet(fl) {
+                    fleet = fl
+                }
+
+                property bool wakuV2LightClientEnabled
+                property bool isDebugEnabled
+                readonly property bool isRuntimeLogLevelSet: ctrlRuntimeLoglevelSet.checked
+                property bool refreshTokenEnabled
+                property bool isCustomScrollingEnabled
+                property bool isCollectingStorageStats
+                property double scrollDeceleration
+                property double scrollVelocity
+                property bool isManageCommunityOnTestModeEnabled
+                property bool copyMessageLinksEnabled
+
+                property int logMaxBackups: 3
+                readonly property double logsFolderSizeBytes: 42
+                function logDir() {
+                    return StandardPaths.writableLocation(StandardPaths.AppDataLocation)
+                }
+                function clearOldLogs() {}
+                function lastStorageStats() {}
+                function refreshLogsFolderSize() {}
+                function collectStorageStats() {}
+                function toggleDebug() {
+                    isDebugEnabled = !isDebugEnabled
+                }
+                function setArchiveProtocolMode(mode) {}
+                function toggleEnsCommunityPermissionsEnabled() {}
+                function setWakuV2LightClientEnabled(lightMode) {
+                    wakuV2LightClientEnabled = lightMode
+                }
+                function setCustomScrollingEnabled(custom) {
+                    isCustomScrollingEnabled = custom
+                }
+                function setScrollDeceleration(value) {}
+                function setMaxLogBackups(max) {
+                    logMaxBackups = max
+                }
+                function toggleManageCommunityOnTestnet() {
+                    isManageCommunityOnTestModeEnabled = !isManageCommunityOnTestModeEnabled
+                }
+                function toggleRefreshTokenEnabled() {
+                    refreshTokenEnabled = !refreshTokenEnabled
+                }
+                function toggleExperimentalFeature(feat) {
+                    if (feat === experimentalFeatures.browser)
+                        advancedView.localAccountSensitiveSettings.isBrowserEnabled = !advancedView.localAccountSensitiveSettings.isBrowserEnabled
+                }
+                function toggleCopyMessageLinksEnabled() {
+                    copyMessageLinksEnabled = !copyMessageLinksEnabled
+                }
+
+                readonly property var experimentalFeatures: QtObject {
+                    readonly property string browser: "browser"
+                }
+            }
+            readonly property var localAccountSensitiveSettings: QtObject {
+                property bool quitOnClose
+                property bool isBrowserEnabled: true
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 300
+            SplitView.preferredHeight: 300
+
+            logsView.logText: logs.logText
+
+            ColumnLayout {
+                anchors.fill: parent
+
+                CheckBox {
+                    id: ctrlProduction
+                    text: "Production"
+                    checked: false
+                }
+                CheckBox {
+                    id: ctrlIsFleetSelectionEnabled
+                    text: "Fleet selection enabled"
+                    checked: false
+                }
+                CheckBox {
+                    id: ctrlIsBrowserEnabled
+                    text: "Browser enabled"
+                    checked: true
+                }
+                CheckBox {
+                    id: ctrlMessageLinkSharingFeatureEnabled
+                    text: "Message link sharing enabled"
+                    checked: false
+                }
+                CheckBox {
+                    id: ctrlMinimizeOnCloseOptionVisible
+                    text: "Minimize on close visible"
+                    checked: true
+                }
+                CheckBox {
+                    id: ctrlRuntimeLoglevelSet
+                    text: "Runtime loglevel set"
+                    checked: false
+                }
+            }
+        }
+    }
+}
+
+// category: Settings
+// status: good

--- a/ui/StatusQ/src/httpstats.cpp
+++ b/ui/StatusQ/src/httpstats.cpp
@@ -190,7 +190,7 @@ void HttpStats::clearCache()
         return;
     }
 
-    for (const auto& cache : caches) {
+    for (const auto& cache : std::as_const(caches)) {
         if (cache.isNull())
             continue;
         // Clear on the cache's thread, and report from inside the same call so a

--- a/ui/StatusQ/src/imageencoderutils.cpp
+++ b/ui/StatusQ/src/imageencoderutils.cpp
@@ -4,7 +4,6 @@
 #include <QUrl>
 #include <QQmlEngine>
 #include <QQuickImageProvider>
-#include <QPixmap>
 
 namespace {
 

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -496,7 +496,6 @@ StatusSectionLayout {
         Component {
             id: advancedViewComp
             AdvancedView {
-                messagingSettingsStore: root.messagingSettingsStore
                 advancedStore: root.advancedStore
                 walletStore: root.walletStore
                 isFleetSelectionEnabled: fleetSelectionEnabled

--- a/ui/app/AppLayouts/Profile/controls/BloomSelectorButton.qml
+++ b/ui/app/AppLayouts/Profile/controls/BloomSelectorButton.qml
@@ -1,72 +1,18 @@
 import QtQuick
-import QtQuick.Controls
-import QtQuick.Layouts
 
-import utils
-import shared
-import shared.panels
-
-import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Controls
 
-Rectangle {
+StatusRadioButton {
     id: root
 
-    property var buttonGroup
-    property string btnText: "change me"
-    property bool checkedByDefault: false
-
-    signal checked()
-    signal toggled(bool checked)
-
-    function toggle() {
-        radioBtn.toggle()
-    }
-
-    border.color: mouseArea.containsMouse || radioBtn.checked ? Theme.palette.primaryColor1 : Theme.palette.border
-    border.width: 1
-    color: StatusColors.transparent
     implicitWidth: 130
     implicitHeight: 120
-    radius: Theme.radius
-
-    StatusRadioButton {
-        id: radioBtn
-        ButtonGroup.group: buttonGroup
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: parent.top
-        anchors.topMargin: 14
-        checked: root.checkedByDefault
-        onCheckedChanged: {
-            if (checked) {
-                root.checked()
-            }
-        }
-    }
-
-    StatusBaseText {
-        id: txt
-        text: btnText
-        anchors.rightMargin: Theme.padding
-        anchors.leftMargin: Theme.padding
-        width: parent.width
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: radioBtn.bottom
-        anchors.topMargin: 6
-        wrapMode: Text.WordWrap
-    }
-
-    StatusMouseArea {
-        id: mouseArea
-        anchors.fill: parent
-        hoverEnabled: true
-        onClicked: {
-            if (radioBtn.checked)
-                return
-            radioBtn.toggle()
-            root.toggled(radioBtn.checked)
-        }
+    padding: Theme.halfPadding
+    background: Rectangle {
+        radius: Theme.radius
+        border.color: root.hovered || root.checked ? Theme.palette.primaryColor1 : Theme.palette.border
+        border.width: 1
+        color: StatusColors.transparent
     }
 }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -21,10 +21,7 @@ import StatusQ.Core.Utils as SQUtils
 import StatusQ.Popups
 import StatusQ.Popups.Dialog
 
-
-import AppLayouts.stores.Messaging 1.0
-
-import "../stores"
+import AppLayouts.Profile.stores
 import "../controls"
 import "../popups"
 import "../panels"
@@ -32,9 +29,10 @@ import "../panels"
 SettingsContentBase {
     id: root
 
-    property MessagingSettingsStore messagingSettingsStore
     property AdvancedStore advancedStore
     property WalletStore walletStore
+
+    property bool isProduction: production
 
     property bool isFleetSelectionEnabled
     property bool isBrowserEnabled: true
@@ -248,30 +246,15 @@ SettingsContentBase {
                 }
             }
 
-            StatusBaseText {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.leftMargin: Theme.padding
-                anchors.rightMargin: Theme.padding
+            StatusSettingsLineButton {
+                width: parent.width
                 text: qsTr("Application Logs") + " (" + root.advancedStore.logDir() + ")"
-                font.underline: mouseArea.containsMouse
-                color: Theme.palette.primaryColor1
-                topPadding: 23
-                wrapMode: Text.Wrap
-                elide: Text.ElideRight
-
-                StatusMouseArea {
-                    id: mouseArea
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    hoverEnabled: true
-                    onClicked: {
-                        if (SQUtils.Utils.isMobile) {
-                            Global.openShakeToSharePopup()
-                            return
-                        }
-                        Qt.openUrlExternally(UrlUtils.urlFromUserInput(root.advancedStore.logDir()))
+                onClicked: {
+                    if (SQUtils.Utils.isMobile) {
+                        Global.openShakeToSharePopup()
+                        return
                     }
+                    Qt.openUrlExternally(UrlUtils.urlFromUserInput(root.advancedStore.logDir()))
                 }
             }
 
@@ -427,31 +410,29 @@ SettingsContentBase {
                         showCancelButton: lightMode
                         onConfirmButtonClicked: {
                             root.advancedStore.setWakuV2LightClientEnabled(lightMode)
+                            close()
                         }
                         onCancelButtonClicked: {
                             close()
                         }
                         onClosed: {
-                            if (root.advancedStore.wakuV2LightClientEnabled){
-                                btnWakuV2Light.toggle()
+                            // revert if canceled
+                            if (root.advancedStore.wakuV2LightClientEnabled) {
+                                btnWakuV2Light.click()
                             } else {
-                                btnWakuV2Full.toggle()
+                                btnWakuV2Full.click()
                             }
+
                             destroy()
                         }
                     }
                 }
 
-                ButtonGroup {
-                    id: wakuV2Group
-                }
-
                 BloomSelectorButton {
                     id: btnWakuV2Light
                     objectName: "lightWakuModeButton"
-                    buttonGroup: wakuV2Group
-                    checkedByDefault: root.advancedStore.wakuV2LightClientEnabled
-                    btnText: qsTr("Light mode")
+                    checked: root.advancedStore.wakuV2LightClientEnabled
+                    text: qsTr("Light mode")
                     onToggled: {
                         Global.openPopup(wakuV2ModeConfirmationDialogComponent, { lightMode: true })
                     }
@@ -460,9 +441,8 @@ SettingsContentBase {
                 BloomSelectorButton {
                     id: btnWakuV2Full
                     objectName: "relayWakuModeButton"
-                    buttonGroup: wakuV2Group
-                    checkedByDefault: !root.advancedStore.wakuV2LightClientEnabled
-                    btnText: qsTr("Relay mode")
+                    checked: !root.advancedStore.wakuV2LightClientEnabled
+                    text: qsTr("Relay mode")
                     onToggled: {
                         Global.openPopup(wakuV2ModeConfirmationDialogComponent, { lightMode: false })
                     }
@@ -489,6 +469,7 @@ SettingsContentBase {
                 text: qsTr("Debug")
                 isSwitch: true
                 enabled: !root.advancedStore.isRuntimeLogLevelSet
+                hoverEnabled: true
                 checked: root.advancedStore.isDebugEnabled
 
                 onClicked: {
@@ -496,20 +477,9 @@ SettingsContentBase {
                     Global.openPopup(enableDebugComponent)
                 }
 
-                StatusMouseArea {
-                    id: overlayMouseArea
-                    anchors.fill: parent
-                    enabled: true
-                    hoverEnabled: true
-                    propagateComposedEvents: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: debugLineButton.clicked()
-                }
-
                 StatusToolTip {
                     text: qsTr("The value is overridden with runtime options")
-                    visible: overlayMouseArea.containsMouse && root.advancedStore.isRuntimeLogLevelSet
-                    delay: 1000
+                    visible: parent.hovered && root.advancedStore.isRuntimeLogLevelSet
                 }
             }
 
@@ -537,6 +507,7 @@ SettingsContentBase {
             StatusSettingsLineButton {
                 width: parent.width
                 id: rpcStatsButton
+                visible: storageStatsSection.visible
                 text: qsTr("RPC statistics")
                 onClicked: rpcStatsModal.open()
             }
@@ -544,6 +515,7 @@ SettingsContentBase {
             StatusSettingsLineButton {
                 width: parent.width
                 id: httpStatsButton
+                visible: storageStatsSection.visible
                 text: qsTr("HTTP statistics")
                 onClicked: httpStatsModal.open()
             }
@@ -558,7 +530,7 @@ SettingsContentBase {
                 anchors.right: parent.right
                 anchors.leftMargin: Theme.padding
                 anchors.rightMargin: Theme.padding
-                text: qsTr("Storage stats")
+                text: qsTr("On-device profile stats")
                 topPadding: Theme.bigPadding
                 bottomPadding: Theme.padding
                 visible: storageStatsSection.visible
@@ -572,7 +544,7 @@ SettingsContentBase {
                 onVisibleChanged: if (visible) d.restoreStorageStats()
 
                 // Non-production and CI builds; in release only behind Debug.
-                visible: !production || TestConfig.testMode || root.advancedStore.isDebugEnabled
+                visible: !root.isProduction || TestConfig.testMode || root.advancedStore.isDebugEnabled
 
                 anchors.left: parent.left
                 anchors.right: parent.right
@@ -583,9 +555,8 @@ SettingsContentBase {
                 StatusBaseText {
                     Layout.fillWidth: true
                     wrapMode: Text.Wrap
-                    color: Theme.palette.baseColor1
                     font.pixelSize: Theme.tertiaryTextFontSize
-                    text: qsTr("Describes the shape of this account's databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.")
+                    text: qsTr("Shows stats for your Status profile, such as counts of chats, messages, communities and collectibles, and app and wallet database sizes. Stats are shown and remain only on your device and include NO message, chat, contact, address or other content. Click Refresh stats to show or update them.")
                 }
 
                 RowLayout {
@@ -595,7 +566,7 @@ SettingsContentBase {
                     StatusButton {
                         objectName: "collectStorageStatsButton"
                         text: root.advancedStore.isCollectingStorageStats
-                              ? qsTr("Collecting...") : qsTr("Collect data")
+                              ? qsTr("Refreshing...") : qsTr("Refresh stats")
                         enabled: !root.advancedStore.isCollectingStorageStats
                         onClicked: {
                             d.beginStorageStatsCollection()
@@ -607,31 +578,31 @@ SettingsContentBase {
                         objectName: "copyStorageStatsButton"
                         visible: d.storageStatsJson !== ""
                         textToCopy: d.storageStatsJson
-                        onCopyClicked: ClipboardUtils.setText(textToCopy)
+                        onCopyClicked: textToCopy => ClipboardUtils.setText(textToCopy)
                     }
+                }
 
-                    StatusBaseText {
-                        objectName: "storageStatsStatusText"
-                        Layout.fillWidth: true
-                        elide: Text.ElideMiddle
-                        font.pixelSize: Theme.tertiaryTextFontSize
-                        color: d.storageStatsError !== ""
-                               ? Theme.palette.dangerColor1 : Theme.palette.baseColor1
-                        text: {
-                            if (d.storageStatsError !== "")
-                                return d.storageStatsError
-                            if (root.advancedStore.isCollectingStorageStats)
-                                return d.storageStatsTotal > 0
-                                        ? qsTr("%1 of %2").arg(d.storageStatsStep).arg(d.storageStatsTotal)
-                                        : qsTr("Starting...")
-                            if (d.storageStatsSnapshotPath !== "")
-                                return qsTr("Collected %1, saved to %2 and picked up by Application Logs")
-                                        .arg(d.formatAge(d.storageStatsAgeSeconds))
-                                        .arg(d.storageStatsSnapshotPath)
-                            if (d.storageStatsAgeSeconds >= 0)
-                                return qsTr("Collected %1").arg(d.formatAge(d.storageStatsAgeSeconds))
-                            return ""
-                        }
+                StatusBaseText {
+                    objectName: "storageStatsStatusText"
+                    Layout.fillWidth: true
+                    elide: Text.ElideRight
+                    wrapMode: Text.Wrap
+                    maximumLineCount: 3
+                    font.pixelSize: Theme.tertiaryTextFontSize
+                    color: d.storageStatsError !== ""
+                           ? Theme.palette.dangerColor1 : Theme.palette.baseColor1
+                    text: {
+                        if (d.storageStatsError !== "")
+                            return d.storageStatsError
+                        if (root.advancedStore.isCollectingStorageStats)
+                            return d.storageStatsTotal > 0
+                                    ? qsTr("%1 of %2").arg(d.storageStatsStep).arg(d.storageStatsTotal)
+                                    : qsTr("Starting...")
+                        if (d.storageStatsSnapshotPath !== "")
+                            return qsTr("Collected %1, saved to %2 and picked up by Application Logs").arg(d.formatAge(d.storageStatsAgeSeconds)).arg(d.storageStatsSnapshotPath)
+                        if (d.storageStatsAgeSeconds >= 0)
+                            return qsTr("Collected %1").arg(d.formatAge(d.storageStatsAgeSeconds))
+                        return ""
                     }
                 }
 

--- a/ui/app/AppLayouts/Profile/views/RPCStatsModal.qml
+++ b/ui/app/AppLayouts/Profile/views/RPCStatsModal.qml
@@ -16,8 +16,7 @@ import utils
 import QtModelsToolkit
 import SortFilterProxyModel
 
-import "../stores"
-
+import AppLayouts.Profile.stores
 
 StatusDialog {
     id: root

--- a/ui/app/AppLayouts/Profile/views/qmldir
+++ b/ui/app/AppLayouts/Profile/views/qmldir
@@ -1,4 +1,5 @@
 AboutView 1.0 AboutView.qml
+AdvancedView 1.0 AdvancedView.qml
 AppearanceView 1.0 AppearanceView.qml
 BackupView 1.0 BackupView.qml
 BrowserView 1.0 BrowserView.qml

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1178,19 +1178,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Storage stats</source>
+        <source>Shows stats for your Status profile, such as counts of chats, messages, communities and collectibles, and app and wallet database sizes. Stats are shown and remain only on your device and include NO message, chat, contact, address or other content. Click Refresh stats to show or update them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <source>Refreshing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Collecting...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Collect data</source>
+        <source>Refresh stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1286,6 +1282,10 @@
     </message>
     <message>
         <source>HTTP statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On-device profile stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1185,19 +1185,15 @@
         <translation>Vývojářské funkce</translation>
     </message>
     <message>
-        <source>Storage stats</source>
+        <source>Shows stats for your Status profile, such as counts of chats, messages, communities and collectibles, and app and wallet database sizes. Stats are shown and remain only on your device and include NO message, chat, contact, address or other content. Click Refresh stats to show or update them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <source>Refreshing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Collecting...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Collect data</source>
+        <source>Refresh stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1294,6 +1290,10 @@
     </message>
     <message>
         <source>HTTP statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On-device profile stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1178,19 +1178,15 @@
         <translation>Funciones para desarrolladores</translation>
     </message>
     <message>
-        <source>Storage stats</source>
+        <source>Shows stats for your Status profile, such as counts of chats, messages, communities and collectibles, and app and wallet database sizes. Stats are shown and remain only on your device and include NO message, chat, contact, address or other content. Click Refresh stats to show or update them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <source>Refreshing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Collecting...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Collect data</source>
+        <source>Refresh stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1286,6 +1282,10 @@
     </message>
     <message>
         <source>HTTP statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On-device profile stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -1178,19 +1178,15 @@
         <translation>Fonctionnalités pour développeurs</translation>
     </message>
     <message>
-        <source>Storage stats</source>
+        <source>Shows stats for your Status profile, such as counts of chats, messages, communities and collectibles, and app and wallet database sizes. Stats are shown and remain only on your device and include NO message, chat, contact, address or other content. Click Refresh stats to show or update them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <source>Refreshing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Collecting...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Collect data</source>
+        <source>Refresh stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1291,6 +1287,10 @@
     <message>
         <source>HTTP statistics</source>
         <translation>Statistiques HTTP</translation>
+    </message>
+    <message>
+        <source>On-device profile stats</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to disable debug mode?</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1171,19 +1171,15 @@
         <translation>개발자 기능</translation>
     </message>
     <message>
-        <source>Storage stats</source>
+        <source>Shows stats for your Status profile, such as counts of chats, messages, communities and collectibles, and app and wallet database sizes. Stats are shown and remain only on your device and include NO message, chat, contact, address or other content. Click Refresh stats to show or update them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Describes the shape of this account&apos;s databases - how many messages, chats and wallet rows it holds, how far behind the sync state is, how large each table is - so that a developer can rebuild an equivalent account to reproduce a bug. Dates appear only as day counts, and no message, chat, contact or address is ever included. Nothing is collected until you press Collect data.</source>
+        <source>Refreshing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Collecting...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Collect data</source>
+        <source>Refresh stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1278,6 +1274,10 @@
     </message>
     <message>
         <source>HTTP statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On-device profile stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
### What does the PR do

- if `production` or `debugEnabled`; the former now being exposed to the outside, and not hardcoded
- add the AdvancedView page to StoryBook, fully functional
- fix some smaller issues, e.g. with not resetting/reverting values back when canceling the ConfirmationDialog

Fixes #22070

### Affected areas

Settings/Advanced

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Dev stats visible:
<img width="2842" height="1990" alt="image" src="https://github.com/user-attachments/assets/2118916b-801a-4849-b4fa-f18916f9fabf" />

Dev stats hidden (prod build):
<img width="2630" height="2478" alt="Snímek obrazovky z 2026-08-24 23-01-28" src="https://github.com/user-attachments/assets/0503f7f2-42c0-473f-81ee-5060d3a42cf5" />

### Impact on end user

Less clunky Settings/Advanced for regular users

### How to test

- check Settings/Advanced on master/dev build and release build

### Risk 

- low
