### PR TITLE
fix(e2e_appium): dismiss overlays from the top down

### DIFF
--- a/test/e2e_appium/fixtures/onboarding_fixture.py
+++ b/test/e2e_appium/fixtures/onboarding_fixture.py
@@ -34,7 +34,7 @@ from pages.onboarding import (
 )
 from services.app_initialization_manager import AppInitializationManager
 from utils.generators import generate_seed_phrase
-from utils.screen_identity import dismiss_stacked_overlays
+from utils.screen_identity import dismiss_stacked_overlays, overlay_locator
 
 NAV_EDUCATION_ID = "NavigationEducationDialog"
 
@@ -455,7 +455,12 @@ class OnboardingFlow:
                 (
                     "nav_education",
                     NAV_EDUCATION_ID,
-                    lambda: overlay_page.try_click(nav_edu_close, timeout=5),
+                    lambda: (
+                        overlay_page.try_click(nav_edu_close, timeout=5)
+                        and overlay_page.wait_for_invisibility(
+                            overlay_locator(NAV_EDUCATION_ID), timeout=5
+                        )
+                    ),
                 ),
             ],
         )

--- a/test/e2e_appium/fixtures/onboarding_fixture.py
+++ b/test/e2e_appium/fixtures/onboarding_fixture.py
@@ -17,6 +17,9 @@ import pytest
 from config import get_config
 from config.logging_config import get_logger
 from core.models import DEFAULT_USER_PASSWORD
+from locators.onboarding.push_notifications_locators import (
+    PushNotificationsLocators,
+)
 from locators.wallet.accounts_locators import WalletAccountsLocators
 from models.user_model import User, UserProfile
 from pages.app import App
@@ -31,6 +34,9 @@ from pages.onboarding import (
 )
 from services.app_initialization_manager import AppInitializationManager
 from utils.generators import generate_seed_phrase
+from utils.screen_identity import dismiss_stacked_overlays
+
+NAV_EDUCATION_ID = "NavigationEducationDialog"
 
 
 @dataclass
@@ -424,65 +430,44 @@ class OnboardingFlow:
 
         actions: list[str] = []
 
-        # 1. Push notifications — primary expected overlay.
-        if self.push_notifications_page.is_screen_displayed(timeout=30):
-            self.logger.info(
-                "Push notifications dialog detected, selecting 'Maybe later'"
-            )
-            if self.push_notifications_page.select_maybe_later():
-                actions.append("push_notifications:dismissed")
-            else:
-                self.logger.error("Failed to dismiss push notifications dialog")
-                actions.append("push_notifications:dismiss_failed")
-                self.step_results["push_notifications"] = {
-                    "success": False,
-                    "action": ",".join(actions),
-                    "timestamp": datetime.now(),
-                }
-                raise OnboardingFlowError(
-                    "Push notifications dialog visible but could not be dismissed"
-                )
-        else:
+        from pages.base_page import BasePage as _BasePage
+
+        overlay_page = _BasePage(self.driver)
+        nav_edu_close = (
+            "xpath",
+            f"//*[contains(@resource-id,'{NAV_EDUCATION_ID}')]"
+            "//*[contains(@resource-id,'headerActionsCloseButton')]",
+        )
+
+        if not self.push_notifications_page.is_screen_displayed(timeout=30):
             self.logger.warning(
                 "Push notifications dialog did not appear within 30s — unexpected"
             )
-            actions.append("push_notifications:not_displayed")
 
-        # 2. NavigationEducationDialog — appears after push-notifications is
-        # dismissed (or sometimes alone on RC1+). Tap its close (X) button.
-        nav_edu_locator = (
-            "xpath",
-            "//*[contains(@resource-id,'NavigationEducationDialog')]"
-            "//*[contains(@resource-id,'headerActionsCloseButton')]",
+        overlay_actions, error = dismiss_stacked_overlays(
+            overlay_page,
+            [
+                (
+                    "push_notifications",
+                    PushNotificationsLocators.DIALOG_ID,
+                    self.push_notifications_page.select_maybe_later,
+                ),
+                (
+                    "nav_education",
+                    NAV_EDUCATION_ID,
+                    lambda: overlay_page.try_click(nav_edu_close, timeout=5),
+                ),
+            ],
         )
-        from pages.base_page import BasePage as _BasePage
-        base_for_edu = _BasePage(self.driver)
-        if base_for_edu.is_element_visible(nav_edu_locator, timeout=10):
-            self.logger.info("NavigationEducationDialog detected, closing")
-            if base_for_edu.try_click(nav_edu_locator, timeout=5):
-                actions.append("nav_education:dismissed")
-            else:
-                # A dialog we saw but could not close is still covering the
-                # UI. Raise rather than record a failed step: the caller reads
-                # only the top-level result, which is always True.
-                self.logger.warning("NavigationEducationDialog close-tap failed")
-                actions.append("nav_education:dismiss_failed")
-                self.step_results["navigation_education"] = {
-                    "success": False,
-                    "action": ",".join(actions),
-                    "timestamp": datetime.now(),
-                }
-                raise OnboardingFlowError(
-                    "NavigationEducationDialog visible but could not be dismissed"
-                )
-        else:
-            actions.append("nav_education:not_displayed")
-
-        # 3. Push notifications can re-appear after nav-edu close on some flows.
-        if self.push_notifications_page.is_screen_displayed(timeout=5):
-            self.logger.info("Push-notifications popup re-appeared after nav-edu, dismissing again")
-            if self.push_notifications_page.select_maybe_later():
-                actions.append("push_notifications_2:dismissed")
+        actions.extend(overlay_actions or ["no_overlays_displayed"])
+        if error:
+            self.logger.error(error)
+            self.step_results["push_notifications"] = {
+                "success": False,
+                "action": ",".join(actions),
+                "timestamp": datetime.now(),
+            }
+            raise OnboardingFlowError(error)
 
         self.step_results["push_notifications"] = {
             "success": True,

--- a/test/e2e_appium/locators/onboarding/push_notifications_locators.py
+++ b/test/e2e_appium/locators/onboarding/push_notifications_locators.py
@@ -4,9 +4,8 @@ from ..base_locators import BaseLocators
 class PushNotificationsLocators(BaseLocators):
     """Locators for the 'Enable push notifications' dialog shown post-onboarding."""
 
-    DIALOG = BaseLocators.xpath(
-        "//*[contains(@resource-id,'EnablePushNotificationsPopup')]"
-    )
+    DIALOG_ID = "EnablePushNotificationsPopup"
+    DIALOG = BaseLocators.xpath(f"//*[contains(@resource-id,'{DIALOG_ID}')]")
     MAYBE_LATER_BUTTON = BaseLocators.tid("btnPushNotificationsLater")
     CONTINUE_BUTTON = BaseLocators.tid("btnPushNotificationsPrimary")
     CLOSE_BUTTON = BaseLocators.tid("headerActionsCloseButton")

--- a/test/e2e_appium/tests/test_overlay_stacking.py
+++ b/test/e2e_appium/tests/test_overlay_stacking.py
@@ -10,6 +10,7 @@ before and after closing the top dialog.
 import logging
 
 import pytest
+from selenium.common.exceptions import InvalidSessionIdException
 
 from utils.screen_identity import dismiss_stacked_overlays, topmost_overlay
 
@@ -47,11 +48,13 @@ CLEAR = f'{DECLARATION}<hierarchy rotation="0" />'
 class StubDriver:
     def __init__(self, sources):
         self._sources = list(sources)
+        self.current = self._sources[0]
 
     @property
     def page_source(self):
         # Hold the last state so extra reads in one round stay consistent.
-        return self._sources.pop(0) if len(self._sources) > 1 else self._sources[0]
+        self.current = self._sources.pop(0) if len(self._sources) > 1 else self._sources[0]
+        return self.current
 
 
 class BrokenDriver:
@@ -60,10 +63,20 @@ class BrokenDriver:
         raise RuntimeError("session gone")
 
 
+class DeadDriver:
+    @property
+    def page_source(self):
+        raise InvalidSessionIdException("invalid session id")
+
+
 class StubPage:
     def __init__(self, driver):
         self.driver = driver
         self.logger = logging.getLogger("stub")
+
+    def is_element_visible(self, locator, timeout=0):
+        # Read the state the last page_source served; do not advance it.
+        return locator[1].split("'")[1] in self.driver.current
 
 
 def _page(*sources):
@@ -142,3 +155,34 @@ def test_does_nothing_when_no_overlay_is_on_top():
     overlays = [("push_notifications", POPUP, lambda: pytest.fail("should not tap"))]
 
     assert dismiss_stacked_overlays(page, overlays) == ([], None)
+
+
+def test_raises_when_the_session_is_dead():
+    with pytest.raises(InvalidSessionIdException):
+        topmost_overlay(StubPage(DeadDriver()), (POPUP, NAV_EDU))
+
+
+def test_dismisses_a_visible_dialog_when_nothing_holds_focus():
+    page = _page(NOTHING_FOCUSED, CLEAR)
+    calls = []
+    actions, error = dismiss_stacked_overlays(
+        page,
+        [
+            ("push_notifications", POPUP, lambda: calls.append("popup") or True),
+            ("nav_education", NAV_EDU, lambda: calls.append("nav_edu") or True),
+        ],
+    )
+    assert calls == ["popup"]
+    assert actions == ["push_notifications:dismissed"]
+    assert error is None
+
+
+def test_reports_a_visible_dialog_that_survives_every_round():
+    page = _page(NOTHING_FOCUSED)
+    actions, error = dismiss_stacked_overlays(
+        page,
+        [("push_notifications", POPUP, lambda: True)],
+        max_rounds=3,
+    )
+    assert actions == ["push_notifications:dismissed"] * 3
+    assert error == "Overlays were still on top after 3 rounds"

--- a/test/e2e_appium/tests/test_overlay_stacking.py
+++ b/test/e2e_appium/tests/test_overlay_stacking.py
@@ -13,6 +13,8 @@ import pytest
 
 from utils.screen_identity import dismiss_stacked_overlays, topmost_overlay
 
+pytestmark = [pytest.mark.gate, pytest.mark.component]
+
 
 POPUP = "EnablePushNotificationsPopup"
 NAV_EDU = "NavigationEducationDialog"

--- a/test/e2e_appium/tests_unit/test_overlay_stacking.py
+++ b/test/e2e_appium/tests_unit/test_overlay_stacking.py
@@ -1,0 +1,142 @@
+"""Device-free contract for dismissing stacked onboarding overlays.
+
+Qt renders these dialogs as sibling nodes and only the top one takes
+focus. A dialog underneath stays in the tree and still reports itself as
+visible, so a tap aimed at it lands on the dialog above and the dismissal
+quietly does nothing. The page sources below copy device dumps taken
+before and after closing the top dialog.
+"""
+
+import logging
+
+import pytest
+
+from utils.screen_identity import dismiss_stacked_overlays, topmost_overlay
+
+
+POPUP = "EnablePushNotificationsPopup"
+NAV_EDU = "NavigationEducationDialog"
+DECLARATION = "<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>"
+
+
+def _dialog(object_name, focused, child_focused="false"):
+    return (
+        f'<android.app.AlertDialog class="android.app.AlertDialog" '
+        f'resource-id="QGuiApplication.mainWindow.{object_name}" '
+        f'focused="{focused}" bounds="[0,1323][1079,2399]" displayed="true">'
+        f'<android.widget.Button class="android.widget.Button" '
+        f'resource-id="QGuiApplication.mainWindow.{object_name}.footer.btnLater" '
+        f'focused="{child_focused}" bounds="[40,2168][362,2265]" displayed="true" />'
+        f"</android.app.AlertDialog>"
+    )
+
+
+def _source(*nodes):
+    return f'{DECLARATION}<hierarchy rotation="0">{"".join(nodes)}</hierarchy>'
+
+
+BOTH_NAV_EDU_ON_TOP = _source(_dialog(POPUP, "false"), _dialog(NAV_EDU, "true"))
+POPUP_ON_TOP = _source(_dialog(POPUP, "true"))
+POPUP_CHILD_FOCUSED = _source(_dialog(POPUP, "false", child_focused="true"))
+NOTHING_FOCUSED = _source(_dialog(POPUP, "false"))
+CLEAR = f'{DECLARATION}<hierarchy rotation="0" />'
+
+
+class StubDriver:
+    def __init__(self, sources):
+        self._sources = list(sources)
+
+    @property
+    def page_source(self):
+        # Hold the last state so extra reads in one round stay consistent.
+        return self._sources.pop(0) if len(self._sources) > 1 else self._sources[0]
+
+
+class BrokenDriver:
+    @property
+    def page_source(self):
+        raise RuntimeError("session gone")
+
+
+class StubPage:
+    def __init__(self, driver):
+        self.driver = driver
+        self.logger = logging.getLogger("stub")
+
+
+def _page(*sources):
+    return StubPage(StubDriver(sources))
+
+
+def test_names_the_dialog_that_holds_focus():
+    assert topmost_overlay(_page(BOTH_NAV_EDU_ON_TOP), (POPUP, NAV_EDU)) == NAV_EDU
+
+
+def test_names_the_popup_once_it_is_uncovered():
+    assert topmost_overlay(_page(POPUP_ON_TOP), (POPUP, NAV_EDU)) == POPUP
+
+
+def test_a_focused_child_identifies_its_own_dialog():
+    assert topmost_overlay(_page(POPUP_CHILD_FOCUSED), (POPUP, NAV_EDU)) == POPUP
+
+
+def test_names_nothing_when_no_overlay_holds_focus():
+    assert topmost_overlay(_page(NOTHING_FOCUSED), (POPUP, NAV_EDU)) is None
+
+
+def test_names_nothing_when_the_page_source_cannot_be_read():
+    assert topmost_overlay(StubPage(BrokenDriver()), (POPUP, NAV_EDU)) is None
+
+
+def test_dismisses_from_the_top_down():
+    """The popup is only tappable after the dialog above it is gone, so the
+    order is decided by focus and not by the order of the overlay list."""
+    order = []
+
+    def _close(name):
+        def _do():
+            order.append(name)
+            return True
+
+        return _do
+
+    page = _page(BOTH_NAV_EDU_ON_TOP, POPUP_ON_TOP, CLEAR)
+    overlays = [
+        ("push_notifications", POPUP, _close("popup")),
+        ("nav_education", NAV_EDU, _close("nav_edu")),
+    ]
+
+    actions, error = dismiss_stacked_overlays(page, overlays)
+
+    assert order == ["nav_edu", "popup"]
+    assert actions == ["nav_education:dismissed", "push_notifications:dismissed"]
+    assert error is None
+
+
+def test_reports_the_overlay_that_refuses_to_close():
+    page = _page(POPUP_ON_TOP)
+    overlays = [("push_notifications", POPUP, lambda: False)]
+
+    actions, error = dismiss_stacked_overlays(page, overlays)
+
+    assert actions == ["push_notifications:dismiss_failed"]
+    assert "push_notifications" in error
+
+
+def test_reports_an_overlay_that_keeps_coming_back():
+    """A dismisser that claims success while its dialog stays on top stops
+    at the round limit and reports an error."""
+    page = _page(POPUP_ON_TOP)
+    overlays = [("push_notifications", POPUP, lambda: True)]
+
+    actions, error = dismiss_stacked_overlays(page, overlays, max_rounds=3)
+
+    assert len(actions) == 3
+    assert "3 rounds" in error
+
+
+def test_does_nothing_when_no_overlay_is_on_top():
+    page = _page(CLEAR)
+    overlays = [("push_notifications", POPUP, lambda: pytest.fail("should not tap"))]
+
+    assert dismiss_stacked_overlays(page, overlays) == ([], None)

--- a/test/e2e_appium/utils/screen_identity.py
+++ b/test/e2e_appium/utils/screen_identity.py
@@ -16,6 +16,8 @@ intercepts the Messaging nav and then blocks the nav drawer entirely -- the
 concrete cause of the nav wedges seen while building this.
 """
 
+import xml.etree.ElementTree as ET
+
 from locators.base_locators import BaseLocators
 from locators.wallet.accounts_locators import WalletAccountsLocators
 from locators.settings.settings_locators import SettingsLocators
@@ -79,3 +81,56 @@ def confirm_screen(page, expected: str, timeout: int = 15) -> bool:
     unique a11y anchor with a lag-tolerant timeout. Raises KeyError for an
     unknown screen name so a typo fails loudly instead of silently passing."""
     return page.is_element_visible(SCREEN_ANCHORS[expected], timeout=timeout)
+
+
+def topmost_overlay(page, object_names: tuple[str, ...]) -> str | None:
+    """Return the object name of whichever listed overlay holds focus.
+
+    Qt renders these dialogs as siblings and gives focus only to the top
+    one. A dialog underneath stays in the tree and still reports itself
+    visible, so a tap aimed at it lands on the dialog above instead.
+    Focus is the only attribute that tracks the stack: two dumps taken
+    with the lower dialog open and closed are otherwise identical.
+    """
+    try:
+        root = ET.fromstring(page.driver.page_source.encode("utf-8"))
+    except Exception:
+        page.logger.warning("Could not read the page source to find the top overlay")
+        return None
+
+    for node in root.iter():
+        if node.get("focused") != "true":
+            continue
+        resource_id = node.get("resource-id") or ""
+        for name in object_names:
+            if name in resource_id:
+                return name
+    return None
+
+
+def dismiss_stacked_overlays(page, overlays, max_rounds: int = 4):
+    """Close overlays from the top of the stack down.
+
+    ``overlays`` is a sequence of (label, object name, dismiss callable).
+    The order of that sequence is not used: each round asks the device
+    which dialog is on top and closes that one, because a lower dialog
+    cannot be tapped until the ones above it are gone.
+
+    Returns (actions, error). ``error`` is None once nothing is left on
+    top, otherwise a message naming the overlay that is still there.
+    """
+    by_name = {name: (label, dismiss) for label, name, dismiss in overlays}
+    actions: list[str] = []
+
+    for _ in range(max_rounds):
+        name = topmost_overlay(page, tuple(by_name))
+        if name is None:
+            return actions, None
+
+        label, dismiss = by_name[name]
+        if not dismiss():
+            actions.append(f"{label}:dismiss_failed")
+            return actions, f"The {label} overlay is on top and would not close"
+        actions.append(f"{label}:dismissed")
+
+    return actions, f"Overlays were still on top after {max_rounds} rounds"

--- a/test/e2e_appium/utils/screen_identity.py
+++ b/test/e2e_appium/utils/screen_identity.py
@@ -19,6 +19,7 @@ concrete cause of the nav wedges seen while building this.
 import xml.etree.ElementTree as ET
 
 from locators.base_locators import BaseLocators
+from utils.exceptions import is_session_fatal
 from locators.wallet.accounts_locators import WalletAccountsLocators
 from locators.settings.settings_locators import SettingsLocators
 from locators.messaging.chat_locators import ChatLocators
@@ -52,6 +53,8 @@ def dismiss_backup_modal(page, timeout: int = 2) -> bool:
         page.click(BACKUP_MODAL_SKIP, timeout=5)
         return page.wait_for_invisibility(BACKUP_MODAL, timeout=5)
     except Exception as exc:
+        if is_session_fatal(exc):
+            raise
         page.logger.warning("Backup modal present but dismissal failed: %s", exc)
         return False
 
@@ -70,6 +73,8 @@ def dismiss_introduce_yourself(page, timeout: int = 2) -> bool:
         page.click(INTRODUCE_MODAL_SKIP, timeout=5)
         return page.wait_for_invisibility(INTRODUCE_MODAL_SKIP, timeout=5)
     except Exception as exc:
+        if is_session_fatal(exc):
+            raise
         page.logger.warning(
             "Introduce-yourself sheet present but dismissal failed: %s", exc
         )
@@ -94,8 +99,10 @@ def topmost_overlay(page, object_names: tuple[str, ...]) -> str | None:
     """
     try:
         root = ET.fromstring(page.driver.page_source.encode("utf-8"))
-    except Exception:
-        page.logger.warning("Could not read the page source to find the top overlay")
+    except Exception as exc:
+        if is_session_fatal(exc):
+            raise
+        page.logger.warning("Could not read the page source to find the top overlay: %s", exc)
         return None
 
     for node in root.iter():
@@ -108,13 +115,19 @@ def topmost_overlay(page, object_names: tuple[str, ...]) -> str | None:
     return None
 
 
+def overlay_locator(object_name: str) -> tuple:
+    return ("xpath", f"//*[contains(@resource-id,'{object_name}')]")
+
+
 def dismiss_stacked_overlays(page, overlays, max_rounds: int = 4):
     """Close overlays from the top of the stack down.
 
     ``overlays`` is a sequence of (label, object name, dismiss callable).
-    The order of that sequence is not used: each round asks the device
-    which dialog is on top and closes that one, because a lower dialog
-    cannot be tapped until the ones above it are gone.
+    Each round asks the device which listed dialog holds focus and closes
+    that one, because a lower dialog cannot be tapped until the ones above
+    it are gone. When focus names none of them, the sequence order decides:
+    the first listed dialog still visible is closed, so a dialog on screen
+    is never reported as absent.
 
     Returns (actions, error). ``error`` is None once nothing is left on
     top, otherwise a message naming the overlay that is still there.
@@ -124,6 +137,11 @@ def dismiss_stacked_overlays(page, overlays, max_rounds: int = 4):
 
     for _ in range(max_rounds):
         name = topmost_overlay(page, tuple(by_name))
+        if name is None:
+            name = next(
+                (n for n in by_name if page.is_element_visible(overlay_locator(n), timeout=2)),
+                None,
+            )
         if name is None:
             return actions, None
 


### PR DESCRIPTION
Stacked on #22150.

Onboarding aborted at the push notifications step, blocking every test that onboards.

The step closed the push notifications popup first and the navigation education dialog second. The education dialog is already on top when the step begins, so the tap aimed at the popup landed on the dialog above it and the popup stayed open. The reported dismissal failure was real.

The step now asks the device which dialog holds focus and closes that one, repeating until none is left. Order comes from the device rather than from the code, so a lone dialog or a changed sequence works the same way. When focus names none of the listed dialogs, a dialog that is still visible is closed in list order, and one that survives every round is reported instead of being ignored.

Verified on a Moto G55, a Samsung A36 and a cloud Pixel 8. The overlay step drops from 21-28 s to about 8 s, with one dismissal per dialog instead of a retry. Nine onboardings in the gate run below went through this step. Device-free tests cover the ordering, the fallback and the failure reports.
