### PR TITLE
mobile-build: proper dependencies for status go stub lib added

### DIFF
--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -78,28 +78,31 @@ endif
 	@cmp -s $(NIM_SDS_SOURCE_DIR)/build/libsds$(LIB_EXT) $(LIB_PATH)/libsds$(LIB_EXT) || cp $(NIM_SDS_SOURCE_DIR)/build/libsds$(LIB_EXT) $(LIB_PATH)/libsds$(LIB_EXT)
 	@cmp -s ../vendor/status-go/build/bin/libstatus$(LIB_EXT) $(LIB_PATH)/libstatus$(LIB_EXT) || cp ../vendor/status-go/build/bin/libstatus$(LIB_EXT) $(LIB_PATH)/libstatus$(LIB_EXT)
 
-$(STATUS_GO_STUB_LIB): $(STATUS_GO_LIB)
+$(STATUS_GO_STUB_LIB): $(STATUS_GO_LIB) $(STATUS_GO_STUB_GEN) $(STATUS_DESKTOP)/mobile/statusgo_stub/statusgo_stub.cpp
 	@echo "Building status-go stub library (UI process)"
 	@mkdir -p $(LIB_PATH)
-	@$(MAKE) $(STATUS_GO_STUB_GEN)
 	@$(CXX) -shared -fPIC $(CXX_OPT_FLAGS) \
 		-o $(STATUS_GO_STUB_LIB) \
 		$(STATUS_DESKTOP)/mobile/statusgo_stub/statusgo_stub.cpp \
 		$(STATUS_GO_STUB_GEN) \
 		-llog -lc++_shared
 
-$(STATUS_GO_SERVICE_LIB): $(STATUS_GO_LIB)
+$(STATUS_GO_SERVICE_LIB): $(STATUS_GO_LIB) $(STATUS_GO_SERVICE_GEN) $(STATUS_DESKTOP)/mobile/statusgo_service/statusgo_service_jni.cpp
 	@echo "Building status-go service JNI library (service process)"
 	@mkdir -p $(LIB_PATH)
-	@$(MAKE) $(STATUS_GO_STUB_GEN)
 	@$(CXX) -shared -fPIC $(CXX_OPT_FLAGS) \
 		-o $(STATUS_GO_SERVICE_LIB) \
 		$(STATUS_DESKTOP)/mobile/statusgo_service/statusgo_service_jni.cpp \
 		$(STATUS_GO_SERVICE_GEN) \
 		-L$(LIB_PATH) -lstatus -llog -lc++_shared
 
-$(STATUS_GO_STUB_GEN):
+# Regenerate stubs when libstatus changes.
+$(STATUS_GO_STUB_GEN): $(STATUS_GO_LIB)
 	@$(MAKE) -C $(STATUS_DESKTOP)/vendor/status-go statusgo-stub-bindings
+
+# statusgo-stub-bindings emits BOTH generated files in a single run; depending on the stub
+# output both orders this after that run and rebuilds it whenever the stub bindings rebuild.
+$(STATUS_GO_SERVICE_GEN): $(STATUS_GO_STUB_GEN)
 
 $(STATUS_Q_LIB): $(STATUS_Q_FILES) $(STATUS_Q_SCRIPT) $(STATUS_Q_UI_FILES)
 	@echo "Building StatusQ"


### PR DESCRIPTION
### What does the PR do

Fixes dependencies on status go stubs to rebuild correctly if stubs are altered.

Closes: #22078

### Affected areas
`mobile/Makefile`

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications
