### PR TITLE
StatusTextArea: custom style-independent placeholder text

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 
+import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Components
 
@@ -69,7 +70,11 @@ TextArea {
     color: Theme.palette.directColor1
     selectedTextColor: color
     selectionColor: Theme.palette.primaryColor2
-    placeholderTextColor: root.enabled ? Theme.palette.baseColor1 : Theme.palette.directColor9
+
+    // The placeholder is rendered by a custom overlay (see below) instead of
+    // the active QtQuick Controls style, so it looks the same on every platform.
+    // Keep the native placeholder invisible so the two don't compete.
+    placeholderTextColor: StatusColors.transparent
 
     font {
         family: Fonts.baseFont.family
@@ -101,6 +106,29 @@ TextArea {
 
     cursorDelegate: StatusCursorDelegate {
         cursorVisible: root.cursorVisible
+    }
+
+    // Style-independent placeholder overlay. Rendering the placeholder ourselves
+    // avoids relying on the active QtQuick Controls style, whose default differs
+    // per platform. Pinpointing to single style is not possible because it
+    // blocks native context menu on iOS.
+    StatusBaseText {
+        id: placeholder
+
+        x: root.leftPadding
+        y: root.topPadding
+        width: root.width - root.leftPadding - root.rightPadding
+        // Constrain to the editable area and clip/elide so long placeholders
+        // never overflow the input's boundaries.
+        height: root.height - root.topPadding - root.bottomPadding
+        clip: true
+
+        visible: root.length === 0 && root.preeditText === ""
+        text: root.placeholderText
+        color: root.enabled ? Theme.palette.baseColor1 : Theme.palette.directColor9
+        font: root.font
+        wrapMode: root.wrapMode
+        elide: Text.ElideRight
     }
 
     // selectedText is not notified correctly when selection is cleared on Android.


### PR DESCRIPTION
Closes: #22105

### What does the PR do

`StatusTextArea` now draws its placeholder via a `StatusBaseText` overlay instead of relying on the native `TextArea.placeholderText` provided by the active Qt Quick Controls style. Thanks to that we can use os-default style for the text area, what is needed for e.g. native ctx menus (see https://github.com/status-im/status-app/pull/21956 for details).

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusTextArea`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="2268" height="2440" alt="image" src="https://github.com/user-attachments/assets/9efba5fc-217a-4c18-9d94-d98af13ac97f" />


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user
Low

### How to test

Go to chat on Android, check if placeholder is there when input is empty.

### Risk 

Low
