### PR TITLE
test(e2e_appium): rename safe_click to click, add contract lint

### DIFF
--- a/test/e2e_appium/conftest.py
+++ b/test/e2e_appium/conftest.py
@@ -685,3 +685,14 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         logger.info("Failure log artifacts:")
         for path in _saved_failure_logs:
             logger.info("  %s", path)
+
+
+def pytest_sessionstart(session):
+    """Click-contract lint at collection: a violation fails the session before
+    any device time is spent. Standalone: python3 scripts/check_click_contract.py"""
+    from scripts.check_click_contract import main as _click_contract_main
+
+    if _click_contract_main(str(session.config.rootpath)):
+        raise pytest.UsageError(
+            "click-contract violations (see above) — branch on try_click, never on click()"
+        )

--- a/test/e2e_appium/conftest.py
+++ b/test/e2e_appium/conftest.py
@@ -463,9 +463,11 @@ def _capture_failure_artifacts(item, rep):
                     except Exception as err:
                         log.warning(f"Failed to persist {log_type} log for {test_id}: {err}")
             if log_paths:
+                captured_any = True
                 global _saved_failure_logs
                 _saved_failure_logs.extend(log_paths)
 
+        setattr(item, "_failure_artifacts_attempted", True)
         if captured_any:
             setattr(item, "_failure_artifacts_saved", True)
         else:
@@ -486,7 +488,8 @@ def pytest_runtest_makereport(item, call):
 
     # Failure evidence is captured in the phase that failed, before any
     # stash gating or teardown mutation (single- and multi-device alike).
-    if rep.failed and not getattr(item, "_failure_artifacts_saved", False):
+    if rep.failed and not getattr(item, "_failure_artifacts_saved", False) \
+            and not getattr(item, "_failure_artifacts_attempted", False):
         _capture_failure_artifacts(item, rep)
 
     if rep.when == "call":

--- a/test/e2e_appium/conftest.py
+++ b/test/e2e_appium/conftest.py
@@ -341,12 +341,153 @@ def _apply_test_cooldown(item) -> None:
     time.sleep(cooldown_seconds)
 
 
+
+def _resolve_failure_drivers(item):
+    """All drivers worth capturing from, deduped: test instance (plain tests),
+    instance.device (StepMixin), and every stash session manager (multi-device
+    secondaries included)."""
+    found = []
+    seen = set()
+
+    def add(label, drv):
+        if drv is not None and id(drv) not in seen:
+            seen.add(id(drv))
+            found.append((label, drv))
+
+    inst = getattr(item, "instance", None)
+    if inst is not None:
+        add("", getattr(inst, "driver", None))
+        device = getattr(inst, "device", None)
+        if device is not None:
+            add("", getattr(device, "driver", None))
+    if hasattr(item, "stash"):
+        for session_managers, _pool, _environment in item.stash.get(
+            MULTI_DEVICE_MANAGERS_KEY, []
+        ):
+            for name, session_manager in session_managers.items():
+                add(name, getattr(session_manager, "driver", None))
+    return found
+
+
+def _capture_failure_artifacts(item, rep):
+    """Capture screenshot + page source + Appium logs for a failed phase.
+
+    Runs in whichever phase failed (setup/call/teardown) so the captured state
+    is the failure's, not whatever teardown left behind. A capture-miss is a
+    WARNING so misses are countable from logs."""
+    log = get_logger("conftest")
+    try:
+        drivers = _resolve_failure_drivers(item)
+        if not drivers:
+            log.warning(
+                "failure-evidence: no driver resolvable for %s (%s phase)",
+                getattr(item, "name", "test"), getattr(rep, "when", "?"),
+            )
+            return
+
+        try:
+            config_obj = get_config()
+            screenshots_dir = config_obj.screenshots_dir or "screenshots"
+            logs_dir = config_obj.logs_dir or "logs"
+        except Exception:
+            screenshots_dir = "screenshots"
+            logs_dir = "logs"
+
+        captured_any = False
+        for dev_label, driver in drivers:
+            test_id = getattr(item, "name", "test") + (
+                f"__{rep.when}" if getattr(rep, "when", None) else ""
+            ) + (f"__{dev_label}" if dev_label else "")
+
+            s_path = None
+            x_path = None
+            try:
+                s_path = save_screenshot(driver, str(screenshots_dir), f"FAILED_{test_id}")
+            except Exception:
+                pass
+            try:
+                x_path = save_page_source(driver, str(screenshots_dir), f"FAILED_{test_id}")
+            except Exception:
+                pass
+            if s_path:
+                log.info(f"Saved failure screenshot: {s_path}")
+                captured_any = True
+            if x_path:
+                log.info(f"Saved failure page source: {x_path}")
+                captured_any = True
+
+            try:
+                import allure
+                if s_path:
+                    allure.attach.file(
+                        str(s_path),
+                        name=f"screenshot_{test_id}",
+                        attachment_type=allure.attachment_type.PNG,
+                    )
+                if x_path:
+                    allure.attach.file(
+                        str(x_path),
+                        name=f"page_source_{test_id}",
+                        attachment_type=allure.attachment_type.XML,
+                    )
+            except ImportError:
+                pass
+
+            log_paths: List[Path] = []
+            try:
+                log_types = set(getattr(driver, "log_types", []) or [])
+            except Exception:
+                log_types = set()
+            desired_types = [t for t in ("server", "logcat") if t in log_types]
+            if desired_types:
+                logs_root = Path(logs_dir)
+                logs_root.mkdir(parents=True, exist_ok=True)
+                for log_type in desired_types:
+                    try:
+                        entries = driver.get_log(log_type) or []
+                    except Exception as err:
+                        log.warning(f"Failed to fetch '{log_type}' log for {test_id}: {err}")
+                        continue
+                    if not entries:
+                        continue
+                    log_file = logs_root / f"FAILED_{test_id}_{log_type}.log"
+                    try:
+                        with log_file.open("w", encoding="utf-8") as handle:
+                            for entry in entries:
+                                timestamp = entry.get("timestamp") or entry.get("time") or ""
+                                level = entry.get("level") or ""
+                                message = entry.get("message") or ""
+                                handle.write(f"{timestamp}\t{level}\t{message}\n")
+                        log.info(f"Saved failure {log_type} log: {log_file}")
+                        log_paths.append(log_file)
+                    except Exception as err:
+                        log.warning(f"Failed to persist {log_type} log for {test_id}: {err}")
+            if log_paths:
+                global _saved_failure_logs
+                _saved_failure_logs.extend(log_paths)
+
+        if captured_any:
+            setattr(item, "_failure_artifacts_saved", True)
+        else:
+            log.warning(
+                "failure-evidence: drivers resolved but nothing captured for %s (%s phase)",
+                getattr(item, "name", "test"), getattr(rep, "when", "?"),
+            )
+    except Exception as e:
+        log.warning(f"Artifact capture failed: {e}")
+
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
 
     setattr(item, "rep_" + rep.when, rep)
+
+    # Failure evidence is captured in the phase that failed, before any
+    # stash gating or teardown mutation (single- and multi-device alike).
+    if rep.failed and not getattr(item, "_failure_artifacts_saved", False):
+        _capture_failure_artifacts(item, rep)
 
     if rep.when == "call":
         logger = get_logger("conftest")
@@ -488,125 +629,6 @@ def pytest_runtest_makereport(item, call):
                     name,
                 )
 
-    # Get screenshot and page source artifacts
-    try:
-        if getattr(rep, "failed", False) and not getattr(
-            item, "_failure_artifacts_saved", False
-        ):
-            driver = None
-            try:
-                if hasattr(item, "instance") and hasattr(item.instance, "driver"):
-                    driver = item.instance.driver
-            except Exception:
-                driver = None
-
-            if driver:
-                # Resolve screenshots directory from environment config; fallback to 'screenshots'
-                try:
-                    config_obj = get_config()
-                    screenshots_dir = config_obj.screenshots_dir or "screenshots"
-                    logs_dir = config_obj.logs_dir or "logs"
-                except Exception:
-                    screenshots_dir = "screenshots"
-                    logs_dir = "logs"
-
-                test_id = getattr(item, "name", "test") + (
-                    f"__{rep.when}" if getattr(rep, "when", None) else ""
-                )
-
-                s_path = None
-                x_path = None
-                try:
-                    s_path = save_screenshot(
-                        driver, str(screenshots_dir), f"FAILED_{test_id}"
-                    )
-                except Exception:
-                    pass
-                try:
-                    x_path = save_page_source(
-                        driver, str(screenshots_dir), f"FAILED_{test_id}"
-                    )
-                except Exception:
-                    pass
-
-                log = get_logger("conftest")
-                if s_path:
-                    log.info(f"Saved failure screenshot: {s_path}")
-                if x_path:
-                    log.info(f"Saved failure page source: {x_path}")
-
-                # Attach artifacts to Allure report
-                try:
-                    import allure
-                    if s_path:
-                        allure.attach.file(
-                            str(s_path),
-                            name=f"screenshot_{test_id}",
-                            attachment_type=allure.attachment_type.PNG,
-                        )
-                    if x_path:
-                        allure.attach.file(
-                            str(x_path),
-                            name=f"page_source_{test_id}",
-                            attachment_type=allure.attachment_type.XML,
-                        )
-                except ImportError:
-                    pass
-
-                # Capture Appium server/logcat logs for deeper diagnostics
-                log_paths: List[Path] = []
-                try:
-                    log_types = set(getattr(driver, "log_types", []) or [])
-                except Exception:
-                    log_types = set()
-
-                desired_types = [
-                    log_type
-                    for log_type in ("server", "logcat")
-                    if log_type in log_types
-                ]
-                if desired_types:
-                    logs_root = Path(logs_dir)
-                    logs_root.mkdir(parents=True, exist_ok=True)
-                    for log_type in desired_types:
-                        try:
-                            entries = driver.get_log(log_type) or []
-                        except Exception as err:
-                            log.warning(
-                                f"Failed to fetch '{log_type}' log for {test_id}: {err}"
-                            )
-                            continue
-
-                        if not entries:
-                            continue
-
-                        log_file = logs_root / f"FAILED_{test_id}_{log_type}.log"
-                        try:
-                            with log_file.open("w", encoding="utf-8") as handle:
-                                for entry in entries:
-                                    timestamp = (
-                                        entry.get("timestamp")
-                                        or entry.get("time")
-                                        or ""
-                                    )
-                                    level = entry.get("level") or ""
-                                    message = entry.get("message") or ""
-                                    handle.write(f"{timestamp}\t{level}\t{message}\n")
-                            log.info(f"Saved failure {log_type} log: {log_file}")
-                            log_paths.append(log_file)
-                        except Exception as err:
-                            log.warning(
-                                f"Failed to persist {log_type} log for {test_id}: {err}"
-                            )
-
-                if log_paths:
-                    global _saved_failure_logs
-                    _saved_failure_logs.extend(log_paths)
-
-                setattr(item, "_failure_artifacts_saved", True)
-    except Exception as e:
-        log = get_logger("conftest")
-        log.warning(f"Artifact capture failed: {e}")
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):

--- a/test/e2e_appium/conftest.py
+++ b/test/e2e_appium/conftest.py
@@ -711,10 +711,19 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
 def pytest_sessionstart(session):
     """Click-contract lint at collection: a violation fails the session before
-    any device time is spent. Standalone: python3 scripts/check_click_contract.py"""
-    from scripts.check_click_contract import main as _click_contract_main
+    any device time is spent. Standalone: python3 scripts/check_click_contract.py
 
-    if _click_contract_main(str(session.config.rootpath)):
+    Loaded by explicit file path (not module import): the scripts/ package name
+    is a namespace merged with the repo-root scripts/, so import-by-name is one
+    stray __init__.py away from breaking. The lint anchors its own scan root."""
+    if hasattr(session.config, "workerinput"):
+        return  # xdist worker — the controller already ran the lint
+    import importlib.util
+    lint_path = Path(__file__).parent / "scripts" / "check_click_contract.py"
+    spec = importlib.util.spec_from_file_location("_click_contract_lint", lint_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    if mod.main():
         raise pytest.UsageError(
             "click-contract violations (see above) — branch on try_click, never on click()"
         )

--- a/test/e2e_appium/conftest.py
+++ b/test/e2e_appium/conftest.py
@@ -430,8 +430,8 @@ def _capture_failure_artifacts(item, rep):
                         name=f"page_source_{test_id}",
                         attachment_type=allure.attachment_type.XML,
                     )
-            except ImportError:
-                pass
+            except Exception as attach_err:
+                log.debug(f"Allure attach failed for {test_id}: {attach_err}")
 
             log_paths: List[Path] = []
             try:
@@ -467,8 +467,10 @@ def _capture_failure_artifacts(item, rep):
                 global _saved_failure_logs
                 _saved_failure_logs.extend(log_paths)
 
-        setattr(item, "_failure_artifacts_attempted", True)
+        state = getattr(item, "_failure_evidence_state", None)
         if captured_any:
+            if state is not None:
+                state["saved"] = True
             setattr(item, "_failure_artifacts_saved", True)
         else:
             log.warning(
@@ -488,9 +490,16 @@ def pytest_runtest_makereport(item, call):
 
     # Failure evidence is captured in the phase that failed, before any
     # stash gating or teardown mutation (single- and multi-device alike).
-    if rep.failed and not getattr(item, "_failure_artifacts_saved", False) \
-            and not getattr(item, "_failure_artifacts_attempted", False):
-        _capture_failure_artifacts(item, rep)
+    # Keyed per rerun execution (pytest-rerunfailures reuses the item), and a
+    # zero-capture attempt may retry in a later phase of the same execution.
+    if rep.failed:
+        execution = getattr(item, "execution_count", 0)
+        state = getattr(item, "_failure_evidence_state", None)
+        if state is None or state.get("execution") != execution:
+            state = {"execution": execution, "saved": False}
+            item._failure_evidence_state = state
+        if not state["saved"]:
+            _capture_failure_artifacts(item, rep)
 
     if rep.when == "call":
         logger = get_logger("conftest")

--- a/test/e2e_appium/core/device_context.py
+++ b/test/e2e_appium/core/device_context.py
@@ -344,7 +344,7 @@ class DeviceContext:
                 return None
 
             try:
-                app.safe_click(invite_action, timeout=5)
+                app.click(invite_action, timeout=5)
             except Exception as exc:
                 self.logger.error("Failed to click Invite contacts: %s", exc)
                 return None

--- a/test/e2e_appium/fixtures/onboarding_fixture.py
+++ b/test/e2e_appium/fixtures/onboarding_fixture.py
@@ -435,7 +435,9 @@ class OnboardingFlow:
             else:
                 self.logger.error("Failed to dismiss push notifications dialog")
                 actions.append("push_notifications:dismiss_failed")
-                success = False
+                raise OnboardingFlowError(
+                    "Push notifications dialog visible but could not be dismissed"
+                )
         else:
             self.logger.warning(
                 "Push notifications dialog did not appear within 30s — unexpected"

--- a/test/e2e_appium/fixtures/onboarding_fixture.py
+++ b/test/e2e_appium/fixtures/onboarding_fixture.py
@@ -423,7 +423,6 @@ class OnboardingFlow:
         step_start = datetime.now()
 
         actions: list[str] = []
-        success = True
 
         # 1. Push notifications — primary expected overlay.
         if self.push_notifications_page.is_screen_displayed(timeout=30):
@@ -435,6 +434,11 @@ class OnboardingFlow:
             else:
                 self.logger.error("Failed to dismiss push notifications dialog")
                 actions.append("push_notifications:dismiss_failed")
+                self.step_results["push_notifications"] = {
+                    "success": False,
+                    "action": ",".join(actions),
+                    "timestamp": datetime.now(),
+                }
                 raise OnboardingFlowError(
                     "Push notifications dialog visible but could not be dismissed"
                 )
@@ -481,7 +485,7 @@ class OnboardingFlow:
                 actions.append("push_notifications_2:dismissed")
 
         self.step_results["push_notifications"] = {
-            "success": success,
+            "success": True,
             "action": ",".join(actions),
             "timestamp": datetime.now(),
         }

--- a/test/e2e_appium/locators/messaging/group_chat_locators.py
+++ b/test/e2e_appium/locators/messaging/group_chat_locators.py
@@ -207,7 +207,7 @@ class GroupChatLocators(BaseLocators):
     #    Qt's accessibility bridge marks these rows ``clickable="false"``
     #    (onClicked is handled at the QML layer, not bridged to a11y), so
     #    we do NOT filter by ``@clickable``; the element-tap fallback in
-    #    ``safe_click`` works regardless of the a11y flag.
+    #    ``click`` works regardless of the a11y flag.
     # 2. Add/remove-members sheet (ExistingContacts.qml /
     #    PickedContacts.qml). Rows there have objectName
     #    "statusMemberListItem-{compressedPubKey}".

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -49,9 +49,13 @@ class App(BasePage):
             return True
         from utils.screen_identity import SCREEN_ANCHORS
         # Landmark early-return: active_section() reads 'unknown' with the
-        # drawer closed even when the chat list is on screen, and the drawer
-        # dance can wedge on exactly that state.
-        if self.is_element_visible(SCREEN_ANCHORS["messages"], timeout=1):
+        # drawer closed even when the chat list is on screen. Qt reports
+        # covered elements as visible, so only trust the landmark when no
+        # drawer is open, and clear the backup sheet like the nav path would.
+        if (self.is_element_visible(SCREEN_ANCHORS["messages"], timeout=1)
+                and not self.is_element_visible(self.locators.LEFT_NAV_ANY, timeout=1)):
+            from utils.screen_identity import dismiss_backup_modal
+            dismiss_backup_modal(self)
             self.logger.info("Messages landmark already visible — skipping nav")
             return True
         return self._click_drawer_nav_with_verify(

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -48,6 +48,12 @@ class App(BasePage):
             self.logger.info("Already in Messages section — skipping nav")
             return True
         from utils.screen_identity import SCREEN_ANCHORS
+        # Landmark early-return: active_section() reads 'unknown' with the
+        # drawer closed even when the chat list is on screen, and the drawer
+        # dance can wedge on exactly that state.
+        if self.is_element_visible(SCREEN_ANCHORS["messages"], timeout=1):
+            self.logger.info("Messages landmark already visible — skipping nav")
+            return True
         return self._click_drawer_nav_with_verify(
             nav_locator=self.locators.LEFT_NAV_MESSAGES,
             landmark_locator=SCREEN_ANCHORS["messages"],

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -54,8 +54,17 @@ class App(BasePage):
         # drawer is open, and clear the backup sheet like the nav path would.
         if (self.is_element_visible(SCREEN_ANCHORS["messages"], timeout=1)
                 and not self.is_element_visible(self.locators.LEFT_NAV_ANY, timeout=1)):
-            from utils.screen_identity import dismiss_backup_modal
+            from utils.screen_identity import BACKUP_MODAL, dismiss_backup_modal
             dismiss_backup_modal(self)
+            # dismiss_backup_modal returns False both when no modal was up and
+            # when one would not close, so re-check rather than trust the bool.
+            if self.is_element_visible(BACKUP_MODAL, timeout=1):
+                self.logger.warning("Backup modal still up — falling back to nav")
+                return self._click_drawer_nav_with_verify(
+                    nav_locator=self.locators.LEFT_NAV_MESSAGES,
+                    landmark_locator=SCREEN_ANCHORS["messages"],
+                    nav_name="Messages",
+                )
             self.logger.info("Messages landmark already visible — skipping nav")
             return True
         return self._click_drawer_nav_with_verify(

--- a/test/e2e_appium/pages/base_page.py
+++ b/test/e2e_appium/pages/base_page.py
@@ -11,6 +11,7 @@ from selenium.common.exceptions import (
     NoSuchElementException,
     StaleElementReferenceException,
     TimeoutException,
+    WebDriverException,
 )
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.remote.webelement import WebElement
@@ -18,6 +19,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 from config import get_config, log_element_action
+from utils.exceptions import SESSION_FATAL
 from utils.app_lifecycle_manager import AppLifecycleManager
 from utils.element_state_checker import ElementStateChecker
 from utils.exceptions import ElementInteractionError
@@ -236,12 +238,18 @@ class BasePage:
         fallback_locators: list[tuple] | None = None,
         max_attempts: int = 3,
         capture_evidence: bool = False,
+        catch_driver_errors: bool = False,
     ) -> bool:
         """click() that returns False instead of raising on exhaustion.
 
-        No failure artifacts by default: try_click sites are probes and
-        optional taps whose False branch handles the miss — pass
-        capture_evidence=True where a screenshot/page dump is wanted.
+        Contract: returns True when the tap was dispatched, False when the
+        element could not be clicked. Never raises for interaction failures.
+        Driver-level errors propagate unless catch_driver_errors=True, and
+        session-fatal errors (SESSION_FATAL) ALWAYS propagate — a dead
+        session must never read as "element not clickable". No failure
+        artifacts by default: try_click sites are probes and optional taps
+        whose False branch handles the miss — pass capture_evidence=True
+        where a screenshot/page dump is wanted.
         """
         try:
             return self.click(
@@ -252,6 +260,16 @@ class BasePage:
                 capture_evidence=capture_evidence,
             )
         except ElementInteractionError:
+            return False
+        except SESSION_FATAL:
+            raise
+        except WebDriverException as e:
+            if not catch_driver_errors:
+                raise
+            self.logger.warning(
+                "try_click swallowed non-interaction error: %s: %s",
+                type(e).__name__, e,
+            )
             return False
 
     def find_element_safe(self, locator: tuple, timeout: int | None = None) -> WebElement | None:

--- a/test/e2e_appium/pages/base_page.py
+++ b/test/e2e_appium/pages/base_page.py
@@ -147,7 +147,7 @@ class BasePage:
                 continue
         return False
 
-    def safe_click(
+    def click(
         self,
         locator: tuple,
         *,
@@ -237,14 +237,14 @@ class BasePage:
         max_attempts: int = 3,
         capture_evidence: bool = False,
     ) -> bool:
-        """safe_click that returns False instead of raising on exhaustion.
+        """click() that returns False instead of raising on exhaustion.
 
         No failure artifacts by default: try_click sites are probes and
         optional taps whose False branch handles the miss — pass
         capture_evidence=True where a screenshot/page dump is wanted.
         """
         try:
-            return self.safe_click(
+            return self.click(
                 locator,
                 timeout=timeout,
                 fallback_locators=fallback_locators,

--- a/test/e2e_appium/pages/base_page.py
+++ b/test/e2e_appium/pages/base_page.py
@@ -19,7 +19,9 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 from config import get_config, log_element_action
-from utils.exceptions import SESSION_FATAL
+from urllib3.exceptions import HTTPError as _TransportError
+
+from utils.exceptions import SESSION_FATAL, is_session_fatal
 from utils.app_lifecycle_manager import AppLifecycleManager
 from utils.element_state_checker import ElementStateChecker
 from utils.exceptions import ElementInteractionError
@@ -261,10 +263,8 @@ class BasePage:
             )
         except ElementInteractionError:
             return False
-        except SESSION_FATAL:
-            raise
-        except WebDriverException as e:
-            if not catch_driver_errors:
+        except (WebDriverException, _TransportError) as e:
+            if is_session_fatal(e) or not catch_driver_errors:
                 raise
             self.logger.warning(
                 "try_click swallowed non-interaction error: %s: %s",

--- a/test/e2e_appium/pages/base_page.py
+++ b/test/e2e_appium/pages/base_page.py
@@ -21,7 +21,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from config import get_config, log_element_action
 from urllib3.exceptions import HTTPError as _TransportError
 
-from utils.exceptions import SESSION_FATAL, is_session_fatal
+from utils.exceptions import is_session_fatal
 from utils.app_lifecycle_manager import AppLifecycleManager
 from utils.element_state_checker import ElementStateChecker
 from utils.exceptions import ElementInteractionError

--- a/test/e2e_appium/pages/base_page.py
+++ b/test/e2e_appium/pages/base_page.py
@@ -262,6 +262,7 @@ class BasePage:
                 capture_evidence=capture_evidence,
             )
         except ElementInteractionError:
+            self.logger.debug("try_click miss: %s", locator[1] if len(locator) > 1 else locator)
             return False
         except (WebDriverException, _TransportError) as e:
             if is_session_fatal(e) or not catch_driver_errors:

--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -525,7 +525,7 @@ class ChatPage(BasePage):
     def open_chat_options_menu(self, timeout: int = 10) -> bool:
         """Open the chat header context menu (More options)."""
         try:
-            self.safe_click(self.locators.CHAT_MORE_OPTIONS_BUTTON, timeout=timeout)
+            self.click(self.locators.CHAT_MORE_OPTIONS_BUTTON, timeout=timeout)
             menu_visible = self.is_element_visible(
                 self.locators.CHAT_MORE_OPTIONS_MENU, timeout=5,
             )
@@ -552,8 +552,8 @@ class ChatPage(BasePage):
             return False
 
         try:
-            self.safe_click(self.locators.CLEAR_HISTORY_MENU_ITEM, timeout=timeout)
-            self.safe_click(self.locators.CLEAR_HISTORY_CONFIRM_BUTTON, timeout=timeout)
+            self.click(self.locators.CLEAR_HISTORY_MENU_ITEM, timeout=timeout)
+            self.click(self.locators.CLEAR_HISTORY_CONFIRM_BUTTON, timeout=timeout)
             return True
         except Exception as exc:
             self.logger.error("Failed to clear chat history: %s", exc)
@@ -566,8 +566,8 @@ class ChatPage(BasePage):
             return False
 
         try:
-            self.safe_click(self.locators.CLOSE_CHAT_MENU_ITEM, timeout=timeout)
-            self.safe_click(self.locators.CLOSE_CHAT_CONFIRM_BUTTON, timeout=timeout)
+            self.click(self.locators.CLOSE_CHAT_MENU_ITEM, timeout=timeout)
+            self.click(self.locators.CLOSE_CHAT_CONFIRM_BUTTON, timeout=timeout)
             return True
         except Exception as exc:
             self.logger.error("Failed to close chat: %s", exc)

--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -183,7 +183,8 @@ class ChatPage(BasePage):
             return False
 
         button_clicked = self.try_click(
-            self.locators.SEND_BUTTON, timeout=3, max_attempts=1
+            self.locators.SEND_BUTTON, timeout=3, max_attempts=1,
+            catch_driver_errors=True,
         )
         if not button_clicked:
             self.logger.info("Send button not clickable — falling back to newline trigger")
@@ -337,10 +338,12 @@ class ChatPage(BasePage):
                     # cost (activate_app + modal check + landmark wait) per
                     # poll iteration, and arrival is re-checked below anyway.
                     app._ensure_main_nav_visible()
-                    app._click_nav_item(app.locators.LEFT_NAV_WALLET)
+                    if not app._click_nav_item(app.locators.LEFT_NAV_WALLET):
+                        self.logger.debug("Nav-toggle: wallet leg missed")
                     time.sleep(1)
                     app._ensure_main_nav_visible()
-                    app._click_nav_item(app.locators.LEFT_NAV_MESSAGES)
+                    if not app._click_nav_item(app.locators.LEFT_NAV_MESSAGES):
+                        self.logger.debug("Nav-toggle: messages leg missed")
                 except Exception as exc:
                     self.logger.debug("Nav-toggle refresh failed: %s", exc)
                 self.dismiss_introduce_prompt(timeout=1)

--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -126,7 +126,7 @@ class ChatPage(BasePage):
             self.dump_page_source(f"open_chat_by_suffix_failure_{chat_identifier}")
             return False
         try:
-            self.safe_click(locator, timeout=5, max_attempts=3)
+            self.click(locator, timeout=5, max_attempts=3)
         except ElementInteractionError as exc:
             self.logger.warning(
                 "Chat row for %s did not take the tap: %s", chat_identifier, exc,

--- a/test/e2e_appium/pages/messaging/group_chat_page.py
+++ b/test/e2e_appium/pages/messaging/group_chat_page.py
@@ -406,7 +406,7 @@ class GroupChatPage(BasePage):
             self.long_press_element(element, duration=press_ms)
             time.sleep(1)
             self.driver.back()
-            # safe_click raises (not returns False) on exhaustion, so gate on
+            # click raises (not returns False) on exhaustion, so gate on
             # visibility first — else a missed long-press skips the retry below.
             if self.is_element_visible(
                 self.locators.REMOVE_FROM_GROUP_ITEM, timeout=5,
@@ -512,7 +512,7 @@ class GroupChatPage(BasePage):
         is NOT one of the known 1:1 chat names".
 
         Returns a (strategy, selector) locator tuple usable with
-        ``is_element_visible`` / ``safe_click`` / ``long_press_element``,
+        ``is_element_visible`` / ``click`` / ``long_press_element``,
         or None if no group row is found.
         """
         if not known_one_to_one_names:

--- a/test/e2e_appium/pages/messaging/group_chat_page.py
+++ b/test/e2e_appium/pages/messaging/group_chat_page.py
@@ -406,8 +406,6 @@ class GroupChatPage(BasePage):
             self.long_press_element(element, duration=press_ms)
             time.sleep(1)
             self.driver.back()
-            # click raises (not returns False) on exhaustion, so gate on
-            # visibility first — else a missed long-press skips the retry below.
             if self.is_element_visible(
                 self.locators.REMOVE_FROM_GROUP_ITEM, timeout=5,
             ):

--- a/test/e2e_appium/pages/onboarding/biometrics_page.py
+++ b/test/e2e_appium/pages/onboarding/biometrics_page.py
@@ -13,7 +13,7 @@ class BiometricsPage(BasePage):
 
     def select_maybe_later(self) -> bool:
         try:
-            self.safe_click(self.locators.MAYBE_LATER_BUTTON)
+            self.click(self.locators.MAYBE_LATER_BUTTON)
         except ElementInteractionError:
             self.logger.error("Failed to tap 'Maybe later' on biometrics prompt", exc_info=True)
             return False

--- a/test/e2e_appium/pages/onboarding/push_notifications_page.py
+++ b/test/e2e_appium/pages/onboarding/push_notifications_page.py
@@ -19,7 +19,7 @@ class PushNotificationsPage(BasePage):
     def select_maybe_later(self) -> bool:
         """Dismiss the dialog by tapping 'Maybe later'."""
         try:
-            self.safe_click(self.locators.MAYBE_LATER_BUTTON)
+            self.click(self.locators.MAYBE_LATER_BUTTON)
         except ElementInteractionError:
             self.logger.error(
                 "Failed to tap 'Maybe later' on push notifications dialog",

--- a/test/e2e_appium/pages/settings/change_password_modal.py
+++ b/test/e2e_appium/pages/settings/change_password_modal.py
@@ -71,13 +71,12 @@ class ChangePasswordModal(BasePage):
                     self.logger.debug(
                         "Restart button still visible; tapping attempt %s", attempt + 1
                     )
-                    try:
-                        self.click(
-                            self.locators.PRIMARY_BUTTON, timeout=5, max_attempts=1
-                        )
-                    except Exception as err:
+                    if not self.try_click(
+                        self.locators.PRIMARY_BUTTON, timeout=5, max_attempts=1,
+                        catch_driver_errors=True,
+                    ):
                         self.logger.debug(
-                            "Restart button tap attempt %s failed: %s", attempt + 1, err
+                            "Restart button tap attempt %s missed", attempt + 1
                         )
                     attempt += 1
                 else:

--- a/test/e2e_appium/pages/settings/change_password_modal.py
+++ b/test/e2e_appium/pages/settings/change_password_modal.py
@@ -48,7 +48,7 @@ class ChangePasswordModal(BasePage):
                     label = ""
             if label.lower() == "close":
                 self.logger.info("Fast password change detected; closing modal, no restart")
-                self.safe_click(self.locators.PRIMARY_BUTTON, timeout=5)
+                self.click(self.locators.PRIMARY_BUTTON, timeout=5)
                 if user and new_password:
                     user.password = new_password
                 return True
@@ -72,7 +72,7 @@ class ChangePasswordModal(BasePage):
                         "Restart button still visible; tapping attempt %s", attempt + 1
                     )
                     try:
-                        self.safe_click(
+                        self.click(
                             self.locators.PRIMARY_BUTTON, timeout=5, max_attempts=1
                         )
                     except Exception as err:

--- a/test/e2e_appium/pages/settings/password_change_page.py
+++ b/test/e2e_appium/pages/settings/password_change_page.py
@@ -47,7 +47,7 @@ class PasswordChangePage(BasePage):
 
         modal = ChangePasswordModal(self.driver)
         try:
-            self.safe_click(self.locators.CHANGE_PASSWORD_BUTTON, timeout=5)
+            self.click(self.locators.CHANGE_PASSWORD_BUTTON, timeout=5)
         except Exception as e:
             self.logger.error(f"Failed to click change password button: {e}")
             return None

--- a/test/e2e_appium/pages/settings/settings_page.py
+++ b/test/e2e_appium/pages/settings/settings_page.py
@@ -41,7 +41,10 @@ class SettingsPage(BasePage):
             self.locators.BACKUP_RECOVERY_MENU_ITEM, timeout=10
         ):
             return None
-        if not self.try_click(self.locators.BACKUP_RECOVERY_MENU_ITEM, timeout=5):
+        if not self.try_click(
+            self.locators.BACKUP_RECOVERY_MENU_ITEM, timeout=5,
+            catch_driver_errors=True,
+        ):
             return None
         modal = BackupSeedModal(self.driver)
         return modal if modal.is_displayed(timeout=10) else None
@@ -53,6 +56,7 @@ class SettingsPage(BasePage):
             self.locators.PASSWORD_MENU_ITEM,
             timeout=5,
             fallback_locators=[self.locators.PASSWORD_MENU_ITEM_TEXT],
+            catch_driver_errors=True,
         ):
             return None
 
@@ -73,7 +77,7 @@ class SettingsPage(BasePage):
         self.try_click(locators.SETTINGS_WALLET_MENU_ITEM)
         if not self.is_element_visible(locators.SAVED_ADDRESSES_ITEM, timeout=10):
             return None
-        if not self.try_click(locators.SAVED_ADDRESSES_ITEM):
+        if not self.try_click(locators.SAVED_ADDRESSES_ITEM, catch_driver_errors=True):
             return None
         page = SavedAddressesPage(self.driver)
         return page if page.is_loaded(timeout=10) else None
@@ -129,5 +133,6 @@ class SettingsPage(BasePage):
         profile_page = self.open_profile_settings()
         if not profile_page:
             return None
-        profile_page.open_identity_tab()
+        if not profile_page.open_identity_tab():
+            return None
         return profile_page.open_share_profile()

--- a/test/e2e_appium/pages/settings/wallet_settings_page.py
+++ b/test/e2e_appium/pages/settings/wallet_settings_page.py
@@ -157,7 +157,7 @@ class WalletSettingsPage(BasePage):
         for attempt in range(3):
             time.sleep(0.4)
             try:
-                self.safe_click(locator, timeout=timeout, max_attempts=1)
+                self.click(locator, timeout=timeout, max_attempts=1)
             except Exception as e:
                 self.logger.debug(f"select_account tap attempt {attempt + 1}: {e}")
             if details.is_loaded(timeout=3):

--- a/test/e2e_appium/pages/settings/wallet_settings_page.py
+++ b/test/e2e_appium/pages/settings/wallet_settings_page.py
@@ -156,10 +156,8 @@ class WalletSettingsPage(BasePage):
         details = AccountDetailsPage(self.driver)
         for attempt in range(3):
             time.sleep(0.4)
-            try:
-                self.click(locator, timeout=timeout, max_attempts=1)
-            except Exception as e:
-                self.logger.debug(f"select_account tap attempt {attempt + 1}: {e}")
+            if not self.try_click(locator, timeout=timeout, max_attempts=1):
+                self.logger.debug(f"select_account tap attempt {attempt + 1} missed")
             if details.is_loaded(timeout=3):
                 return True
             self.logger.debug(f"Account '{name}' tap did not open details (attempt {attempt + 1})")

--- a/test/e2e_appium/pages/wallet/add_edit_account_modal.py
+++ b/test/e2e_appium/pages/wallet/add_edit_account_modal.py
@@ -54,7 +54,7 @@ class AddEditAccountModal(BasePage):
         return True
 
     def save_changes(self) -> bool:
-        self.safe_click(self.locators.ADD_ACCOUNT_PRIMARY, timeout=10)
+        self.click(self.locators.ADD_ACCOUNT_PRIMARY, timeout=10)
         return True
 
     def wait_until_hidden(self, timeout: int | None = 10) -> bool:

--- a/test/e2e_appium/pages/wallet/add_edit_account_modal.py
+++ b/test/e2e_appium/pages/wallet/add_edit_account_modal.py
@@ -54,8 +54,7 @@ class AddEditAccountModal(BasePage):
         return True
 
     def save_changes(self) -> bool:
-        self.click(self.locators.ADD_ACCOUNT_PRIMARY, timeout=10)
-        return True
+        return self.try_click(self.locators.ADD_ACCOUNT_PRIMARY, timeout=10)
 
     def wait_until_hidden(self, timeout: int | None = 10) -> bool:
         return self.wait_for_invisibility(self.locators.ADD_ACCOUNT_MODAL, timeout=timeout)

--- a/test/e2e_appium/pages/wallet/keycard_auth_modal.py
+++ b/test/e2e_appium/pages/wallet/keycard_auth_modal.py
@@ -59,7 +59,7 @@ class KeycardAuthenticationModal(BasePage):
                 self.dump_page_source("auth_button_not_enabled")
                 return False
 
-            self.safe_click(self.locators.KEYCARD_AUTHENTICATE_BUTTON, timeout=timeout)
+            self.click(self.locators.KEYCARD_AUTHENTICATE_BUTTON, timeout=timeout)
             if not self.wait_for_invisibility(self.locators.KEYCARD_POPUP, timeout=timeout):
                 self.logger.error("Auth popup did not close after clicking Authenticate")
                 self.dump_page_source("auth_popup_still_visible")
@@ -75,5 +75,5 @@ class KeycardAuthenticationModal(BasePage):
     def cancel(self) -> bool:
         if not self.is_displayed(timeout=2):
             return True
-        self.safe_click(self.locators.KEYCARD_CANCEL_BUTTON, timeout=5)
+        self.click(self.locators.KEYCARD_CANCEL_BUTTON, timeout=5)
         return self.wait_for_invisibility(self.locators.KEYCARD_POPUP, timeout=5)

--- a/test/e2e_appium/pages/wallet/keycard_auth_modal.py
+++ b/test/e2e_appium/pages/wallet/keycard_auth_modal.py
@@ -60,7 +60,8 @@ class KeycardAuthenticationModal(BasePage):
                 return False
 
             if not self.try_click(
-                self.locators.KEYCARD_AUTHENTICATE_BUTTON, timeout=timeout
+                self.locators.KEYCARD_AUTHENTICATE_BUTTON, timeout=timeout,
+                catch_driver_errors=True,
             ):
                 self.logger.error("Failed to tap Authenticate")
                 self.dump_page_source("auth_button_tap_failed")

--- a/test/e2e_appium/pages/wallet/keycard_auth_modal.py
+++ b/test/e2e_appium/pages/wallet/keycard_auth_modal.py
@@ -1,5 +1,5 @@
 from locators.wallet.accounts_locators import WalletAccountsLocators
-from utils.exceptions import SESSION_FATAL
+from utils.exceptions import is_session_fatal
 
 from ..base_page import BasePage
 
@@ -72,9 +72,9 @@ class KeycardAuthenticationModal(BasePage):
                 return False
             return True
 
-        except SESSION_FATAL:
-            raise
         except Exception as exc:
+            if is_session_fatal(exc):
+                raise
             self.logger.error("Auth flow failed: %s", exc, exc_info=True)
             return False
 

--- a/test/e2e_appium/pages/wallet/keycard_auth_modal.py
+++ b/test/e2e_appium/pages/wallet/keycard_auth_modal.py
@@ -1,5 +1,5 @@
 from locators.wallet.accounts_locators import WalletAccountsLocators
-from utils.exceptions import ElementInteractionError
+from utils.exceptions import SESSION_FATAL
 
 from ..base_page import BasePage
 
@@ -59,14 +59,19 @@ class KeycardAuthenticationModal(BasePage):
                 self.dump_page_source("auth_button_not_enabled")
                 return False
 
-            self.click(self.locators.KEYCARD_AUTHENTICATE_BUTTON, timeout=timeout)
+            if not self.try_click(
+                self.locators.KEYCARD_AUTHENTICATE_BUTTON, timeout=timeout
+            ):
+                self.logger.error("Failed to tap Authenticate")
+                self.dump_page_source("auth_button_tap_failed")
+                return False
             if not self.wait_for_invisibility(self.locators.KEYCARD_POPUP, timeout=timeout):
                 self.logger.error("Auth popup did not close after clicking Authenticate")
                 self.dump_page_source("auth_popup_still_visible")
                 return False
             return True
 
-        except ElementInteractionError:
+        except SESSION_FATAL:
             raise
         except Exception as exc:
             self.logger.error("Auth flow failed: %s", exc, exc_info=True)
@@ -75,5 +80,5 @@ class KeycardAuthenticationModal(BasePage):
     def cancel(self) -> bool:
         if not self.is_displayed(timeout=2):
             return True
-        self.click(self.locators.KEYCARD_CANCEL_BUTTON, timeout=5)
+        self.try_click(self.locators.KEYCARD_CANCEL_BUTTON, timeout=5)
         return self.wait_for_invisibility(self.locators.KEYCARD_POPUP, timeout=5)

--- a/test/e2e_appium/pages/wallet/remove_account_modal.py
+++ b/test/e2e_appium/pages/wallet/remove_account_modal.py
@@ -13,7 +13,7 @@ class RemoveAccountConfirmationModal(BasePage):
     def acknowledge_derivation_path(self) -> bool:
         if self._is_element_checked(self.locators.REMOVE_ACCOUNT_ACK_CHECKBOX):
             return True
-        self.safe_click(self.locators.REMOVE_ACCOUNT_ACK_CHECKBOX, timeout=5)
+        self.click(self.locators.REMOVE_ACCOUNT_ACK_CHECKBOX, timeout=5)
         return self._is_element_checked(self.locators.REMOVE_ACCOUNT_ACK_CHECKBOX)
 
     def confirm_removal(self, timeout: int = 15) -> bool:
@@ -29,5 +29,5 @@ class RemoveAccountConfirmationModal(BasePage):
             self.logger.error("Remove account confirm button did not become enabled")
             return False
 
-        self.safe_click(self.locators.REMOVE_ACCOUNT_CONFIRM_BUTTON, timeout=timeout)
+        self.click(self.locators.REMOVE_ACCOUNT_CONFIRM_BUTTON, timeout=timeout)
         return True

--- a/test/e2e_appium/pages/wallet/wallet_left_panel.py
+++ b/test/e2e_appium/pages/wallet/wallet_left_panel.py
@@ -205,7 +205,7 @@ class WalletLeftPanel(BasePage):
 
     def open_add_account_popup(self) -> AddEditAccountModal | None:
         try:
-            self.safe_click(self.locators.ADD_ACCOUNT_BUTTON, timeout=5)
+            self.click(self.locators.ADD_ACCOUNT_BUTTON, timeout=5)
         except Exception as e:
             self.logger.error("Add account button not clickable: %s", e)
             self.take_screenshot("add_account_button_not_clickable")
@@ -351,7 +351,7 @@ class WalletLeftPanel(BasePage):
             self.logger.error("Failed to open account context menu via long-press")
             return False
 
-        self.safe_click(self.locators.ACCOUNT_MENU_EDIT, timeout=5)
+        self.click(self.locators.ACCOUNT_MENU_EDIT, timeout=5)
 
         modal = AddEditAccountModal(self.driver)
         if not modal.is_displayed(timeout=10):
@@ -381,7 +381,7 @@ class WalletLeftPanel(BasePage):
         Returns:
             bool: True if deletion completed successfully.
         """
-        self.safe_click(self.locators.ACCOUNT_MENU_DELETE, timeout=5)
+        self.click(self.locators.ACCOUNT_MENU_DELETE, timeout=5)
 
         confirmation = RemoveAccountConfirmationModal(self.driver)
         if confirmation.is_displayed(timeout=5):

--- a/test/e2e_appium/pages/wallet/wallet_left_panel.py
+++ b/test/e2e_appium/pages/wallet/wallet_left_panel.py
@@ -225,7 +225,9 @@ class WalletLeftPanel(BasePage):
         if not modal.set_name(name):
             self.logger.error(f"Failed to set account name to '{name}'")
             return False
-        modal.save_changes()
+        if not modal.save_changes():
+            self.logger.error("Failed to save account changes")
+            return False
 
         auth_modal = KeycardAuthenticationModal(self.driver)
         if not auth_modal.is_displayed(timeout=5):
@@ -362,7 +364,9 @@ class WalletLeftPanel(BasePage):
             self.logger.error(f"Failed to set account name to '{new_name}'")
             return False
 
-        modal.save_changes()
+        if not modal.save_changes():
+            self.logger.error("Failed to save account changes")
+            return False
 
         if not modal.wait_until_hidden(timeout=10):
             self.logger.error("Edit account modal did not close after saving")

--- a/test/e2e_appium/scripts/check_click_contract.py
+++ b/test/e2e_appium/scripts/check_click_contract.py
@@ -1,86 +1,226 @@
 #!/usr/bin/env python3
-"""Click-contract checker (AST-based).
+"""Click-contract checker v2 (AST, two-pass). DDR-001 enforcement.
 
-click() raises on failure and only ever returns True; try_click() is the
-bool-returning, never-raising variant. Branching, asserting, looping, or
-assigning on click()'s result is therefore dead code — as is a bool-annotated
-wrapper whose tail is 'return x.click(...)' (True-or-raise leaks to callers).
-Zero-argument .click() is WebElement.click(), which returns None: branching on
-it is always-False and equally flagged. Runs at pytest collection via
-conftest; standalone: python3 scripts/check_click_contract.py [root].
-Known limits: bare raising clicks inside bool functions and dynamic dispatch
-are not detected."""
-import ast, pathlib, sys
+Contract: click() raises on failure and only ever returns True (True = input
+dispatched, not UI reacted); try_click() returns bool and never raises for
+interaction failures. Suite-defined ``-> bool`` methods are either
+best-effort (BEST_EFFORT names: ignoring the result is legal) or
+outcome-reporting (result MUST be consumed: assert/if/return/assign).
 
-CLICK_NAMES = {"click"}  # the page helper; safe_click is banned outright below
-SKIP_DIRS = {".venv", "venv", "env", "__pycache__", "node_modules", ".git"}
+Rules: R-CONSUME (branch/assert/assign/walrus/not/while on raising click());
+R-ELEMENT (branching on zero-arg WebElement.click(), returns None);
+R-WRAPPER (bool-annotated def whose tail returns raising click());
+R-ALWAYS-TRUE (bool-annotated def, every return literal True, body contains a
+bare raising click()); R-IGNORED (statement-level call of an indexed
+outcome-reporting bool method); R-CONFLICT (same method name indexed with
+conflicting contracts); safe_click token ban.
 
-def is_helper_click(node):
-    """Call of X.click(...)/X.safe_click(...) WITH args = page helper (raises).
-    Zero-arg .click() = WebElement — branching on that is a different, also-flagged bug."""
+Accepted false negatives (documented per DDR-001 §4): ``_ = x()`` discards;
+dynamic dispatch/getattr; contracts of methods called through variables;
+bare raising clicks inside bool functions without a returning tail;
+decorator-altered return contracts.
+
+Standalone: python3 scripts/check_click_contract.py  (root = the e2e_appium
+tree this file lives in — never the CWD). Wired into pytest sessionstart.
+"""
+import ast
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".venv", "venv", "env", "__pycache__", "node_modules", ".git", "reports",
+             "scripts", "cli", "locators"}  # tooling + locator factories — outside the click-contract domain
+SKIP_REL = {"pages/base_page.py", "scripts/check_click_contract.py"}
+CLICK = "click"
+
+BEST_EFFORT_PREFIXES = (
+    "try_", "is_", "has_", "wait_", "ensure_", "scroll_", "dismiss_", "hide_",
+    "swipe_", "tap", "activation_", "activate_", "terminate_", "find_", "close",
+    "_try_", "_is_", "_has_", "_wait_", "_ensure_", "_scroll_", "_dismiss_",
+    "_hide_", "_swipe_", "_tap", "_activation_", "_activate_", "_close",
+)
+BEST_EFFORT_NAMES = {
+    "hide_keyboard", "element_tap", "double_tap", "long_press_element",
+    "perform_initial_activation", "select_maybe_later", "dismiss_if_present",
+    "restart_app", "restart_app_with_data_cleared",
+}
+
+
+def best_effort(name: str) -> bool:
+    return name in BEST_EFFORT_NAMES or name.startswith(BEST_EFFORT_PREFIXES)
+
+
+def is_click_call(node):
     return (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-            and node.func.attr in CLICK_NAMES)
+            and node.func.attr == CLICK)
 
-def helper_has_args(node):
-    return bool(node.args or node.keywords)
 
-class V(ast.NodeVisitor):
-    def __init__(self, path):
-        self.path, self.bad = path, []
-    def flag(self, node, msg):
-        self.bad.append(f"{self.path}:{node.lineno}: {msg}")
-    def check_expr_tree(self, test, ctx):
-        for n in ast.walk(test):
-            if is_helper_click(n):
-                if helper_has_args(n):
-                    self.flag(n, f"{ctx} on raising {n.func.attr}() — use try_click")
-                else:
-                    self.flag(n, f"{ctx} on WebElement.click() (returns None — always falsy)")
-    def visit_If(self, n): self.check_expr_tree(n.test, "branch"); self.generic_visit(n)
-    def visit_While(self, n): self.check_expr_tree(n.test, "loop condition"); self.generic_visit(n)
-    def visit_Assert(self, n): self.check_expr_tree(n.test, "assert"); self.generic_visit(n)
-    def visit_Assign(self, n):
-        if is_helper_click(n.value) and helper_has_args(n.value):
-            self.flag(n, f"bool assignment of raising {n.value.func.attr}() — use try_click")
-        self.generic_visit(n)
-    def visit_NamedExpr(self, n):
-        if is_helper_click(n.value) and helper_has_args(n.value):
-            self.flag(n, "walrus on raising click() — use try_click")
-        self.generic_visit(n)
-    def visit_UnaryOp(self, n):
-        if isinstance(n.op, ast.Not) and is_helper_click(n.operand):
-            self.flag(n, "negation of raising click() — use try_click")
-        self.generic_visit(n)
-    def visit_FunctionDef(self, n):
-        ret = n.returns
-        is_bool = (isinstance(ret, ast.Name) and ret.id == "bool")
-        if is_bool and n.name not in ("safe_click", "click", "try_click"):
-            for stmt in ast.walk(n):
-                if isinstance(stmt, ast.Return) and stmt.value is not None \
-                   and is_helper_click(stmt.value) and helper_has_args(stmt.value):
-                    self.flag(stmt, f"bool-annotated wrapper '{n.name}' returns raising "
-                                    f"{stmt.value.func.attr}() — tail can raise, callers' "
-                                    f"bool guards are dead; return try_click or catch")
-        self.generic_visit(n)
+def has_args(call):
+    return bool(call.args or call.keywords)
+
+
+def is_bool_annotation(returns):
+    if isinstance(returns, ast.Name) and returns.id == "bool":
+        return True
+    if isinstance(returns, ast.Constant) and returns.value == "bool":
+        return True
+    return False
+
+
+class Indexer(ast.NodeVisitor):
+    """Pass 1: name -> set of contracts ('bool', 'always_true_bare_click')."""
+
+    def __init__(self):
+        self.bool_methods = {}   # name -> True
+        self.always_true = {}    # name -> [locations]
+        self.conflicts = {}      # name -> set of contract kinds seen
+
+    def visit_FunctionDef(self, node):
+        self._handle(node)
+        self.generic_visit(node)
+
     visit_AsyncFunctionDef = visit_FunctionDef
 
-def main(root):
-    root = pathlib.Path(root)
+    def _handle(self, node):
+        kind = "bool" if is_bool_annotation(node.returns) else "other"
+        self.conflicts.setdefault(node.name, set()).add(kind)
+        if kind != "bool":
+            return
+        self.bool_methods[node.name] = True
+        returns = [n for n in own_nodes(node) if isinstance(n, ast.Return)]
+        all_true = returns and all(
+            isinstance(r.value, ast.Constant) and r.value.value is True for r in returns
+        )
+        if all_true:
+            for n in own_nodes(node):
+                if isinstance(n, ast.Expr) and is_click_call(n.value) and has_args(n.value):
+                    self.always_true.setdefault(node.name, [])
+                    break
+
+
+def own_nodes(func):
+    """Walk a function body WITHOUT descending into nested function defs."""
+    stack = list(func.body)
+    while stack:
+        n = stack.pop()
+        yield n
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        stack.extend(ast.iter_child_nodes(n))
+
+
+class Checker(ast.NodeVisitor):
+    def __init__(self, relpath, index):
+        self.rel, self.index, self.bad, self.seen = relpath, index, [], set()
+
+    def flag(self, node, rule, msg):
+        key = (node.lineno, getattr(node, "col_offset", 0), rule)
+        if key in self.seen:
+            return
+        self.seen.add(key)
+        self.bad.append(f"{self.rel}:{node.lineno}: [{rule}] {msg}")
+
+    def _check_value(self, node, ctx):
+        for n in ast.walk(node):
+            if is_click_call(n):
+                if has_args(n):
+                    self.flag(n, "R-CONSUME", f"{ctx} on raising click() — use try_click")
+                else:
+                    self.flag(n, "R-ELEMENT",
+                              f"{ctx} on WebElement.click() (returns None — always falsy)")
+
+    def visit_If(self, n): self._check_value(n.test, "branch"); self.generic_visit(n)
+    def visit_While(self, n): self._check_value(n.test, "loop condition"); self.generic_visit(n)
+    def visit_Assert(self, n): self._check_value(n.test, "assert"); self.generic_visit(n)
+    def visit_IfExp(self, n): self._check_value(n.test, "ternary condition"); self.generic_visit(n)
+    def visit_comprehension(self, n):
+        for cond in n.ifs: self._check_value(cond, "comprehension condition")
+
+    def visit_Assign(self, n):
+        self._check_value(n.value, "bool assignment"); self.generic_visit(n)
+
+    def visit_AnnAssign(self, n):
+        if n.value is not None:
+            self._check_value(n.value, "bool assignment")
+        self.generic_visit(n)
+
+    def visit_NamedExpr(self, n):
+        self._check_value(n.value, "walrus"); self.generic_visit(n)
+
+    def visit_Expr(self, n):
+        v = n.value
+        if isinstance(v, ast.Call) and isinstance(v.func, ast.Attribute):
+            name = v.func.attr
+            if name in self.index.bool_methods and not best_effort(name) and name != CLICK:
+                self.flag(n, "R-IGNORED",
+                          f"result of bool method '{name}' ignored — assert or branch on it")
+        self.generic_visit(n)
+
+    def visit_FunctionDef(self, n):
+        if is_bool_annotation(n.returns) and n.name not in (CLICK, "try_click"):
+            for st in own_nodes(n):
+                if isinstance(st, ast.Return) and st.value is not None:
+                    for c in ast.walk(st.value):
+                        if is_click_call(c) and has_args(c):
+                            self.flag(st, "R-WRAPPER",
+                                      f"bool wrapper '{n.name}' returns raising click() — "
+                                      "tail can raise; return try_click or catch")
+            if n.name in self.index.always_true:
+                for st in own_nodes(n):
+                    if isinstance(st, ast.Expr) and is_click_call(st.value) and has_args(st.value):
+                        self.flag(st, "R-ALWAYS-TRUE",
+                                  f"'{n.name}' always returns True but contains a bare raising "
+                                  "click() — callers' bool guards are dead")
+        self.generic_visit(n)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+
+def iter_files():
+    for p in sorted(ROOT.rglob("*.py")):
+        rel = p.relative_to(ROOT)
+        if any(part in SKIP_DIRS for part in rel.parts):
+            continue
+        if str(rel) in SKIP_REL:
+            continue
+        yield p, rel
+
+
+def main():
     bad = []
-    for p in sorted(root.rglob("*.py")):
-        if any(part in SKIP_DIRS for part in p.parts): continue
-        if p.name in ("base_page.py",): continue
+    index = Indexer()
+    trees = {}
+    for p, rel in iter_files():
         try:
             tree = ast.parse(p.read_text(encoding="utf-8"), filename=str(p))
         except SyntaxError as e:
-            bad.append(f"{p}: unparseable: {e}"); continue
-        v = V(p.relative_to(root)); v.visit(tree); bad += v.bad
-        for n in ast.walk(tree):  # safe_click token ban (post-rename only meaningful)
+            bad.append(f"{rel}: unparseable: {e}")
+            continue
+        trees[rel] = tree
+        index.visit(tree)
+
+    for name, kinds in index.conflicts.items():
+        if "bool" in kinds and "other" in kinds and not best_effort(name) and name != CLICK:
+            # Same name, conflicting contracts across classes — R-IGNORED keys on
+            # the name, so this ambiguity must be surfaced, not guessed away.
+            bad.append(f"[R-CONFLICT] method name '{name}' is bool in one class and "
+                       f"non-bool in another — unify or rename")
+
+    for rel, tree in trees.items():
+        c = Checker(rel, index)
+        c.visit(tree)
+        bad.extend(c.bad)
+        for n in ast.walk(tree):
             if isinstance(n, ast.Attribute) and n.attr == "safe_click":
-                bad.append(f"{p}:{n.lineno}: safe_click reference (renamed to click)")
+                bad.append(f"{rel}:{n.lineno}: safe_click reference (renamed to click)")
+
     if bad:
-        print("click-contract violations:"); print("\n".join(bad)); return 1
-    print("click contract clean"); return 0
+        print("click-contract violations:")
+        print("\n".join(sorted(bad)))
+        return 1
+    print("click contract clean")
+    return 0
+
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "."))
+    sys.exit(main())

--- a/test/e2e_appium/scripts/check_click_contract.py
+++ b/test/e2e_appium/scripts/check_click_contract.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Click-contract checker (AST-based).
+
+click() raises on failure and only ever returns True; try_click() is the
+bool-returning, never-raising variant. Branching, asserting, looping, or
+assigning on click()'s result is therefore dead code — as is a bool-annotated
+wrapper whose tail is 'return x.click(...)' (True-or-raise leaks to callers).
+Zero-argument .click() is WebElement.click(), which returns None: branching on
+it is always-False and equally flagged. Runs at pytest collection via
+conftest; standalone: python3 scripts/check_click_contract.py [root].
+Known limits: bare raising clicks inside bool functions and dynamic dispatch
+are not detected."""
+import ast, pathlib, sys
+
+CLICK_NAMES = {"click"}  # the page helper; safe_click is banned outright below
+SKIP_DIRS = {".venv", "venv", "env", "__pycache__", "node_modules", ".git"}
+
+def is_helper_click(node):
+    """Call of X.click(...)/X.safe_click(...) WITH args = page helper (raises).
+    Zero-arg .click() = WebElement — branching on that is a different, also-flagged bug."""
+    return (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and node.func.attr in CLICK_NAMES)
+
+def helper_has_args(node):
+    return bool(node.args or node.keywords)
+
+class V(ast.NodeVisitor):
+    def __init__(self, path):
+        self.path, self.bad = path, []
+    def flag(self, node, msg):
+        self.bad.append(f"{self.path}:{node.lineno}: {msg}")
+    def check_expr_tree(self, test, ctx):
+        for n in ast.walk(test):
+            if is_helper_click(n):
+                if helper_has_args(n):
+                    self.flag(n, f"{ctx} on raising {n.func.attr}() — use try_click")
+                else:
+                    self.flag(n, f"{ctx} on WebElement.click() (returns None — always falsy)")
+    def visit_If(self, n): self.check_expr_tree(n.test, "branch"); self.generic_visit(n)
+    def visit_While(self, n): self.check_expr_tree(n.test, "loop condition"); self.generic_visit(n)
+    def visit_Assert(self, n): self.check_expr_tree(n.test, "assert"); self.generic_visit(n)
+    def visit_Assign(self, n):
+        if is_helper_click(n.value) and helper_has_args(n.value):
+            self.flag(n, f"bool assignment of raising {n.value.func.attr}() — use try_click")
+        self.generic_visit(n)
+    def visit_NamedExpr(self, n):
+        if is_helper_click(n.value) and helper_has_args(n.value):
+            self.flag(n, "walrus on raising click() — use try_click")
+        self.generic_visit(n)
+    def visit_UnaryOp(self, n):
+        if isinstance(n.op, ast.Not) and is_helper_click(n.operand):
+            self.flag(n, "negation of raising click() — use try_click")
+        self.generic_visit(n)
+    def visit_FunctionDef(self, n):
+        ret = n.returns
+        is_bool = (isinstance(ret, ast.Name) and ret.id == "bool")
+        if is_bool and n.name not in ("safe_click", "click", "try_click"):
+            for stmt in ast.walk(n):
+                if isinstance(stmt, ast.Return) and stmt.value is not None \
+                   and is_helper_click(stmt.value) and helper_has_args(stmt.value):
+                    self.flag(stmt, f"bool-annotated wrapper '{n.name}' returns raising "
+                                    f"{stmt.value.func.attr}() — tail can raise, callers' "
+                                    f"bool guards are dead; return try_click or catch")
+        self.generic_visit(n)
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+def main(root):
+    root = pathlib.Path(root)
+    bad = []
+    for p in sorted(root.rglob("*.py")):
+        if any(part in SKIP_DIRS for part in p.parts): continue
+        if p.name in ("base_page.py",): continue
+        try:
+            tree = ast.parse(p.read_text(encoding="utf-8"), filename=str(p))
+        except SyntaxError as e:
+            bad.append(f"{p}: unparseable: {e}"); continue
+        v = V(p.relative_to(root)); v.visit(tree); bad += v.bad
+        for n in ast.walk(tree):  # safe_click token ban (post-rename only meaningful)
+            if isinstance(n, ast.Attribute) and n.attr == "safe_click":
+                bad.append(f"{p}:{n.lineno}: safe_click reference (renamed to click)")
+    if bad:
+        print("click-contract violations:"); print("\n".join(bad)); return 1
+    print("click contract clean"); return 0
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "."))

--- a/test/e2e_appium/scripts/check_click_contract.py
+++ b/test/e2e_appium/scripts/check_click_contract.py
@@ -215,8 +215,16 @@ def main():
         c.visit(tree)
         bad.extend(c.bad)
         for n in ast.walk(tree):
-            if isinstance(n, ast.Attribute) and n.attr == "safe_click":
-                bad.append(f"{rel}:{n.lineno}: safe_click reference (renamed to click)")
+            hit = (
+                (isinstance(n, ast.Attribute) and n.attr == "safe_click")
+                or (isinstance(n, ast.Name) and n.id == "safe_click")
+                or (isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and n.name == "safe_click")
+                or (isinstance(n, ast.alias)
+                    and "safe_click" in (n.name, n.asname))
+            )
+            if hit:
+                bad.append(f"{rel}:{getattr(n, 'lineno', 0)}: safe_click reference (renamed to click)")
 
     if bad:
         print("click-contract violations:")

--- a/test/e2e_appium/scripts/check_click_contract.py
+++ b/test/e2e_appium/scripts/check_click_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Click-contract checker v2 (AST, two-pass). DDR-001 enforcement.
+"""Click-contract checker v2 (AST, two-pass).
 
 Contract: click() raises on failure and only ever returns True (True = input
 dispatched, not UI reacted); try_click() returns bool and never raises for
@@ -15,7 +15,7 @@ bare raising click()); R-IGNORED (statement-level call of an indexed
 outcome-reporting bool method); R-CONFLICT (same method name indexed with
 conflicting contracts); safe_click token ban.
 
-Accepted false negatives (documented per DDR-001 §4): ``_ = x()`` discards;
+Accepted false negatives: ``_ = x()`` discards; await/dynamic edge cases below;
 dynamic dispatch/getattr; contracts of methods called through variables;
 bare raising clicks inside bool functions without a returning tail;
 decorator-altered return contracts.
@@ -38,6 +38,7 @@ BEST_EFFORT_PREFIXES = (
     "swipe_", "tap", "activation_", "activate_", "terminate_", "find_", "close",
     "_try_", "_is_", "_has_", "_wait_", "_ensure_", "_scroll_", "_dismiss_",
     "_hide_", "_swipe_", "_tap", "_activation_", "_activate_", "_close",
+    "_find_", "_terminate_",
 )
 BEST_EFFORT_NAMES = {
     "hide_keyboard", "element_tap", "double_tap", "long_press_element",
@@ -72,7 +73,6 @@ class Indexer(ast.NodeVisitor):
 
     def __init__(self):
         self.bool_methods = {}   # name -> True
-        self.always_true = {}    # name -> [locations]
         self.conflicts = {}      # name -> set of contract kinds seen
 
     def visit_FunctionDef(self, node):
@@ -84,18 +84,8 @@ class Indexer(ast.NodeVisitor):
     def _handle(self, node):
         kind = "bool" if is_bool_annotation(node.returns) else "other"
         self.conflicts.setdefault(node.name, set()).add(kind)
-        if kind != "bool":
-            return
-        self.bool_methods[node.name] = True
-        returns = [n for n in own_nodes(node) if isinstance(n, ast.Return)]
-        all_true = returns and all(
-            isinstance(r.value, ast.Constant) and r.value.value is True for r in returns
-        )
-        if all_true:
-            for n in own_nodes(node):
-                if isinstance(n, ast.Expr) and is_click_call(n.value) and has_args(n.value):
-                    self.always_true.setdefault(node.name, [])
-                    break
+        if kind == "bool":
+            self.bool_methods[node.name] = True
 
 
 def own_nodes(func):
@@ -134,7 +124,9 @@ class Checker(ast.NodeVisitor):
     def visit_Assert(self, n): self._check_value(n.test, "assert"); self.generic_visit(n)
     def visit_IfExp(self, n): self._check_value(n.test, "ternary condition"); self.generic_visit(n)
     def visit_comprehension(self, n):
-        for cond in n.ifs: self._check_value(cond, "comprehension condition")
+        for cond in n.ifs:
+            self._check_value(cond, "comprehension condition")
+        self.generic_visit(n)
 
     def visit_Assign(self, n):
         self._check_value(n.value, "bool assignment"); self.generic_visit(n)
@@ -149,9 +141,16 @@ class Checker(ast.NodeVisitor):
 
     def visit_Expr(self, n):
         v = n.value
-        if isinstance(v, ast.Call) and isinstance(v.func, ast.Attribute):
-            name = v.func.attr
-            if name in self.index.bool_methods and not best_effort(name) and name != CLICK:
+        if isinstance(v, ast.Await):
+            v = v.value
+        if isinstance(v, ast.Call):
+            name = None
+            if isinstance(v.func, ast.Attribute):
+                name = v.func.attr
+            elif isinstance(v.func, ast.Name):
+                name = v.func.id
+            if (name and name in self.index.bool_methods
+                    and not best_effort(name) and name != CLICK):
                 self.flag(n, "R-IGNORED",
                           f"result of bool method '{name}' ignored — assert or branch on it")
         self.generic_visit(n)
@@ -165,7 +164,12 @@ class Checker(ast.NodeVisitor):
                             self.flag(st, "R-WRAPPER",
                                       f"bool wrapper '{n.name}' returns raising click() — "
                                       "tail can raise; return try_click or catch")
-            if n.name in self.index.always_true:
+            returns = [st for st in own_nodes(n) if isinstance(st, ast.Return)]
+            all_true = returns and all(
+                isinstance(r.value, ast.Constant) and r.value.value is True
+                for r in returns
+            )
+            if all_true:
                 for st in own_nodes(n):
                     if isinstance(st, ast.Expr) and is_click_call(st.value) and has_args(st.value):
                         self.flag(st, "R-ALWAYS-TRUE",

--- a/test/e2e_appium/scripts/check_click_contract.py
+++ b/test/e2e_appium/scripts/check_click_contract.py
@@ -7,9 +7,10 @@ interaction failures. Suite-defined ``-> bool`` methods are either
 best-effort (BEST_EFFORT names: ignoring the result is legal) or
 outcome-reporting (result MUST be consumed: assert/if/return/assign).
 
-Rules: R-CONSUME (branch/assert/assign/walrus/not/while on raising click());
+Rules: R-CONSUME (branch/assert/assign/augassign/walrus/not/while/short-circuit
+on raising click());
 R-ELEMENT (branching on zero-arg WebElement.click(), returns None);
-R-WRAPPER (bool-annotated def whose tail returns raising click());
+R-WRAPPER (any def whose tail returns raising click());
 R-ALWAYS-TRUE (bool-annotated def, every return literal True, body contains a
 bare raising click()); R-IGNORED (statement-level call of an indexed
 outcome-reporting bool method); R-CONFLICT (same method name indexed with
@@ -30,7 +31,7 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SKIP_DIRS = {".venv", "venv", "env", "__pycache__", "node_modules", ".git", "reports",
              "scripts", "cli", "locators"}  # tooling + locator factories — outside the click-contract domain
-SKIP_REL = {"pages/base_page.py", "scripts/check_click_contract.py"}
+SKIP_REL = {"scripts/check_click_contract.py"}
 CLICK = "click"
 
 BEST_EFFORT_PREFIXES = (
@@ -139,10 +140,15 @@ class Checker(ast.NodeVisitor):
     def visit_NamedExpr(self, n):
         self._check_value(n.value, "walrus"); self.generic_visit(n)
 
+    def visit_AugAssign(self, n):
+        self._check_value(n.value, "augmented assignment"); self.generic_visit(n)
+
     def visit_Expr(self, n):
         v = n.value
         if isinstance(v, ast.Await):
             v = v.value
+        if isinstance(v, ast.BoolOp):
+            self._check_value(v, "short-circuit")
         if isinstance(v, ast.Call):
             name = None
             if isinstance(v.func, ast.Attribute):
@@ -156,14 +162,18 @@ class Checker(ast.NodeVisitor):
         self.generic_visit(n)
 
     def visit_FunctionDef(self, n):
-        if is_bool_annotation(n.returns) and n.name not in (CLICK, "try_click"):
+        if n.name not in (CLICK, "try_click"):
+            # Any function whose tail returns a raising click() is a wrapper
+            # its callers will guard as if it returned False; the annotation
+            # (or its absence) does not change that.
             for st in own_nodes(n):
                 if isinstance(st, ast.Return) and st.value is not None:
                     for c in ast.walk(st.value):
                         if is_click_call(c) and has_args(c):
                             self.flag(st, "R-WRAPPER",
-                                      f"bool wrapper '{n.name}' returns raising click() — "
+                                      f"wrapper '{n.name}' returns raising click() — "
                                       "tail can raise; return try_click or catch")
+        if is_bool_annotation(n.returns) and n.name not in (CLICK, "try_click"):
             returns = [st for st in own_nodes(n) if isinstance(st, ast.Return)]
             all_true = returns and all(
                 isinstance(r.value, ast.Constant) and r.value.value is True

--- a/test/e2e_appium/scripts/check_click_contract.py
+++ b/test/e2e_appium/scripts/check_click_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Click-contract checker v2 (AST, two-pass).
+"""Click-contract checker (AST, two-pass).
 
 Contract: click() raises on failure and only ever returns True (True = input
 dispatched, not UI reacted); try_click() returns bool and never raises for

--- a/test/e2e_appium/tests/messaging/conftest.py
+++ b/test/e2e_appium/tests/messaging/conftest.py
@@ -721,7 +721,7 @@ async def _setup_group_chat_context(
         one_to_one_names_by_device: dict[str, list[str]] = {}
         for ctx_dev in (admin, member_b, member_c):
             try:
-                _App(ctx_dev.driver).click_messages_button()
+                assert _App(ctx_dev.driver).click_messages_button(), "Failed to navigate to Messages"
                 await asyncio.sleep(0.5)
                 names = _extract_chat_row_names(ctx_dev)
                 one_to_one_names_by_device[ctx_dev.device_id] = names

--- a/test/e2e_appium/tests/messaging/test_emoji_and_media.py
+++ b/test/e2e_appium/tests/messaging/test_emoji_and_media.py
@@ -104,13 +104,13 @@ class TestEmojiAndMedia:
 
         if not secondary_chat.wait_for_message_input(timeout=3):
             secondary_chat.dismiss_backup_prompt(timeout=3)
-            secondary_app.click_messages_button()
+            assert secondary_app.click_messages_button(), "Failed to navigate to Messages"
             secondary_chat.dismiss_backup_prompt(timeout=2)
 
             display_name = (
                 self.primary.user.display_name if self.primary and self.primary.user else None
             )
-            secondary_chat.open_chat_by_suffix(
+            assert secondary_chat.open_chat_by_suffix(
                 self.primary_suffix,
                 display_name=display_name,
                 timeout=self.CROSS_DEVICE_TIMEOUT,

--- a/test/e2e_appium/tests/messaging/test_emoji_and_media.py
+++ b/test/e2e_appium/tests/messaging/test_emoji_and_media.py
@@ -115,7 +115,12 @@ class TestEmojiAndMedia:
                 display_name=display_name,
                 timeout=self.CROSS_DEVICE_TIMEOUT,
             ):
-                self.logger.debug("open_chat_by_suffix reported a miss; checking arrival")
+                # Dispatch can report a miss although the chat opened (W3C
+                # timeout race); on phone layouts an open chat replaces the
+                # list, so a retry would false-fail. Arrival is asserted on
+                # the composer; chat identity is not separately verifiable
+                # here (bubble titles are not in the a11y tree).
+                self.logger.warning("open_chat_by_suffix reported a miss; trusting arrival check")
             assert secondary_chat.wait_for_message_input(timeout=10), (
                 "Chat did not open on secondary device"
             )

--- a/test/e2e_appium/tests/messaging/test_emoji_and_media.py
+++ b/test/e2e_appium/tests/messaging/test_emoji_and_media.py
@@ -110,12 +110,15 @@ class TestEmojiAndMedia:
             display_name = (
                 self.primary.user.display_name if self.primary and self.primary.user else None
             )
-            assert secondary_chat.open_chat_by_suffix(
+            if not secondary_chat.open_chat_by_suffix(
                 self.primary_suffix,
                 display_name=display_name,
                 timeout=self.CROSS_DEVICE_TIMEOUT,
+            ):
+                self.logger.debug("open_chat_by_suffix reported a miss; checking arrival")
+            assert secondary_chat.wait_for_message_input(timeout=10), (
+                "Chat did not open on secondary device"
             )
-            secondary_chat.wait_for_message_input(timeout=10)
 
         secondary_count_before = secondary_chat.message_count()
 

--- a/test/e2e_appium/tests/messaging/test_group_chat.py
+++ b/test/e2e_appium/tests/messaging/test_group_chat.py
@@ -122,7 +122,7 @@ class TestGroupChat:
         chat_page = ChatPage(device_driver)
 
         chat_page.dismiss_backup_prompt(timeout=2)
-        app.click_messages_button()
+        assert app.click_messages_button(), "Failed to navigate to Messages"
         chat_page.dismiss_backup_prompt(timeout=2)
         await asyncio.sleep(0.5)
         return chat_page

--- a/test/e2e_appium/tests/messaging/test_message_context_menu.py
+++ b/test/e2e_appium/tests/messaging/test_message_context_menu.py
@@ -78,7 +78,7 @@ class _MessageContextMenuBase:
         # Navigate to messages tab
         self.logger.info("Navigating to Messages tab")
         chat_page.dismiss_backup_prompt(timeout=3)
-        app.click_messages_button()
+        assert app.click_messages_button(), "Failed to navigate to Messages"
         chat_page.dismiss_backup_prompt(timeout=2)
 
         # Allow the UI to settle after navigation (BrowserStack latency)
@@ -139,7 +139,7 @@ class _MessageContextMenuBase:
         # Navigate to messages
         self.logger.info("Navigating secondary to Messages tab")
         secondary_chat.dismiss_backup_prompt(timeout=3)
-        secondary_app.click_messages_button()
+        assert secondary_app.click_messages_button(), "Failed to navigate to Messages"
         secondary_chat.dismiss_backup_prompt(timeout=2)
 
         # Allow the UI to settle after navigation (BrowserStack latency)

--- a/test/e2e_appium/tests/messaging/test_z_chat_management.py
+++ b/test/e2e_appium/tests/messaging/test_z_chat_management.py
@@ -58,7 +58,7 @@ class TestChatManagement:
             return chat_page
 
         chat_page.dismiss_backup_prompt(timeout=3)
-        app.click_messages_button()
+        assert app.click_messages_button(), "Failed to navigate to Messages"
         chat_page.dismiss_backup_prompt(timeout=2)
         await asyncio.sleep(0.5)
 
@@ -90,7 +90,7 @@ class TestChatManagement:
             return secondary_chat
 
         secondary_chat.dismiss_backup_prompt(timeout=3)
-        secondary_app.click_messages_button()
+        assert secondary_app.click_messages_button(), "Failed to navigate to Messages"
         secondary_chat.dismiss_backup_prompt(timeout=2)
         await asyncio.sleep(0.5)
 
@@ -160,7 +160,7 @@ class TestChatManagement:
         async with self.step("Verify chat still in primary's chat list"):
             app = App(self.driver)
             chat_page.dismiss_backup_prompt(timeout=3)
-            app.click_messages_button()
+            assert app.click_messages_button(), "Failed to navigate to Messages"
             chat_page.dismiss_backup_prompt(timeout=2)
             await asyncio.sleep(0.5)
 
@@ -207,7 +207,7 @@ class TestChatManagement:
             await asyncio.sleep(1)  # Let UI settle after close
             app = App(self.driver)
             chat_page.dismiss_backup_prompt(timeout=3)
-            app.click_messages_button()
+            assert app.click_messages_button(), "Failed to navigate to Messages"
             chat_page.dismiss_backup_prompt(timeout=2)
             await asyncio.sleep(0.5)
 
@@ -226,7 +226,7 @@ class TestChatManagement:
             secondary_app = App(self.ctx.secondary.driver)
 
             secondary_chat.dismiss_backup_prompt(timeout=3)
-            secondary_app.click_messages_button()
+            assert secondary_app.click_messages_button(), "Failed to navigate to Messages"
             secondary_chat.dismiss_backup_prompt(timeout=2)
             await asyncio.sleep(0.5)
 

--- a/test/e2e_appium/tests/test_onboarding_import_seed.py
+++ b/test/e2e_appium/tests/test_onboarding_import_seed.py
@@ -91,7 +91,7 @@ class TestOnboardingImportSeed(StepMixin):
                 "//*[contains(@resource-id,'headerActionsCloseButton')]")
             base_for_edu = BasePage(driver)
             if base_for_edu.is_element_visible(nav_edu, timeout=5):
-                base_for_edu.safe_click(nav_edu, timeout=5)
+                base_for_edu.click(nav_edu, timeout=5)
             # Re-check push notifications in case it pops up after nav-edu.
             PushNotificationsPage(driver).dismiss_if_present(timeout=5)
 
@@ -101,7 +101,7 @@ class TestOnboardingImportSeed(StepMixin):
             app = App(driver)
 
             # Use click_wallet_button(), which calls _ensure_main_nav_visible()
-            # to open the drawer in portrait. Direct safe_click on
+            # to open the drawer in portrait. Direct click on
             # LEFT_NAV_WALLET fails in portrait — the nav item is behind a
             # closed drawer.
             assert app.click_wallet_button(), "Failed to navigate to Wallet"
@@ -182,7 +182,7 @@ class TestOnboardingImportSeed(StepMixin):
 
         async with self.step(self.device, "Select Create profile from dropdown"):
             try:
-                base.safe_click(
+                base.click(
                     rel.CREATE_PROFILE_DROPDOWN_ITEM, timeout=10, max_attempts=2
                 )
             except Exception:

--- a/test/e2e_appium/tests/test_saved_addresses.py
+++ b/test/e2e_appium/tests/test_saved_addresses.py
@@ -20,7 +20,7 @@ class TestSavedAddresses(StepMixin):
         async with self.step(self.device, "Navigate to Saved Addresses"):
             app = App(self.device.driver)
             # click_wallet_button() opens the drawer first in portrait mode
-            # via _ensure_main_nav_visible(); a raw safe_click on
+            # via _ensure_main_nav_visible(); a raw click on
             # LEFT_NAV_WALLET fails in portrait because the nav item is
             # behind a closed drawer.
             assert app.click_wallet_button(), "Failed to open Wallet"

--- a/test/e2e_appium/tests/test_wallet_send_smoke.py
+++ b/test/e2e_appium/tests/test_wallet_send_smoke.py
@@ -148,9 +148,7 @@ class TestWalletSendSmoke(StepMixin):
             for _ in range(4):
                 if not base.is_element_visible(back_button, timeout=2):
                     break
-                try:
-                    base.click(back_button, timeout=3, max_attempts=1)
-                except Exception:
+                if not base.try_click(back_button, timeout=3, max_attempts=1):
                     break
                 time.sleep(0.3)
 

--- a/test/e2e_appium/tests/test_wallet_send_smoke.py
+++ b/test/e2e_appium/tests/test_wallet_send_smoke.py
@@ -93,7 +93,7 @@ class TestWalletSendSmoke(StepMixin):
                 "//*[contains(@resource-id,'headerActionsCloseButton')]")
             base_for_edu = BasePage(driver)
             if base_for_edu.is_element_visible(nav_edu, timeout=5):
-                base_for_edu.safe_click(nav_edu, timeout=5)
+                base_for_edu.click(nav_edu, timeout=5)
             PushNotificationsPage(driver).dismiss_if_present(timeout=5)
 
     @pytest.mark.smoke
@@ -149,7 +149,7 @@ class TestWalletSendSmoke(StepMixin):
                 if not base.is_element_visible(back_button, timeout=2):
                     break
                 try:
-                    base.safe_click(back_button, timeout=3, max_attempts=1)
+                    base.click(back_button, timeout=3, max_attempts=1)
                 except Exception:
                     break
                 time.sleep(0.3)

--- a/test/e2e_appium/utils/chat_state.py
+++ b/test/e2e_appium/utils/chat_state.py
@@ -33,7 +33,8 @@ def ensure_chat_visible(
         return
 
     chat_page.dismiss_backup_prompt(timeout=2)
-    app.click_messages_button()
+    if not app.click_messages_button():
+        chat_page.logger.debug("ensure_chat_visible: Messages nav missed; re-checking")
     chat_page.dismiss_backup_prompt(timeout=2)
 
     if chat_page.wait_for_message_input(timeout=3):

--- a/test/e2e_appium/utils/exceptions.py
+++ b/test/e2e_appium/utils/exceptions.py
@@ -8,11 +8,29 @@ clear error handling throughout the test automation framework.
 from typing import Dict, Any, Optional
 
 
-from selenium.common.exceptions import InvalidSessionIdException
+from selenium.common.exceptions import (
+    InvalidSessionIdException,
+    NoSuchWindowException,
+)
 
 # Session-fatal driver errors: the Appium session is gone and no recovery,
 # swallow, or retry at any layer is meaningful — these must always propagate.
-SESSION_FATAL = (InvalidSessionIdException,)
+# A crashed UIA2 instrumentation serializes as a bare WebDriverException with
+# an instrumentation message, so it is matched by text, not type.
+SESSION_FATAL = (InvalidSessionIdException, NoSuchWindowException)
+
+_SESSION_FATAL_MARKERS = (
+    "instrumentation process is not running",
+    "instrumentation process cannot continue",
+    "cannot be proxied to uiautomator2 server",
+)
+
+
+def is_session_fatal(exc: BaseException) -> bool:
+    if isinstance(exc, SESSION_FATAL):
+        return True
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _SESSION_FATAL_MARKERS)
 
 class ProfileCreationFlowError(Exception):
     """

--- a/test/e2e_appium/utils/exceptions.py
+++ b/test/e2e_appium/utils/exceptions.py
@@ -8,21 +8,23 @@ clear error handling throughout the test automation framework.
 from typing import Dict, Any, Optional
 
 
-from selenium.common.exceptions import (
-    InvalidSessionIdException,
-    NoSuchWindowException,
-)
+from selenium.common.exceptions import InvalidSessionIdException
+from urllib3.exceptions import MaxRetryError, NewConnectionError
 
-# Session-fatal driver errors: the Appium session is gone and no recovery,
-# swallow, or retry at any layer is meaningful — these must always propagate.
-# A crashed UIA2 instrumentation serializes as a bare WebDriverException with
-# an instrumentation message, so it is matched by text, not type.
-SESSION_FATAL = (InvalidSessionIdException, NoSuchWindowException)
+# Session-fatal driver errors: the session or its server is gone and no
+# recovery, swallow, or retry at any layer is meaningful — these must always
+# propagate. A crashed UIA2 instrumentation serializes as a bare
+# WebDriverException whose message carries one of the marker texts (taken
+# from appium-uiautomator2-server core and appium jwproxy), so fatality is
+# decided by is_session_fatal(), never by an isinstance check alone.
+SESSION_FATAL = (InvalidSessionIdException, MaxRetryError, NewConnectionError)
 
 _SESSION_FATAL_MARKERS = (
     "instrumentation process is not running",
-    "instrumentation process cannot continue",
+    "instrumentation process has been unexpectedly terminated",
     "cannot be proxied to uiautomator2 server",
+    "could not proxy command to the remote server",
+    "socket hang up",
 )
 
 

--- a/test/e2e_appium/utils/exceptions.py
+++ b/test/e2e_appium/utils/exceptions.py
@@ -8,6 +8,12 @@ clear error handling throughout the test automation framework.
 from typing import Dict, Any, Optional
 
 
+from selenium.common.exceptions import InvalidSessionIdException
+
+# Session-fatal driver errors: the Appium session is gone and no recovery,
+# swallow, or retry at any layer is meaningful — these must always propagate.
+SESSION_FATAL = (InvalidSessionIdException,)
+
 class ProfileCreationFlowError(Exception):
     """
     Custom exception for profile creation and onboarding flow failures.

--- a/test/e2e_appium/utils/screen_identity.py
+++ b/test/e2e_appium/utils/screen_identity.py
@@ -43,11 +43,11 @@ def dismiss_backup_modal(page, timeout: int = 2) -> bool:
 
     Never raises: callers use this as a guard inside nav retry loops, so a
     failed dismissal must fall through to the caller's own retry, not abort
-    it (safe_click raises on exhaustion)."""
+    it (click raises on exhaustion)."""
     if not page.is_element_visible(BACKUP_MODAL, timeout=timeout):
         return False
     try:
-        page.safe_click(BACKUP_MODAL_SKIP, timeout=5)
+        page.click(BACKUP_MODAL_SKIP, timeout=5)
         return page.wait_for_invisibility(BACKUP_MODAL, timeout=5)
     except Exception as exc:
         page.logger.warning("Backup modal present but dismissal failed: %s", exc)
@@ -65,7 +65,7 @@ def dismiss_introduce_yourself(page, timeout: int = 2) -> bool:
     if not page.is_element_visible(INTRODUCE_MODAL_SKIP, timeout=timeout):
         return False
     try:
-        page.safe_click(INTRODUCE_MODAL_SKIP, timeout=5)
+        page.click(INTRODUCE_MODAL_SKIP, timeout=5)
         return page.wait_for_invisibility(INTRODUCE_MODAL_SKIP, timeout=5)
     except Exception as exc:
         page.logger.warning(


### PR DESCRIPTION
### What does the PR do

Stacked on #22149. `safe_click` described its retries, not its failure mode. It is now `click()`; the `try_` prefix means "returns bool, never raises", and `scripts/check_click_contract.py` enforces that at pytest start.

- The lint flags branching on `click()`, any wrapper whose tail is a raising `click()`, ignored results of bool-returning methods outside a named best-effort list, and any `safe_click` reference
- `try_click` propagates driver-level errors unless a site opts in; session-fatal errors always propagate
- The failure-evidence hook captures in the phase that failed, from every device, once per test
- Every result the lint reported is now consumed (10 navigation calls became asserts, one of them a proven false pass)

Not covered: the lint keys on method names, so `_ = x()` discards and methods called through variables are not checked (listed in the file header). A standalone CI job for the lint is a follow-up; today it runs inside every pytest session, including the per-PR gate.
