### PR TITLE
fix(ci): apply status-go ref override after make update

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -116,16 +116,18 @@ pipeline {
         sh 'git submodule update --init --recursive'
       }
     }
-    stage('Override status-go ref') {
-      when { expression { params.STATUS_GO_REF?.trim() } }
-      steps {
-        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
-      }
-    }
     stage('Deps') {
       steps {
         sh 'make update'
         sh 'make deps'
+      }
+    }
+
+    stage('Override status-go ref') {
+      /* Must run after `make update`, which resets submodules. */
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -120,12 +120,6 @@ pipeline {
         sh 'git submodule update --init --recursive'
       }
     }
-    stage('Override status-go ref') {
-      when { expression { params.STATUS_GO_REF?.trim() } }
-      steps {
-        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
-      }
-    }
     stage('Deps') {
       steps {
         sh 'make update'
@@ -138,6 +132,14 @@ pipeline {
         ]) {
           sh 'make deps'
         }
+      }
+    }
+
+    stage('Override status-go ref') {
+      /* Must run after `make update`, which resets submodules. */
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -123,16 +123,18 @@ pipeline {
         sh 'git submodule update --init --recursive'
       }
     }
-    stage('Override status-go ref') {
-      when { expression { params.STATUS_GO_REF?.trim() } }
-      steps {
-        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
-      }
-    }
     stage('Deps') {
       steps {
         sh 'make update'
         sh 'make deps'
+      }
+    }
+
+    stage('Override status-go ref') {
+      /* Must run after `make update`, which resets submodules. */
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
 


### PR DESCRIPTION
### What does the PR do

Moved the `Override status-go ref` stage after `Deps` in `ci/Jenkinsfile.{linux,windows,macos}`. 

`make update` was dropping the effect of override and bringing back current submodule pointer.