### PR TITLE
ChatTextArea: auto quote-wrapping for multi-line txt pasted in quote block

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -121,6 +121,7 @@ add_test(NAME PagesValidator COMMAND PagesValidator)
 
 add_executable(QmlTests
     qmlTests/main.cpp
+    qmlTests/inputmethodtester.h
     ${TEST_QML_FILES})
 
 target_compile_definitions(QmlTests PRIVATE

--- a/storybook/qmlTests/inputmethodtester.h
+++ b/storybook/qmlTests/inputmethodtester.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QCoreApplication>
+#include <QInputMethodEvent>
+#include <QObject>
+#include <QQuickItem>
+
+// Test-only helper: synthesizes a real QInputMethodEvent and dispatches it to a QQuickItem, so
+// tests can exercise e.g. the InputMethodEventFilter path.
+class InputMethodTester : public QObject
+{
+    Q_OBJECT
+
+public:
+    using QObject::QObject;
+
+    // Deliver `commitString` as an IME commit to `item`. If the item's installed InputMethodEventFilter
+    // accepts it the raw insert is suppressed; otherwise the item inserts the text itself.
+    Q_INVOKABLE void commit(QQuickItem* item, const QString& commitString)
+    {
+        if (!item)
+            return;
+        QInputMethodEvent event;
+        event.setCommitString(commitString);
+        QCoreApplication::sendEvent(item, &event);
+    }
+
+    // Set `preeditString` as the active IME composition (preedit) on `item`, the way an IME shows
+    // in-progress text before it is committed. An empty string clears the composition.
+    Q_INVOKABLE void setPreedit(QQuickItem* item, const QString& preeditString)
+    {
+        if (!item)
+            return;
+        QList<QInputMethodEvent::Attribute> attributes;
+        if (!preeditString.isEmpty())
+            attributes.append(QInputMethodEvent::Attribute(
+                QInputMethodEvent::Cursor, preeditString.length(), 1, QVariant()));
+        QInputMethodEvent event(preeditString, attributes);
+        QCoreApplication::sendEvent(item, &event);
+    }
+};

--- a/storybook/qmlTests/main.cpp
+++ b/storybook/qmlTests/main.cpp
@@ -10,6 +10,8 @@
 
 #include <StatusQ/typesregistration.h>
 
+#include "inputmethodtester.h"
+
 using namespace Qt::Literals::StringLiterals;
 
 extern "C" void statusq_installBoostedIncubationController(void* engine, int msPerTick,
@@ -49,6 +51,9 @@ public slots:
             engine->addImportPath(path);
 
         registerStatusQTypes();
+
+        // Test-only helper for driving the IME/input-method path from QML tests.
+        qmlRegisterType<InputMethodTester>("Storybook.Testing", 1, 0, "InputMethodTester");
 
         // Register the same context-property mocks the storybook app uses (e.g. userProfile),
         // so components that read them (via Utils) behave the same under test.

--- a/storybook/qmlTests/tests/tst_ChatTextArea.qml
+++ b/storybook/qmlTests/tests/tst_ChatTextArea.qml
@@ -4,6 +4,8 @@ import QtTest
 import StatusQ
 import shared.status
 
+import Storybook.Testing
+
 Item {
     id: root
     width: 600
@@ -44,6 +46,13 @@ Item {
             required property int start
             required property int length
         }
+    }
+
+    // Drives the input-method (IME) path: dispatches a real QInputMethodEvent commit to the
+    // control, the way an on-screen keyboard delivers text (e.g. Android's virtual-keyboard
+    // context-menu "Paste").
+    InputMethodTester {
+        id: imeTester
     }
 
     SignalSpy {
@@ -663,6 +672,64 @@ Item {
             tryCompare(plain, "text", "A@aliceB")
         }
 
+        // Internal round-trip of multi-line plain text: copying multiple blocks writes paragraph
+        // separators into the private MIME (type-2 tokens), and pasting them back reconstructs the
+        // block structure exactly.
+        function test_copyPaste_multiLineRoundTrip() {
+            control.text = "a\nb\nc"
+            control.forceActiveFocus()
+            control.selectAll()
+            keyClick(Qt.Key_C, Qt.ControlModifier)
+
+            control.text = ""
+            control.cursorPosition = 0
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "a\nb\nc")
+            compare(control.cursorPosition, control.length)
+        }
+
+        // Internal round-trip preserving a mention that sits across a paragraph break: the type-0
+        // text, type-1 mention and type-2 paragraph-separator tokens all round-trip together.
+        function test_copyPaste_mentionAcrossParagraphsRoundTrip() {
+            const M = String.fromCharCode(0xFFFC)
+            control.text = "A"
+            control.insertMention(1, "@alice", "0xabc")
+            control.insert(control.length, "\nB") // -> "A<mention>\nB"
+            compare(control.text, "A" + M + "\nB")
+            tryCompare(mentionsRepeater, "count", 1)
+
+            control.forceActiveFocus()
+            control.selectAll()
+            keyClick(Qt.Key_C, Qt.ControlModifier)
+
+            control.text = ""
+            control.cursorPosition = 0
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "A" + M + "\nB")
+            tryCompare(mentionsRepeater, "count", 1)
+            compare(mentionsRepeater.itemAt(0).name, "@alice")
+            compare(mentionsRepeater.itemAt(0).pubKey, "0xabc")
+        }
+
+        // A multi-line internal paste (several insertBlock/insertText tokens) collapses into a single
+        // undo step: one Ctrl+Z removes the whole paste and restores the pre-paste text.
+        function test_pasteInternalMultiLine_singleUndoRestores() {
+            control.text = "a\nb"
+            control.forceActiveFocus()
+            control.selectAll()
+            keyClick(Qt.Key_C, Qt.ControlModifier)
+
+            control.text = "Z"
+            control.cursorPosition = control.length
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+            tryCompare(control, "text", "Za\nb")
+
+            keyClick(Qt.Key_Z, Qt.ControlModifier)
+            compare(control.text, "Z")
+        }
+
         // Pasting over a selection replaces it in a single undo step: one Ctrl+Z restores the
         // replaced text directly (the selection removal and the insertion share one edit block),
         // with the caret left at the end of the restored text (not collapsed to its start).
@@ -680,6 +747,271 @@ Item {
             // Caret restored to the end of the originally-selected text ("bc"), not collapsed to
             // the document start.
             compare(control.cursorPosition, 3)
+        }
+
+        // ── paste into a quote block ─────────────────────────────────────────────
+
+        // Pasting multi-line text into a quote keeps the whole paste inside the quote: the first
+        // line merges into the current "> " line, every following line gains a "> " prefix. The
+        // caret lands at the end of the pasted content.
+        function test_pasteMultiLineIntoQuote_prefixesContinuationLines() {
+            control.text = "> "
+            control.forceActiveFocus()
+            control.cursorPosition = 2 // quote content start, right after "> "
+            ClipboardUtils.setText("a\nb\nc")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "> a\n> b\n> c")
+            compare(control.cursorPosition, control.length) // end of the last pasted line
+        }
+
+        // A single-line paste into a quote is unchanged (no continuation lines to prefix).
+        function test_pasteSingleLineIntoQuote_unchanged() {
+            control.text = "> "
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+            ClipboardUtils.setText("x")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "> x")
+            compare(control.cursorPosition, 3)
+        }
+
+        // Outside a quote block, a multi-line paste is inserted verbatim — no "> " prefixing.
+        function test_pasteMultiLineOutsideQuote_unchanged() {
+            control.text = ""
+            control.forceActiveFocus()
+            control.cursorPosition = 0
+            ClipboardUtils.setText("a\nb")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "a\nb")
+            compare(control.cursorPosition, control.length)
+        }
+
+        // A multi-line paste into a quote (with its added "> " prefixes) is one undo step: a single
+        // Ctrl+Z restores the pre-paste state.
+        function test_pasteMultiLineIntoQuote_singleUndoRestores() {
+            control.text = "> "
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+            ClipboardUtils.setText("a\nb\nc")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+            tryCompare(control, "text", "> a\n> b\n> c")
+
+            keyClick(Qt.Key_Z, Qt.ControlModifier)
+            compare(control.text, "> ")
+        }
+
+        // Undo then redo of a multi-line paste into a quote restores the text and leaves the caret
+        // at the end of the pasted content — not on the second line (regression: the prefixes must
+        // be inserted inline so the last edit ends at the paste end).
+        function test_pasteMultiLineIntoQuote_redoKeepsCaretAtEnd() {
+            control.text = "> "
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+            ClipboardUtils.setText("a\nb\nc")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+            tryCompare(control, "text", "> a\n> b\n> c")
+
+            keySequence(StandardKey.Undo)
+            compare(control.text, "> ")
+
+            keySequence(StandardKey.Redo)
+            tryCompare(control, "text", "> a\n> b\n> c")
+            compare(control.cursorPosition, control.length) // end of paste, not the second line
+        }
+
+        // The internal (mention-preserving) paste path is quote-aware too: a multi-line selection
+        // copied from the input keeps every continuation line in the quote when pasted into it.
+        function test_pasteInternalMultiLineIntoQuote_prefixesContinuationLines() {
+            control.text = "a\nb\nc"
+            control.forceActiveFocus()
+            control.selectAll()
+            keyClick(Qt.Key_C, Qt.ControlModifier)
+
+            control.text = "> "
+            control.cursorPosition = 2
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "> a\n> b\n> c")
+            compare(control.cursorPosition, control.length)
+        }
+
+        // ── IME commit paste ──────────────────
+
+        // Pasting via the on-screen keyboard's context menu arrives as an IME commit string, not a
+        // key event or the in-app "Paste" action — so it bypasses pasteText()/Keys.onPressed. When
+        // the caret is in a quote block, the InputMethodEventFilter must reroute a multi-line commit
+        // through the quote-aware paste path instead of letting the TextArea insert it verbatim
+        // (which would break out of the quote). Continuation lines gain a "> " prefix.
+        function test_imeCommitMultiLineIntoQuote_prefixesContinuationLines() {
+            control.text = "> "
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+            ClipboardUtils.setText("a\nb\nc")
+
+            imeTester.commit(control, "a\nb\nc")
+
+            tryCompare(control, "text", "> a\n> b\n> c")
+            compare(control.cursorPosition, control.length)
+        }
+
+        // The rerouted IME paste is one undo step (same as the Ctrl+V / in-app-menu path): a single
+        // Ctrl+Z restores the pre-paste "> ".
+        function test_imeCommitMultiLineIntoQuote_singleUndoRestores() {
+            control.text = "> "
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+            ClipboardUtils.setText("a\nb\nc")
+
+            imeTester.commit(control, "a\nb\nc")
+            tryCompare(control, "text", "> a\n> b\n> c")
+
+            keyClick(Qt.Key_Z, Qt.ControlModifier)
+            compare(control.text, "> ")
+        }
+
+        // Outside a quote block the IME commit is left to the TextArea and inserted verbatim — the
+        // filter must not intercept it (no "> " prefixing, no double insertion).
+        function test_imeCommitMultiLineOutsideQuote_insertedVerbatim() {
+            control.text = ""
+            control.forceActiveFocus()
+            control.cursorPosition = 0
+            ClipboardUtils.setText("a\nb")
+
+            imeTester.commit(control, "a\nb")
+
+            tryCompare(control, "text", "a\nb")
+        }
+
+        // A single-line IME commit inside a quote is ordinary typing/paste with nothing to prefix —
+        // the filter must not intercept it, so it inserts once, verbatim.
+        function test_imeCommitSingleLineIntoQuote_insertedVerbatim() {
+            control.text = "> "
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+            ClipboardUtils.setText("x")
+
+            imeTester.commit(control, "x")
+
+            tryCompare(control, "text", "> x")
+        }
+
+        // ── IME commit: quote continuation (OSK new-line) ────────────────────────
+
+        // The on-screen keyboard's new-line commits "\n" through the IME, bypassing Keys.onPressed.
+        // Inside a quote block the filter applies the same continuation as desktop Enter: start a
+        // new "> " line and consume the event so no bare "\n" is inserted. Mirrors
+        // test_quoteEnterContinues via the IME path.
+        function test_imeNewline_continuesQuoteBlock() {
+            control.text = "> A"
+            control.forceActiveFocus()
+            control.cursorPosition = control.length
+
+            imeTester.commit(control, "\n")
+
+            compare(control.text, "> A\n> ")
+            compare(control.cursorPosition, control.length)
+        }
+
+        // A new-line committed on the second of two consecutive empty quote lines drops both,
+        // exiting the quote — the IME-path counterpart of test_quoteDoubleEnterExits.
+        function test_imeNewline_doubleEmptyExitsQuote() {
+            control.text = "> A\n> \n> "
+            control.forceActiveFocus()
+            control.cursorPosition = control.length
+
+            imeTester.commit(control, "\n")
+
+            compare(control.text, "> A\n")
+        }
+
+        // Outside a quote block the "\n" commit is not intercepted — the TextArea inserts a real
+        // newline as usual (continueQuoteBlock returns false, event not accepted).
+        function test_imeNewline_outsideQuoteInsertsNewline() {
+            control.text = "ab"
+            control.forceActiveFocus()
+            control.cursorPosition = control.length
+
+            imeTester.commit(control, "\n")
+
+            compare(control.text, "ab\n")
+        }
+
+        // ── IME commit: ASCII-emoji conversion (OSK space / new-line) ─────────────
+
+        // Completing an emoticon with a space committed through the IME converts it, just like the
+        // desktop Space key: convertAsciiEmoji() runs before the TextArea inserts the space.
+        function test_imeSpace_convertsAsciiEmoji() {
+            control.asciiEmojiConversion = true
+            control.text = "hi :)"
+            control.forceActiveFocus()
+            control.cursorPosition = control.length
+
+            imeTester.commit(control, " ")
+
+            compare(control.textWithMentions(), "hi " + slightlySmiling + " ")
+        }
+
+        // A new-line committed through the IME converts the emoticon too. Outside a quote block, so
+        // the newline is inserted (no quote continuation) after the conversion.
+        function test_imeNewline_convertsAsciiEmoji() {
+            control.asciiEmojiConversion = true
+            control.text = "hi :)"
+            control.forceActiveFocus()
+            control.cursorPosition = control.length
+
+            imeTester.commit(control, "\n")
+
+            compare(control.textWithMentions(), "hi " + slightlySmiling + "\n")
+        }
+
+        // ── IME preedit (composition) awareness ──────────────────────────────────
+
+        // While an IME composition is active, the mention filter splices in the preedit text so
+        // suggestions reflect what the user visually typed (committed "@a" + preedit "bc" → "abc").
+        function test_preedit_extendsMentionFilter() {
+            control.text = "@a"
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+
+            imeTester.setPreedit(control, "bc")
+
+            tryCompare(control, "enteringSuggestion", true)
+            tryCompare(control, "mentionsFilter", "abc")
+        }
+
+        // The emoji shortcode context is preedit-aware too: a committed ":a" plus a preedit reaches
+        // the two-char trigger threshold and the filter includes the composition.
+        function test_preedit_extendsEmojiFilter() {
+            control.text = ":a"
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+
+            imeTester.setPreedit(control, "bc")
+
+            tryCompare(control, "enteringEmoji", true)
+            tryCompare(control, "emojiFilter", "abc")
+        }
+
+        // An active IME composition suppresses ASCII-emoji conversion: asciiEmojiBeforeCaret() bails
+        // while preedit text is present, so a forced convert mid-composition is a no-op.
+        function test_preedit_blocksAsciiEmojiConversion() {
+            control.asciiEmojiConversion = true
+            control.text = ":)"
+            control.forceActiveFocus()
+            control.cursorPosition = 2
+
+            imeTester.setPreedit(control, "x")
+            control.convertAsciiEmoji()
+
+            compare(control.textWithMentions(), ":)")
         }
 
         // ── image paste ─────────────────────────────────────────────────────────

--- a/ui/StatusQ/src/chatinputhighlighter.cpp
+++ b/ui/StatusQ/src/chatinputhighlighter.cpp
@@ -796,6 +796,11 @@ void ChatInputHighlighter::pasteFromClipboard(int selectionStart, int selectionE
     // it up front) so the first insert replaces it as one selection-aware operation — this makes a
     // single Ctrl+Z restore the replaced text with the caret back at its end, rather than two undo
     // steps that collapse the caret to the document start.
+    // Insertion begins at the selection start (or the caret). Remember whether that spot is inside a
+    // quote block so continuation lines of a multi-line paste can be kept in the quote (see below).
+    const int insertPos = (selectionStart != selectionEnd) ? selectionStart : cursorPosition;
+    const bool inQuote = isInQuoteBlock(insertPos);
+
     QTextCursor cursor(document());
     if (selectionStart != selectionEnd) {
         cursor.setPosition(selectionStart);
@@ -833,10 +838,22 @@ void ChatInputHighlighter::pasteFromClipboard(int selectionStart, int selectionE
                 if (cursor.hasSelection())
                     cursor.removeSelectedText();
                 cursor.insertBlock();
+                // Pasting into a quote block: keep this continuation line in the quote by
+                // prefixing it right away, so following tokens append after the "> ".
+                if (inQuote)
+                    cursor.insertText(QStringLiteral("> "));
             }
         }
     } else if (mime->hasText()) {
-        insertEmojiAwareText(cursor, mime->text());
+        // Pasting into a quote block: keep every continuation line in the quote by turning each
+        // line break into "\n> ". The first line has no leading break, so it merges into the
+        // already-present "> " prefix. Done inline (not as a post-pass) so the final insert ends
+        // at the end of the pasted content — this keeps the caret there on the initial paste and
+        // after undo→redo. Pre-existing "> " lines get double-prefixed ("> > "), which is fine.
+        QString text = mime->text();
+        if (inQuote)
+            text.replace(QLatin1Char('\n'), QStringLiteral("\n> "));
+        insertEmojiAwareText(cursor, text);
     }
     cursor.endEditBlock();
 }

--- a/ui/imports/shared/status/ChatTextArea.qml
+++ b/ui/imports/shared/status/ChatTextArea.qml
@@ -243,8 +243,22 @@ StatusTextArea {
         onInputMethodEventReceived: (imeEvent) => {
             if (imeEvent.commitString === " " || imeEvent.commitString === "\n")
                 root.convertAsciiEmoji()
-            if (imeEvent.commitString === "\n" && d.continueQuoteBlock())
+            if (imeEvent.commitString === "\n" && d.continueQuoteBlock()) {
                 imeEvent.accept()
+                return
+            }
+            // A multi-character commit carrying a newline is a clipboard paste delivered through
+            // the IME — e.g. Android's virtual-keyboard context-menu "Paste", which reaches neither
+            // Keys.onPressed nor the in-app menu. Inside a quote block the TextArea would insert it
+            // verbatim and break out of the quote, so route it through the same quote-aware paste
+            // path (pasteText → pasteFromClipboard) and consume the event to suppress the raw
+            // insertion. The committed text equals the clipboard for an OSK paste, so pasteText's
+            // ClipboardUtils-based logic (char limit, mention restore, "> " prefixing) applies.
+            if (imeEvent.commitString.length > 1 && imeEvent.commitString.includes("\n")
+                    && highlighter.isInQuoteBlock(root.cursorPosition)) {
+                root.pasteText()
+                imeEvent.accept()
+            }
         }
     }
 


### PR DESCRIPTION
### What does the PR do

When the cursors is inside quote block, wrap the pasted content (both internal and external paste) into quote block. It's done as as a single undo step, preserving proper undo/redo and cursor positioning.

Closes: #22087

### Affected areas
`ChatTextArea`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[Screencast from 26.08.2026 15:41:09.webm](https://github.com/user-attachments/assets/3dcc6d68-e806-4584-923d-92c21dd4bace)

### Impact on end user

Low

### How to test

Copy multi-line content, paste into chat input in a line with active quote block

### Risk 
Low
