### PR TITLE
feat(chat): add thread support for 1-1 and group conversations

### DIFF
--- a/src/app/modules/main/chat_section/active_item.nim
+++ b/src/app/modules/main/chat_section/active_item.nim
@@ -20,6 +20,7 @@ QtObject:
 
   proc setActiveItemData*(self: ActiveItem, item: ChatItem) =
     self.item = item
+    self.idChanged()
 
   # Used when there is no longer an active item (last channel was deleted)
   proc resetActiveItemData*(self: ActiveItem) =
@@ -82,6 +83,24 @@ QtObject:
 
   QtProperty[int] type:
     read = getType
+
+  proc getIsThread(self: ActiveItem): bool {.slot.} =
+    if(self.item.isNil):
+      return false
+    return self.item.isThread
+
+  QtProperty[bool] isThread:
+    read = getIsThread
+    notify = idChanged
+
+  proc getParentChatId(self: ActiveItem): string {.slot.} =
+    if(self.item.isNil):
+      return ""
+    return self.item.parentChatId
+
+  QtProperty[string] parentChatId:
+    read = getParentChatId
+    notify = idChanged
 
   proc getHasUnreadMessages(self: ActiveItem): bool {.slot.} =
     if(self.item.isNil):

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -519,8 +519,8 @@ proc muteChat*(self: Controller, chatId: string, interval: int) =
 proc unmuteChat*(self: Controller, chatId: string) =
   self.chatService.unmuteChat(chatId)
 
-proc markAllMessagesRead*(self: Controller, chatId: string) =
-  self.messageService.markAllMessagesRead(chatId)
+proc markAllMessagesRead*(self: Controller, chatId: string, threadId: string = "") =
+  self.messageService.markAllMessagesRead(chatId, threadId)
 
 proc clearChatHistory*(self: Controller, chatId: string) =
   self.chatService.clearChatHistory(chatId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -220,7 +220,7 @@ method onCategoryMuted*(self: AccessInterface, categoryId: string) {.base.} =
 method onCategoryUnmuted*(self: AccessInterface, categoryId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method markAllMessagesRead*(self: AccessInterface, chatId: string) {.base.} =
+method markAllMessagesRead*(self: AccessInterface, chatId: string, threadId: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method clearChatHistory*(self: AccessInterface, chatId: string) {.base.} =

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -18,6 +18,7 @@ type
     emoji: string
     description: string
     lastMessageTimestamp: int
+    sortTimestamp: int
     hasUnreadMessages: bool
     lastMessageText: string
     notificationsCount: int
@@ -92,6 +93,7 @@ proc initChatItem*(
     permissionsCheckOngoing: bool = false,
     isThread: bool = false,
     parentChatId: string = "",
+    sortTimestamp: int = -1,
     ): ChatItem =
   result = ChatItem()
   result.id = id
@@ -105,6 +107,7 @@ proc initChatItem*(
   result.description = description
   result.`type` = `type`
   result.lastMessageTimestamp = lastMessageTimestamp
+  result.sortTimestamp = if sortTimestamp == -1: lastMessageTimestamp else: sortTimestamp
   result.lastMessageText = lastMessageText
   result.hasUnreadMessages = hasUnreadMessages
   result.notificationsCount = notificationsCount
@@ -270,6 +273,12 @@ proc lastMessageTimestamp*(self: ChatItem): int =
 
 proc `lastMessageTimestamp=`*(self: var ChatItem, value: int) =
   self.lastMessageTimestamp = value
+
+proc sortTimestamp*(self: ChatItem): int =
+  self.sortTimestamp
+
+proc `sortTimestamp=`*(self: var ChatItem, value: int) =
+  self.sortTimestamp = value
 
 proc lastMessageText*(self: ChatItem): string =
   self.lastMessageText

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -43,6 +43,7 @@ type
     permissionsCheckOngoing: bool
     hidden: bool # cached: row hidden by its collapsed category (see recomputeHidden)
     isThread: bool
+    parentChatId: string
 
 # Row is hidden by its collapsed category. Active, unmuted-unread and
 # notification-carrying chats stay visible so the list can surface them.
@@ -90,6 +91,7 @@ proc initChatItem*(
     missingEncryptionKey: bool = false,
     permissionsCheckOngoing: bool = false,
     isThread: bool = false,
+    parentChatId: string = "",
     ): ChatItem =
   result = ChatItem()
   result.id = id
@@ -128,6 +130,7 @@ proc initChatItem*(
   result.permissionsCheckOngoing = permissionsCheckOngoing
   result.recomputeHidden()
   result.isThread = isThread
+  result.parentChatId = parentChatId
 
 proc `$`*(self: ChatItem): string =
   result = fmt"""chat_section/ChatItem(
@@ -200,6 +203,8 @@ proc toJsonNode*(self: ChatItem): JsonNode =
     "viewersCanPostReactions": self.viewersCanPostReactions,
     "hideIfPermissionsNotMet": self.hideIfPermissionsNotMet,
     "permissionsCheckOngoing": self.permissionsCheckOngoing,
+    "isThread": self.isThread,
+    "parentChatId": self.parentChatId,
   }
 
 proc delete*(self: ChatItem) =
@@ -416,3 +421,6 @@ proc `permissionsCheckOngoing=`*(self: var ChatItem, value: bool) =
 
 proc isThread*(self: ChatItem): bool =
   self.isThread
+
+proc parentChatId*(self: ChatItem): string =
+  self.parentChatId

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -17,6 +17,7 @@ type
     Description
     Type
     LastMessageTimestamp
+    SortTimestamp
     LastMessageText
     HasUnreadMessages
     NotificationsCount
@@ -119,6 +120,7 @@ QtObject:
       ModelRole.Description.int:"description",
       ModelRole.Type.int:"type",
       ModelRole.LastMessageTimestamp.int:"lastMessageTimestamp",
+      ModelRole.SortTimestamp.int:"sortTimestamp",
       ModelRole.LastMessageText.int:"lastMessageText",
       ModelRole.HasUnreadMessages.int:"hasUnreadMessages",
       ModelRole.NotificationsCount.int:"notificationsCount",
@@ -179,6 +181,8 @@ QtObject:
       result = newQVariant(item.`type`)
     of ModelRole.LastMessageTimestamp:
       result = newQVariant(item.lastMessageTimestamp)
+    of ModelRole.SortTimestamp:
+      result = newQVariant(item.sortTimestamp)
     of ModelRole.LastMessageText:
       result = newQVariant(item.lastMessageText)
     of ModelRole.HasUnreadMessages:
@@ -548,6 +552,12 @@ QtObject:
     updateItemRolesAndNotify self.getItemIdxById(id):
       updateRole(lastMessageText)
       updateRole(lastMessageTimestamp)
+      updateRoleWithValue(sortTimestamp, lastMessageTimestamp)
+
+    for ind in 0 ..< self.items.len:
+      if self.items[ind].isThread and self.items[ind].parentChatId == id:
+        updateRolesAndNotify:
+          updateRoleWithValue(sortTimestamp, lastMessageTimestamp)
 
   proc reorderChats*(
       self: Model,

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -45,6 +45,8 @@ type
     PermissionsCheckOngoing
     Hidden # derived: chat hidden by its collapsed category
            # (depends on CategoryOpened, Active, Muted, HasUnreadMessages, NotificationsCount)
+    IsThread
+    ParentChatId
 
 QtObject:
   type
@@ -143,6 +145,8 @@ QtObject:
       ModelRole.MissingEncryptionKey.int:"missingEncryptionKey",
       ModelRole.PermissionsCheckOngoing.int:"permissionsCheckOngoing",
       ModelRole.Hidden.int:"hidden",
+      ModelRole.IsThread.int:"isThread",
+      ModelRole.ParentChatId.int:"parentChatId",
 
     }.toTable
 
@@ -227,6 +231,10 @@ QtObject:
       return newQVariant(item.permissionsCheckOngoing)
     of ModelRole.Hidden:
       return newQVariant(item.hidden)
+    of ModelRole.IsThread:
+      return newQVariant(item.isThread)
+    of ModelRole.ParentChatId:
+      return newQVariant(item.parentChatId)
 
   proc getItemIdxById(items: seq[ChatItem], id: string): int =
     var idx = 0

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -532,6 +532,7 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
     canView = parentItem.canView,
     canPostReactions = parentItem.canPostReactions,
     isThread = true,
+    parentChatId = parentChatId,
   )
 
   self.view.chatsModel().appendItemAfterParent(threadItem, parentIndex)
@@ -982,9 +983,24 @@ method onReorderCategory*(self: Module, catId: string, position: int) =
 method onCategoryNameChanged*(self: Module, category: Category) =
   self.view.chatsModel().renameCategory(category.id, category.name)
 
+proc removeThreadsForParent(self: Module, parentChatId: string) =
+  var threadIds: seq[string]
+  for item in self.view.chatsModel().items:
+    if item.isThread and item.parentChatId == parentChatId:
+      threadIds.add(item.id)
+
+  for threadId in threadIds:
+    self.view.chatsModel().removeItemById(threadId)
+    self.removeSubmodule(threadId)
+    self.threadChatIds.excl(threadId)
+
 method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
   if not self.chatContentModules.contains(chatId):
     return
+  if self.isChatThread(chatId):
+    self.threadChatIds.excl(chatId)
+  else:
+    self.removeThreadsForParent(chatId)
   self.view.chatsModel().removeItemById(chatId)
   self.removeSubmodule(chatId)
 
@@ -1265,8 +1281,8 @@ method onMarkMessageAsUnread*(self: Module, chat: ChatDto) =
 method onSectionMutedChanged*(self: Module) =
   self.updateParentBadgeNotifications()
 
-method markAllMessagesRead*(self: Module, chatId: string) =
-  self.controller.markAllMessagesRead(chatId)
+method markAllMessagesRead*(self: Module, chatId: string, threadId: string = "") =
+  self.controller.markAllMessagesRead(chatId, threadId)
 
 method clearChatHistory*(self: Module, chatId: string) =
   self.controller.clearChatHistory(chatId)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -533,6 +533,7 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
     canPostReactions = parentItem.canPostReactions,
     isThread = true,
     parentChatId = parentChatId,
+    sortTimestamp = parentItem.lastMessageTimestamp,
   )
 
   self.view.chatsModel().appendItemAfterParent(threadItem, parentIndex)
@@ -541,7 +542,12 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
 
 proc updateActiveChatMembership*(self: Module) =
   let activeChatId = self.controller.getActiveChatId()
-  let chat = self.controller.getChatDetails(activeChatId)
+  let activeChatItem = self.view.chatsModel().getItemById(activeChatId)
+  let membershipChatId = if not activeChatItem.isNil and activeChatItem.isThread:
+      activeChatItem.parentChatId
+    else:
+      activeChatId
+  let chat = self.controller.getChatDetails(membershipChatId)
 
   if chat.chatType == ChatType.PrivateGroupChat:
     let amIMember = any(chat.members, proc (member: ChatMember): bool = member.id == singletonInstance.userProfile.getPubKey())
@@ -1005,7 +1011,7 @@ method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
   self.removeSubmodule(chatId)
 
   let activeChatId = self.controller.getActiveChatId()
-  if chatId == activeChatId:
+  if self.view.chatsModel().getItemById(activeChatId).isNil:
     self.setFirstChannelAsActive()
 
   self.updateParentBadgeNotifications()

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -163,8 +163,8 @@ QtObject:
   proc unmuteCategory*(self: View, categoryId: string) {.slot.} =
     self.delegate.unmuteCategory(categoryId)
 
-  proc markAllMessagesRead*(self: View, chatId: string) {.slot.} =
-    self.delegate.markAllMessagesRead(chatId)
+  proc markAllMessagesRead*(self: View, chatId: string, threadId: string = "") {.slot.} =
+    self.delegate.markAllMessagesRead(chatId, threadId)
 
   proc clearChatHistory*(self: View, chatId: string) {.slot.} =
     self.delegate.clearChatHistory(chatId)

--- a/test/nim/chat_section_model_test.nim
+++ b/test/nim/chat_section_model_test.nim
@@ -115,6 +115,36 @@ suite "updating chat items":
     let chat = model.getItemById("0xc")
     check(chat.categoryOpened == false)
 
+  test "parent timestamp updates thread sort timestamps":
+    let parent = createTestChatItem("0xparent")
+    let thread = initChatItem(
+      id = "0xthread",
+      name = "",
+      usesDefaultName = true,
+      icon = "",
+      color = "",
+      emoji = "",
+      description = "",
+      `type` = 0,
+      memberRole = MemberRole.None,
+      lastMessageTimestamp = 0,
+      lastMessageText = "",
+      hasUnreadMessages = false,
+      notificationsCount = 0,
+      muted = false,
+      blocked = false,
+      active = false,
+      position = 0,
+      isThread = true,
+      parentChatId = parent.id,
+    )
+    model.setData(@[parent, thread])
+
+    model.updateLastMessageOnItemById("0xparent", "new message", 123)
+
+    check(parent.sortTimestamp == 123)
+    check(thread.sortTimestamp == 123)
+
 suite "hidden role (chat list virtualization)":
   setup:
     # fresh items per test — ChatItem is a ref, shared globals leak state

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -601,19 +601,22 @@ QtObject {
         }
 
         property var oneToOneContactModelEntryLoader: Loader {
-            active: d.activeChatId && d.activeChatType === Constants.chatType.oneToOne
+            active: d.activeContactId && d.activeChatType === Constants.chatType.oneToOne
 
             sourceComponent: ContactModelEntry {
-                publicKey: d.activeChatId
+                publicKey: d.activeContactId
                 contactsModel: root.contactsModel
                 onPopulateContactDetailsRequested: {
-                    root.populateContactDetailsRequested(d.activeChatId)
+                    root.populateContactDetailsRequested(d.activeContactId)
                 }
             }
         }
 
         readonly property string activeChatId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ? chatCommunitySectionModule.activeItem.id : ""
         readonly property int activeChatType: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ? chatCommunitySectionModule.activeItem.type : -1
+        readonly property bool activeIsThread: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ? chatCommunitySectionModule.activeItem.isThread : false
+        readonly property string activeContactId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ?
+                                                     (d.activeIsThread ? chatCommunitySectionModule.activeItem.parentChatId : d.activeChatId) : ""
         readonly property bool amIMember: chatCommunitySectionModule ? chatCommunitySectionModule.amIMember : false
 
         property var oneToOneChatContact: oneToOneContactModelEntryLoader.active ? d.oneToOneContactModelEntryLoader.item.contactDetails : undefined

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -516,7 +516,7 @@ Item {
                         }
                         onOpenThread: (messageId) => {
                             if (root.threadsFeatureEnabled
-                                    && root.activeChatType === Constants.chatType.communityChat
+                                    && Utils.isThreadSupportedChatType(root.activeChatType)
                                     && !d.activeMessagesStore.threadId) {
                                 d.activeMessagesStore.createThread(messageId)
                             }

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -115,20 +115,10 @@ Item {
                     }
                 ]
                 sorters: FastExpressionSorter {
-                    expectedRoles: ["itemId", "parentChatId", "isThread", "lastMessageTimestamp", "position"]
+                    expectedRoles: ["sortTimestamp", "isThread", "position"]
                     expression: {
-                        function timestampFor(item) {
-                            if (!item.isThread)
-                                return item.lastMessageTimestamp
-
-                            const parent = JSON.parse(root.chatSectionModule.getItemAsJson(item.parentChatId))
-                            return parent.lastMessageTimestamp
-                        }
-
-                        const leftTimestamp = timestampFor(modelLeft)
-                        const rightTimestamp = timestampFor(modelRight)
-                        if (leftTimestamp !== rightTimestamp)
-                            return rightTimestamp - leftTimestamp
+                        if (modelLeft.sortTimestamp !== modelRight.sortTimestamp)
+                            return modelRight.sortTimestamp - modelLeft.sortTimestamp
 
                         if (modelLeft.isThread !== modelRight.isThread)
                             return modelLeft.isThread ? 1 : -1
@@ -163,7 +153,7 @@ Item {
                     amIChatAdmin = obj.memberRole === Constants.memberRole.owner ||
                             obj.memberRole === Constants.memberRole.admin ||
                             obj.memberRole === Constants.memberRole.tokenMaster
-                    chatId = obj.itemId
+                    chatId = obj.isThread ? obj.parentChatId : obj.itemId
                     chatName = obj.name
                     chatDescription = obj.description
                     chatEmoji = obj.emoji

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import StatusQ
 import StatusQ.Core
 import StatusQ.Core.Utils as SQUtils
 import StatusQ.Core.Theme
@@ -113,9 +114,27 @@ Item {
                         enabled: searchInput.visible && !!searchPhrase
                     }
                 ]
-                sorters: RoleSorter {
-                    roleName: "lastMessageTimestamp"
-                    sortOrder: Qt.DescendingOrder
+                sorters: FastExpressionSorter {
+                    expectedRoles: ["itemId", "parentChatId", "isThread", "lastMessageTimestamp", "position"]
+                    expression: {
+                        function timestampFor(item) {
+                            if (!item.isThread)
+                                return item.lastMessageTimestamp
+
+                            const parent = JSON.parse(root.chatSectionModule.getItemAsJson(item.parentChatId))
+                            return parent.lastMessageTimestamp
+                        }
+
+                        const leftTimestamp = timestampFor(modelLeft)
+                        const rightTimestamp = timestampFor(modelRight)
+                        if (leftTimestamp !== rightTimestamp)
+                            return rightTimestamp - leftTimestamp
+
+                        if (modelLeft.isThread !== modelRight.isThread)
+                            return modelLeft.isThread ? 1 : -1
+
+                        return modelLeft.position - modelRight.position
+                    }
                 }
             }
 
@@ -152,6 +171,8 @@ Item {
                     chatIcon = obj.icon
                     chatType = obj.type
                     chatMuted = obj.muted
+                    isThread = obj.isThread
+                    threadId = obj.isThread ? obj.itemId : ""
                 }
 
                 onMuteChat: (chatId, interval) => {
@@ -162,8 +183,8 @@ Item {
                     root.chatSectionModule.unmuteChat(chatId)
                 }
 
-                onMarkAllMessagesRead: (chatId) => {
-                    root.chatSectionModule.markAllMessagesRead(chatId)
+                onMarkAllMessagesRead: (chatId, threadId) => {
+                    root.chatSectionModule.markAllMessagesRead(chatId, threadId)
                 }
 
                 onClearChatHistory: (chatId) => {

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -320,7 +320,7 @@ Item {
 
                             isCommunityChat = root.communitySectionModule.isCommunity()
                             amIChatAdmin = root.isSectionAdmin
-                            chatId = obj.itemId
+                            chatId = obj.isThread ? obj.parentChatId : obj.itemId
                             chatName = obj.name
                             chatDescription = obj.description
                             chatIcon = obj.icon

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -328,6 +328,8 @@ Item {
                             chatColor = obj.color
                             chatType = obj.type
                             chatMuted = obj.muted
+                            isThread = obj.isThread
+                            threadId = obj.isThread ? obj.itemId : ""
                             channelPosition = obj.position
                             chatCategoryId = obj.categoryId
                             viewersCanPostReactions = obj.viewersCanPostReactions
@@ -347,8 +349,8 @@ Item {
                         root.communitySectionModule.unmuteChat(chatId)
                     }
 
-                    onMarkAllMessagesRead: (chatId) => {
-                        root.communitySectionModule.markAllMessagesRead(chatId)
+                    onMarkAllMessagesRead: (chatId, threadId) => {
+                        root.communitySectionModule.markAllMessagesRead(chatId, threadId)
                     }
 
                     onClearChatHistory: (chatId) => {

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -17,6 +17,7 @@ StatusMenu {
     property bool isCommunityChat: false
     property bool amIChatAdmin: false
     property string chatId: ""
+    property string threadId: ""
     property string chatName: ""
     property string chatDescription: ""
     property string chatEmoji: ""
@@ -30,12 +31,13 @@ StatusMenu {
     property bool showDebugOptions: false
     property alias deleteChatConfirmationDialog: deleteChatConfirmationDialogComponent
     property bool hideIfPermissionsNotMet: false
+    property bool isThread: false
 
     signal displayProfilePopup(string publicKey)
     signal displayEditChannelPopup(string chatId)
     signal unmuteChat(string chatId)
     signal muteChat(string chatId, int interval)
-    signal markAllMessagesRead(string chatId)
+    signal markAllMessagesRead(string chatId, string threadId)
     signal clearChatHistory(string chatId)
     signal deleteCommunityChat(string chatId)
     signal leaveChat(string chatId)
@@ -46,7 +48,7 @@ StatusMenu {
     width: root.amIChatAdmin && (root.chatType === Constants.chatType.privateGroupChat) ? 207 : implicitWidth
 
     ViewProfileMenuItem {
-        enabled: root.chatType === Constants.chatType.oneToOne
+        enabled: !root.isThread && root.chatType === Constants.chatType.oneToOne
         onTriggered: root.displayProfilePopup(root.chatId)
     }
 
@@ -54,7 +56,7 @@ StatusMenu {
         objectName: "addRemoveFromGroupStatusAction"
         text: root.amIChatAdmin ? qsTr("Add / remove from group") : qsTr("Add to group")
         icon.name: "add-to-dm"
-        enabled: (root.chatType === Constants.chatType.privateGroupChat)
+        enabled: !root.isThread && root.chatType === Constants.chatType.privateGroupChat
         onTriggered: { root.addRemoveGroupMember() }
     }
 
@@ -62,7 +64,7 @@ StatusMenu {
         objectName: "copyChannelLinkStatusAction"
         text: qsTr("Copy channel link")
         icon.name: "copy"
-        enabled: root.isCommunityChat
+        enabled: !root.isThread && root.isCommunityChat
         onTriggered: {
             const link = Utils.getCommunityChannelShareLinkWithChatId(root.chatId)
             ClipboardUtils.setText(link)
@@ -70,14 +72,14 @@ StatusMenu {
     }
 
     StatusMenuSeparator {
-        visible: root.chatType === Constants.chatType.oneToOne || root.chatType === Constants.chatType.privateGroupChat || root.isCommunityChat
+        visible: !root.isThread && (root.chatType === Constants.chatType.oneToOne || root.chatType === Constants.chatType.privateGroupChat || root.isCommunityChat)
     }
 
     StatusAction {
         objectName: "editNameAndImageMenuItem"
         text: qsTr("Edit name and image")
         icon.name: "edit_pencil"
-        enabled: root.chatType === Constants.chatType.privateGroupChat
+        enabled: !root.isThread && root.chatType === Constants.chatType.privateGroupChat
         onTriggered: {
             Global.openPopup(renameGroupPopupComponent, {
                 activeGroupName: root.chatName,
@@ -99,7 +101,7 @@ StatusMenu {
     }
 
     MuteChatMenuItem {
-        enabled: !root.chatMuted
+        enabled: !root.isThread && !root.chatMuted
         isCommunityChat: root.isCommunityChat
 
         onMuteTriggered: {
@@ -109,7 +111,7 @@ StatusMenu {
 
     StatusAction {
         objectName: "muteChatStatusAction"
-        enabled: root.chatMuted
+        enabled: !root.isThread && root.chatMuted
         text: root.isCommunityChat ? qsTr("Unmute Channel") : qsTr("Unmute Chat")
         icon.name: "notification"
         onTriggered: {
@@ -121,8 +123,9 @@ StatusMenu {
         objectName: "chatMarkAsReadMenuItem"
         text: qsTr("Mark as Read")
         icon.name: "checkmark-circle"
+        enabled: !root.isThread
         onTriggered: {
-            root.markAllMessagesRead(root.chatId)
+            root.markAllMessagesRead(root.chatId, root.threadId)
         }
     }
 
@@ -138,7 +141,7 @@ StatusMenu {
 
     StatusMenu {
         title: qsTr("Debug actions")
-        enabled: root.showDebugOptions
+        enabled: root.showDebugOptions && !root.isThread
 
         StatusAction {
             text: root.isCommunityChat ? qsTr("Copy channel ID") : qsTr("Copy chat ID")
@@ -154,7 +157,7 @@ StatusMenu {
     StatusAction {
         id: clearHistoryGroupMenuItem
         objectName: "clearHistoryGroupMenuItem"
-        enabled: (root.chatType !== Constants.chatType.oneToOne)
+        enabled: !root.isThread && (root.chatType !== Constants.chatType.oneToOne)
         text: qsTr("Clear History")
         icon.name: "delete"
         type: StatusAction.Type.Danger
@@ -189,13 +192,13 @@ StatusMenu {
             }
         }
 
-        enabled: !root.isCommunityChat || root.amIChatAdmin
+        enabled: !root.isThread && (!root.isCommunityChat || root.amIChatAdmin)
     }
 
     StatusAction {
         id: clearHistoryMenuItem
         objectName: "clearHistoryMenuItem"
-        enabled: (root.chatType === Constants.chatType.oneToOne)
+        enabled: !root.isThread && (root.chatType === Constants.chatType.oneToOne)
         text: qsTr("Clear History")
         icon.name: "delete"
         type: StatusAction.Type.Danger

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -123,7 +123,6 @@ StatusMenu {
         objectName: "chatMarkAsReadMenuItem"
         text: qsTr("Mark as Read")
         icon.name: "checkmark-circle"
-        enabled: !root.isThread
         onTriggered: {
             root.markAllMessagesRead(root.chatId, root.threadId)
         }
@@ -133,7 +132,7 @@ StatusMenu {
         objectName: "editChannelMenuItem"
         text: qsTr("Edit Channel")
         icon.name: "edit"
-        enabled: root.isCommunityChat && root.amIChatAdmin
+        enabled: root.isCommunityChat && root.amIChatAdmin && !root.isThread
         onTriggered: {
             root.displayEditChannelPopup(root.chatId);
         }
@@ -141,12 +140,13 @@ StatusMenu {
 
     StatusMenu {
         title: qsTr("Debug actions")
-        enabled: root.showDebugOptions && !root.isThread
+        enabled: root.showDebugOptions
 
         StatusAction {
-            text: root.isCommunityChat ? qsTr("Copy channel ID") : qsTr("Copy chat ID")
+            text: root.isThread ? qsTr("Copy thread ID") :
+                                  root.isCommunityChat ? qsTr("Copy channel ID") : qsTr("Copy chat ID")
             icon.name: "copy"
-            onTriggered: ClipboardUtils.setText(root.chatId)
+            onTriggered: ClipboardUtils.setText(root.isThread ? root.threadId : root.chatId)
         }
     }
 

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -342,7 +342,7 @@ StatusMenu {
         onTriggered: root.openThread()
         enabled: !root.disabledForChat &&
                 root.threadsFeatureEnabled &&
-                root.chatType === Constants.chatType.communityChat
+                Utils.isThreadSupportedChatType(root.chatType)
     }
 
     MsgCtxAction {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -1337,6 +1337,12 @@ QtObject {
         return getCommunityChannelShareLink(communityId, channelId)
     }
 
+    function isThreadSupportedChatType(chatType) {
+        return chatType === Constants.chatType.communityChat ||
+                chatType === Constants.chatType.oneToOne ||
+                chatType === Constants.chatType.privateGroupChat
+    }
+
     function getCommunityDataFromSharedLink(link: string) {
         const communityDataString = sharedUrlsModuleInst.parseCommunitySharedUrl(link)
         try {


### PR DESCRIPTION
### What does the PR do

Fixes #21895
status-go PR: https://github.com/status-im/status-go/pull/7767

Expose thread actions for supported personal and group chats and display threads as child chat rows. Preserve parent-chat context for contacts, message loading, sending, context-menu actions, and per-thread read state.

### Affected areas

- chat_section module files
- chat root store
- chat context menu

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[thread-groups-and-1-1.webm](https://github.com/user-attachments/assets/6e332d56-2d74-4ead-92c9-70839fccb2c2)

### Impact on end user

Enables to create threads in all types of chats available

### How to test

Use the feature flags (see root PR)

### Risk 

None because of feature flag. Once enabled, there might be some small issues with chat ordering and unread messages
