### PR TITLE
ChatTextArea: wrap url when pasted over selection

### DIFF
--- a/storybook/qmlTests/tests/tst_ChatTextArea.qml
+++ b/storybook/qmlTests/tests/tst_ChatTextArea.qml
@@ -843,6 +843,130 @@ Item {
             compare(control.cursorPosition, control.length)
         }
 
+        // ── paste URL over selection: link wrapping ──────────────────────────────
+
+        // Pasting a URL while plain text is selected wraps the selection as the link's label
+        // ("[selection](url)") instead of replacing it, with the caret left just after the ")".
+        function test_pasteUrlOverSelection_wrapsAsLink() {
+            control.text = "Hello world"
+            control.forceActiveFocus()
+            control.select(6, 11) // select "world"
+            ClipboardUtils.setText("http://link.com")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "Hello [world](http://link.com)")
+            compare(control.cursorPosition, control.length) // right after the closing ")"
+        }
+
+        // With no selection, a pasted URL is inserted verbatim — no bracketing.
+        function test_pasteUrlNoSelection_insertsVerbatim() {
+            control.text = "Hello "
+            control.forceActiveFocus()
+            control.cursorPosition = control.length
+            ClipboardUtils.setText("http://link.com")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "Hello http://link.com")
+        }
+
+        // Pasting non-URL text over a selection still replaces it (the wrapping is URL-only).
+        function test_pasteNonUrlOverSelection_replaces() {
+            control.text = "Hello world"
+            control.forceActiveFocus()
+            control.select(6, 11) // select "world"
+            ClipboardUtils.setText("there")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "Hello there")
+        }
+
+        // The link wrap is one undo step: a single Ctrl+Z restores the pre-paste text.
+        function test_pasteUrlOverSelection_singleUndoRestores() {
+            control.text = "Hello world"
+            control.forceActiveFocus()
+            control.select(6, 11)
+            ClipboardUtils.setText("http://link.com")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+            tryCompare(control, "text", "Hello [world](http://link.com)")
+
+            keyClick(Qt.Key_Z, Qt.ControlModifier)
+            compare(control.text, "Hello world")
+        }
+
+        // Undoing the link wrap restores the caret to the end of the originally-selected text
+        // (like a normal paste-over-selection undo), not collapsed to the document start.
+        function test_pasteUrlOverSelection_undoRestoresCaretAfterSelection() {
+            control.text = "Hello world"
+            control.forceActiveFocus()
+            control.select(6, 11) // select "world"
+            ClipboardUtils.setText("http://link.com")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+            tryCompare(control, "text", "Hello [world](http://link.com)")
+
+            keyClick(Qt.Key_Z, Qt.ControlModifier)
+            compare(control.text, "Hello world")
+            compare(control.cursorPosition, 11) // end of the restored "world", not the doc start
+        }
+
+        // A selection containing a mention pill is not clean plain text, so the URL replaces the
+        // selection (falls back to a normal paste) rather than wrapping it.
+        function test_pasteUrlOverMentionSelection_fallsBack() {
+            const M = makeMentionDoc() // "A<mention>B"
+            control.forceActiveFocus()
+            control.selectAll()
+            ClipboardUtils.setText("http://link.com")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "http://link.com")
+            tryCompare(mentionsRepeater, "count", 0)
+        }
+
+        // A selection spanning a line break cannot be a single-line label, so the URL replaces it.
+        function test_pasteUrlOverMultilineSelection_fallsBack() {
+            control.text = "a\nb"
+            control.forceActiveFocus()
+            control.selectAll()
+            ClipboardUtils.setText("http://link.com")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "http://link.com")
+        }
+
+        // Link wrapping works inside a quote block: the selection is kept in the quote as the label.
+        function test_pasteUrlOverSelectionInQuote_wraps() {
+            control.text = "> Hello world"
+            control.forceActiveFocus()
+            control.select(8, 13) // select "world"
+            ClipboardUtils.setText("http://link.com")
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            tryCompare(control, "text", "> Hello [world](http://link.com)")
+        }
+
+        // A wrap that would exceed the character limit is rejected whole: nothing is inserted and
+        // attemptToExceedHardLimit fires (the kept selection plus wrapping syntax is counted).
+        function test_pasteUrlWrapExceedsLimit_rejected() {
+            control.characterLimit = 12
+            control.text = "Hello world" // length 11
+            control.forceActiveFocus()
+            control.select(6, 11)
+            ClipboardUtils.setText("http://link.com")
+            limitSpy.clear()
+
+            keyClick(Qt.Key_V, Qt.ControlModifier)
+
+            compare(control.text, "Hello world") // unchanged
+            compare(limitSpy.count, 1)
+        }
+
         // ── IME commit paste ──────────────────
 
         // Pasting via the on-screen keyboard's context menu arrives as an IME commit string, not a
@@ -901,6 +1025,20 @@ Item {
             imeTester.commit(control, "x")
 
             tryCompare(control, "text", "> x")
+        }
+
+        // An OSK "Paste" of a single URL over a selection arrives as a plain (newline-free) IME
+        // commit; the filter reroutes it through pasteText() so the selection is wrapped as the
+        // link's label rather than replaced.
+        function test_imeCommitUrlOverSelection_wrapsAsLink() {
+            control.text = "Hello world"
+            control.forceActiveFocus()
+            control.select(6, 11) // select "world"
+            ClipboardUtils.setText("http://link.com")
+
+            imeTester.commit(control, "http://link.com")
+
+            tryCompare(control, "text", "Hello [world](http://link.com)")
         }
 
         // ── IME commit: quote continuation (OSK new-line) ────────────────────────

--- a/ui/StatusQ/include/StatusQ/chatinputhighlighter.h
+++ b/ui/StatusQ/include/StatusQ/chatinputhighlighter.h
@@ -143,6 +143,20 @@ public:
     Q_INVOKABLE void pasteFromClipboard(int selectionStart, int selectionEnd,
                                         int cursorPosition);
 
+    // True when the whole trimmed `text` is exactly one auto-detected URL (a single full-span
+    // link, no surrounding text, no bracket/paren characters). Used to decide whether a paste
+    // over a selection should wrap it as a markdown link label.
+    Q_INVOKABLE bool isSingleUrl(const QString& text) const;
+
+    // True when `[start, end)` contains only plain text — no mention pills, no inline emoji image
+    // objects, and no paragraph/line break. Guards the "wrap only clean text" rule for link paste.
+    Q_INVOKABLE bool isPlainTextRange(int start, int end) const;
+
+    // Wraps `[start, end)` as a markdown link label: inserts "[" at start and "](url)" at end,
+    // preserving the selected text as the label, as a single undo step. The caller repositions
+    // the caret (typically to just after the closing ")").
+    Q_INVOKABLE void wrapSelectionInLink(int start, int end, const QString& url);
+
     // Returns the whole document as plain text, each mention pill rendered as its "@"+pubKey
     // wire form and paragraph separators as '\n'. Inverse of setTextWithMentions.
     Q_INVOKABLE QString textWithMentions() const;

--- a/ui/StatusQ/src/chatinputhighlighter.cpp
+++ b/ui/StatusQ/src/chatinputhighlighter.cpp
@@ -858,6 +858,61 @@ void ChatInputHighlighter::pasteFromClipboard(int selectionStart, int selectionE
     cursor.endEditBlock();
 }
 
+bool ChatInputHighlighter::isSingleUrl(const QString& text) const
+{
+    const QString trimmed = text.trimmed();
+    if (trimmed.isEmpty())
+        return false;
+    // A genuine bare URL never contains brackets/parens or whitespace (the autolink rule stops at
+    // them), while an explicit "[label](url)" string does — reject those so they are not mistaken
+    // for a single URL and wrapped again.
+    for (const QChar c : trimmed) {
+        if (c.isSpace() || c == QLatin1Char('[') || c == QLatin1Char(']')
+                || c == QLatin1Char('(') || c == QLatin1Char(')')
+                || c == QLatin1Char('{') || c == QLatin1Char('}'))
+            return false;
+    }
+    const QVariantList links = parseLinks(trimmed);
+    if (links.size() != 1)
+        return false;
+    const QVariantMap link = links.first().toMap();
+    return link.value(QStringLiteral("start")).toInt() == 0
+            && link.value(QStringLiteral("length")).toInt() == trimmed.size();
+}
+
+bool ChatInputHighlighter::isPlainTextRange(int start, int end) const
+{
+    if (!document() || start >= end)
+        return false;
+
+    QTextCursor cursor(document());
+    cursor.setPosition(start);
+    cursor.setPosition(end, QTextCursor::KeepAnchor);
+    const QString sel = cursor.selectedText();
+    // U+2029 (ParagraphSeparator) marks a block/newline break; U+FFFC (ObjectReplacementCharacter)
+    // marks a mention pill or an inline emoji image. Either disqualifies the range from being a
+    // clean, single-line plain-text label.
+    return !sel.contains(QChar::ParagraphSeparator)
+            && !sel.contains(QChar::ObjectReplacementCharacter);
+}
+
+void ChatInputHighlighter::wrapSelectionInLink(int start, int end, const QString& url)
+{
+    if (!document() || start >= end)
+        return;
+
+    // Put the selection *on the cursor* and replace it with "[" + label + "](url)" in a single
+    // insert. Because it is one selection-aware operation (not brackets inserted around the text),
+    // a single Ctrl+Z restores the original text with the caret back at the end of the selection —
+    // rather than two undo steps that collapse the caret to the document start. The range is
+    // guaranteed plain text by the caller (isPlainTextRange), so the label is safe to re-insert.
+    QTextCursor cursor(document());
+    cursor.setPosition(start);
+    cursor.setPosition(end, QTextCursor::KeepAnchor);
+    const QString label = cursor.selectedText();
+    cursor.insertText(QLatin1Char('[') + label + QStringLiteral("](") + url + QLatin1Char(')'));
+}
+
 QString ChatInputHighlighter::textWithMentions() const
 {
     if (!document())

--- a/ui/imports/shared/status/ChatTextArea.qml
+++ b/ui/imports/shared/status/ChatTextArea.qml
@@ -176,14 +176,34 @@ StatusTextArea {
             root.pasteImageRequested()
             return
         }
+        // With a plain-text selection active, pasting a bare URL turns the selection into the
+        // link's label ("[selection](url)") instead of replacing it. Only clean single-line text
+        // qualifies — pills, emoji or newlines fall back to a normal replace (isPlainTextRange).
+        const selLen = root.selectionEnd - root.selectionStart
+        const url = ClipboardUtils.text.trim()
+        const wrapAsLink = selLen > 0
+                && highlighter.isSingleUrl(url)
+                && highlighter.isPlainTextRange(root.selectionStart, root.selectionEnd)
+
         // The clipboard's plain text length is the character count; for an internal
         // mention paste this slightly over-counts (names vs 1-char pills), erring
-        // toward stricter blocking.
-        const selLen = root.selectionEnd - root.selectionStart
-        if (root.length - selLen + ClipboardUtils.text.length > root.characterLimit) {
+        // toward stricter blocking. When wrapping, the selection is kept as the label, so the
+        // added length is the wrapping syntax ("[", "](", ")") plus the url — not url − selection.
+        const newLength = wrapAsLink ? root.length + 4 + url.length
+                                     : root.length - selLen + ClipboardUtils.text.length
+        if (newLength > root.characterLimit) {
             root.attemptToExceedHardLimit()
             return
         }
+
+        if (wrapAsLink) {
+            const start = root.selectionStart
+            highlighter.wrapSelectionInLink(start, root.selectionEnd, url)
+            root.cursorPosition = start + selLen + url.length + 4 // just after the closing ")"
+            d.ensureCursorRectanglePosition()
+            return
+        }
+
         highlighter.pasteFromClipboard(root.selectionStart, root.selectionEnd,
                                        root.cursorPosition)
         d.ensureCursorRectanglePosition()
@@ -256,6 +276,17 @@ StatusTextArea {
             // ClipboardUtils-based logic (char limit, mention restore, "> " prefixing) applies.
             if (imeEvent.commitString.length > 1 && imeEvent.commitString.includes("\n")
                     && highlighter.isInQuoteBlock(root.cursorPosition)) {
+                root.pasteText()
+                imeEvent.accept()
+                return
+            }
+            // An OSK "Paste" of a single URL over a selection arrives as a plain (newline-free)
+            // commit, so it misses the branch above. Route it through the same pasteText() path so
+            // the selection-aware link wrapping applies, and consume the raw insertion. Gated on a
+            // live selection (rare during OSK typing) so ordinary typing is unaffected.
+            if (imeEvent.commitString.length > 1
+                    && root.selectionStart !== root.selectionEnd
+                    && highlighter.isSingleUrl(imeEvent.commitString)) {
                 root.pasteText()
                 imeEvent.accept()
             }


### PR DESCRIPTION
### What does the PR do

Wraps the link with a label from currently selected text

Closes: #21548


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`ChatTextArea`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[Screencast from 27.08.2026 12:27:22.webm](https://github.com/user-attachments/assets/9a1b443e-0457-4930-90d0-b5be16220ccf)

### Impact on end user
Low

### How to test

Copy link, select text in chat input (single line) and paste.

### Risk 
Low
