### PR TITLE
fix(@qml): keep nested StatusDialog as an overlay Item on Linux

### DIFF
--- a/storybook/qmlTests/tests/tst_StatusDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusDialog.qml
@@ -62,6 +62,25 @@ Item {
             compare(controlUnderTest.bottomSheet, false) // not bottom sheet on desktop
         }
 
+        function test_popupType_is_item() {
+            compare(controlUnderTest.popupType, Popup.Item)
+        }
+
+        function test_nested_dialog_stays_item_and_centered() {
+            controlUnderTest.open()
+            tryCompare(controlUnderTest, "opened", true)
+
+            const nested = createTemporaryObject(componentUnderTest, root)
+            verify(!!nested)
+            nested.open()
+            tryCompare(nested, "opened", true)
+
+            compare(nested.popupType, Popup.Item)
+            tryVerify(() => nested.x > 0)
+            tryVerify(() => nested.y > 0)
+            compare(nested.parent, nested.Overlay.overlay)
+        }
+
         function test_bottomSheet_on_mobile() {
             root.width = d.mobileWindowWidth
             root.height = d.mobileWindowHeight

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -177,6 +177,7 @@ Dialog {
     }
 
     parent: Overlay.overlay
+    popupType: Popup.Item
 
     modal: true
 


### PR DESCRIPTION
### What does the PR do

Fix for nested StatusDialog/StatusModal (e.g. community logo crop on top of Create Community) was opening as a detached OS window on Linux (top-left, native chrome)


<img width="2560" height="1393" alt="image" src="https://github.com/user-attachments/assets/58664b2b-9ecf-44bb-b825-c3e18dfbe6a0" />


