### PR TITLE
[CHERRY-PICK] fix(ci): apply status-go ref override after make update (#22108)

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -116,16 +116,18 @@ pipeline {
         sh 'git submodule update --init --recursive'
       }
     }
-    stage('Override status-go ref') {
-      when { expression { params.STATUS_GO_REF?.trim() } }
-      steps {
-        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
-      }
-    }
     stage('Deps') {
       steps {
         sh 'make update'
         sh 'make deps'
+      }
+    }
+
+    stage('Override status-go ref') {
+      /* Must run after `make update`, which resets submodules. */
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -120,12 +120,6 @@ pipeline {
         sh 'git submodule update --init --recursive'
       }
     }
-    stage('Override status-go ref') {
-      when { expression { params.STATUS_GO_REF?.trim() } }
-      steps {
-        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
-      }
-    }
     stage('Deps') {
       steps {
         sh 'make update'
@@ -138,6 +132,14 @@ pipeline {
         ]) {
           sh 'make deps'
         }
+      }
+    }
+
+    stage('Override status-go ref') {
+      /* Must run after `make update`, which resets submodules. */
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -123,16 +123,18 @@ pipeline {
         sh 'git submodule update --init --recursive'
       }
     }
-    stage('Override status-go ref') {
-      when { expression { params.STATUS_GO_REF?.trim() } }
-      steps {
-        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
-      }
-    }
     stage('Deps') {
       steps {
         sh 'make update'
         sh 'make deps'
+      }
+    }
+
+    stage('Override status-go ref') {
+      /* Must run after `make update`, which resets submodules. */
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-app/pull/22108

The Override status-go ref stage ran before Deps. `make update` calls nimbus-build-system's `update-common`, which runs `git submodule update --init --recursive` and `git submodule foreach --recursive 'git reset --hard'`, resetting vendor/status-go to the pinned pointer and discarding the override. Every status-go PR check therefore built and E2E-tested the submodule pointer instead of the PR.

Jenkinsfile.ios and Jenkinsfile.android have no `make update` between the override and the build, so they were already correct and are unchanged.

