### PR TITLE
fix: crash when remove headphones from the usb fixed

### DIFF
--- a/storybook/qmlTests/tests/tst_StatusSoundEffect.qml
+++ b/storybook/qmlTests/tests/tst_StatusSoundEffect.qml
@@ -1,0 +1,95 @@
+import QtQuick
+import QtTest
+import QtMultimedia
+
+import StatusQ.Components
+
+Item {
+    id: root
+
+    width: 200
+    height: 200
+
+    Component {
+        id: soundEffectComponent
+
+        StatusSoundEffect {
+            source: Qt.resolvedUrl("../../testData/audio_file_example.wav")
+        }
+    }
+
+    TestCase {
+        name: "StatusSoundEffect"
+        when: windowShown
+
+        // statusString of a StatusSoundEffect without an underlying SoundEffect instance
+        readonly property string idleStatus: String(SoundEffect.Null)
+        readonly property string readyStatus: String(SoundEffect.Ready)
+
+        // Waits until the sample has been loaded and playback has started.
+        // Without an audio output device (e.g. on CI) SoundEffect ends up in the
+        // Error state - possibly only after having reported `playing` already -
+        // so wait for the status to settle first and skip the test on error.
+        function waitForPlaybackStart(sound) {
+            tryVerify(() => sound.isError || sound.statusString === readyStatus, 5000)
+            if (sound.isError)
+                skip("no usable audio output device")
+
+            tryVerify(() => sound.playing, 5000)
+        }
+
+        function test_idleWithoutUnderlyingSoundEffect() {
+            const sound = createTemporaryObject(soundEffectComponent, root)
+            verify(!!sound)
+
+            compare(sound.playing, false)
+            compare(sound.isError, false)
+            compare(sound.statusString, idleStatus)
+        }
+
+        function test_releasedAfterPlaybackFinished() {
+            const sound = createTemporaryObject(soundEffectComponent, root)
+            verify(!!sound)
+
+            sound.play()
+            verify(sound.statusString !== idleStatus) // SoundEffect created on demand
+            waitForPlaybackStart(sound)
+
+            tryVerify(() => !sound.playing, 5000) // the sample is < 1s long
+            tryCompare(sound, "statusString", idleStatus)
+        }
+
+        function test_releasedAfterStop() {
+            const sound = createTemporaryObject(soundEffectComponent, root)
+            verify(!!sound)
+
+            sound.play()
+            waitForPlaybackStart(sound)
+
+            sound.stop()
+            compare(sound.playing, false)
+            tryCompare(sound, "statusString", idleStatus)
+        }
+
+        function test_stopPlaySequenceKeepsPlaying() {
+            const sound = createTemporaryObject(soundEffectComponent, root)
+            verify(!!sound)
+
+            sound.play()
+            waitForPlaybackStart(sound)
+
+            // the idiom used by the application for every notification sound
+            sound.stop()
+            sound.play()
+            compare(sound.playing, true)
+
+            // the deferred release must not kill the restarted playback
+            wait(100)
+            compare(sound.playing, true)
+            verify(sound.statusString !== idleStatus)
+
+            tryVerify(() => !sound.playing, 5000)
+            tryCompare(sound, "statusString", idleStatus)
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/StatusSoundEffect.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSoundEffect.qml
@@ -6,27 +6,61 @@ import StatusQ
 Item {
     id: root
 
-    property alias muted: soundEffect.muted
-    property alias volume: soundEffect.volume
-    property alias source: soundEffect.source
+    property bool muted: false
+    property real volume: 1.0
+    property url source
 
-    readonly property alias playing: soundEffect.playing
-    readonly property bool isError: soundEffect.status === SoundEffect.Error
-    readonly property string statusString: soundEffect.status
+    readonly property bool playing: d.soundEffect ? d.soundEffect.playing : false
+    readonly property bool isError: d.status === SoundEffect.Error
+    readonly property string statusString: d.status
 
     function play() {
-        soundEffect.play()
+        if (!d.soundEffect)
+            d.soundEffect = soundEffectComponent.createObject(root)
+
+        d.soundEffect.play()
     }
 
     function stop() {
-        soundEffect.stop()
+        if (d.soundEffect)
+            d.soundEffect.stop()
     }
 
     function convertVolume(volume) {
         return AudioUtils.convertLogarithmicToLinearVolumeScale(volume)
     }
 
-    SoundEffect {
-        id: soundEffect
+    QtObject {
+        id: d
+
+        property SoundEffect soundEffect: null
+        readonly property int status: soundEffect ? soundEffect.status : SoundEffect.Null
+
+        function scheduleRelease() {
+            Qt.callLater(d.releaseIfIdle)
+        }
+
+        function releaseIfIdle() {
+            if (!soundEffect || soundEffect.playing)
+                return
+
+            soundEffect.destroy()
+            soundEffect = null
+        }
+    }
+
+    Component {
+        id: soundEffectComponent
+
+        SoundEffect {
+            source: root.source
+            volume: root.volume
+            muted: root.muted
+
+            onPlayingChanged: {
+                if (!playing)
+                    d.scheduleRelease()
+            }
+        }
     }
 }


### PR DESCRIPTION
This is a QT bug actually logged here https://qt-project.atlassian.net/browse/QTBUG-145704 As stated there it is fixed in Qt 6.11.1 but we're using 6.11.0

The issue was that a loaded SoundEffect keeps a platform audio sink stream open on the current default output device for as long as it exists, even when nothing is playing and AppMain instantiates three of them permanently, so plugging in and removing USB headphones while logged in crashed the app.

The issue is fixed by creating the underlying SoundEffect on play() and destroy it once playback stops and that way the app avoids holding an idle audio stream open for the app's lifetime.

Fixes #22049