### PR TITLE
fix(wallet): offer only currencies market data exists for

### DIFF
--- a/src/app_service/service/market/service.nim
+++ b/src/app_service/service/market/service.nim
@@ -1,4 +1,4 @@
-import nimqml, tables, chronicles
+import nimqml, strutils, tables, chronicles
 
 import app/core/eventemitter
 import app/core/signals/types
@@ -40,6 +40,7 @@ QtObject:
     leaderboardPageLoading: bool
     totalLeaderboardCount: int
     currentPage: int
+    currentCurrency: string
 
   # forward declaration
   proc handleLeaderboardPageLoaded(self: Service, data: WalletSignal)
@@ -58,6 +59,7 @@ QtObject:
     result.leaderboardPageLoading = false
     result.totalLeaderboardCount = 0
     result.currentPage = -1
+    result.currentCurrency = ""
     result.marketLeaderboardTokens = @[]
 
   proc init*(self: Service) =
@@ -71,6 +73,14 @@ QtObject:
         of EventLeaderboardPagePricesUpdated:
           self.handlePricesUpdated(data)
 
+  proc updateBelongsToPage(self: Service, currency: string): bool =
+    ## An update belongs to the displayed page when it carries the currency
+    ## that page is in. That is normally the selected currency, but the backend
+    ## serves a fallback one when the market data provider cannot price the
+    ## selection, and the updates then arrive in the fallback too.
+    return currency.cmpIgnoreCase(self.currentCurrency) == 0 or
+        currency.cmpIgnoreCase(self.settingsService.getCurrency()) == 0
+
   proc handleLeaderboardPageLoaded(self: Service, data: WalletSignal) =
     try:
       let leaderboardData = Json.decode($data.message, LeaderboardPage, allowUnknownFields = true)
@@ -78,6 +88,7 @@ QtObject:
         self.leaderboardPageLoading = false
         self.totalLeaderboardCount = leaderboardData.totalCount
         self.marketLeaderboardTokens = leaderboardData.data
+        self.currentCurrency = leaderboardData.currency
         self.events.emit(SIGNAL_MARKET_LEADERBOARD_PAGE_LOADED, Args())
     except:
       error "Error parsing page loaded leaderboard data"
@@ -86,7 +97,8 @@ QtObject:
     try:
       let leaderboardData = Json.decode($data.message, LeaderboardPage, allowUnknownFields = true)
       if self.currentPage == leaderboardData.page and
-          self.settingsService.getCurrency() == leaderboardData.currency:
+          self.updateBelongsToPage(leaderboardData.currency):
+        self.currentCurrency = leaderboardData.currency
 
         var updates: seq[LeaderboardTokenUpdated] = @[]
 
@@ -106,7 +118,7 @@ QtObject:
     try:
       let leaderboardPricesUpdate = Json.decode($data.message, LeaderboardPagePrices, allowUnknownFields = true)
       if self.currentPage == leaderboardPricesUpdate.page and
-          self.settingsService.getCurrency() == leaderboardPricesUpdate.currency:
+          self.updateBelongsToPage(leaderboardPricesUpdate.currency):
 
         # Create a temporary Table for fast lookups: key => (index, MarketItem)
         var tokenMap = initTable[string, int]()

--- a/storybook/pages/StatusCurrencySelectorPage.qml
+++ b/storybook/pages/StatusCurrencySelectorPage.qml
@@ -70,12 +70,12 @@ SplitView {
             isToken: false
         }
         ListElement {
-            key: "stn"
-            shortName: "SNT"
-            name: qsTr("Status Network Token")
-            symbol: ""
+            key: "btc"
+            shortName: "BTC"
+            name: qsTr("Bitcoin")
+            symbol: "฿"
             category: qsTr("Tokens")
-            imageSource: "../../assets/png/tokens/SNT.png"
+            imageSource: "../../assets/png/tokens/WBTC.png"
             selected: false
             isToken: true
         }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2866,7 +2866,7 @@ Item {
 
     Shortcut {
         context: Qt.ApplicationShortcut
-        sequences: ["Ctrl+,", StandardKey.Preferences]
+        sequence: "Ctrl+,"
         onActivated: globalConns.onAppSectionBySectionTypeChanged(Constants.appSection.profile,
                                                                   Utils.getSettingsSubsectionForSection(d.activeSectionType))
     }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -5170,23 +5170,11 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Status Network Token</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dai</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>United Arab Emirates dirham</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other Fiat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Afghan afghani</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5198,15 +5186,7 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Barbadian dollar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bangladeshi taka</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bulgarian lev</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5214,19 +5194,7 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Brunei dollar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bolivian boliviano</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Brazillian real</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bhutanese ngultrum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5246,14 +5214,6 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Colombian peso</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Costa Rican colón</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Czech koruna</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5262,31 +5222,11 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Dominican peso</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Egyptian pound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ethiopian birr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Georgian lari</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ghanaian cedi</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Hong Kong dollar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Croatian kuna</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5306,19 +5246,7 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Icelandic króna</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Jamaican dollar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Japanese yen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Kenyan shilling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5326,27 +5254,7 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Kazakhstani tenge</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sri Lankan rupee</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Moroccan dirham</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Moldovan leu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mauritian rupee</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Malawian kwacha</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5358,14 +5266,6 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mozambican metical</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Namibian dollar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Nigerian naira</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5374,23 +5274,7 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Nepalese rupee</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>New Zealand dollar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Omani rial</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Peruvian sol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Papua New Guinean kina</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5403,22 +5287,6 @@ Remember your password and don&apos;t share it with anyone.</source>
     </message>
     <message>
         <source>Polish złoty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Paraguayan guaraní</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Qatari riyal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Romanian leu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Serbian dinar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5438,15 +5306,7 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trinidad and Tobago dollar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>New Taiwan dollar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tanzanian shilling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5455,18 +5315,6 @@ Remember your password and don&apos;t share it with anyone.</source>
     </message>
     <message>
         <source>Ukrainian hryvnia</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ugandan shilling</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Uruguayan peso</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Venezuelan bolívar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -5203,24 +5203,12 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <source>Status Network Token</source>
-        <translation>Status Network Token</translation>
-    </message>
-    <message>
-        <source>Dai</source>
-        <translation>Dai</translation>
-    </message>
-    <message>
         <source>United Arab Emirates dirham</source>
         <translation>Dirham Spojených arabských emirátů</translation>
     </message>
     <message>
         <source>Other Fiat</source>
         <translation>Ostatní fiat</translation>
-    </message>
-    <message>
-        <source>Afghan afghani</source>
-        <translation>Afghánský afghání</translation>
     </message>
     <message>
         <source>Argentine peso</source>
@@ -5231,36 +5219,16 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
         <translation>Australský dolar</translation>
     </message>
     <message>
-        <source>Barbadian dollar</source>
-        <translation>Barbadoský dolar</translation>
-    </message>
-    <message>
         <source>Bangladeshi taka</source>
         <translation>Bangladéšská taka</translation>
-    </message>
-    <message>
-        <source>Bulgarian lev</source>
-        <translation>Bulharský lev</translation>
     </message>
     <message>
         <source>Bahraini dinar</source>
         <translation>Bahrajnský dinár</translation>
     </message>
     <message>
-        <source>Brunei dollar</source>
-        <translation>Brunejský dolar</translation>
-    </message>
-    <message>
-        <source>Bolivian boliviano</source>
-        <translation>Bolivijské boliviano</translation>
-    </message>
-    <message>
         <source>Brazillian real</source>
         <translation>Brazilský real</translation>
-    </message>
-    <message>
-        <source>Bhutanese ngultrum</source>
-        <translation>Bhútánský ngultrum</translation>
     </message>
     <message>
         <source>Canadian dollar</source>
@@ -5279,14 +5247,6 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
         <translation>Čínský jüan</translation>
     </message>
     <message>
-        <source>Colombian peso</source>
-        <translation>Kolumbijské peso</translation>
-    </message>
-    <message>
-        <source>Costa Rican colón</source>
-        <translation>Kostarický colón</translation>
-    </message>
-    <message>
         <source>Czech koruna</source>
         <translation>Česká koruna</translation>
     </message>
@@ -5295,32 +5255,12 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
         <translation>Dánská koruna</translation>
     </message>
     <message>
-        <source>Dominican peso</source>
-        <translation>Dominikánské peso</translation>
-    </message>
-    <message>
-        <source>Egyptian pound</source>
-        <translation>Egyptská libra</translation>
-    </message>
-    <message>
-        <source>Ethiopian birr</source>
-        <translation>Etiopský birr</translation>
-    </message>
-    <message>
         <source>Georgian lari</source>
         <translation>Gruzínské lari</translation>
     </message>
     <message>
-        <source>Ghanaian cedi</source>
-        <translation>Ghanský cedi</translation>
-    </message>
-    <message>
         <source>Hong Kong dollar</source>
         <translation>Hongkongský dolar</translation>
-    </message>
-    <message>
-        <source>Croatian kuna</source>
-        <translation>Chorvatská kuna</translation>
     </message>
     <message>
         <source>Hungarian forint</source>
@@ -5339,48 +5279,16 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
         <translation>Indická rupie</translation>
     </message>
     <message>
-        <source>Icelandic króna</source>
-        <translation>Islandská koruna</translation>
-    </message>
-    <message>
-        <source>Jamaican dollar</source>
-        <translation>Jamajský dolar</translation>
-    </message>
-    <message>
         <source>Japanese yen</source>
         <translation>Japonský jen</translation>
-    </message>
-    <message>
-        <source>Kenyan shilling</source>
-        <translation>Keňský šilink</translation>
     </message>
     <message>
         <source>Kuwaiti dinar</source>
         <translation>Kuvajtský dinár</translation>
     </message>
     <message>
-        <source>Kazakhstani tenge</source>
-        <translation>Kazašské tenge</translation>
-    </message>
-    <message>
         <source>Sri Lankan rupee</source>
         <translation>Srílanská rupie</translation>
-    </message>
-    <message>
-        <source>Moroccan dirham</source>
-        <translation>Marocký dirham</translation>
-    </message>
-    <message>
-        <source>Moldovan leu</source>
-        <translation>Moldavské leu</translation>
-    </message>
-    <message>
-        <source>Mauritian rupee</source>
-        <translation>Mauricijská rupie</translation>
-    </message>
-    <message>
-        <source>Malawian kwacha</source>
-        <translation>Malawijská kwacha</translation>
     </message>
     <message>
         <source>Mexican peso</source>
@@ -5391,14 +5299,6 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
         <translation>Malajský ringgit</translation>
     </message>
     <message>
-        <source>Mozambican metical</source>
-        <translation>Mosambický metical</translation>
-    </message>
-    <message>
-        <source>Namibian dollar</source>
-        <translation>Namibijský dolar</translation>
-    </message>
-    <message>
         <source>Nigerian naira</source>
         <translation>Nigerijská naira</translation>
     </message>
@@ -5407,24 +5307,8 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
         <translation>Norská koruna</translation>
     </message>
     <message>
-        <source>Nepalese rupee</source>
-        <translation>Nepálská rupie</translation>
-    </message>
-    <message>
         <source>New Zealand dollar</source>
         <translation>Novozélandský dolar</translation>
-    </message>
-    <message>
-        <source>Omani rial</source>
-        <translation>Ománský rijál</translation>
-    </message>
-    <message>
-        <source>Peruvian sol</source>
-        <translation>Peruánský sol</translation>
-    </message>
-    <message>
-        <source>Papua New Guinean kina</source>
-        <translation>Papuánská kina</translation>
     </message>
     <message>
         <source>Philippine peso</source>
@@ -5437,22 +5321,6 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
     <message>
         <source>Polish złoty</source>
         <translation>Polský zlotý</translation>
-    </message>
-    <message>
-        <source>Paraguayan guaraní</source>
-        <translation>Paraguayské guaraní</translation>
-    </message>
-    <message>
-        <source>Qatari riyal</source>
-        <translation>Katarský rijál</translation>
-    </message>
-    <message>
-        <source>Romanian leu</source>
-        <translation>Rumunské leu</translation>
-    </message>
-    <message>
-        <source>Serbian dinar</source>
-        <translation>Srbský dinár</translation>
     </message>
     <message>
         <source>Saudi riyal</source>
@@ -5471,16 +5339,8 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
         <translation>Thajský baht</translation>
     </message>
     <message>
-        <source>Trinidad and Tobago dollar</source>
-        <translation>Dolar Trinidadu a Tobaga</translation>
-    </message>
-    <message>
         <source>New Taiwan dollar</source>
         <translation>Nový tchajwanský dolar</translation>
-    </message>
-    <message>
-        <source>Tanzanian shilling</source>
-        <translation>Tanzanský šilink</translation>
     </message>
     <message>
         <source>Turkish lira</source>
@@ -5489,18 +5349,6 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
     <message>
         <source>Ukrainian hryvnia</source>
         <translation>Ukrajinská hřivna</translation>
-    </message>
-    <message>
-        <source>Ugandan shilling</source>
-        <translation>Ugandský šilink</translation>
-    </message>
-    <message>
-        <source>Uruguayan peso</source>
-        <translation>Uruguayské peso</translation>
-    </message>
-    <message>
-        <source>Venezuelan bolívar</source>
-        <translation>Venezuelský bolívar</translation>
     </message>
     <message>
         <source>Vietnamese đồng</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -5181,24 +5181,12 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <source>Status Network Token</source>
-        <translation>Status Network Token</translation>
-    </message>
-    <message>
-        <source>Dai</source>
-        <translation>Dai</translation>
-    </message>
-    <message>
         <source>United Arab Emirates dirham</source>
         <translation>Dirham de los Emiratos Árabes Unidos</translation>
     </message>
     <message>
         <source>Other Fiat</source>
         <translation>Otra moneda fiat</translation>
-    </message>
-    <message>
-        <source>Afghan afghani</source>
-        <translation>Afgani afgano</translation>
     </message>
     <message>
         <source>Argentine peso</source>
@@ -5209,36 +5197,16 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
         <translation>Dólar australiano</translation>
     </message>
     <message>
-        <source>Barbadian dollar</source>
-        <translation>Dólar de Barbados</translation>
-    </message>
-    <message>
         <source>Bangladeshi taka</source>
         <translation>Taka de Bangladesh</translation>
-    </message>
-    <message>
-        <source>Bulgarian lev</source>
-        <translation>Lev búlgaro</translation>
     </message>
     <message>
         <source>Bahraini dinar</source>
         <translation>Dinar de Baréin</translation>
     </message>
     <message>
-        <source>Brunei dollar</source>
-        <translation>Dólar de Brunéi</translation>
-    </message>
-    <message>
-        <source>Bolivian boliviano</source>
-        <translation>Boliviano</translation>
-    </message>
-    <message>
         <source>Brazillian real</source>
         <translation>Real brasileño</translation>
-    </message>
-    <message>
-        <source>Bhutanese ngultrum</source>
-        <translation>Ngultrum de Bután</translation>
     </message>
     <message>
         <source>Canadian dollar</source>
@@ -5257,14 +5225,6 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
         <translation>Yuan chino</translation>
     </message>
     <message>
-        <source>Colombian peso</source>
-        <translation>Peso colombiano</translation>
-    </message>
-    <message>
-        <source>Costa Rican colón</source>
-        <translation>Colón costarricense</translation>
-    </message>
-    <message>
         <source>Czech koruna</source>
         <translation>Corona checa</translation>
     </message>
@@ -5273,32 +5233,12 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
         <translation>Corona danesa</translation>
     </message>
     <message>
-        <source>Dominican peso</source>
-        <translation>Peso dominicano</translation>
-    </message>
-    <message>
-        <source>Egyptian pound</source>
-        <translation>Libra egipcia</translation>
-    </message>
-    <message>
-        <source>Ethiopian birr</source>
-        <translation>Birr etíope</translation>
-    </message>
-    <message>
         <source>Georgian lari</source>
         <translation>Lari georgiano</translation>
     </message>
     <message>
-        <source>Ghanaian cedi</source>
-        <translation>Cedi de Ghana</translation>
-    </message>
-    <message>
         <source>Hong Kong dollar</source>
         <translation>Dólar de Hong Kong</translation>
-    </message>
-    <message>
-        <source>Croatian kuna</source>
-        <translation>Kuna croata</translation>
     </message>
     <message>
         <source>Hungarian forint</source>
@@ -5317,48 +5257,16 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
         <translation>Rupia india</translation>
     </message>
     <message>
-        <source>Icelandic króna</source>
-        <translation>Corona islandesa</translation>
-    </message>
-    <message>
-        <source>Jamaican dollar</source>
-        <translation>Dólar jamaiquino</translation>
-    </message>
-    <message>
         <source>Japanese yen</source>
         <translation>Yen japonés</translation>
-    </message>
-    <message>
-        <source>Kenyan shilling</source>
-        <translation>Chelín keniano</translation>
     </message>
     <message>
         <source>Kuwaiti dinar</source>
         <translation>Dinar kuwaití</translation>
     </message>
     <message>
-        <source>Kazakhstani tenge</source>
-        <translation>Tenge kazajo</translation>
-    </message>
-    <message>
         <source>Sri Lankan rupee</source>
         <translation>Rupia de Sri Lanka</translation>
-    </message>
-    <message>
-        <source>Moroccan dirham</source>
-        <translation>Dirham marroquí</translation>
-    </message>
-    <message>
-        <source>Moldovan leu</source>
-        <translation>Leu moldavo</translation>
-    </message>
-    <message>
-        <source>Mauritian rupee</source>
-        <translation>Rupia de Mauricio</translation>
-    </message>
-    <message>
-        <source>Malawian kwacha</source>
-        <translation>Kwacha de Malawi</translation>
     </message>
     <message>
         <source>Mexican peso</source>
@@ -5369,14 +5277,6 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
         <translation>Ringgit malayo</translation>
     </message>
     <message>
-        <source>Mozambican metical</source>
-        <translation>Metical mozambiqueño</translation>
-    </message>
-    <message>
-        <source>Namibian dollar</source>
-        <translation>Dólar namibio</translation>
-    </message>
-    <message>
         <source>Nigerian naira</source>
         <translation>Naira nigeriana</translation>
     </message>
@@ -5385,24 +5285,8 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
         <translation>Corona noruega</translation>
     </message>
     <message>
-        <source>Nepalese rupee</source>
-        <translation>Rupia nepalí</translation>
-    </message>
-    <message>
         <source>New Zealand dollar</source>
         <translation>Dólar neozelandés</translation>
-    </message>
-    <message>
-        <source>Omani rial</source>
-        <translation>Rial omaní</translation>
-    </message>
-    <message>
-        <source>Peruvian sol</source>
-        <translation>Sol peruano</translation>
-    </message>
-    <message>
-        <source>Papua New Guinean kina</source>
-        <translation>Kina de Papúa Nueva Guinea</translation>
     </message>
     <message>
         <source>Philippine peso</source>
@@ -5415,22 +5299,6 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
     <message>
         <source>Polish złoty</source>
         <translation>Złoty polaco</translation>
-    </message>
-    <message>
-        <source>Paraguayan guaraní</source>
-        <translation>Guaraní paraguayo</translation>
-    </message>
-    <message>
-        <source>Qatari riyal</source>
-        <translation>Rial catarí</translation>
-    </message>
-    <message>
-        <source>Romanian leu</source>
-        <translation>Leu rumano</translation>
-    </message>
-    <message>
-        <source>Serbian dinar</source>
-        <translation>Dinar serbio</translation>
     </message>
     <message>
         <source>Saudi riyal</source>
@@ -5449,16 +5317,8 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
         <translation>Baht tailandés</translation>
     </message>
     <message>
-        <source>Trinidad and Tobago dollar</source>
-        <translation>Dólar de Trinidad y Tobago</translation>
-    </message>
-    <message>
         <source>New Taiwan dollar</source>
         <translation>Nuevo dólar de Taiwán</translation>
-    </message>
-    <message>
-        <source>Tanzanian shilling</source>
-        <translation>Chelín tanzano</translation>
     </message>
     <message>
         <source>Turkish lira</source>
@@ -5467,18 +5327,6 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
     <message>
         <source>Ukrainian hryvnia</source>
         <translation>Grivna ucraniana</translation>
-    </message>
-    <message>
-        <source>Ugandan shilling</source>
-        <translation>Chelín ugandés</translation>
-    </message>
-    <message>
-        <source>Uruguayan peso</source>
-        <translation>Peso uruguayo</translation>
-    </message>
-    <message>
-        <source>Venezuelan bolívar</source>
-        <translation>Bolívar venezolano</translation>
     </message>
     <message>
         <source>Vietnamese đồng</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -5179,24 +5179,12 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <source>Status Network Token</source>
-        <translation>Jeton Status Network</translation>
-    </message>
-    <message>
-        <source>Dai</source>
-        <translation>Dai</translation>
-    </message>
-    <message>
         <source>United Arab Emirates dirham</source>
         <translation>Dirham des Émirats arabes unis</translation>
     </message>
     <message>
         <source>Other Fiat</source>
         <translation>Autres devises fiduciaires</translation>
-    </message>
-    <message>
-        <source>Afghan afghani</source>
-        <translation>Afghani afghan</translation>
     </message>
     <message>
         <source>Argentine peso</source>
@@ -5207,36 +5195,16 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
         <translation>Dollar australien</translation>
     </message>
     <message>
-        <source>Barbadian dollar</source>
-        <translation>Dollar barbadien</translation>
-    </message>
-    <message>
         <source>Bangladeshi taka</source>
         <translation>Taka bangladais</translation>
-    </message>
-    <message>
-        <source>Bulgarian lev</source>
-        <translation>Lev bulgare</translation>
     </message>
     <message>
         <source>Bahraini dinar</source>
         <translation>Dinar bahreïni</translation>
     </message>
     <message>
-        <source>Brunei dollar</source>
-        <translation>Dollar du Brunei</translation>
-    </message>
-    <message>
-        <source>Bolivian boliviano</source>
-        <translation>boliviano bolivien</translation>
-    </message>
-    <message>
         <source>Brazillian real</source>
         <translation>real brésilien</translation>
-    </message>
-    <message>
-        <source>Bhutanese ngultrum</source>
-        <translation>ngultroum bhoutanais</translation>
     </message>
     <message>
         <source>Canadian dollar</source>
@@ -5255,14 +5223,6 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
         <translation>yuan chinois</translation>
     </message>
     <message>
-        <source>Colombian peso</source>
-        <translation>peso colombien</translation>
-    </message>
-    <message>
-        <source>Costa Rican colón</source>
-        <translation>colón costaricien</translation>
-    </message>
-    <message>
         <source>Czech koruna</source>
         <translation>couronne tchèque</translation>
     </message>
@@ -5271,32 +5231,12 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
         <translation>couronne danoise</translation>
     </message>
     <message>
-        <source>Dominican peso</source>
-        <translation>peso dominicain</translation>
-    </message>
-    <message>
-        <source>Egyptian pound</source>
-        <translation>livre égyptienne</translation>
-    </message>
-    <message>
-        <source>Ethiopian birr</source>
-        <translation>birr éthiopien</translation>
-    </message>
-    <message>
         <source>Georgian lari</source>
         <translation>lari géorgien</translation>
     </message>
     <message>
-        <source>Ghanaian cedi</source>
-        <translation>cedi ghanéen</translation>
-    </message>
-    <message>
         <source>Hong Kong dollar</source>
         <translation>dollar hongkongais</translation>
-    </message>
-    <message>
-        <source>Croatian kuna</source>
-        <translation>kuna croate</translation>
     </message>
     <message>
         <source>Hungarian forint</source>
@@ -5315,48 +5255,16 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
         <translation>Roupie indienne</translation>
     </message>
     <message>
-        <source>Icelandic króna</source>
-        <translation>Couronne islandaise</translation>
-    </message>
-    <message>
-        <source>Jamaican dollar</source>
-        <translation>Dollar jamaïcain</translation>
-    </message>
-    <message>
         <source>Japanese yen</source>
         <translation>Yen japonais</translation>
-    </message>
-    <message>
-        <source>Kenyan shilling</source>
-        <translation>Shilling kenyan</translation>
     </message>
     <message>
         <source>Kuwaiti dinar</source>
         <translation>Dinar koweïtien</translation>
     </message>
     <message>
-        <source>Kazakhstani tenge</source>
-        <translation>Tenge kazakh</translation>
-    </message>
-    <message>
         <source>Sri Lankan rupee</source>
         <translation>Roupie sri lankaise</translation>
-    </message>
-    <message>
-        <source>Moroccan dirham</source>
-        <translation>Dirham marocain</translation>
-    </message>
-    <message>
-        <source>Moldovan leu</source>
-        <translation>Leu moldave</translation>
-    </message>
-    <message>
-        <source>Mauritian rupee</source>
-        <translation>Roupie mauricienne</translation>
-    </message>
-    <message>
-        <source>Malawian kwacha</source>
-        <translation>Kwacha malawien</translation>
     </message>
     <message>
         <source>Mexican peso</source>
@@ -5367,14 +5275,6 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
         <translation>Ringgit malaisien</translation>
     </message>
     <message>
-        <source>Mozambican metical</source>
-        <translation>Métical mozambicain</translation>
-    </message>
-    <message>
-        <source>Namibian dollar</source>
-        <translation>Dollar namibien</translation>
-    </message>
-    <message>
         <source>Nigerian naira</source>
         <translation>Naira nigérian</translation>
     </message>
@@ -5383,24 +5283,8 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
         <translation>Couronne norvégienne</translation>
     </message>
     <message>
-        <source>Nepalese rupee</source>
-        <translation>Roupie népalaise</translation>
-    </message>
-    <message>
         <source>New Zealand dollar</source>
         <translation>dollar néo-zélandais</translation>
-    </message>
-    <message>
-        <source>Omani rial</source>
-        <translation>rial omanais</translation>
-    </message>
-    <message>
-        <source>Peruvian sol</source>
-        <translation>sol péruvien</translation>
-    </message>
-    <message>
-        <source>Papua New Guinean kina</source>
-        <translation>kina papouasien</translation>
     </message>
     <message>
         <source>Philippine peso</source>
@@ -5413,22 +5297,6 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
     <message>
         <source>Polish złoty</source>
         <translation>złoty polonais</translation>
-    </message>
-    <message>
-        <source>Paraguayan guaraní</source>
-        <translation>guarani paraguayen</translation>
-    </message>
-    <message>
-        <source>Qatari riyal</source>
-        <translation>rial qatarien</translation>
-    </message>
-    <message>
-        <source>Romanian leu</source>
-        <translation>leu roumain</translation>
-    </message>
-    <message>
-        <source>Serbian dinar</source>
-        <translation>dinar serbe</translation>
     </message>
     <message>
         <source>Saudi riyal</source>
@@ -5447,16 +5315,8 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
         <translation>baht thaïlandais</translation>
     </message>
     <message>
-        <source>Trinidad and Tobago dollar</source>
-        <translation>dollar de Trinité-et-Tobago</translation>
-    </message>
-    <message>
         <source>New Taiwan dollar</source>
         <translation>nouveau dollar taïwanais</translation>
-    </message>
-    <message>
-        <source>Tanzanian shilling</source>
-        <translation>shilling tanzanien</translation>
     </message>
     <message>
         <source>Turkish lira</source>
@@ -5465,18 +5325,6 @@ N’oubliez pas votre mot de passe et ne le partagez avec personne.</translation
     <message>
         <source>Ukrainian hryvnia</source>
         <translation>hryvnia ukrainienne</translation>
-    </message>
-    <message>
-        <source>Ugandan shilling</source>
-        <translation>shilling ougandais</translation>
-    </message>
-    <message>
-        <source>Uruguayan peso</source>
-        <translation>peso uruguayen</translation>
-    </message>
-    <message>
-        <source>Venezuelan bolívar</source>
-        <translation>bolívar vénézuélien</translation>
     </message>
     <message>
         <source>Vietnamese đồng</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -5158,24 +5158,12 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>비트코인</translation>
     </message>
     <message>
-        <source>Status Network Token</source>
-        <translation>Status Network Token</translation>
-    </message>
-    <message>
-        <source>Dai</source>
-        <translation>Dai</translation>
-    </message>
-    <message>
         <source>United Arab Emirates dirham</source>
         <translation>아랍에미리트 디르함</translation>
     </message>
     <message>
         <source>Other Fiat</source>
         <translation>기타 법정화폐</translation>
-    </message>
-    <message>
-        <source>Afghan afghani</source>
-        <translation>아프가니스탄 아프가니</translation>
     </message>
     <message>
         <source>Argentine peso</source>
@@ -5186,36 +5174,16 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>호주 달러</translation>
     </message>
     <message>
-        <source>Barbadian dollar</source>
-        <translation>바베이도스 달러</translation>
-    </message>
-    <message>
         <source>Bangladeshi taka</source>
         <translation>방글라데시 타카</translation>
-    </message>
-    <message>
-        <source>Bulgarian lev</source>
-        <translation>불가리아 레프</translation>
     </message>
     <message>
         <source>Bahraini dinar</source>
         <translation>바레인 디나르</translation>
     </message>
     <message>
-        <source>Brunei dollar</source>
-        <translation>브루나이 달러</translation>
-    </message>
-    <message>
-        <source>Bolivian boliviano</source>
-        <translation>볼리비아노</translation>
-    </message>
-    <message>
         <source>Brazillian real</source>
         <translation>브라질 레알</translation>
-    </message>
-    <message>
-        <source>Bhutanese ngultrum</source>
-        <translation>부탄 눌트럼</translation>
     </message>
     <message>
         <source>Canadian dollar</source>
@@ -5234,14 +5202,6 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>중국 위안화</translation>
     </message>
     <message>
-        <source>Colombian peso</source>
-        <translation>콜롬비아 페소</translation>
-    </message>
-    <message>
-        <source>Costa Rican colón</source>
-        <translation>코스타리카 콜론</translation>
-    </message>
-    <message>
         <source>Czech koruna</source>
         <translation>체코 코루나</translation>
     </message>
@@ -5250,32 +5210,12 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>덴마크 크로네</translation>
     </message>
     <message>
-        <source>Dominican peso</source>
-        <translation>도미니카 페소</translation>
-    </message>
-    <message>
-        <source>Egyptian pound</source>
-        <translation>이집트 파운드</translation>
-    </message>
-    <message>
-        <source>Ethiopian birr</source>
-        <translation>에티오피아 비르</translation>
-    </message>
-    <message>
         <source>Georgian lari</source>
         <translation>조지아 라리</translation>
     </message>
     <message>
-        <source>Ghanaian cedi</source>
-        <translation>가나 세디</translation>
-    </message>
-    <message>
         <source>Hong Kong dollar</source>
         <translation>홍콩 달러</translation>
-    </message>
-    <message>
-        <source>Croatian kuna</source>
-        <translation>크로아티아 쿠나</translation>
     </message>
     <message>
         <source>Hungarian forint</source>
@@ -5294,48 +5234,16 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>인도 루피</translation>
     </message>
     <message>
-        <source>Icelandic króna</source>
-        <translation>아이슬란드 크로나</translation>
-    </message>
-    <message>
-        <source>Jamaican dollar</source>
-        <translation>자메이카 달러</translation>
-    </message>
-    <message>
         <source>Japanese yen</source>
         <translation>일본 엔</translation>
-    </message>
-    <message>
-        <source>Kenyan shilling</source>
-        <translation>케냐 실링</translation>
     </message>
     <message>
         <source>Kuwaiti dinar</source>
         <translation>쿠웨이트 디나르</translation>
     </message>
     <message>
-        <source>Kazakhstani tenge</source>
-        <translation>카자흐스탄 텡게</translation>
-    </message>
-    <message>
         <source>Sri Lankan rupee</source>
         <translation>스리랑카 루피</translation>
-    </message>
-    <message>
-        <source>Moroccan dirham</source>
-        <translation>모로코 디르함</translation>
-    </message>
-    <message>
-        <source>Moldovan leu</source>
-        <translation>몰도바 레우</translation>
-    </message>
-    <message>
-        <source>Mauritian rupee</source>
-        <translation>모리셔스 루피</translation>
-    </message>
-    <message>
-        <source>Malawian kwacha</source>
-        <translation>말라위 콰차</translation>
     </message>
     <message>
         <source>Mexican peso</source>
@@ -5346,14 +5254,6 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>말레이시아 링깃</translation>
     </message>
     <message>
-        <source>Mozambican metical</source>
-        <translation>모잠비크 메티칼</translation>
-    </message>
-    <message>
-        <source>Namibian dollar</source>
-        <translation>나미비아 달러</translation>
-    </message>
-    <message>
         <source>Nigerian naira</source>
         <translation>나이지리아 나이라</translation>
     </message>
@@ -5362,24 +5262,8 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>노르웨이 크로네</translation>
     </message>
     <message>
-        <source>Nepalese rupee</source>
-        <translation>네팔 루피</translation>
-    </message>
-    <message>
         <source>New Zealand dollar</source>
         <translation>뉴질랜드 달러</translation>
-    </message>
-    <message>
-        <source>Omani rial</source>
-        <translation>오만 리얄</translation>
-    </message>
-    <message>
-        <source>Peruvian sol</source>
-        <translation>페루 솔</translation>
-    </message>
-    <message>
-        <source>Papua New Guinean kina</source>
-        <translation>파푸아뉴기니 키나</translation>
     </message>
     <message>
         <source>Philippine peso</source>
@@ -5392,22 +5276,6 @@ Remember your password and don&apos;t share it with anyone.</source>
     <message>
         <source>Polish złoty</source>
         <translation>폴란드 즈워티</translation>
-    </message>
-    <message>
-        <source>Paraguayan guaraní</source>
-        <translation>파라과이 과라니</translation>
-    </message>
-    <message>
-        <source>Qatari riyal</source>
-        <translation>카타르 리얄</translation>
-    </message>
-    <message>
-        <source>Romanian leu</source>
-        <translation>루마니아 레우</translation>
-    </message>
-    <message>
-        <source>Serbian dinar</source>
-        <translation>세르비아 디나르</translation>
     </message>
     <message>
         <source>Saudi riyal</source>
@@ -5426,16 +5294,8 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>태국 바트</translation>
     </message>
     <message>
-        <source>Trinidad and Tobago dollar</source>
-        <translation>트리니다드 토바고 달러</translation>
-    </message>
-    <message>
         <source>New Taiwan dollar</source>
         <translation>신 타이완 달러</translation>
-    </message>
-    <message>
-        <source>Tanzanian shilling</source>
-        <translation>탄자니아 실링</translation>
     </message>
     <message>
         <source>Turkish lira</source>
@@ -5444,18 +5304,6 @@ Remember your password and don&apos;t share it with anyone.</source>
     <message>
         <source>Ukrainian hryvnia</source>
         <translation>우크라이나 그리브나</translation>
-    </message>
-    <message>
-        <source>Ugandan shilling</source>
-        <translation>우간다 실링</translation>
-    </message>
-    <message>
-        <source>Uruguayan peso</source>
-        <translation>우루과이 페소</translation>
-    </message>
-    <message>
-        <source>Venezuelan bolívar</source>
-        <translation>베네수엘라 볼리바르</translation>
     </message>
     <message>
         <source>Vietnamese đồng</source>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -5203,24 +5203,12 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <source>Status Network Token</source>
-        <translation>Токен мережі Status</translation>
-    </message>
-    <message>
-        <source>Dai</source>
-        <translation>Dai</translation>
-    </message>
-    <message>
         <source>United Arab Emirates dirham</source>
         <translation>Дирхам Об’єднаних Арабських Еміратів</translation>
     </message>
     <message>
         <source>Other Fiat</source>
         <translation>Інший фіат</translation>
-    </message>
-    <message>
-        <source>Afghan afghani</source>
-        <translation>Афганський афгані</translation>
     </message>
     <message>
         <source>Argentine peso</source>
@@ -5231,36 +5219,16 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>Австралійський долар</translation>
     </message>
     <message>
-        <source>Barbadian dollar</source>
-        <translation>Барбадоський долар</translation>
-    </message>
-    <message>
         <source>Bangladeshi taka</source>
         <translation>Бангладеська така</translation>
-    </message>
-    <message>
-        <source>Bulgarian lev</source>
-        <translation>Болгарський лев</translation>
     </message>
     <message>
         <source>Bahraini dinar</source>
         <translation>Бахрейнський динар</translation>
     </message>
     <message>
-        <source>Brunei dollar</source>
-        <translation>Брунейський долар</translation>
-    </message>
-    <message>
-        <source>Bolivian boliviano</source>
-        <translation>Болівійський болівіано</translation>
-    </message>
-    <message>
         <source>Brazillian real</source>
         <translation>Бразильський реал</translation>
-    </message>
-    <message>
-        <source>Bhutanese ngultrum</source>
-        <translation>Бутанський нгултрум</translation>
     </message>
     <message>
         <source>Canadian dollar</source>
@@ -5279,14 +5247,6 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>Китайський юань</translation>
     </message>
     <message>
-        <source>Colombian peso</source>
-        <translation>Колумбійське песо</translation>
-    </message>
-    <message>
-        <source>Costa Rican colón</source>
-        <translation>Костариканський колон</translation>
-    </message>
-    <message>
         <source>Czech koruna</source>
         <translation>Чеська крона</translation>
     </message>
@@ -5295,32 +5255,12 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>Данська крона</translation>
     </message>
     <message>
-        <source>Dominican peso</source>
-        <translation>Домініканське песо</translation>
-    </message>
-    <message>
-        <source>Egyptian pound</source>
-        <translation>Єгипетський фунт</translation>
-    </message>
-    <message>
-        <source>Ethiopian birr</source>
-        <translation>Ефіопський бир</translation>
-    </message>
-    <message>
         <source>Georgian lari</source>
         <translation>Грузинський ларі</translation>
     </message>
     <message>
-        <source>Ghanaian cedi</source>
-        <translation>Ганський седі</translation>
-    </message>
-    <message>
         <source>Hong Kong dollar</source>
         <translation>Гонконзький долар</translation>
-    </message>
-    <message>
-        <source>Croatian kuna</source>
-        <translation>Хорватська куна</translation>
     </message>
     <message>
         <source>Hungarian forint</source>
@@ -5339,48 +5279,16 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>Індійська рупія</translation>
     </message>
     <message>
-        <source>Icelandic króna</source>
-        <translation>Ісландська крона</translation>
-    </message>
-    <message>
-        <source>Jamaican dollar</source>
-        <translation>Ямайський долар</translation>
-    </message>
-    <message>
         <source>Japanese yen</source>
         <translation>Японська єна</translation>
-    </message>
-    <message>
-        <source>Kenyan shilling</source>
-        <translation>Кенійський шилінг</translation>
     </message>
     <message>
         <source>Kuwaiti dinar</source>
         <translation>Кувейтський динар</translation>
     </message>
     <message>
-        <source>Kazakhstani tenge</source>
-        <translation>Казахстанський тенге</translation>
-    </message>
-    <message>
         <source>Sri Lankan rupee</source>
         <translation>Шрі-ланкійська рупія</translation>
-    </message>
-    <message>
-        <source>Moroccan dirham</source>
-        <translation>Марокканський дирхам</translation>
-    </message>
-    <message>
-        <source>Moldovan leu</source>
-        <translation>Молдовський лей</translation>
-    </message>
-    <message>
-        <source>Mauritian rupee</source>
-        <translation>Маврикійська рупія</translation>
-    </message>
-    <message>
-        <source>Malawian kwacha</source>
-        <translation>Малавійська квача</translation>
     </message>
     <message>
         <source>Mexican peso</source>
@@ -5391,14 +5299,6 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>Малайзійський рингіт</translation>
     </message>
     <message>
-        <source>Mozambican metical</source>
-        <translation>Мозамбіцький метикал</translation>
-    </message>
-    <message>
-        <source>Namibian dollar</source>
-        <translation>Намібійський долар</translation>
-    </message>
-    <message>
         <source>Nigerian naira</source>
         <translation>Нігерійська найра</translation>
     </message>
@@ -5407,24 +5307,8 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>Норвезька крона</translation>
     </message>
     <message>
-        <source>Nepalese rupee</source>
-        <translation>Непальська рупія</translation>
-    </message>
-    <message>
         <source>New Zealand dollar</source>
         <translation>Новозеландський долар</translation>
-    </message>
-    <message>
-        <source>Omani rial</source>
-        <translation>Оманський ріал</translation>
-    </message>
-    <message>
-        <source>Peruvian sol</source>
-        <translation>Перуанський соль</translation>
-    </message>
-    <message>
-        <source>Papua New Guinean kina</source>
-        <translation>Кіна Папуа-Нової Гвінеї</translation>
     </message>
     <message>
         <source>Philippine peso</source>
@@ -5437,22 +5321,6 @@ Remember your password and don&apos;t share it with anyone.</source>
     <message>
         <source>Polish złoty</source>
         <translation>Польський злотий</translation>
-    </message>
-    <message>
-        <source>Paraguayan guaraní</source>
-        <translation>Парагвайський гуарані</translation>
-    </message>
-    <message>
-        <source>Qatari riyal</source>
-        <translation>Катарський ріал</translation>
-    </message>
-    <message>
-        <source>Romanian leu</source>
-        <translation>Румунський лей</translation>
-    </message>
-    <message>
-        <source>Serbian dinar</source>
-        <translation>Сербський динар</translation>
     </message>
     <message>
         <source>Saudi riyal</source>
@@ -5471,16 +5339,8 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>Тайський бат</translation>
     </message>
     <message>
-        <source>Trinidad and Tobago dollar</source>
-        <translation>Долар Тринідаду і Тобаго</translation>
-    </message>
-    <message>
         <source>New Taiwan dollar</source>
         <translation>Новий тайванський долар</translation>
-    </message>
-    <message>
-        <source>Tanzanian shilling</source>
-        <translation>Танзанійський шилінг</translation>
     </message>
     <message>
         <source>Turkish lira</source>
@@ -5489,18 +5349,6 @@ Remember your password and don&apos;t share it with anyone.</source>
     <message>
         <source>Ukrainian hryvnia</source>
         <translation>Українська гривня</translation>
-    </message>
-    <message>
-        <source>Ugandan shilling</source>
-        <translation>Угандійський шилінг</translation>
-    </message>
-    <message>
-        <source>Uruguayan peso</source>
-        <translation>Уругвайське песо</translation>
-    </message>
-    <message>
-        <source>Venezuelan bolívar</source>
-        <translation>Венесуельський болівар</translation>
     </message>
     <message>
         <source>Vietnamese đồng</source>

--- a/ui/imports/shared/stores/CurrenciesModel.qml
+++ b/ui/imports/shared/stores/CurrenciesModel.qml
@@ -79,45 +79,12 @@ ListModel {
     }
 
     ListElement {
-        key: "stn"
-        shortName: "SNT"
-        name: qsTr("Status Network Token")
-        symbol: ""
-        category: qsTr("Tokens")
-        imageSource: "../../assets/png/tokens/SNT.png"
-        selected: false
-        isToken: true
-    }
-
-    ListElement {
-        key: "dai"
-        shortName: "DAI"
-        name: qsTr("Dai")
-        symbol: "◈"
-        category: qsTr("Tokens")
-        imageSource: "../../assets/png/tokens/DAI.png"
-        selected: false
-        isToken: true
-    }
-
-    ListElement {
         key: "aed"
         shortName: "AED"
         name: qsTr("United Arab Emirates dirham")
         symbol: "د.إ"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1e6-1f1ea.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "afn"
-        shortName: "AFN"
-        name: qsTr("Afghan afghani")
-        symbol: "؋"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e6-1f1eb.svg"
         selected: false
         isToken: false
     }
@@ -145,34 +112,12 @@ ListModel {
     }
 
     ListElement {
-        key: "bbd"
-        shortName: "BBD"
-        name: qsTr("Barbadian dollar")
-        symbol: "$"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e7-1f1e7.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "bdt"
         shortName: "BDT"
         name: qsTr("Bangladeshi taka")
         symbol: "Tk"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1e7-1f1e9.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "bgn"
-        shortName: "BGN"
-        name: qsTr("Bulgarian lev")
-        symbol: "лв"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e7-1f1ec.svg"
         selected: false
         isToken: false
     }
@@ -189,45 +134,12 @@ ListModel {
     }
 
     ListElement {
-        key: "bnd"
-        shortName: "BND"
-        name: qsTr("Brunei dollar")
-        symbol: "$"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e7-1f1f3.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "bob"
-        shortName: "BOB"
-        name: qsTr("Bolivian boliviano")
-        symbol: "$b"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e7-1f1f4.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "brl"
         shortName: "BRL"
         name: qsTr("Brazillian real")
         symbol: "R$"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1e7-1f1f7.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "btn"
-        shortName: "BTN"
-        name: qsTr("Bhutanese ngultrum")
-        symbol: "Nu."
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e7-1f1f9.svg"
         selected: false
         isToken: false
     }
@@ -277,28 +189,6 @@ ListModel {
     }
 
     ListElement {
-        key: "cop"
-        shortName: "COP"
-        name: qsTr("Colombian peso")
-        symbol: "$"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e8-1f1f4.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "crc"
-        shortName: "CRC"
-        name: qsTr("Costa Rican colón")
-        symbol: "₡"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e8-1f1f7.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "czk"
         shortName: "CZK"
         name: qsTr("Czech koruna")
@@ -321,39 +211,6 @@ ListModel {
     }
 
     ListElement {
-        key: "dop"
-        shortName: "DOP"
-        name: qsTr("Dominican peso")
-        symbol: "RD$"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1e9-1f1f4.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "egp"
-        shortName: "EGP"
-        name: qsTr("Egyptian pound")
-        symbol: "£"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1ea-1f1ec.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "etb"
-        shortName: "ETB"
-        name: qsTr("Ethiopian birr")
-        symbol: "Br"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1ea-1f1f9.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "gel"
         shortName: "GEL"
         name: qsTr("Georgian lari")
@@ -365,34 +222,12 @@ ListModel {
     }
 
     ListElement {
-        key: "ghs"
-        shortName: "GHS"
-        name: qsTr("Ghanaian cedi")
-        symbol: "¢"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1ec-1f1ed.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "hkd"
         shortName: "HKD"
         name: qsTr("Hong Kong dollar")
         symbol: "$"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1ed-1f1f0.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "hrk"
-        shortName: "HRK"
-        name: qsTr("Croatian kuna")
-        symbol: "kn"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1ed-1f1f7.svg"
         selected: false
         isToken: false
     }
@@ -442,45 +277,12 @@ ListModel {
     }
 
     ListElement {
-        key: "isk"
-        shortName: "ISK"
-        name: qsTr("Icelandic króna")
-        symbol: "kr"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1ee-1f1f8.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "jmd"
-        shortName: "JMD"
-        name: qsTr("Jamaican dollar")
-        symbol: "J$"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1ef-1f1f2.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "jpy"
         shortName: "JPY"
         name: qsTr("Japanese yen")
         symbol: "¥"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1ef-1f1f5.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "kes"
-        shortName: "KES"
-        name: qsTr("Kenyan shilling")
-        symbol: "KSh"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f0-1f1ea.svg"
         selected: false
         isToken: false
     }
@@ -497,67 +299,12 @@ ListModel {
     }
 
     ListElement {
-        key: "kzt"
-        shortName: "KZT"
-        name: qsTr("Kazakhstani tenge")
-        symbol: "лв"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f0-1f1ff.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "lkr"
         shortName: "LKR"
         name: qsTr("Sri Lankan rupee")
         symbol: "₨"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1f1-1f1f0.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "mad"
-        shortName: "MAD"
-        name: qsTr("Moroccan dirham")
-        symbol: "MAD"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f2-1f1e6.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "mdl"
-        shortName: "MDL"
-        name: qsTr("Moldovan leu")
-        symbol: "MDL"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f2-1f1e9.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "mur"
-        shortName: "MUR"
-        name: qsTr("Mauritian rupee")
-        symbol: "₨"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f2-1f1f7.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "mwk"
-        shortName: "MWK"
-        name: qsTr("Malawian kwacha")
-        symbol: "MK"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f2-1f1fc.svg"
         selected: false
         isToken: false
     }
@@ -585,28 +332,6 @@ ListModel {
     }
 
     ListElement {
-        key: "mzn"
-        shortName: "MZN"
-        name: qsTr("Mozambican metical")
-        symbol: "MT"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f2-1f1ff.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "nad"
-        shortName: "NAD"
-        name: qsTr("Namibian dollar")
-        symbol: "$"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f3-1f1e6.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "ngn"
         shortName: "NGN"
         name: qsTr("Nigerian naira")
@@ -629,55 +354,12 @@ ListModel {
     }
 
     ListElement {
-        key: "npr"
-        shortName: "NPR"
-        name: qsTr("Nepalese rupee")
-        symbol: "₨"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f3-1f1f5.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "nzd"
         shortName: "NZD"
         name: qsTr("New Zealand dollar")
         symbol: "$"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1f3-1f1ff.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "omr"
-        shortName: "OMR"
-        name: qsTr("Omani rial")
-        symbol: "﷼"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f4-1f1f2.svg"
-        selected: false
-    }
-
-    ListElement {
-        key: "pen"
-        shortName: "PEN"
-        name: qsTr("Peruvian sol")
-        symbol: "S/."
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f5-1f1ea.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "pgk"
-        shortName: "PGK"
-        name: qsTr("Papua New Guinean kina")
-        symbol: "K"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f5-1f1ec.svg"
         selected: false
         isToken: false
     }
@@ -711,50 +393,6 @@ ListModel {
         symbol: "zł"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1f5-1f1f1.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "pyg"
-        shortName: "PYG"
-        name: qsTr("Paraguayan guaraní")
-        symbol: "Gs"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f5-1f1fe.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "qar"
-        shortName: "QAR"
-        name: qsTr("Qatari riyal")
-        symbol: "﷼"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f6-1f1e6.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "ron"
-        shortName: "RON"
-        name: qsTr("Romanian leu")
-        symbol: "lei"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f7-1f1f4.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "rsd"
-        shortName: "RSD"
-        name: qsTr("Serbian dinar")
-        symbol: "Дин."
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f7-1f1f8.svg"
         selected: false
         isToken: false
     }
@@ -804,34 +442,12 @@ ListModel {
     }
 
     ListElement {
-        key: "ttd"
-        shortName: "TTD"
-        name: qsTr("Trinidad and Tobago dollar")
-        symbol: "TT$"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f9-1f1f9.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
         key: "twd"
         shortName: "TWD"
         name: qsTr("New Taiwan dollar")
         symbol: "NT$"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1f9-1f1fc.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "tzs"
-        shortName: "TZS"
-        name: qsTr("Tanzanian shilling")
-        symbol: "TSh"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1f9-1f1ff.svg"
         selected: false
         isToken: false
     }
@@ -854,39 +470,6 @@ ListModel {
         symbol: "₴"
         category: qsTr("Other Fiat")
         imageSource: "../../assets/twemoji/svg/1f1fa-1f1e6.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "ugx"
-        shortName: "UGX"
-        name: qsTr("Ugandan shilling")
-        symbol: "USh"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1fa-1f1ec.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "uyu"
-        shortName: "UYU"
-        name: qsTr("Uruguayan peso")
-        symbol: "$U"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1fa-1f1fe.svg"
-        selected: false
-        isToken: false
-    }
-
-    ListElement {
-        key: "vef"
-        shortName: "VEF"
-        name: qsTr("Venezuelan bolívar")
-        symbol: "Bs"
-        category: qsTr("Other Fiat")
-        imageSource: "../../assets/twemoji/svg/1f1fb-1f1ea.svg"
         selected: false
         isToken: false
     }

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -15,7 +15,32 @@ QtObject {
 
     readonly property var currenciesModel: CurrenciesModel {}
 
-    readonly property string currentCurrency: Global.appIsReady ? walletSection.currentCurrency : "USD"
+    readonly property string currentCurrency: d.isSupported(d.storedCurrency) ? d.storedCurrency
+                                                                              : d.fallbackCurrency
+
+    readonly property QtObject _d: QtObject {
+        id: d
+
+        readonly property string fallbackCurrency: "USD"
+
+        readonly property string storedCurrency: Global.appIsReady ? walletSection.currentCurrency : ""
+
+        function isSupported(shortName) {
+            return !!shortName && SQUtils.ModelUtils.indexOf(root.currenciesModel, "shortName", shortName) !== -1
+        }
+
+        // A currency the model does not carry leaves the picker with no
+        // selection and every amount formatted against a currency nothing can
+        // price. Write the fallback back, so the correction reaches the rest of
+        // the app rather than only this store's readers.
+        onStoredCurrencyChanged: {
+            if (!storedCurrency || isSupported(storedCurrency))
+                return
+            console.warn("Unsupported display currency %1, falling back to %2"
+                         .arg(storedCurrency).arg(fallbackCurrency))
+            root.updateCurrency(fallbackCurrency)
+        }
+    }
 
     function updateCurrency(shortName) {
         walletSection.updateCurrency(shortName)


### PR DESCRIPTION
### What does the PR do

Part of #21273.

- Trims the currency picker to 45 codes.
- Removes 36 fiats CoinGecko cannot price.
- Removes display currencies that are not supported by coingecko.
- An unknown stored currency falls back to USD.
- Persists that fallback, not just the display.
- Fixes Cmd+, opening settings on macOS.
- Bumps status-go for the backend counterpart.

Backend: https://github.com/status-im/status-go/pull/7766
Proxy: https://github.com/status-im/market-proxy/pull/81

### Affected areas

wallet, market, shortcuts

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Not captured — the desktop app does not build in this environment. QML lint
passes with no new findings; the status-go side is covered by unit tests.