### PR TITLE
feat(biometrics): store wrapped DEK instead of raw password

### DIFF
--- a/docs/FURPS/dek-encryption-and-biometrics.md
+++ b/docs/FURPS/dek-encryption-and-biometrics.md
@@ -1,0 +1,71 @@
+# Profile DEK Encryption & Biometric Login
+
+**Relevant issues/PRs**
+- https://github.com/status-im/status-app/issues/21877
+  - https://github.com/status-im/status-go/pull/7691
+  - https://github.com/status-im/status-app/pull/21878
+- https://github.com/status-im/status-app/issues/22036
+  - https://github.com/status-im/status-go/pull/7762
+  - https://github.com/status-im/status-app/pull/22080
+
+----
+
+**Definitions:**
+
+- **DEK** (data encryption key): a random 32-byte key that encrypts a profile's databases and keystore files. Stored only in the profile's envelope file (<keyUID>-profile.kek), wrapped by the KEK.
+- **KEK** (key encryption key): the client-hashed password, or for Keycard profiles the card-exported encryption public key. Unwraps the DEK, encrypts nothing else.
+- **Migrated profile**: a profile whose envelope file exists (databases/keystore encrypted with the DEK). Legacy profile: no envelope, databases encrypted directly with the KEK.
+
+----
+
+**Functionality**
+
+- **Encryption scheme**
+  - New profiles (created, restored, or received via pairing) must be DEK-encrypted from creation.
+  - A legacy profile must be migrated to DEK encryption as a one-time action, and **only** as part of a password change. No other action (enabling biometrics, logging in, syncing) triggers the migration or any database re-encryption.
+  - The DEK must be obtainable from the backend only via `ExportProfileDEK`.
+
+- **Password change**
+  - For a migrated profile, a password change without rekey only re-wraps the envelope (fast path): databases, keystore, and the running node are untouched, and no app restart is required. The DEK is unchanged.
+  - A password change with rekey must generate a new DEK and re-encrypt databases and keystore.
+  - A password change on a legacy profile must perform the one-time DEK migration (full re-encryption) using the new password as the KEK.
+  - A caller holding only a session credential (e.g. a biometric DEK) may use the fast path; rekey and migration require the typed old password.
+
+- **Biometric credential contents**
+  - The OS keychain item (service `StatusDesktop`, account = profile keyUID) must contain, per profile type:
+    - migrated password profile → the DEK, tagged `dek:<64-hex>`;
+    - legacy password profile → the raw password (untagged; pre-existing behavior preserved until migration);
+    - Keycard profile → the 6-digit PIN (untagged). The physical card is always required for Keycard login and signing; the DEK must never be stored for Keycard profiles.
+  - A `dek:`-tagged value is stored for a migrated profiles.
+
+- **Enabling biometrics**
+  - Enabling biometrics must be instant: it stores the tagged dek and never triggers profile migration or re-encryption.
+  - If the credential cannot be prepared or stored, biometrics must remain disabled, means no partial or wrong value may be saved.
+
+- **Biometric login**
+  - A `dek:`-tagged secret must be submitted as a raw DEK in the dedicated login field, an untagged secret represents the password (or Keycard PIN).
+  - A DEK login is valid only for migrated profiles.
+  - A wrong or stale DEK must fail exactly like a wrong password and fall back to manual entry.
+
+- **Credential refresh (migration of stored values)**
+  - After any successful authentication where a keychain item exists and the profile is migrated but the item is legacy, the item must be silently refreshed to the tagged DEK. This never re-encrypts anything.
+  - After every successful password change with an existing item, the item must be refreshed (fast change: same DEK; rekey: new DEK; legacy→migrated: password replaced by DEK).
+  - If the refresh fails, the stale item must be deleted and biometrics disabled with the preference set to `notNow`.
+
+- **In-app authentication & signing**
+  - Within an unlocked session, the backend must accept the client-hashed DEK wherever it accepts the hashed password (verification, signing, keystore operations), the stored DEK uses the existing password flows.
+  - Keycard transaction signing and authorization always require the card and PIN, biometrics only supplies the PIN.
+  - Device syncing / keystore export (pairing) requires the typed password — the DEK cannot substitute for it (the password itself is validated against and transferred with the keystore). A biometric attempt that yields a DEK must fall back to manual password entry.
+
+- **Lifecycle**
+  - Disabling biometrics must delete the keychain item and record the `never` preference, while failure-triggered deletions record `notNow`.
+  - Converting a profile to/from Keycard must not leave a usable stale biometric credential behind.
+
+----
+
+**Supportability / Security**
+
+- Platforms: macOS, iOS, Android. Windows/Linux have no biometric support.
+- The raw DEK crosses the client/backend boundary only in the dedicated login field and the `ExportProfileDEK` response, both are masked (`***`) in request logs.
+- The client-hashed DEK grants nothing outside an unlocked session, at the end only the KEK can unwrap the envelope.
+- Compromise of a stored DEK affects only that one profile on that one device, it reveals no reusable password and cannot be transferred to another device.

--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -44,6 +44,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/Theme.AppSplash"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:hasFragileUserData="true"
         android:fullBackupOnly="false">
         <activity

--- a/mobile/android/qt6/res/xml/backup_rules.xml
+++ b/mobile/android/qt6/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="QtAT_Keychain.xml" />
+</full-backup-content>

--- a/mobile/android/qt6/res/xml/data_extraction_rules.xml
+++ b/mobile/android/qt6/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="QtAT_Keychain.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="QtAT_Keychain.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/mobile/android/qt6/src/app/status/mobile/SecureAndroidAuthentication.java
+++ b/mobile/android/qt6/src/app/status/mobile/SecureAndroidAuthentication.java
@@ -22,6 +22,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 
 import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.security.keystore.KeyProperties;
 
 /**
@@ -134,7 +135,22 @@ public final class SecureAndroidAuthentication {
     public boolean beginSaveCredential(String account, String password) {
         if (Build.VERSION.SDK_INT < 28) { nativeCredentialError(-10, "BiometricPrompt requires API 28"); return false; }
         try {
-            Cipher enc = newEncryptCipher();
+            Cipher enc;
+            try {
+                enc = newEncryptCipher();
+            } catch (KeyPermanentlyInvalidatedException e) {
+                // Biometric enrollment changed: the old key (and everything it encrypted) is
+                // permanently dead. For a SAVE that is recoverable — wipe the dead state and
+                // encrypt the new credential under a freshly generated key.
+                Log.w(TAG, "beginSave: key invalidated by enrollment change, regenerating", e);
+                if (!handleInvalidatedKey()) {
+                    // Inconsistent cleanup would leave stale ciphertext under a new key;
+                    // the invalidated alias is untouched, so the next attempt retries.
+                    nativeCredentialError(-1, "beginSave: invalidated-key cleanup failed");
+                    return false;
+                }
+                enc = newEncryptCipher();
+            }
             pending = PendingType.SAVE;
             pendingAccount = account;
             pendingPlain = password;
@@ -161,7 +177,25 @@ public final class SecureAndroidAuthentication {
             byte[] ct = loadCT(account);
             if (iv == null || ct == null) { nativeCredentialLoaded(account, null); return true; }
 
-            Cipher dec = newDecryptCipher(iv);
+            Cipher dec;
+            try {
+                dec = newDecryptCipher(iv);
+            } catch (KeyPermanentlyInvalidatedException e) {
+                // Biometric enrollment changed: the stored ciphertext is permanently
+                // unreadable. Wipe the dead key and blobs so hasCredential() stops lying,
+                // and report the credential as gone (callers fall back to password entry
+                // and can re-enable biometrics, which generates a fresh key).
+                Log.w(TAG, "beginGet: key invalidated by enrollment change, wiping stored credentials", e);
+                if (!handleInvalidatedKey()) {
+                    // State is unchanged (alias intact): the next attempt re-triggers the
+                    // invalidation and retries the cleanup. Report a plain error, not
+                    // not-found — the blobs are still there.
+                    nativeCredentialError(-2, "beginGet: invalidated-key cleanup failed");
+                    return false;
+                }
+                nativeCredentialError(-12, "Key invalidated by biometric enrollment change");
+                return false;
+            }
             pending = PendingType.GET;
             pendingAccount = account;
             pendingPlain = null;
@@ -234,6 +268,36 @@ public final class SecureAndroidAuthentication {
         }
         KeyStore.SecretKeyEntry e = (KeyStore.SecretKeyEntry) ks.getEntry(KC_ALIAS, null);
         return e.getSecretKey();
+    }
+
+    /**
+     * Removes every stored blob and then the invalidated AES key. All accounts share the
+     * one key, so after an enrollment change every ciphertext is undecryptable dead data.
+     *
+     * Order matters: the blobs are cleared first (synchronously, result checked), because
+     * if the alias were deleted first and the process stopped before the prefs write, the
+     * next use would silently generate a fresh key and the leftover ciphertext would turn
+     * into permanent ghost entries — hasCredential() true, decryption always failing.
+     *
+     * @return true when the state is consistent again (blobs verifiably gone). Alias
+     *         removal afterwards is best-effort: with the blobs gone no ghosts are
+     *         possible, and a surviving invalidated alias merely re-triggers this cleanup
+     *         on the next use.
+     */
+    private boolean handleInvalidatedKey() {
+        // The prefs file holds nothing but our iv_/ct_ blobs — clear it entirely.
+        if (!prefs().edit().clear().commit()) {
+            Log.w(TAG, "handleInvalidatedKey: failed to clear credential blobs");
+            return false;
+        }
+        try {
+            KeyStore ks = KeyStore.getInstance("AndroidKeyStore");
+            ks.load(null);
+            if (ks.containsAlias(KC_ALIAS)) ks.deleteEntry(KC_ALIAS);
+        } catch (Exception e) {
+            Log.w(TAG, "handleInvalidatedKey: failed to delete key alias", e);
+        }
+        return true;
     }
 
     private Cipher newEncryptCipher() throws Exception {

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -52,6 +52,9 @@ proc changePassword*(self: Controller, password: string, newPassword: string, re
 proc isProfileMigratedToDEKEncryption*(self: Controller): bool =
   return self.privacyService.isProfileMigratedToDEKEncryption()
 
+proc getBiometricCredentialForStorage*(self: Controller, keyUid: string, password: string): string =
+  return self.privacyService.getBiometricCredentialForStorage(keyUid, password)
+
 proc getMnemonic*(self: Controller): string =
   return self.privacyService.getMnemonic()
 

--- a/src/app/modules/main/profile_section/privacy/io_interface.nim
+++ b/src/app/modules/main/profile_section/privacy/io_interface.nim
@@ -28,6 +28,9 @@ method isMnemonicBackedUp*(self: AccessInterface): bool {.base.} =
 method changePassword*(self: AccessInterface, password: string, newPassword: string, rekey: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getBiometricCredentialForStorage*(self: AccessInterface, keyUid: string, password: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method isProfileMigratedToDEKEncryption*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/privacy/io_interface.nim
+++ b/src/app/modules/main/profile_section/privacy/io_interface.nim
@@ -31,6 +31,9 @@ method changePassword*(self: AccessInterface, password: string, newPassword: str
 method getBiometricCredentialForStorage*(self: AccessInterface, keyUid: string, password: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method setBiometricPreferenceNotNow*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method isProfileMigratedToDEKEncryption*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -58,6 +58,9 @@ method isProfileMigratedToDEKEncryption*(self: Module): bool =
 method getBiometricCredentialForStorage*(self: Module, keyUid: string, password: string): string =
   return self.controller.getBiometricCredentialForStorage(keyUid, password)
 
+method setBiometricPreferenceNotNow*(self: Module) =
+  singletonInstance.localAccountSettings.setStoreToKeychainValue(LS_VALUE_NOT_NOW)
+
 method isMnemonicBackedUp*(self: Module): bool =
   return self.controller.isMnemonicBackedUp()
 

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -55,6 +55,9 @@ method changePassword*(self: Module, password: string, newPassword: string, reke
 method isProfileMigratedToDEKEncryption*(self: Module): bool =
   return self.controller.isProfileMigratedToDEKEncryption()
 
+method getBiometricCredentialForStorage*(self: Module, keyUid: string, password: string): string =
+  return self.controller.getBiometricCredentialForStorage(keyUid, password)
+
 method isMnemonicBackedUp*(self: Module): bool =
   return self.controller.isMnemonicBackedUp()
 
@@ -62,9 +65,6 @@ method mnemonicBackedUp*(self: Module) =
   self.view.emitMnemonicBackedUpSignal()
 
 method onPasswordChanged*(self: Module, success: bool, errorMsg: string) =
-  if singletonInstance.localAccountSettings.getStoreToKeychainValue() != LS_VALUE_NEVER:
-    singletonInstance.localAccountSettings.setStoreToKeychainValue(LS_VALUE_NOT_NOW)
-
   self.view.emitPasswordChangedSignal(success, errorMsg)
 
 method getMnemonic*(self: Module): string =

--- a/src/app/modules/main/profile_section/privacy/view.nim
+++ b/src/app/modules/main/profile_section/privacy/view.nim
@@ -22,6 +22,9 @@ QtObject:
   proc isProfileMigratedToDEKEncryption*(self: View): bool {.slot.} =
     return self.delegate.isProfileMigratedToDEKEncryption()
 
+  proc getBiometricCredentialForStorage*(self: View, keyUid: string, password: string): string {.slot.} =
+    return self.delegate.getBiometricCredentialForStorage(keyUid, password)
+
   proc passwordChanged(self: View, success: bool, errorMsg: string) {.signal.}
   proc emitPasswordChangedSignal*(self: View, success: bool, errorMsg: string) =
     self.passwordChanged(success, errorMsg)

--- a/src/app/modules/main/profile_section/privacy/view.nim
+++ b/src/app/modules/main/profile_section/privacy/view.nim
@@ -25,6 +25,9 @@ QtObject:
   proc getBiometricCredentialForStorage*(self: View, keyUid: string, password: string): string {.slot.} =
     return self.delegate.getBiometricCredentialForStorage(keyUid, password)
 
+  proc setBiometricPreferenceNotNow*(self: View) {.slot.} =
+    self.delegate.setBiometricPreferenceNotNow()
+
   proc passwordChanged(self: View, success: bool, errorMsg: string) {.signal.}
   proc emitPasswordChangedSignal*(self: View, success: bool, errorMsg: string) =
     self.passwordChanged(success, errorMsg)

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -217,6 +217,9 @@ proc login*(
     walletXPub,
   )
 
+proc loginWithDEK*(self: Controller, account: AccountDto, dek: string) =
+  self.accountsService.login(account, hashedPassword = "", dek = dek)
+
 proc getKeypairByKeyUidFromDb*(self: Controller, keyUid: string): wallet_account_service.KeypairDto =
   return self.walletAccountService.getKeypairByKeyUidFromDb(keyUid)
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -321,7 +321,7 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
     # SaveBiometrics task should be scheduled after any other tasks
     if saveBiometrics:
       let credential = if pin.len > 0: pin else: password
-      self.postLoginTasks.add(newSaveBiometricsTask(credential))
+      self.postLoginTasks.add(newSaveBiometricsTask(credential, isPin = pin.len > 0))
     if backupImportFileUrl != "":
       self.postLoginTasks.add(newLocalBackupTask(backupImportFileUrl))
 
@@ -335,12 +335,21 @@ method loginRequested*[T](self: Module[T], keyUid: string, loginFlow: int, dataJ
     self.tmpKeyUid = keyUid
     self.loginFlow = LoginMethod(loginFlow)
 
+    # drop any queued tasks by previous (failed) attempts so a stale credential can never be saved
+    self.postLoginTasks = self.postLoginTasks.filterIt(it.kind != kPostOnboardingTaskSaveBiometrics)
+
     let data = parseJson(dataJson)
     let account = self.controller.getAccountByKeyUid(keyUid)
 
     case self.loginFlow:
       of LoginMethod.Password:
-        self.controller.login(account, data["password"].str)
+        let dek = data{"dek"}.getStr
+        if dek.len > 0:
+          self.controller.loginWithDEK(account, dek)
+        else:
+          if data{"updateBiometrics"}.getBool(false):
+            self.postLoginTasks.add(newSaveBiometricsTask(data["password"].str, isPin = false, keyUid = keyUid))
+          self.controller.login(account, data["password"].str)
       of LoginMethod.Keycard:
         self.loginKeycard(keyUid, data["pin"].str, data{"pairingPassword"}.getStr)
       of LoginMethod.Mnemonic:

--- a/src/app/modules/onboarding/post_onboarding/save_biometrics_task.nim
+++ b/src/app/modules/onboarding/post_onboarding/save_biometrics_task.nim
@@ -3,21 +3,37 @@ import task
 import ../io_interface
 
 import app_service/service/accounts/service as accounts_service
+import app_service/common/keychain_credential
 
 export task
 
 type SaveBiometricsTask* = ref object of PostOnboardingTask
   credential*: string
+  isPin*: bool
+  keyUid*: string # empty only for onboarding flows, when the profile is created during the flow
 
-proc newSaveBiometricsTask*(credential: string): SaveBiometricsTask =
+proc newSaveBiometricsTask*(credential: string, isPin: bool = false, keyUid: string = ""): SaveBiometricsTask =
   result = SaveBiometricsTask(
       kind: kPostOnboardingTaskSaveBiometrics,
       credential: credential,
+      isPin: isPin,
+      keyUid: keyUid,
     )
 
 proc run*(self: SaveBiometricsTask, accountsService: accounts_service.Service, onboardingModule: AccessInterface) =
   debug "running post-onboarding SaveBiometricsTask"
 
-  let keyUid = accountsService.getLoggedInAccount().keyUid
-  onboardingModule.requestSaveBiometrics(keyUid, self.credential)
+  let loggedInKeyUid = accountsService.getLoggedInAccount().keyUid
+  if self.keyUid.len > 0 and self.keyUid != loggedInKeyUid:
+    warn "skipping biometric save, the logged-in account does not match the task's account"
+    return
 
+  var toStore = self.credential
+  if not self.isPin:
+    # Password profiles store the wrapped DEK when the profile is DEK-migrated, the raw password otherwise.
+    # Keycard profiles (isPin) store the PIN.
+    toStore = biometricCredentialForPasswordProfile(loggedInKeyUid, self.credential)
+  if toStore.len == 0:
+    error "failed to prepare biometric credential, biometrics will not be enabled"
+    return
+  onboardingModule.requestSaveBiometrics(loggedInKeyUid, toStore)

--- a/src/app_service/common/keychain_credential.nim
+++ b/src/app_service/common/keychain_credential.nim
@@ -1,0 +1,35 @@
+import json, chronicles
+
+import ../../backend/privacy as status_privacy
+import ./utils
+
+logScope:
+  topics = "keychain-credential"
+
+const DEK_CREDENTIAL_PREFIX* = "dek:"
+
+proc biometricCredentialForPasswordProfile*(keyUid: string, password: string): string =
+  ## Returns the value to store in the OS keychain for biometric login for a password based profile.
+  ## Keycard profiles store the PIN directly and must never go through here.
+  ## - profile migrated to DEK encryption -> "dek:<64-hex>" (the wrapped DEK, tagged)
+  ## - legacy profile                     -> the raw password (current behavior preserved)
+  ## - failure                            -> "" (don't save, or delete the existing item)
+  ## When `password` is already the raw DEK (a re-save after a dek-tagged biometric auth), the value is returned as is.
+  try:
+    let info = status_privacy.getProfileEncryptionInfo(keyUid)
+    if info.result.isNil or info.result.kind != JObject or
+        info.result{"error"}.getStr.len > 0 or
+        not info.result.hasKey("migrated") or info.result["migrated"].kind != JBool:
+      error "unexpected profile encryption info response", keyUid
+      return ""
+    if not info.result["migrated"].getBool:
+      return password
+    let response = status_privacy.exportProfileDEK(keyUid, hashPassword(password))
+    let dek = response.result{"dek"}.getStr
+    if dek.len == 0:
+      error "export-profile-dek returned no DEK", keyUid, err = response.result{"error"}.getStr
+      return ""
+    return DEK_CREDENTIAL_PREFIX & dek
+  except Exception as e:
+    error "failed to prepare biometric credential", errName = e.name, errDesription = e.msg
+    return ""

--- a/src/app_service/service/accounts/dto/login_request.nim
+++ b/src/app_service/service/accounts/dto/login_request.nim
@@ -10,6 +10,7 @@ export api_config
 type
   LoginAccountRequest* = object
     passwordHash*: string
+    dek*: string
     keyUID*: string
     kdfIterations*: int
     runtimeLogLevel*: string
@@ -27,6 +28,7 @@ type
 proc toJson*(self: LoginAccountRequest): JsonNode =
   result = %* {
     "password": self.passwordHash,
+    "dek": self.dek,
     "keyUid": self.keyUID,
     "kdfIterations": self.kdfIterations,
     "runtimeLogLevel": self.runtimeLogLevel,

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -434,12 +434,13 @@ QtObject:
     self.events.emit(SIGNAL_DERIVED_ADDRESSES_FROM_NOT_IMPORTED_MNEMONIC_FETCHED, data)
 
   proc doLogin(self: Service, account: AccountDto, passwordHash: string, chatPrivateKey: string = "", mnemonic: string = "",
-    walletXPub: string = "") =
+    walletXPub: string = "", dek: string = "") =
 
     var request = LoginAccountRequest(
       keyUid: account.keyUid,
       kdfIterations: account.kdfIterations,
       passwordHash: passwordHash,
+      dek: dek,
       keycardWhisperPrivateKey: chatPrivateKey,
       walletXPub: walletXPub,
       mnemonic: mnemonic,
@@ -465,9 +466,9 @@ QtObject:
     self.setLocalAccountSettingsFile()
 
   proc login*(self: Service, account: AccountDto, hashedPassword: string, chatPrivateKey: string = "", mnemonic: string = "",
-    walletXPub: string = "") =
+    walletXPub: string = "", dek: string = "") =
     try:
-      self.doLogin(account, hashedPassword, chatPrivateKey, mnemonic, walletXPub)
+      self.doLogin(account, hashedPassword, chatPrivateKey, mnemonic, walletXPub, dek)
 
     except Exception as e:
       error "login failed", errName = e.name, errDesription = e.msg

--- a/src/app_service/service/privacy/service.nim
+++ b/src/app_service/service/privacy/service.nim
@@ -10,6 +10,7 @@ import ../../../app/core/tasks/[qt, threadpool]
 import ../../../backend/privacy as status_privacy
 
 import ../../common/utils as common_utils
+import ../../common/keychain_credential as keychain_credential
 
 include ./async_tasks
 
@@ -100,6 +101,9 @@ QtObject:
     except Exception as e:
       error "error: ", procName="isProfileMigratedToDEKEncryption", errName = e.name, errDesription = e.msg
       return false
+
+  proc getBiometricCredentialForStorage*(self: Service, keyUid: string, password: string): string =
+    return keychain_credential.biometricCredentialForPasswordProfile(keyUid, password)
 
   proc isMnemonicBackedUp*(self: Service): bool =
     return self.settingsService.getMnemonic().len == 0

--- a/src/backend/privacy.nim
+++ b/src/backend/privacy.nim
@@ -34,3 +34,15 @@ proc getProfileEncryptionInfo*(keyUID: string): RpcResponse[JsonNode] =
   except RpcException as e:
     error "error", methodName = "getProfileEncryptionInfo", exception=e.msg
     raise newException(RpcException, e.msg)
+
+proc exportProfileDEK*(keyUID: string, hashedPassword: string): RpcResponse[JsonNode] =
+  try:
+    let request = %* {
+      "keyUID": keyUID,
+      "password": hashedPassword,
+    }
+    let response = status_go.exportProfileDEK($request)
+    result.result = Json.decode(response, JsonNode)
+  except RpcException as e:
+    error "error", methodName = "exportProfileDEK", exception=e.msg
+    raise newException(RpcException, e.msg)

--- a/src/status_go.nim
+++ b/src/status_go.nim
@@ -149,6 +149,11 @@ proc getProfileEncryptionInfo*(paramsJSON: string): string =
   defer: go_shim.free(funcOut)
   return $funcOut
 
+proc exportProfileDEK*(paramsJSON: string): string =
+  var funcOut = go_shim.exportProfileDEK(paramsJSON.cstring)
+  defer: go_shim.free(funcOut)
+  return $funcOut
+
 proc validateMnemonic*(mnemonic: string): string =
   var funcOut = go_shim.validateMnemonic(mnemonic.cstring)
   defer: go_shim.free(funcOut)

--- a/src/status_go/impl.nim
+++ b/src/status_go/impl.nim
@@ -64,6 +64,8 @@ proc changeDatabasePasswordV2*(paramsJSON: cstring): cstring {.importc: "ChangeD
 
 proc getProfileEncryptionInfo*(paramsJSON: cstring): cstring {.importc: "GetProfileEncryptionInfo".}
 
+proc exportProfileDEK*(paramsJSON: cstring): cstring {.importc: "ExportProfileDEK".}
+
 proc validateMnemonic*(mnemonic: cstring): cstring {.importc: "ValidateMnemonic".}
 
 proc getRandomMnemonic*(): cstring {.importc: "GetRandomMnemonic".}

--- a/storybook/pages/ChangePasswordViewPage.qml
+++ b/storybook/pages/ChangePasswordViewPage.qml
@@ -47,6 +47,18 @@ SplitView {
                     }
                 }
 
+                // The view invokes these on the store itself (the storybook stub is empty,
+                // so they are defined on the instance)
+                function getBiometricCredentialForStorage(keyUid, password) {
+                    // mimics the backend rule: DEK-migrated profiles store the tagged DEK,
+                    // legacy ones the raw password
+                    return ctrlFastPasswordChange.checked ? "dek:mocked-dek-hex" : password
+                }
+
+                function setBiometricPreferenceNotNow() {
+                    logs.logEvent("privacyStore::setBiometricPreferenceNotNow")
+                }
+
                 readonly property string keyUid: keyUidInput.text
 
                 function tryStoreToKeyChain(errorDescription) {

--- a/storybook/pages/KeychainMock.qml
+++ b/storybook/pages/KeychainMock.qml
@@ -44,6 +44,12 @@ Keychain {
         return Keychain.StatusSuccess
     }
 
+    function updateCredential(account, password) {
+        if (d.store[account] === undefined)
+            return Keychain.StatusSuccess
+        return saveCredential(account, password)
+    }
+
     function requestGetCredential(reason, account) {
         if (!root.available) {
             root.getCredentialRequestCompleted(Keychain.StatusUnavailable, "")

--- a/storybook/qmlTests/tests/tst_AuthSignPopupBase.qml
+++ b/storybook/qmlTests/tests/tst_AuthSignPopupBase.qml
@@ -46,6 +46,7 @@ Item {
         // Shadows the C++ members so no real OS keychain/biometrics is touched
         Keychain {
             property int requestCount: 0
+            property var updatedCredentials: []
             readonly property bool available: true
             function hasCredential(account) {
                 return account === "key-uid-1" ? Keychain.StatusSuccess
@@ -53,6 +54,10 @@ Item {
             }
             function requestGetCredential(reason, account) {
                 requestCount++
+                return Keychain.StatusSuccess
+            }
+            function updateCredential(account, credential) {
+                updatedCredentials.push({ account, credential })
                 return Keychain.StatusSuccess
             }
         }
@@ -124,6 +129,101 @@ Item {
             const bioButton = findChild(popup, "useBiometricsButton")
             verify(!!bioButton)
             verify(!bioButton.visible)
+        }
+    }
+
+    TestCase {
+        name: "AuthSignPopupBase_dekCredential"
+        when: windowShown
+
+        property var popup: null
+        property var mockKeychain: null
+
+        function init() {
+            mockKeychain = createTemporaryObject(mockedKeychainComponent, root)
+            verify(!!mockKeychain)
+        }
+
+        function cleanup() {
+            if (popup) {
+                popup.destroy()
+                popup = null
+            }
+        }
+
+        function createPasswordPopup(extraProperties) {
+            const properties = Object.assign({
+                                                 keychain: mockKeychain,
+                                                 isKeycardKeyPair: false,
+                                                 userProfileMigratedToColdWallet: false
+                                             }, extraProperties || {})
+            const created = createTemporaryObject(componentUnderTest, root, properties)
+            verify(!!created)
+            return created
+        }
+
+        // A dek-tagged biometric secret is stripped and used on the password rails;
+        // the stored item is already current, so no keychain update happens.
+        function test_dekSecretIsStrippedAndUsedAsPassword() {
+            let capturedPassword = ""
+            popup = createPasswordPopup()
+            popup.performPasswordAction = (password) => {
+                capturedPassword = password
+                return true
+            }
+            popup.open()
+            tryCompare(popup, "opened", true)
+            tryCompare(mockKeychain, "requestCount", 1)
+
+            mockKeychain.getCredentialRequestCompleted(Keychain.StatusSuccess, "dek:aabbcc001122")
+
+            tryCompare(popup, "lastUsedPin", "") // password path, not keycard
+            compare(capturedPassword, "aabbcc001122")
+            compare(mockKeychain.updatedCredentials.length, 0)
+        }
+
+        // A legacy (untagged) biometric secret that authenticates successfully is refreshed
+        // in the keychain through the injected transform (upgrade to the wrapped DEK).
+        function test_legacySecretUpgradesStoredCredential() {
+            let capturedPassword = ""
+            popup = createPasswordPopup({
+                                            getCredentialForStorage: (keyUid, password) => "dek:transformed-" + password
+                                        })
+            popup.performPasswordAction = (password) => {
+                capturedPassword = password
+                return true
+            }
+            popup.open()
+            tryCompare(popup, "opened", true)
+            tryCompare(mockKeychain, "requestCount", 1)
+
+            mockKeychain.getCredentialRequestCompleted(Keychain.StatusSuccess, "legacy-password")
+
+            compare(capturedPassword, "legacy-password")
+            tryCompare(mockKeychain.updatedCredentials, "length", 1)
+            compare(mockKeychain.updatedCredentials[0].account, "key-uid-1")
+            compare(mockKeychain.updatedCredentials[0].credential, "dek:transformed-legacy-password")
+        }
+
+        // Flows that transfer the password itself (device syncing) cannot accept a DEK:
+        // the popup must fall back to manual password entry without running the action.
+        function test_requirePlainCredentialFallsBackToManualEntry() {
+            let actionRuns = 0
+            popup = createPasswordPopup({ requirePlainCredential: true })
+            popup.performPasswordAction = (password) => {
+                actionRuns++
+                return true
+            }
+            popup.open()
+            tryCompare(popup, "opened", true)
+            tryCompare(mockKeychain, "requestCount", 1)
+
+            mockKeychain.getCredentialRequestCompleted(Keychain.StatusSuccess, "dek:aabbcc001122")
+
+            waitForRendering(popup.contentItem)
+            compare(actionRuns, 0)
+            compare(mockKeychain.updatedCredentials.length, 0)
+            verify(popup.opened) // stays open for manual entry
         }
     }
 

--- a/storybook/qmlTests/tests/tst_ChangePasswordView.qml
+++ b/storybook/qmlTests/tests/tst_ChangePasswordView.qml
@@ -1,0 +1,224 @@
+import QtQuick
+import QtQuick.Controls
+
+import QtTest
+
+import StatusQ
+
+import AppLayouts.Profile.views
+import AppLayouts.Profile.stores
+
+import utils
+
+Item {
+    id: root
+
+    width: 600
+    height: 700
+
+    readonly property string testKeyUid: "key-uid-1"
+
+    // Simulates the app-level biometric preference ("store"/"notNow"/"never").
+    property string preference: "store"
+
+    // What the credential transform returns; "" simulates a helper failure.
+    property string transformResult: "dek:fresh-dek-hex"
+
+    property var keychainMock: null
+    property var view: null
+
+    Component {
+        id: mockedKeychainComponent
+
+        // Shadows the C++ members so no real OS keychain/biometrics is touched
+        Keychain {
+            property var creds: ({})
+            property bool asyncDelete: false // Android-style delivery of credentialDeleted
+            property var updateCalls: []
+            property int updateStatus: Keychain.StatusSuccess
+            property int deleteStatus: Keychain.StatusSuccess
+
+            function hasCredential(account) {
+                return creds[account] !== undefined ? Keychain.StatusSuccess
+                                                    : Keychain.StatusNotFound
+            }
+            function updateCredential(account, credential) {
+                updateCalls.push({ account, credential })
+                if (updateStatus === Keychain.StatusSuccess && creds[account] !== undefined)
+                    creds[account] = credential
+                return updateStatus
+            }
+            function deleteCredential(account) {
+                if (deleteStatus !== Keychain.StatusSuccess)
+                    return deleteStatus // failure: item untouched, no signal emitted
+                delete creds[account]
+                if (asyncDelete)
+                    Qt.callLater(() => credentialDeleted(account))
+                else
+                    credentialDeleted(account)
+                return Keychain.StatusSuccess
+            }
+            function requestGetCredential(reason, account) {}
+        }
+    }
+
+    // Mimics ui/main.qml's app-level handler: ANY deletion records a permanent opt-out.
+    // Declared before the view is created, matching the app's connection order.
+    Connections {
+        target: root.keychainMock
+
+        function onCredentialDeleted(account) {
+            root.preference = "never"
+        }
+    }
+
+    Component {
+        id: viewComponent
+
+        ChangePasswordView {
+            sectionTitle: "Password"
+            contentWidth: 500
+            passwordStrengthScoreFunction: (newPass) => Math.min(newPass.length - 1, 4)
+
+            privacyStore: PrivacyStore {
+                // The storybook PrivacyStore stub is empty; the API used by the view is
+                // declared here, following the established qmlTests store-mock pattern.
+                readonly property string keyUid: root.testKeyUid
+
+                property QtObject privacyModule: QtObject {
+                    signal passwordChanged(success: bool, errorMsg: string)
+                }
+
+                function changePassword(password, newPassword, rekey = false) {}
+
+                function isProfileMigratedToDEKEncryption() {
+                    return true
+                }
+
+                function getBiometricCredentialForStorage(keyUid, password) {
+                    return root.transformResult
+                }
+
+                function setBiometricPreferenceNotNow() {
+                    root.preference = "notNow"
+                }
+            }
+
+            keychain: root.keychainMock
+        }
+    }
+
+    TestCase {
+        name: "ChangePasswordView_keychainFlow"
+        when: windowShown
+
+        function init() {
+            root.preference = "store"
+            root.transformResult = "dek:fresh-dek-hex"
+            root.keychainMock = createTemporaryObject(mockedKeychainComponent, root)
+            verify(!!root.keychainMock)
+            root.keychainMock.deleteStatus = Keychain.StatusSuccess
+            root.view = createTemporaryObject(viewComponent, root)
+            verify(!!root.view)
+        }
+
+        function cleanup() {
+            if (root.view) {
+                root.view.destroy()
+                root.view = null
+            }
+            // keychainMock is left in place until init() replaces it: the view's destroy is
+            // deferred and its bindings would re-evaluate against a null keychain.
+        }
+
+        function emitPasswordChanged(success) {
+            const newPswInput = findChild(root.view, "passwordViewNewPassword")
+            verify(!!newPswInput)
+            newPswInput.text = "new-password-1"
+            root.view.privacyStore.privacyModule.passwordChanged(success, success ? "" : "some error")
+        }
+
+        // Successful change with a stored item: the item is refreshed with the transformed
+        // credential (wrapped DEK); the preference is untouched.
+        function test_successRefreshesStoredCredential() {
+            root.keychainMock.creds[root.testKeyUid] = "old-password"
+
+            emitPasswordChanged(true)
+
+            compare(root.keychainMock.updateCalls.length, 1)
+            compare(root.keychainMock.updateCalls[0].account, root.testKeyUid)
+            compare(root.keychainMock.updateCalls[0].credential, "dek:fresh-dek-hex")
+            compare(root.keychainMock.creds[root.testKeyUid], "dek:fresh-dek-hex")
+            compare(root.preference, "store")
+        }
+
+        // No stored item: the keychain is never touched.
+        function test_successWithoutItemLeavesKeychainAlone() {
+            emitPasswordChanged(true)
+
+            compare(root.keychainMock.updateCalls.length, 0)
+            compare(root.preference, "store")
+        }
+
+        // Failed password change: the keychain is never touched.
+        function test_failureLeavesKeychainAlone() {
+            root.keychainMock.creds[root.testKeyUid] = "old-password"
+
+            emitPasswordChanged(false)
+
+            compare(root.keychainMock.updateCalls.length, 0)
+            compare(root.keychainMock.creds[root.testKeyUid], "old-password")
+            compare(root.preference, "store")
+        }
+
+        function test_storageFailureDisablesBiometrics_data() {
+            return [
+                { tag: "helper failure, sync delete", transform: "", updateStatus: Keychain.StatusSuccess, asyncDelete: false },
+                { tag: "helper failure, async delete (Android)", transform: "", updateStatus: Keychain.StatusSuccess, asyncDelete: true },
+                { tag: "update failure, sync delete", transform: "dek:fresh-dek-hex", updateStatus: Keychain.StatusGenericError, asyncDelete: false },
+                { tag: "update failure, async delete (Android)", transform: "dek:fresh-dek-hex", updateStatus: Keychain.StatusGenericError, asyncDelete: true },
+            ]
+        }
+
+        // A storage failure deletes the stale item and must end with the preference on
+        // "notNow" — even though the deletion handler records "never", and even when
+        // credentialDeleted arrives asynchronously (Android).
+        function test_storageFailureDisablesBiometrics(data) {
+            root.transformResult = data.transform
+            root.keychainMock.updateStatus = data.updateStatus
+            root.keychainMock.asyncDelete = data.asyncDelete
+            root.keychainMock.creds[root.testKeyUid] = "old-password"
+
+            emitPasswordChanged(true)
+
+            tryVerify(() => root.keychainMock.creds[root.testKeyUid] === undefined)
+            tryCompare(root, "preference", "notNow")
+        }
+
+        // A FAILED deletion emits no credentialDeleted: the failure preference must still be
+        // applied directly, and the pending flag must not leak onto a later explicit deletion
+        // (which records a permanent "never" opt-out and must stay that way).
+        function test_deletionFailureAppliesPreferenceAndDoesNotPoisonLaterDeletes() {
+            root.transformResult = "" // helper failure triggers the deletion path
+            root.keychainMock.deleteStatus = Keychain.StatusGenericError
+            root.keychainMock.creds[root.testKeyUid] = "old-password"
+
+            emitPasswordChanged(true)
+
+            compare(root.keychainMock.creds[root.testKeyUid], "old-password") // deletion failed
+            tryCompare(root, "preference", "notNow")
+
+            // later, the user explicitly disables biometrics
+            root.preference = "store"
+            root.keychainMock.deleteStatus = Keychain.StatusSuccess
+            root.keychainMock.deleteCredential(root.testKeyUid)
+
+            // drain the Qt.callLater queue deterministically: any (wrongly) deferred
+            // correction was queued before this sentinel, so it has run once we see it
+            let drained = false
+            Qt.callLater(() => drained = true)
+            tryVerify(() => drained)
+            compare(root.preference, "never")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -683,6 +683,8 @@ Item {
                 const resultData = loginSpy.signalArguments[0][2]
                 verify(!!resultData)
                 compare(resultData.password, data.password)
+                // a keychain item exists while biometrics is on -> ask the backend to refresh it post-login
+                compare(!!resultData.updateBiometrics, !!data.biometrics)
 
                 // verify validation & pass error
                 tryCompare(passwordInput, "hasError", data.password !== mockDriver.dummyNewPassword)
@@ -742,6 +744,47 @@ Item {
                 verify(!!resultData)
                 compare(resultData.pin, data.pin)
             }
+        }
+
+        function test_loginScreen_biometricsWithDek_data() {
+            return [{ tag: "dek-tagged biometric secret" }] // dummy to skip global data, and run just once
+        }
+
+        // Biometric login for a DEK-migrated profile: the keychain returns a dek-tagged
+        // secret which must be submitted as { dek } (raw, un-hashed path) — never as a
+        // password, and never shown in the password box.
+        function test_loginScreen_biometricsWithDek() {
+            verify(!!controlUnderTest)
+            controlUnderTest.onboardingStore.loginAccountsModel = loginAccountsModel
+            controlUnderTest.restartFlow()
+
+            mockDriver.biometricsAvailable = true
+
+            const page = getCurrentPage(controlUnderTest.stack, LoginScreen)
+            const userSelector = findChild(page, "loginUserSelector")
+            verify(!!userSelector)
+            userSelector.setSelection("uid_1")
+            tryCompare(userSelector, "selectedProfileKeyId", "uid_1")
+
+            const passwordInput = findChild(page, "loginPasswordInput")
+            verify(!!passwordInput)
+            const passwordBox = findChild(page, "passwordBox")
+            verify(!!passwordBox)
+
+            const dekHex = "8a9f7d2b6c1e4f3a5d8b9c0e2f4a6b8d0c2e4f6a8b0d2c4e6f8a0b2d4c6e8f0a"
+            controlUnderTest.keychain.getCredentialRequestCompleted(
+                        Keychain.StatusSuccess, "dek:" + dekHex)
+
+            // the DEK is not a password: it never appears in the password box
+            compare(passwordInput.text, "")
+
+            tryCompare(loginSpy, "count", 1)
+            compare(loginSpy.signalArguments[0][0], "uid_1")
+            compare(loginSpy.signalArguments[0][1], Onboarding.LoginMethod.Password)
+            const resultData = loginSpy.signalArguments[0][2]
+            verify(!!resultData)
+            compare(resultData.dek, dekHex)
+            compare(resultData.password, undefined)
         }
 
         function test_loginScreen_profileSelectionIsSavedAndRestoredAfterWrongPassword_data() {

--- a/ui/StatusQ/src/keychain_android.cpp
+++ b/ui/StatusQ/src/keychain_android.cpp
@@ -286,6 +286,13 @@ static void jni_nativeCredentialError(JNIEnv*, jobject, jint code, jstring jMsg)
         return;
     }
 
+    if (code == -12) { // Key invalidated by biometric enrollment change; stored blobs were wiped
+        QMetaObject::invokeMethod(s_keychain, [msg]{
+            emit s_keychain->getCredentialRequestCompleted(Keychain::StatusNotFound, QString());
+        }, Qt::QueuedConnection);
+        return;
+    }
+
     QMetaObject::invokeMethod(s_keychain, [msg]{
         emit s_keychain->getCredentialRequestCompleted(Keychain::StatusGenericError, QString());
     }, Qt::QueuedConnection);

--- a/ui/StatusQ/src/keychain_apple.mm
+++ b/ui/StatusQ/src/keychain_apple.mm
@@ -68,6 +68,36 @@ Keychain::Status convertError(NSError *error)
     }
 }
 
+// Base attributes addressing a credential item. On macOS, hardened (biometric-bound) items
+// live in the data-protection keychain, while items saved before the hardening (or by
+// builds lacking the required entitlements) live in the legacy file-based keychain —
+// `dataProtection` selects which one a query addresses. On iOS there is only the
+// data-protection keychain, so the flag is irrelevant.
+static NSMutableDictionary *baseQuery(const QString &service, const QString &account, bool dataProtection)
+{
+    NSMutableDictionary *query = [NSMutableDictionary dictionary];
+    query[(__bridge id) kSecClass] = (__bridge id) kSecClassGenericPassword;
+    query[(__bridge id) kSecAttrService] = service.toNSString();
+    query[(__bridge id) kSecAttrAccount] = account.toNSString();
+#if TARGET_OS_OSX
+    if (dataProtection)
+        query[(__bridge id) kSecUseDataProtectionKeychain] = @YES;
+#else
+    Q_UNUSED(dataProtection)
+#endif
+    return query;
+}
+
+// The data-protection keychain requires keychain entitlements (proper code signing);
+// unsigned dev builds fail with errSecMissingEntitlement — the only condition under which
+// operations may fall back to (or degrade to) the legacy file-based keychain, besides a
+// plain errSecItemNotFound. Anything else (e.g. errSecNotAvailable, a general availability
+// failure) leaves the hardened store's state unknown and must be propagated as an error.
+static bool dataProtectionUnavailable(OSStatus status)
+{
+    return status == errSecMissingEntitlement;
+}
+
 Keychain::Keychain(QObject *parent)
     : QObject(parent)
 {
@@ -187,14 +217,15 @@ Keychain::Status Keychain::saveCredential(const QString &account, const QString 
     CFErrorRef error = NULL;
 
     // On iOS there is no Apple Watch companion unlock; keep flags minimal.
-    // We still create an access control object even if it's not added to the query (left commented below),
-    // to keep parity with macOS and make it easy to enable later.
     #if TARGET_OS_OSX
         auto flags = kSecAccessControlBiometryCurrentSet | kSecAccessControlOr | kSecAccessControlWatch;
     #else
         auto flags = kSecAccessControlBiometryCurrentSet;
     #endif
 
+    // The keychain itself enforces biometrics for reading the item, and BiometryCurrentSet
+    // invalidates it when the biometric enrollment changes. ThisDeviceOnly accessibility
+    // (embedded in the access control) keeps the item out of any sync/backup.
     auto accessControl = SecAccessControlCreateWithFlags(NULL,
                                                          kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
                                                          flags,
@@ -208,21 +239,49 @@ Keychain::Status Keychain::saveCredential(const QString &account, const QString 
         return StatusGenericError;
     }
 
-    NSDictionary *query = @{
-        (__bridge id) kSecClass: (__bridge id) kSecClassGenericPassword,
-        (__bridge id) kSecAttrService: m_service.toNSString(),
-        (__bridge id) kSecAttrAccount: account.toNSString(),
-        (__bridge id) kSecValueData: [password.toNSString() dataUsingEncoding:NSUTF8StringEncoding],
-        // (__bridge id)kSecAttrAccessControl: (__bridge id)accessControl, // enable if you want Keychain to enforce biometrics
+    NSData *value = [password.toNSString() dataUsingEncoding:NSUTF8StringEncoding];
 
-    };
+    // Remove any previous item from both keychains: every overwrite thereby doubles as the
+    // migration of a legacy (pre-hardening) item to the hardened, biometric-bound form.
+    // Each store must be confirmed deleted/absent — a stale copy left behind would shadow
+    // or survive the new item.
+    const auto dpDelete = SecItemDelete((__bridge CFDictionaryRef) baseQuery(m_service, account, true));
+    if (dpDelete != errSecSuccess && dpDelete != errSecItemNotFound && !dataProtectionUnavailable(dpDelete)) {
+        qWarning() << "Keychain: failed to clear previous hardened item OSStatus=" << (long) dpDelete;
+        CFRelease(accessControl);
+        return convertStatus(dpDelete);
+    }
+    const auto legacyDelete = SecItemDelete((__bridge CFDictionaryRef) baseQuery(m_service, account, false));
+    if (legacyDelete != errSecSuccess && legacyDelete != errSecItemNotFound) {
+        qWarning() << "Keychain: failed to clear previous legacy item OSStatus=" << (long) legacyDelete;
+        CFRelease(accessControl);
+        return convertStatus(legacyDelete);
+    }
 
-    SecItemDelete((__bridge CFDictionaryRef) query);                  // Ensure old item is removed
-    auto status = SecItemAdd((__bridge CFDictionaryRef) query, NULL); // Add item
+    NSMutableDictionary *query = baseQuery(m_service, account, true);
+    query[(__bridge id) kSecValueData] = value;
+    query[(__bridge id) kSecAttrAccessControl] = (__bridge id) accessControl;
+
+    auto status = SecItemAdd((__bridge CFDictionaryRef) query, NULL);
+
+    if (status != errSecSuccess && dataProtectionUnavailable(status)) {
+        // The biometric-bound item requires the data-protection keychain, which in turn
+        // requires proper code signing (keychain entitlements) — unsigned dev builds fail
+        // here. Degrade to a legacy item (pre-hardening protection level, still gated by
+        // the app-level LAContext authentication) rather than losing biometrics entirely.
+        // Any other failure is reported as-is.
+        qWarning() << "Keychain: data-protection keychain unavailable OSStatus=" << (long) status
+                   << ", storing legacy item instead";
+        NSMutableDictionary *legacyQuery = baseQuery(m_service, account, false);
+        legacyQuery[(__bridge id) kSecValueData] = value;
+        status = SecItemAdd((__bridge CFDictionaryRef) legacyQuery, NULL);
+    }
 
     CFRelease(accessControl);
     if (status == errSecSuccess) {
         emit credentialSaved(account);
+    } else {
+        qWarning() << "Keychain: saveCredential failed OSStatus=" << (long) status;
     }
 
     return convertStatus(status);
@@ -230,17 +289,28 @@ Keychain::Status Keychain::saveCredential(const QString &account, const QString 
 
 Keychain::Status Keychain::deleteCredential(const QString &account)
 {
-    NSDictionary *query = @{
-        (__bridge id) kSecClass: (__bridge id) kSecClassGenericPassword,
-        (__bridge id) kSecAttrService: m_service.toNSString(),
-        (__bridge id) kSecAttrAccount: account.toNSString(),
-    };
-    const auto status = SecItemDelete((__bridge CFDictionaryRef) query);
-    if (status == errSecSuccess) {
-        emit credentialDeleted(account);
+    // The item may live in either keychain (hardened or legacy/pre-hardening); remove both.
+    const auto dpStatus = SecItemDelete((__bridge CFDictionaryRef) baseQuery(m_service, account, true));
+    const auto legacyStatus = SecItemDelete((__bridge CFDictionaryRef) baseQuery(m_service, account, false));
+
+    // Success is only reported when BOTH stores are confirmed deleted or absent — otherwise
+    // a copy could remain accessible after credentialDeleted was emitted.
+    const bool dpResolved = dpStatus == errSecSuccess || dpStatus == errSecItemNotFound
+                            || dataProtectionUnavailable(dpStatus);
+    const bool legacyResolved = legacyStatus == errSecSuccess || legacyStatus == errSecItemNotFound;
+
+    if (!dpResolved || !legacyResolved) {
+        const auto failure = !dpResolved ? dpStatus : legacyStatus;
+        qWarning() << "Keychain: deleteCredential failed OSStatus=" << (long) failure;
+        return convertStatus(failure);
     }
 
-    return convertStatus(status);
+    if (dpStatus != errSecSuccess && legacyStatus != errSecSuccess) {
+        return StatusNotFound; // nothing existed in either store
+    }
+
+    emit credentialDeleted(account);
+    return StatusSuccess;
 }
 
 Keychain::Status Keychain::getCredential(const QString &reason, const QString &account, QString *out)
@@ -258,26 +328,34 @@ Keychain::Status Keychain::getCredential(const QString &reason, const QString &a
         return authStatus;
     }
 
-    NSDictionary *query = @{
-        (__bridge id) kSecClass: (__bridge id) kSecClassGenericPassword,
-        (__bridge id) kSecAttrService: m_service.toNSString(),
-        (__bridge id) kSecAttrAccount: account.toNSString(),
-        (__bridge id) kSecReturnData: @YES,
-        (__bridge id) kSecMatchLimit: (__bridge id) kSecMatchLimitOne,
-        (__bridge id) kSecUseAuthenticationContext: m_activeAuthContext,
+    // The freshly evaluated LAContext satisfies the item's access control without a second
+    // prompt (iOS 11+/macOS 10.13+ support kSecUseAuthenticationContext).
+    const auto copyItem = [this, &account](bool dataProtection, CFDataRef *data) {
+        NSMutableDictionary *query = baseQuery(m_service, account, dataProtection);
+        query[(__bridge id) kSecReturnData] = @YES;
+        query[(__bridge id) kSecMatchLimit] = (__bridge id) kSecMatchLimitOne;
+        query[(__bridge id) kSecUseAuthenticationContext] = m_activeAuthContext;
+        return SecItemCopyMatching((__bridge CFDictionaryRef) query, (CFTypeRef *) data);
     };
-
-    // Use the LAContext with Keychain when available. iOS 11+/macOS 10.13+ support kSecUseAuthenticationContext.
-    #if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000) || \
-        (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101300)
-        NSMutableDictionary *mutableQuery = [query mutableCopy];
-        mutableQuery[(__bridge id)kSecUseAuthenticationContext] = m_activeAuthContext;
-        query = mutableQuery;
-    #endif
 
     CFDataRef data = NULL;
 
-    const auto status = SecItemCopyMatching((__bridge CFDictionaryRef) query, (CFTypeRef *) &data);
+    // Hardened item first.
+    auto status = copyItem(true, &data);
+
+    // A biometric re-enrollment invalidates the BiometryCurrentSet-bound item: report it as
+    // missing so callers fall back to password entry (the next successful save re-binds the
+    // item to the new enrollment). Deliberately no legacy fallback here — a leftover legacy
+    // copy must never resurrect a credential the invalidation just revoked.
+    if (status == errSecAuthFailed) {
+        qWarning() << "Keychain: hardened item invalidated (errSecAuthFailed), reporting not found";
+        return StatusNotFound;
+    }
+
+    // Items saved before the hardening (or by builds without keychain entitlements) remain
+    // readable from the legacy keychain; any other failure is propagated as-is.
+    if (status == errSecItemNotFound || dataProtectionUnavailable(status))
+        status = copyItem(false, &data);
 
     if (status != errSecSuccess) {
         qWarning() << "Keychain: SecItemCopyMatching failed OSStatus=" << (long) status
@@ -319,16 +397,30 @@ void Keychain::reevaluateAvailability()
 
 Keychain::Status Keychain::hasCredential(const QString &account) const
 {
-    NSDictionary *query = @{
-        (__bridge id) kSecClass: (__bridge id) kSecClassGenericPassword,
-        (__bridge id) kSecAttrService: m_service.toNSString(),
-        (__bridge id) kSecAttrAccount: account.toNSString(),
-        (__bridge id) kSecReturnData: @NO,
-        (__bridge id) kSecReturnAttributes: @YES,
-        (__bridge id) kSecMatchLimit: (__bridge id) kSecMatchLimitOne,
+    // Existence check must never prompt: request attributes only and forbid interaction
+    // (a non-interactive LAContext makes protected queries fail with
+    // errSecInteractionNotAllowed instead of showing a biometric prompt).
+    LAContext *silentContext = [[[LAContext alloc] init] autorelease];
+    silentContext.interactionNotAllowed = YES;
+
+    const auto check = [this, &account, silentContext](bool dataProtection) {
+        NSMutableDictionary *query = baseQuery(m_service, account, dataProtection);
+        query[(__bridge id) kSecReturnData] = @NO;
+        query[(__bridge id) kSecReturnAttributes] = @YES;
+        query[(__bridge id) kSecMatchLimit] = (__bridge id) kSecMatchLimitOne;
+        query[(__bridge id) kSecUseAuthenticationContext] = silentContext;
+        return SecItemCopyMatching((__bridge CFDictionaryRef) query, nil);
     };
 
-    const auto status = SecItemCopyMatching((__bridge CFDictionaryRef) query, nil);
+    auto status = check(true);
+    if (status == errSecItemNotFound || dataProtectionUnavailable(status))
+        status = check(false); // legacy (pre-hardening) item; other errors are propagated
+
+    // The item exists: reading it would merely require authentication, or is currently
+    // blocked by an enrollment invalidation (handled at read time as not-found).
+    if (status == errSecInteractionNotAllowed || status == errSecAuthFailed)
+        return StatusSuccess;
+
     return convertStatus(status);
 }
 

--- a/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
@@ -79,6 +79,11 @@ OnboardingPage {
 
         if (d.currentProfileIsKeycard) {
             keycardBox.setPin(secret) // automatic login, emits loginRequested() already
+        } else if (secret.startsWith(Constants.keychain.dekPrefix)) {
+            passwordBox.validationError = ""
+            root.loginRequested(root.selectedProfileKeyId, Onboarding.LoginMethod.Password,{
+                                    dek: secret.slice(Constants.keychain.dekPrefix.length)
+                                })
         } else {
             passwordBox.validationError = ""
             passwordBox.password = secret
@@ -127,7 +132,10 @@ OnboardingPage {
             if (password.length === 0)
                 return
 
-            root.loginRequested(root.selectedProfileKeyId, Onboarding.LoginMethod.Password, { password })
+            root.loginRequested(root.selectedProfileKeyId, Onboarding.LoginMethod.Password,{
+                                    password,
+                                    updateBiometrics: root.isBiometricsLogin
+                                })
         }
 
         property string lastPin: ""
@@ -140,8 +148,7 @@ OnboardingPage {
 
             root.loginRequested(root.selectedProfileKeyId, Onboarding.LoginMethod.Keycard, {
                                     pin,
-                                    pairingPassword:
-                                    keycardBox.pairingPassword
+                                    pairingPassword: keycardBox.pairingPassword
                                 })
         }
 
@@ -151,8 +158,7 @@ OnboardingPage {
 
             root.loginRequested(root.selectedProfileKeyId, Onboarding.LoginMethod.Keycard, {
                                     pin: d.lastPin,
-                                    pairingPassword:
-                                    keycardBox.pairingPassword
+                                    pairingPassword: keycardBox.pairingPassword
                                 })
         }
     }

--- a/ui/app/AppLayouts/Profile/stores/PrivacyStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/PrivacyStore.qml
@@ -27,6 +27,14 @@ QtObject {
         return root.privacyModule.isProfileMigratedToDEKEncryption()
     }
 
+    function getBiometricCredentialForStorage(keyUid, password) {
+        return root.privacyModule.getBiometricCredentialForStorage(keyUid, password)
+    }
+
+    function setBiometricPreferenceNotNow() {
+        root.privacyModule.setBiometricPreferenceNotNow()
+    }
+
     function getMnemonic() {
         return root.privacyModule.getMnemonic()
     }

--- a/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
+++ b/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
@@ -42,6 +42,9 @@ SettingsContentBase {
 
         property bool enablingBiometrics: false
 
+        // Set when a credential-update failure forces a deletion
+        property bool pendingFailureDelete: false
+
         readonly property bool biometricsEnabled: {
             reevaluateTrigger // Reference for binding
             return keychain.hasCredential(privacyStore.keyUid) === Keychain.StatusSuccess
@@ -75,8 +78,10 @@ SettingsContentBase {
                 return
             d.enablingBiometrics = false
 
-            const credential = pin !== "" ? pin : password
-            // If credential not retrieved (cancelled or failed)
+            const credential = pin !== "" ?
+                                 pin
+                               : root.privacyStore.getBiometricCredentialForStorage(keyUid, password)
+            // If credential not retrieved (cancelled, failed, or could not be prepared)
             if (keyUid === "" || credential === "") {
                 d.showErrorToast()
                 return
@@ -97,6 +102,15 @@ SettingsContentBase {
 
         function onCredentialSaved(account: string) {
             d.showSuccessToast()
+            d.reevaluateHasCredential()
+        }
+
+        function onCredentialDeleted(account: string) {
+            if (!d.pendingFailureDelete || account !== root.privacyStore.keyUid)
+                return
+            d.pendingFailureDelete = false
+            // The global deletion handler records a permanent "never" opt-out
+            Qt.callLater(() => root.privacyStore.setBiometricPreferenceNotNow())
             d.reevaluateHasCredential()
         }
 
@@ -213,8 +227,29 @@ SettingsContentBase {
                 function onPasswordChanged(success: bool, errorMsg: string) {
                     if (success) {
                         confirmPasswordChangePopup.passwordSuccessfulyChanged()
-                        keychain.updateCredential(privacyStore.keyUid,
-                                                  choosePasswordForm.newPswText)
+                        if (root.keychain.hasCredential(root.privacyStore.keyUid) === Keychain.StatusSuccess) {
+                            const cred = root.privacyStore.getBiometricCredentialForStorage(root.privacyStore.keyUid, choosePasswordForm.newPswText)
+                            const ok = cred !== ""
+                                     && root.keychain.updateCredential(root.privacyStore.keyUid, cred) === Keychain.StatusSuccess
+                            if (!ok) {
+                                // Never leave a stale credential behind: disable biometrics
+                                d.pendingFailureDelete = true
+                                const deleteStatus = root.keychain.deleteCredential(root.privacyStore.keyUid)
+                                if (deleteStatus !== Keychain.StatusSuccess) {
+                                    // No credentialDeleted signal will arrive - clear the pending flag
+                                    d.pendingFailureDelete = false
+                                    root.privacyStore.setBiometricPreferenceNotNow()
+                                }
+                                Global.displayToastMessage(
+                                            qsTr("Biometric login disabled — re-enable it in Settings"),
+                                            "",
+                                            "warning",
+                                            false,
+                                            Constants.ephemeralNotificationType.danger,
+                                            "")
+                                d.reevaluateHasCredential()
+                            }
+                        }
                         // Reset, cause no restart in this case.
                         choosePasswordForm.reset()
                         return

--- a/ui/app/mainui/Handlers/EnableBiometricsPopupHandler.qml
+++ b/ui/app/mainui/Handlers/EnableBiometricsPopupHandler.qml
@@ -49,8 +49,10 @@ QtObject {
                         return
                     popup.enablingBiometrics = false
 
-                    const credential = pin !== "" ? pin : password
-                    // If credential not retrieved (cancelled or failed)
+                    const credential = pin !== "" ?
+                                         pin
+                                       : root.privacyStore.getBiometricCredentialForStorage(keyUid, password)
+                    // If credential not retrieved (cancelled, failed, or could not be prepared)
                     if (keyUid === "" || credential === "") {
                         popup.loading = false
                         popup.errorText = qsTr("Biometric setup failed. Try again.")

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -757,6 +757,8 @@ QtObject {
             AuthenticationPopup {
                 store: root.authenticationStore
                 keychain: root.keychain
+                getCredentialForStorage: (keyUid, password) => root.privacyStore.getBiometricCredentialForStorage(keyUid, password)
+                requirePlainCredential: reason === Constants.authenticationReason.syncDevice
                 onAuthenticationSuccess: function(reason, password, pin, keyUid, chatPrivateKey) {
                     root.authenticationStore.passwordProvided(keyUid, password)
                     Global.authenticationResult(reason, password, pin, keyUid, chatPrivateKey)
@@ -776,6 +778,7 @@ QtObject {
 
                 store: root.signingStore
                 keychain: root.keychain
+                getCredentialForStorage: (keyUid, password) => root.privacyStore.getBiometricCredentialForStorage(keyUid, password)
 
                 onPasswordProvided: function(password) {
                     // in case of signing tx via keycard no password (enc pub key)

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2984,6 +2984,10 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Biometric login disabled — re-enable it in Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13358,6 +13362,10 @@ to load</source>
     </message>
     <message>
         <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please enter your password — biometrics cannot be used for this action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2999,6 +2999,10 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <translation>Zrušit</translation>
     </message>
     <message>
+        <source>Biometric login disabled — re-enable it in Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change</source>
         <translation>Změnit</translation>
     </message>
@@ -13440,6 +13444,10 @@ selhalo</translation>
     <message>
         <source>Continue</source>
         <translation type="unfinished">Pokračovat</translation>
+    </message>
+    <message>
+        <source>Please enter your password — biometrics cannot be used for this action</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to update stored credentials</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2986,6 +2986,10 @@ Do you wish to override the security check and continue?</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <source>Biometric login disabled — re-enable it in Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
@@ -13374,6 +13378,10 @@ al cargar</translation>
     <message>
         <source>Continue</source>
         <translation type="unfinished">Continuar</translation>
+    </message>
+    <message>
+        <source>Please enter your password — biometrics cannot be used for this action</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to update stored credentials</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -2985,6 +2985,10 @@ Do you wish to override the security check and continue?</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <source>Biometric login disabled — re-enable it in Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change</source>
         <translation>Changer</translation>
     </message>
@@ -13373,6 +13377,10 @@ Seul le détenteur du jeton Owner peut distribuer des jetons TokenMaster. Ces je
     <message>
         <source>Continue</source>
         <translation>Continuer</translation>
+    </message>
+    <message>
+        <source>Please enter your password — biometrics cannot be used for this action</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to update stored credentials</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2972,6 +2972,10 @@ Do you wish to override the security check and continue?</source>
         <translation>비밀번호 변경</translation>
     </message>
     <message>
+        <source>Biometric login disabled — re-enable it in Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change</source>
         <translation>변경</translation>
     </message>
@@ -13309,6 +13313,10 @@ to load</source>
     <message>
         <source>Continue</source>
         <translation type="unfinished">계속</translation>
+    </message>
+    <message>
+        <source>Please enter your password — biometrics cannot be used for this action</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to update stored credentials</source>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -2999,6 +2999,10 @@ Do you wish to override the security check and continue?</source>
         <translation>Скасувати</translation>
     </message>
     <message>
+        <source>Biometric login disabled — re-enable it in Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
@@ -13443,6 +13447,10 @@ to load</source>
     <message>
         <source>Continue</source>
         <translation>Продовжити</translation>
+    </message>
+    <message>
+        <source>Please enter your password — biometrics cannot be used for this action</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to update stored credentials</source>

--- a/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
+++ b/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
@@ -47,6 +47,14 @@ StatusDialog {
 
     property bool externalAuthorization: false // when set, the credential is not collected here, instead an "Authorize" buutton is shown, emitting authorizeRequested signal
 
+    property var getCredentialForStorage: null // (keyUid: string, password: string) => string - value to store in the OS keychain, if "" signals failure
+
+    // Set for flows that need the actual password and cannot accept the profile's DEK
+    // (e.g. device syncing, where the password itself is validated against and transferred
+    // with the keystore). When the biometric secret turns out to be a DEK, the popup falls
+    // back to manual password entry instead.
+    property bool requirePlainCredential: false
+
     signal authorizeRequested()
 
     // buttons
@@ -207,7 +215,25 @@ StatusDialog {
             d.biometricsInProgress = false
             if (!contentLoader.item)
                 return
-            contentLoader.item.password = secret
+
+            let value = secret
+            d.lastSecretWasLegacy = true
+            if (value.startsWith(Constants.keychain.dekPrefix)) {
+                value = value.slice(Constants.keychain.dekPrefix.length)
+                d.lastSecretWasLegacy = false
+                if (root.requirePlainCredential) {
+                    d.credentialCameFromBiometrics = false
+                    Global.displayToastMessage(
+                                qsTr("Please enter your password — biometrics cannot be used for this action"),
+                                "",
+                                "warning",
+                                false,
+                                Constants.ephemeralNotificationType.danger,
+                                "")
+                    return
+                }
+            }
+            contentLoader.item.password = value
             d.performPasswordActionInternal()
         }
     }
@@ -237,18 +263,30 @@ StatusDialog {
         property bool biometricsInProgress: false
         property bool credentialMismatchAfterBiometrics: false
         property bool credentialCameFromBiometrics: false
+        property bool lastSecretWasLegacy: false
         property bool verifying: false
         property bool success: false
         property string error: ""
         property string lastPin: ""
 
-        function updateKeychainCredentialIfNeeded(credential) {
-            if (!d.credentialMismatchAfterBiometrics) {
+        function updateKeychainCredentialIfNeeded(credential, isPin) {
+            // If successful action:
+            // - biometrics produced a stale credential, the user typed a working one
+            // - biometrics produced a legacy (untagged) credential - refresh it so DEK-migrated profiles store the wrapped DEK instead of the raw password
+            const upgrade = d.credentialCameFromBiometrics && d.lastSecretWasLegacy && !isPin
+            if (!d.credentialMismatchAfterBiometrics && !upgrade) {
                 return
             }
 
-            const status = root.keychain.updateCredential(root.useKeyUid, credential)
-            if (status !== Keychain.StatusSuccess) {
+            let toStore = credential
+            if (!isPin) {
+                if (!root.getCredentialForStorage)
+                    return
+                toStore = root.getCredentialForStorage(root.useKeyUid, credential)
+            }
+
+            if (toStore === ""
+                    || root.keychain.updateCredential(root.useKeyUid, toStore) !== Keychain.StatusSuccess) {
                 Global.displayToastMessage(qsTr("Failed to update stored credentials"), "", "warning", false, Constants.ephemeralNotificationType.danger, "")
             }
         }
@@ -282,6 +320,7 @@ StatusDialog {
             d.error = ""
             d.credentialCameFromBiometrics = false
             d.credentialMismatchAfterBiometrics = false
+            d.lastSecretWasLegacy = false
             root.keychain.requestGetCredential("authenticate", root.useKeyUid)
         }
 
@@ -306,7 +345,7 @@ StatusDialog {
                 return
             }
 
-            d.updateKeychainCredentialIfNeeded(password)
+            d.updateKeychainCredentialIfNeeded(password, false)
             d.success = true
         }
 
@@ -334,7 +373,7 @@ StatusDialog {
         function handleKeycardSuccess() {
             d.verifying = false
             d.success = true
-            d.updateKeychainCredentialIfNeeded(d.lastPin)
+            d.updateKeychainCredentialIfNeeded(d.lastPin, true)
         }
 
         // Called by the concrete popup when keycard action fails

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -205,6 +205,8 @@ QtObject {
             readonly property string notNow: "notNow"
             readonly property string never: "never"
         }
+
+        readonly property string dekPrefix: "dek:"
     }
 
     readonly property int chatSectionLeftColumnWidth: 304


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/7762

Closes #22036

This PR relies on the work done here https://github.com/status-im/status-app/pull/21878

More details on the FURPS can be found at `/docs/FURPS/dek-encryption-and-biometrics.md`
