### PR TITLE
chore(@e2e): fix nightly failures and handling of activity center animation

### DIFF
--- a/test/e2e/gui/components/activity_center.py
+++ b/test/e2e/gui/components/activity_center.py
@@ -7,7 +7,6 @@ import object as squish_object
 
 import configs.timeouts
 import driver
-from driver.objects_access import find_notification_button_on_card
 from helpers.chat_helper import skip_message_backup_popup_if_visible
 from gui.elements.button import Button
 from gui.elements.object import QObject
@@ -15,9 +14,6 @@ from gui.elements.scroll import Scroll
 from gui.objects_map import names, activity_center_names
 
 LOG = logging.getLogger(__name__)
-
-_ACCEPT_BUTTON = activity_center_names.notificationCardAcceptButton['objectName']
-_DECLINE_BUTTON = activity_center_names.notificationCardDeclineButton['objectName']
 
 
 class ContactRequest:
@@ -29,30 +25,22 @@ class ContactRequest:
             self.contact_request = str(title).strip() if title not in (None, '') else None
         except Exception:
             self.contact_request = None
+        self.accept_button = Button(activity_center_names.notificationCardAcceptButton)
+        self.decline_button = Button(activity_center_names.notificationCardDeclineButton)
 
     def __repr__(self):
         return self.contact_request
 
-    def _button(self, object_name: str) -> Button:
-        btn = find_notification_button_on_card(self.object, object_name)
-        if btn is None:
-            raise LookupError(
-                f'Button {object_name!r} not found on notification card {self.contact_request!r}'
-            )
-        return Button(real_name=driver.objectMap.realName(btn))
-
     @allure.step('Accept request')
     def accept(self):
-        button = self._button(_ACCEPT_BUTTON)
-        button.click()
-        button.wait_until_hidden()
+        self.accept_button.click()
+        self.accept_button.wait_until_hidden()
         skip_message_backup_popup_if_visible()
 
     @allure.step('Decline request')
     def decline(self):
-        button = self._button(_DECLINE_BUTTON)
-        button.click()
-        button.wait_until_hidden()
+        self.decline_button.click()
+        self.decline_button.wait_until_hidden()
 
 
 class ActivityCenter(QObject):
@@ -111,9 +99,15 @@ class ActivityCenter(QObject):
         self._close_button.click()
         return self
 
+    @allure.step('Wait until activity center is fully open')
     def _scroll_notification_into_view(self, card_ref) -> None:
         """ListView may clip the row; clicks outside the viewport often do nothing."""
         try:
+            slide = driver.waitForObject(
+                activity_center_names.activityCenterSlideContainer,
+                configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
+            )
+            driver.waitFor(lambda: slide._fullyOpen, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
             list_obj = driver.waitForObject(
                 activity_center_names.activityCenterListView,
                 configs.timeouts.UI_LOAD_TIMEOUT_MSEC,

--- a/test/e2e/gui/elements/window.py
+++ b/test/e2e/gui/elements/window.py
@@ -24,23 +24,22 @@ class Window(QObject):
     @allure.step("Maximize {0}")
     def maximize(self):
         assert driver.toplevel_window.maximize(self.real_name), 'Maximize failed'
-        LOG.info('Window %s was maximized', self.title)
+        LOG.info('Window was maximized')
 
     @allure.step("Minimize {0}")
     def minimize(self):
-        title = self.title
         assert driver.toplevel_window.minimize(self.real_name), 'Minimize failed'
-        LOG.info('Window %s was minimized', title)
+        LOG.info('Window was minimized')
 
     @allure.step("Set focus on {0}")
     def set_focus(self):
         assert driver.toplevel_window.set_focus(self.real_name), 'Set focus failed'
-        LOG.info('Window %s was focused', self.title)
+        LOG.info('Window was focused')
 
     @allure.step("Move {0} on top")
     def on_top_level(self):
         assert driver.toplevel_window.on_top_level(self.real_name), 'Set on top failed'
-        LOG.info('Window %s moved on top', self.title)
+        LOG.info('Window moved on top')
 
     @allure.step("Close {0}")
     def close(self):
@@ -59,5 +58,5 @@ class Window(QObject):
 
     def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
         super().wait_until_appears(timeout_msec)
-        LOG.info('Window %s appears', self.title)
+        LOG.info('Window appears')
         return self

--- a/test/e2e/gui/objects_map/activity_center_names.py
+++ b/test/e2e/gui/objects_map/activity_center_names.py
@@ -3,6 +3,7 @@ from objectmaphelper import *
 
 # Map for activity center
 
+activityCenterSlideContainer = {"container": statusDesktop_mainWindow, "objectName": "activityCenterSlideContainer", "type": "Rectangle", "visible": True}
 activityCenterPanel = {"container": statusDesktop_mainWindow, "objectName": "activityCenterPanel", "type": "ActivityCenterPanel", "visible": True}
 activityCenterCloseButton = {"container": activityCenterPanel, "objectName": "closeButton", "type": "StatusFlatRoundButton", "visible": True}
 activityCenterListView = {"container": activityCenterPanel, "objectName": "listView", "type": "StatusListView", "visible": True}

--- a/test/e2e/gui/screens/messages.py
+++ b/test/e2e/gui/screens/messages.py
@@ -167,7 +167,13 @@ class Message:
         self.link_preview_title_object: typing.Optional[QObject] = None
         self._image_message: typing.Optional[QObject] = None
         self.banner_image: typing.Optional[QObject] = None
-        self.community_invitation: dict = {}
+        self._go_to_community_button: typing.Optional[Button] = None
+        self._community_invitation: dict = {}
+
+    @property
+    def community_invitation(self) -> dict:
+        self._ensure_ui_parsed()
+        return self._community_invitation
 
     @property
     def text(self) -> typing.Optional[str]:
@@ -207,10 +213,10 @@ class Message:
 
                     if object_name == 'StatusDateGroupLabel':
                         self.date = str(getattr(child, 'text', ''))
-                    elif child_id == 'title':
-                        self.community_invitation['name'] = str(getattr(child, 'text', ''))
-                    elif child_id == 'description':
-                        self.community_invitation['description'] = str(getattr(child, 'text', ''))
+                    elif object_name == 'communityName':
+                        self._community_invitation['name'] = str(getattr(child, 'text', ''))
+                    elif object_name == 'communityDescription':
+                        self._community_invitation['description'] = str(getattr(child, 'text', ''))
                     elif child_id == 'titleLayout':
                         self.link_preview_title_object = child
                     elif object_name == 'StatusTextMessage_chatText' or child_id == 'chatText':
@@ -233,6 +239,10 @@ class Message:
                                 self._image_message = child
                             case 'bannerImage':
                                 self.banner_image = QObject(real_name=driver.objectMap.realName(child))
+                            case 'joinBtn':
+                                self._go_to_community_button = Button(
+                                    real_name=driver.objectMap.realName(child)
+                                )
                 except (AttributeError, RuntimeError, LookupError):
                     # Skip children that can't be accessed safely
                     continue
@@ -272,6 +282,41 @@ class Message:
             raise LookupError(f'Message text bubble was not found for link {href!r}')
         text_bubble.linkActivated(href)
 
+    def _find_go_to_community_button(self) -> typing.Optional[Button]:
+        self._ensure_ui_parsed()
+        if self._go_to_community_button is not None:
+            return self._go_to_community_button
+        try:
+            for child in walk_children(self.object, self._UI_PARSE_DEPTH):
+                if str(getattr(child, 'text', '')) == 'Go to Community':
+                    return Button(real_name=driver.objectMap.realName(child))
+        except (RuntimeError, AttributeError, LookupError):
+            pass
+        return None
+
+    def _go_to_community_button_ready(self, button: Button) -> bool:
+        try:
+            obj = button.object
+            if not bool(getattr(obj, 'visible', False)):
+                return False
+            if bool(getattr(obj, 'loading', False)):
+                return False
+            return True
+        except (RuntimeError, AttributeError, LookupError):
+            return False
+
+    def _click_go_to_community_button(self) -> bool:
+        button = self._find_go_to_community_button()
+        if button is None:
+            return False
+        if not driver.waitFor(
+            lambda: self._go_to_community_button_ready(button),
+            configs.timeouts.COMMUNITY_LOAD_TIMEOUT_MSEC,
+        ):
+            return False
+        button.click()
+        return True
+
     @allure.step('Open community invitation')
     def open_community_invitation(
             self,
@@ -284,12 +329,18 @@ class Message:
                 f'expected={expected_link.strip()!r}, actual={community_link!r}'
             )
 
-        if community_link is not None:
-            self.activate_link(community_link)
+        if self._click_go_to_community_button():
+            return CommunityScreen().wait_for_content_loaded()
+
+        href = expected_link.strip() if expected_link else community_link
+        if href is not None:
+            self.activate_link(href)
         elif self.delegate_button is not None:
             self.delegate_button.click()
         else:
-            raise LookupError('Community invitation has neither a link nor a clickable delegate')
+            raise LookupError(
+                'Community invitation has neither a card button, a link, nor a clickable delegate'
+            )
 
         return CommunityScreen().wait_for_content_loaded()
 
@@ -496,11 +547,6 @@ class ChatView(QObject):
             )
         return message
 
-    @allure.step('Open community invitation')
-    def click_community_invite(self, community: str, index: int) -> 'CommunityScreen':
-        message = self.search_for_invitation(community, index)
-        return message.open_community_invitation()
-
     def _find_community_invitation_message(self, index: typing.Optional[int] = 0) -> typing.Optional[Message]:
         for _message in self.messages(index):
             if _message.has_community_invite():
@@ -514,42 +560,73 @@ class ChatView(QObject):
                 return message
         return None
 
+    def _invitation_matches_community(self, message: Message, community: str) -> bool:
+        invitation_name = message.community_invitation.get('name', '')
+        if invitation_name == community:
+            return True
+        return message.has_community_invite() and not invitation_name
+
+    def _find_named_invitation_message(
+            self,
+            community: str,
+            index: typing.Optional[int],
+    ) -> typing.Optional[Message]:
+        for _message in self.messages(index):
+            if self._invitation_matches_community(_message, community):
+                return _message
+        return None
+
+    def _find_invitation_message(
+            self,
+            community: typing.Optional[str] = None,
+            index: typing.Optional[int] = 0,
+    ) -> typing.Optional[Message]:
+        if community:
+            message = self._find_named_invitation_message(community, index)
+            if message is not None:
+                return message
+            for message_index in range(20):
+                message = self._find_named_invitation_message(community, message_index)
+                if message is not None:
+                    return message
+            return None
+
+        message = self._find_community_invitation_message(index)
+        if message is not None:
+            return message
+        return self._find_community_invitation_message_from_newest(0)
+
+    def _wait_for_invitation_message(
+            self,
+            community: typing.Optional[str] = None,
+            index: typing.Optional[int] = 0,
+            timeout_msec: int = configs.timeouts.MESSAGING_TIMEOUT_SEC * 1000,
+    ) -> Message:
+        message = None
+
+        def invitation_found() -> bool:
+            nonlocal message
+            message = self._find_invitation_message(community, index)
+            return message is not None
+
+        if not driver.waitFor(invitation_found, timeout_msec):
+            label = community or 'Community invitation'
+            raise LookupError(f'{label} was not found within {timeout_msec} ms')
+        return message
+
     @allure.step('Open community invitation without relying on preview name')
     def click_community_invite_message(
             self,
             index: int = 0,
             expected_link: str = None,
     ) -> CommunityScreen:
-        message = None
-
-        def invitation_found() -> bool:
-            nonlocal message
-            message = self._find_community_invitation_message(index)
-            if message is None:
-                message = self._find_community_invitation_message_from_newest(0)
-            return message is not None
-
-        timeout_msec = configs.timeouts.MESSAGING_TIMEOUT_SEC * 1000
-        if not driver.waitFor(invitation_found, timeout_msec):
-            raise LookupError(f'Community invitation was not found within {timeout_msec} ms')
+        message = self._wait_for_invitation_message(index=index)
         return message.open_community_invitation(expected_link=expected_link)
 
     @allure.step('Open banned community invitation')
     def open_banned_community(self, community, index) -> 'BannedCommunityScreen':
-        message = self.search_for_invitation(community, index)
+        message = self._wait_for_invitation_message(community=community, index=index)
         return message.open_banned_community_invitation()
-
-    def search_for_invitation(self, community, index):
-        message = None
-        started_at = time.monotonic()
-        while message is None:
-            for _message in self.messages(index):
-                if _message.community_invitation.get('name', '') == community:
-                    message = _message
-                    break
-            if time.monotonic() - started_at > 80:
-                raise LookupError(f'Community invitation was not found')
-        return message
 
     @allure.step('Wait until a sticker message appears in chat')
     def wait_until_sticker_message(

--- a/test/e2e/gui/screens/wallet.py
+++ b/test/e2e/gui/screens/wallet.py
@@ -29,8 +29,8 @@ from gui.elements.object import QObject
 from gui.elements.text_label import TextLabel
 from gui.objects_map import wallet_names, settings_names, names
 from helpers.wallet_helper import (
-    _asset_items_finished_loading,
     is_activity_tab_content_loaded,
+    is_assets_tab_content_loaded,
 )
 
 LOG = logging.getLogger(__name__)
@@ -408,17 +408,11 @@ class WalletAccountView(QObject):
         self,
         timeout_msec: int | None = configs.timeouts.WALLET_SYNC_TIMEOUT_MSEC,
     ):
-        assets_tab_view = QObject(wallet_names.assets_tab_view)
-
-        def assets_loaded():
-            if not assets_tab_view.is_visible:
-                return False
-            items = driver.findAllObjects(self._asset_item.real_name)
-            if not items:
-                return False
-            return _asset_items_finished_loading(self._asset_item)
-
-        _wait_until(assets_loaded, timeout_msec, 'Assets tab did not finish loading')
+        _wait_until(
+            lambda: is_assets_tab_content_loaded(self._asset_item),
+            timeout_msec,
+            'Assets tab did not finish loading',
+        )
         return self
 
     @allure.step('Wait for collectibles tab content to finish loading')

--- a/test/e2e/helpers/multiple_instances_helper.py
+++ b/test/e2e/helpers/multiple_instances_helper.py
@@ -8,6 +8,12 @@ from allure_commons._allure import step
 import configs
 
 
+def _attach_and_prepare(aut, main_window):
+    aut.attach()
+    main_window.prepare()
+    main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC)
+
+
 @allure.step('Switch to AUT and prepare main window')
 def switch_to_aut(aut, main_window):
     """
@@ -17,22 +23,19 @@ def switch_to_aut(aut, main_window):
         aut: The AUT to switch to
         main_window: MainWindow instance
     """
-    aut.attach()
-    main_window.prepare()
+    _attach_and_prepare(aut, main_window)
 
 
 @allure.step('Authorize user in AUT')
 def authorize_user_in_aut(aut, main_window, user_account):
-    aut.attach()
-    main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
+    _attach_and_prepare(aut, main_window)
     main_window.authorize_user(user_account)
     main_window.minimize()
 
 
 @allure.step('Get chat key from user')
 def get_chat_key(aut, main_window):
-    aut.attach()
-    main_window.prepare()
+    _attach_and_prepare(aut, main_window)
     profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
     chat_key = profile_popup.copy_chat_key
     main_window.left_panel.click()
@@ -53,8 +56,7 @@ def send_contact_request_from_settings(aut, main_window, chat_key, message):
     Returns:
         ContactsSettingsView: The contacts settings view instance
     """
-    aut.attach()
-    main_window.prepare()
+    _attach_and_prepare(aut, main_window)
     settings = main_window.left_panel.open_settings()
     messaging_settings = settings.left_panel.open_messaging_settings()
     contacts_settings = messaging_settings.open_contacts_settings()
@@ -73,8 +75,7 @@ def accept_contact_request_from_settings(aut, main_window, user_name):
         main_window: MainWindow instance
         user_name: Name of the user to accept request from
     """
-    aut.attach()
-    main_window.prepare()
+    _attach_and_prepare(aut, main_window)
     settings = main_window.left_panel.open_settings()
     messaging_settings = settings.left_panel.open_messaging_settings()
     contacts_settings = messaging_settings.open_contacts_settings()

--- a/test/e2e/helpers/wallet_helper.py
+++ b/test/e2e/helpers/wallet_helper.py
@@ -5,7 +5,7 @@ import driver
 from configs import WALLET_SEED
 from gui.objects_map import wallet_names
 from constants import ReturningUser
-from constants.wallet import WalletNetworkSettings
+from constants.wallet import WALLET_ACCOUNT_EXPECTED_ASSET_TITLES, WalletNetworkSettings
 from gui.components.authenticate_popup import AuthenticatePopup
 from helpers.onboarding_helper import open_create_profile_view, import_seed_and_log_in
 from helpers.settings_helper import enable_testnet_mode
@@ -25,11 +25,22 @@ def wait_for_wallet_balances_loaded(
     ), f'Wallet total balance is still loading, got: {balance.text!r}'
 
 
-def _asset_items_finished_loading(asset_item) -> bool:
+def is_assets_tab_content_loaded(asset_item) -> bool:
+    views = driver.findAllObjects(wallet_names.assets_view)
+    try:
+        if not (views and getattr(views[0], 'visible', False)):
+            return False
+    except (RuntimeError, AttributeError):
+        return False
+
     items = driver.findAllObjects(asset_item.real_name)
     if not items:
         return False
+
     try:
+        titles = {str(getattr(item, 'title', '')) for item in items}
+        if WALLET_ACCOUNT_EXPECTED_ASSET_TITLES.issubset(titles):
+            return True
         return not any(getattr(item, 'balanceLoading', False) for item in items)
     except (RuntimeError, AttributeError):
         # Squish may briefly return destroyed/null asset delegates while the list rebuilds.

--- a/test/e2e/tests/communities/test_communities_kick_ban.py
+++ b/test/e2e/tests/communities/test_communities_kick_ban.py
@@ -51,11 +51,11 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
         with step(f'User {user_one.name}, accept invitation from {user_two.name}'):
             switch_to_aut(aut_one, main_screen)
             messages_view = main_screen.left_panel.open_messages_screen()
-            skip_message_backup_popup_if_visible()
             assert driver.waitFor(lambda: user_two.name in messages_view.left_panel.get_chats_names,
                                   10000)
             chat = messages_view.left_panel.click_chat_by_name(user_two.name)
-            community_screen = chat.click_community_invite(community.name, 0)
+            skip_message_backup_popup_if_visible()
+            community_screen = chat.click_community_invite_message()
 
         with step(f'User {user_one.name}, verify welcome community popup'):
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()
@@ -109,7 +109,7 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
             messages_view1 = main_screen.left_panel.open_messages_screen()
             chat = messages_view1.left_panel.click_chat_by_name(user_two.name)
             time.sleep(1)
-            community_screen = chat.click_community_invite(community.name, 0)
+            community_screen = chat.click_community_invite_message()
 
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()
             welcome_popup.join().authenticate(user_one.password)
@@ -132,7 +132,7 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
             switch_to_aut(aut_one, main_screen)
             messages_view = main_screen.left_panel.open_messages_screen()
             chat = messages_view.left_panel.click_chat_by_name(user_two.name)
-            community_screen = chat.click_community_invite(community.name, 0)
+            community_screen = chat.click_community_invite_message()
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()
             welcome_popup.join().authenticate(user_one.password)
             assert driver.waitFor(lambda: not community_screen.left_panel.is_join_community_visible,

--- a/test/e2e/tests/communities/test_join_leave_profile_showcase_community.py
+++ b/test/e2e/tests/communities/test_join_leave_profile_showcase_community.py
@@ -58,7 +58,7 @@ def test_join_leave_profile_showcase_community(multiple_instances):
                 configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
             ), f'Chat with {owner.name} not in list'
             chat = messages_view.left_panel.click_chat_by_name(owner.name)
-            community_screen = chat.click_community_invite(community.name, 0)
+            community_screen = chat.click_community_invite_message()
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()
             assert community.name in welcome_popup.title
             assert community.introduction == welcome_popup.intro

--- a/test/e2e/tests/communities/test_send_accept_reject_join_requests.py
+++ b/test/e2e/tests/communities/test_send_accept_reject_join_requests.py
@@ -86,7 +86,7 @@ def test_send_accept_reject_join_requests(multiple_instances):
             switch_to_aut(aut_three, main_screen)
             messages_view = main_screen.left_panel.open_messages_screen()
             chat = messages_view.left_panel.click_chat_by_name(user_two.name)
-            community_screen = chat.click_community_invite(community.name, 0)
+            community_screen = chat.click_community_invite_message()
 
         with step(f'User {user_three.name}, verify welcome community popup and request to join'):
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()
@@ -101,7 +101,7 @@ def test_send_accept_reject_join_requests(multiple_instances):
             messages_view = main_screen.left_panel.open_messages_screen()
             skip_message_backup_popup_if_visible()
             chat = messages_view.left_panel.click_chat_by_name(user_two.name)
-            community_screen = chat.click_community_invite(community.name, 0)
+            community_screen = chat.click_community_invite_message()
 
         with step(f'User {user_one.name}, verify welcome community popup and request to join'):
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1905,6 +1905,7 @@ Item {
 
             // Container for the Activity Center Area in Landscape
             Rectangle {
+                objectName: "activityCenterSlideContainer"
                 readonly property bool openPanel: !mainLayoutItem.isPortraitMode ? mainLayoutItem.openACCenterPanel : false
 
                 // Keep alive while closing animation


### PR DESCRIPTION
### What does the PR do

A couple of tests failed in nightly, so i fixed it. Also, group chat tests fails from time to time because of misclicking accept request button, so i added some tweak to wait for animation on activity center to end and then click, it should help
