### PR TITLE
fix(SimpleSendModal): UI fixes

### DIFF
--- a/storybook/pages/AccountSelectorPage.qml
+++ b/storybook/pages/AccountSelectorPage.qml
@@ -33,11 +33,6 @@ SplitView {
         }
 
         readonly property var currencyStore: CurrenciesStore{}
-        readonly property var nonWatchWalletAcounts: SortFilterProxyModel {
-            sourceModel: walletAccountsModel
-            filters: ValueFilter { roleName: "canSend"; value: true }
-        }
-
         readonly property var filteredFlatNetworksModel: SortFilterProxyModel {
             sourceModel: d.flatNetworks
             filters: ValueFilter { roleName: "isTest"; value: true }
@@ -178,7 +173,6 @@ SplitView {
                 }
             }
         }
-
     }
 
     Item {
@@ -209,3 +203,4 @@ SplitView {
 }
 
 // category: Components
+// status: good

--- a/storybook/pages/SendModalFooterPage.qml
+++ b/storybook/pages/SendModalFooterPage.qml
@@ -5,6 +5,7 @@ import QtQml.Models
 import StatusQ.Core.Theme
 
 import Storybook
+import Models
 
 import AppLayouts.Wallet.views
 import AppLayouts.Wallet.controls
@@ -21,7 +22,7 @@ SplitView {
         SendModalFooter {
             id: footer
             anchors.centerIn: parent
-            width: 595
+            implicitWidth: 595
 
             loading: loadingCheckbox.checked
             error: errorCheckbox.checked
@@ -41,7 +42,7 @@ SplitView {
         RouterErrorTag {
             errorTitle: "Error 2"
             buttonText: "Add ETH"
-            errorDetails: "Details will appear here"
+            errorDetails: ModelsData.descriptions.longLoremIpsum
             expandable: true
         }
     }

--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -37,7 +37,8 @@ SplitView {
         readonly property WalletAssetsStoreMock walletAssetStore: WalletAssetsStoreMock {
             walletTokensStore: TokensStoreMock {
                 tokenGroupsModel: TokenGroupsModel{}
-                _displayAssetsBelowBalanceThresholdDisplayAmountFunc: () => 0
+                tokenSelectorStubData: sendAssetsModel
+                displayAssetsBelowBalance: true
             }
         }
 
@@ -46,7 +47,7 @@ SplitView {
         function getCurrencyAmount(amount, symbol) {
             return ({
                         amount: amount,
-                        symbol: symbol ? symbol.toUpperCase() : root.currentCurrency,
+                        symbol: symbol ? symbol.toUpperCase() : simpleSend.currentCurrency,
                         displayDecimals: 2,
                         stripTrailingZeroes: false
                     })
@@ -601,7 +602,7 @@ SplitView {
                 text: "displayOnlyAssets"
             }
 
-            Text {
+            Label {
                 text: "Select an accounts"
             }
             ComboBox {
@@ -623,7 +624,7 @@ SplitView {
                 id: testNetworksCheckbox
                 text: "are test networks enabled"
             }
-            Text {
+            Label {
                 text: "Select a network"
             }
             ComboBox {
@@ -634,7 +635,7 @@ SplitView {
                 currentIndex: 0
             }
 
-            Text {
+            Label {
                 text: "Select a token"
             }
             ComboBox {
@@ -679,11 +680,11 @@ SplitView {
                     ]
 
                     markerRoleName: "which_model"
-                    expectedRoles: ["key", "name", "addressPerChain", "chainId", "ownership", "type", "tokenType", "addressPerChain"]
+                    expectedRoles: ["key", "name", "addressPerChain", "chainId", "ownership", "type", "tokenType"]
                 }
                 delegate: ItemDelegate {
                     contentItem: RowLayout {
-                        Text {
+                        Label {
                             text: model.name
                         }
                         StatusIcon {
@@ -744,7 +745,7 @@ SplitView {
                 }
             }
 
-            Text {
+            Label {
                 text: "Select a recipient"
             }
             RowLayout {
@@ -760,7 +761,7 @@ SplitView {
                 }
             }
 
-            Text {
+            Label {
                 text: "Number of saved wallet accounts"
             }
             SpinBox {
@@ -775,20 +776,20 @@ SplitView {
                 }
             }
 
-            Text {
+            Label {
                 text: "account selected is: \n"
                       + simpleSend.selectedAccountAddress
             }
-            Text {
+            Label {
                 text: "network selected is: " + simpleSend.selectedChainId
             }
-            Text {
-                text: "token selected is: " + simpleSend.selectedTokenKey
+            Label {
+                text: "token selected is: " + simpleSend.selectedGroupKey
             }
-            Text {
+            Label {
                 text: "raw amount entered is: " + simpleSend.selectedRawAmount
             }
-            Text {
+            Label {
                 text: "selected recipient is: \n" + simpleSend.selectedRecipientAddress
             }
         }

--- a/storybook/stubs/nim/sectionmocks/GlobalUtils.qml
+++ b/storybook/stubs/nim/sectionmocks/GlobalUtils.qml
@@ -18,4 +18,8 @@ QtObject {
     function getCompressedPk(publicKey) {
         return publicKey
     }
+
+    function getStatusSupportBotChatKey() {
+        return "0xdeadb07"
+    }
 }

--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -166,10 +166,6 @@ StatusComboBox {
         relativeX: parent.width - width
         relativeY: parent.height + 4
 
-        padding: 1
-        topPadding: 8
-        bottomPadding: !!d.window.window ? d.window.window.SafeArea.margins.bottom: 0
-
         flatNetworks: root.flatNetworks
         disableChainsWithNoCommunitiesSupport: root.disableChainsWithNoCommunitiesSupport
         selectionAllowed: root.selectionAllowed

--- a/ui/app/AppLayouts/Wallet/controls/RecipientViewDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/RecipientViewDelegate.qml
@@ -50,9 +50,11 @@ StatusListItem {
     color: sensor.containsMouse || highlighted ? Theme.palette.baseColor2 : "transparent"
 
     statusListItemSubTitle.wrapMode: Text.NoWrap
-    statusListItemSubTitle.font.family: Fonts.monoFont.family
-    statusListItemSubTitle.elide: Text.ElideNone
+    statusListItemSubTitle.font.family: Fonts.codeFont.family
+    statusListItemSubTitle.font.pixelSize: Theme.fontSize(14)
+    statusListItemSubTitle.elide: Text.ElideRight
     statusListItemSubTitle.customColor: sensor.containsMouse ? Theme.palette.directColor1 : Theme.palette.baseColor1
+    statusListItemTitle.elide: Text.ElideRight
     statusListItemTitle.font.family: Fonts.monoFont.family
     statusListItemIcon.name: useAddressAsLetterIdenticon ? root.address : title
 

--- a/ui/app/AppLayouts/Wallet/controls/RouterErrorTag.qml
+++ b/ui/app/AppLayouts/Wallet/controls/RouterErrorTag.qml
@@ -101,6 +101,8 @@ Control {
 
             color: Theme.palette.dangerColor1
             font.pixelSize: Theme.additionalTextSize
+            wrapMode: Text.Wrap
+            maximumLineCount: 5
             elide: Text.ElideRight
 
             visible: root.expandable ? expandButton.checked : !!text

--- a/ui/app/AppLayouts/Wallet/controls/SendRecipientInput.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SendRecipientInput.qml
@@ -78,15 +78,5 @@ StatusInput {
         }
     }
 
-    Connections {
-        target: root.input
-        function onKeyPressed(event) {
-            if (event.matches(StandardKey.Paste)) {
-                event.accepted = true
-                root.text = ClipboardUtils.text // paste plain text
-            }
-        }
-    }
-
-    Keys.onTabPressed: event.accepted = true
+    Keys.onTabPressed: event => event.accepted = true
 }

--- a/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
@@ -70,7 +70,7 @@ Rectangle {
     }
 
     implicitHeight: childrenRect.height + (!!selectedRecipientAddress ? 0 : Theme.halfPadding/2)
-    color: Theme.palette.indirectColor1
+    color: Theme.palette.secondaryMenuBackground
     radius: 8
 
     onSearchPatternChanged: {
@@ -145,7 +145,7 @@ Rectangle {
             onKeyPressed: (event) => d.handleKeyPressOnSearch(event)
         }
 
-        SharedPanels.Separator {
+        Rectangle {
             Layout.preferredHeight: 1
             Layout.fillWidth: true
             color: Theme.palette.baseColor2
@@ -185,10 +185,9 @@ Rectangle {
             visible: !root.selectedRecipientAddress && !d.searchInProgress
         }
 
-        SharedPanels.Separator {
+        Rectangle {
             Layout.preferredHeight: 1
             Layout.fillWidth: true
-            Layout.topMargin: -Theme.halfPadding
             color: Theme.palette.baseColor2
             visible: recipientTypeTabBar.visible
         }

--- a/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
@@ -9,7 +9,7 @@ import AppLayouts.Wallet.controls
 
 import utils
 
-RowLayout {
+Flow {
     id: root
 
     /**
@@ -89,8 +89,6 @@ RowLayout {
         tokenSelector.setSelection(name, icon, key)
     }
 
-    implicitHeight: sendModalTitleText.height
-
     spacing: 8
 
     // if not closed during scrolling they move with the header and it feels undesirable
@@ -101,10 +99,9 @@ RowLayout {
 
     StatusBaseText {
         id: sendModalTitleText
+        width: root.width
 
         objectName: "sendModalTitleText"
-
-        Layout.preferredWidth: contentWidth
 
         lineHeightMode: Text.FixedHeight
         lineHeight: root.isStickyHeader ? 30 : 38
@@ -114,76 +111,73 @@ RowLayout {
         text: qsTr("Send")
     }
 
-    TokenSelector {
-        id: tokenSelector
+    RowLayout {
+        width: root.width
+        TokenSelector {
+            id: tokenSelector
 
-        objectName: "tokenSelector"
+            objectName: "tokenSelector"
 
-        Layout.fillWidth: true
-        Layout.maximumWidth: implicitWidth
+            size: root.isStickyHeader ?
+                      TokenSelectorButton.Size.Small:
+                      TokenSelectorButton.Size.Normal
 
-        size: root.isStickyHeader ?
-                  TokenSelectorButton.Size.Small:
-                  TokenSelectorButton.Size.Normal
+            enabled: root.interactive
+            showSectionName: false
 
-        enabled: root.interactive
-        showSectionName: false
+            assetsModel: root.assetsModel
+            formatCurrencyBalance: root.formatCurrencyBalance
+            collectiblesModel: root.displayOnlyAssets ? null: root.collectiblesModel
 
-        assetsModel: root.assetsModel
-        formatCurrencyBalance: root.formatCurrencyBalance
-        collectiblesModel: root.displayOnlyAssets ? null: root.collectiblesModel
+            flatNetworksModel: root.networksModel
+            selectedChainId: root.selectedChainId
 
-        flatNetworksModel: root.networksModel
-        selectedChainId: root.selectedChainId
-
-        onCollectibleSelected: (key) => root.collectibleSelected(key)
-        onCollectionSelected: (key) => root.collectionSelected(key)
-        onAssetSelected: (key) => root.assetSelected(key)
-        onSearchInAssets: (keyword) => root.searchInAssets(keyword)
-        onFetchMoreAssets: root.fetchMoreAssets()
-        onChainSelected: (chainId) => { if (chainId !== -1) root.networkSelected(chainId) }
-    }
-
-    // Horizontal spacer
-    RowLayout {}
-
-    StatusBaseText {
-        Layout.alignment: Qt.AlignRight
-
-        text: qsTr("On:")
-        color: Theme.palette.baseColor1
-        font.pixelSize: Theme.additionalTextSize
-        lineHeight: 38
-        lineHeightMode: Text.FixedHeight
-        verticalAlignment: Text.AlignVCenter
-
-        visible: networkFilter.visible
-    }
-
-    NetworkFilter {
-        id: networkFilter
-
-        objectName: "networkFilter"
-
-        Layout.alignment: Qt.AlignTop
-
-        flatNetworks: root.networksModel
-
-        multiSelection: false
-        showSelectionIndicator: false
-        showTitle: false
-        interactive: root.interactive
-
-        Binding on selection {
-            value: [root.selectedChainId]
-            when: root.selectedChainId !== 0
+            onCollectibleSelected: (key) => root.collectibleSelected(key)
+            onCollectionSelected: (key) => root.collectionSelected(key)
+            onAssetSelected: (key) => root.assetSelected(key)
+            onSearchInAssets: (keyword) => root.searchInAssets(keyword)
+            onFetchMoreAssets: root.fetchMoreAssets()
+            onChainSelected: (chainId) => { if (chainId !== -1) root.networkSelected(chainId) }
         }
-        onSelectionChanged: {
-            if (root.selectedChainId !== selection[0]) {
-                root.networkSelected(selection[0])
+
+        Item { Layout.fillWidth: true }
+
+        StatusBaseText {
+            Layout.alignment: Qt.AlignRight
+            text: qsTr("On:")
+            color: Theme.palette.baseColor1
+            font.pixelSize: Theme.additionalTextSize
+            lineHeight: 38
+            lineHeightMode: Text.FixedHeight
+            verticalAlignment: Text.AlignVCenter
+
+            visible: networkFilter.visible
+        }
+
+        NetworkFilter {
+            Layout.topMargin: 6
+
+            id: networkFilter
+            objectName: "networkFilter"
+
+            flatNetworks: root.networksModel
+
+            multiSelection: false
+            showSelectionIndicator: false
+            showTitle: false
+            interactive: root.interactive
+
+            Binding on selection {
+                value: [root.selectedChainId]
+                when: root.selectedChainId !== 0
             }
-        }
+            onSelectionChanged: {
+                if (root.selectedChainId !== selection[0]) {
+                    root.networkSelected(selection[0])
+                }
+            }
 
-        onToggleNetwork: (chainId) => root.networkSelected(chainId)
+            onToggleNetwork: (chainId, index) => root.networkSelected(chainId)
+        }
     }
 }

--- a/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
@@ -36,26 +36,10 @@ StatusDropdown {
     signal toggleNetwork(int chainId, int index)
     signal manageNetworksClicked()
 
-
     modal: false
 
     padding: 4
     implicitWidth: 300
-
-    background: Rectangle {
-        radius: Theme.radius
-        color: Theme.palette.background
-        border.color: Theme.palette.border
-        layer.enabled: true
-        layer.effect: DropShadow {
-            verticalOffset: 3
-            radius: 8
-            samples: 15
-            fast: true
-            cached: true
-            color: "#22000000"
-        }
-    }
 
     // Keeps the single-selection invariant (exactly one selected network,
     // defaulting to the first one) while the view below is not instantiated.

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -581,9 +581,10 @@ StatusDialog {
 
             objectName: "accountSelector"
 
-            y: -height - Theme.bigPadding
             anchors.left: parent.left
             anchors.leftMargin: -Theme.xlPadding
+            anchors.bottom: parent.top
+            anchors.bottomMargin: root.topPadding + 4
 
             model: root.accountsModel
 

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -895,6 +895,8 @@ StatusDialog {
     footer: SendModalFooter {
         objectName: "sendModalFooter"
 
+        bottomSheet: root.bottomSheet
+
         estimatedTime: root.estimatedTime
         estimatedFees: root.estimatedFiatFees
 

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -895,8 +895,6 @@ StatusDialog {
     footer: SendModalFooter {
         objectName: "sendModalFooter"
 
-        width: root.width
-
         estimatedTime: root.estimatedTime
         estimatedFees: root.estimatedFiatFees
 

--- a/ui/app/AppLayouts/Wallet/views/RecipientView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RecipientView.qml
@@ -147,13 +147,17 @@ Loader {
                 d.validationTimer.restart()
             }
 
-            width: parent.width
+            leftPadding: 4
+            rightPadding: 4
+            bottomPadding: 4
+            topPadding: 4
             height: visible ? implicitHeight: 0
 
             checkMarkVisible: !d.isBeingEvaluated && d.isValidAddress
             loading: d.isBeingEvaluated
             input.edit.textFormat: Text.AutoText
             error: !d.isBeingEvaluated && !!d.inputError && root.model.ModelCount.count === 0 ? d.inputError : ""
+            input.background.color: Theme.palette.secondaryMenuBackground
 
             onTextChanged: Qt.callLater(() => validateInput())
             onClearClicked: {

--- a/ui/imports/shared/controls/AccountSelectorHeader.qml
+++ b/ui/imports/shared/controls/AccountSelectorHeader.qml
@@ -14,7 +14,7 @@ AccountSelector {
     control.rightInset: -6 //broken indicator positioning
     control.spacing: 4
 
-    indicator.color: Theme.palette.indirectColor1
+    indicator.color: textContent.color
 
     control.background: Rectangle {
         objectName: "headerBackground"


### PR DESCRIPTION
### What does the PR do

Fixes a couple of UI issue with the SimpleSendModal, namely:
- Fixes https://github.com/status-im/status-app/issues/22084
- Fixes https://github.com/status-im/status-app/issues/20670
- Fixes https://github.com/status-im/status-app/issues/19403
- Fixes https://github.com/status-im/status-app/issues/18645

### Affected areas

SimpleSendModal

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Dark mode:
<img width="2944" height="1800" alt="Snímek obrazovky z 2026-08-27 18-31-05" src="https://github.com/user-attachments/assets/d303ed43-1040-42a5-9fcb-6cf349e06940" />

Light mode:
<img width="2944" height="1800" alt="Snímek obrazovky z 2026-08-27 18-30-59" src="https://github.com/user-attachments/assets/9e699e6a-d6de-4707-9e14-0404d6c1cdcd" />

Dark mode compact:
<img width="660" height="1800" alt="Snímek obrazovky z 2026-08-27 18-31-57" src="https://github.com/user-attachments/assets/63734374-3c03-43e4-ad07-8688d213969a" />

Error tag not overflowing:
<img width="2366" height="1800" alt="Snímek obrazovky z 2026-08-27 18-34-06" src="https://github.com/user-attachments/assets/3666992b-7e79-4e54-9dac-b10533f0ec7c" />

### Impact on end user

UI/UX

### How to test

- open the Send modal, check the issues being fixed in this PR

### Risk 

low
