### PR TITLE
fix(e2e_appium): pick the peer's chat row by identity, not position

### DIFF
--- a/test/e2e_appium/constants/__init__.py
+++ b/test/e2e_appium/constants/__init__.py
@@ -1,5 +1,6 @@
 """Shared constants for the e2e Appium test suite."""
 
 from .app_sections import AppSections
+from .support_bot import SUPPORT_BOT_CHAT_KEY, SUPPORT_BOT_DISPLAY_NAME
 
-__all__ = ["AppSections"]
+__all__ = ["AppSections", "SUPPORT_BOT_CHAT_KEY", "SUPPORT_BOT_DISPLAY_NAME"]

--- a/test/e2e_appium/constants/support_bot.py
+++ b/test/e2e_appium/constants/support_bot.py
@@ -1,0 +1,4 @@
+"""The support bot that every new profile sends a contact request to on start."""
+
+SUPPORT_BOT_CHAT_KEY = "zQ3shX8r9eRDTEQQhks4qciDunphxdY1w1KjvZ32Pn7dGdWTL"
+SUPPORT_BOT_DISPLAY_NAME = "Status Bot Test"

--- a/test/e2e_appium/locators/messaging/chat_locators.py
+++ b/test/e2e_appium/locators/messaging/chat_locators.py
@@ -1,4 +1,4 @@
-from ..base_locators import BaseLocators
+from ..base_locators import BaseLocators, xpath_string
 
 
 class ChatLocators(BaseLocators):
@@ -75,20 +75,14 @@ class ChatLocators(BaseLocators):
         "//*[contains(@resource-id,'startChatButton')]"
     )
 
-    # First chat item in the list (for open_first_chat)
-    FIRST_CHAT_ITEM = BaseLocators.xpath(
-        "(//android.widget.Button[contains(@resource-id,'StatusDraggableListItem')])[1]"
+    CHAT_ROWS = BaseLocators.xpath(
+        "//android.widget.Button[contains(@resource-id,'StatusDraggableListItem')]"
     )
+    CHAT_HEADER_NAME = BaseLocators.resource_id_contains("statusChatInfoButtonNameText")
 
     @staticmethod
-    def dm_row_button(chat_identifier: str) -> tuple:
-        escaped = chat_identifier.replace("'", "\\'")
-        xpath = (
-            "//android.widget.Button[contains(@resource-id,'StatusDraggableListItem')]"
-            f"[(contains(@resource-id,\"{escaped}\") or contains(@content-desc,\"{escaped}\")"
-            f" or contains(@text,\"{escaped}\"))]"
-        )
-        return BaseLocators.xpath(xpath)
+    def chat_row(resource_id: str) -> tuple:
+        return BaseLocators.xpath(f"//*[@resource-id={xpath_string(resource_id)}]")
 
     @staticmethod
     def chat_list_item(display_name: str) -> tuple:

--- a/test/e2e_appium/locators/settings/contacts_locators.py
+++ b/test/e2e_appium/locators/settings/contacts_locators.py
@@ -1,3 +1,5 @@
+from constants.support_bot import SUPPORT_BOT_CHAT_KEY, SUPPORT_BOT_DISPLAY_NAME
+
 from ..base_locators import BaseLocators
 
 
@@ -11,11 +13,18 @@ class ContactsSettingsLocators(BaseLocators):
     PENDING_REQUEST_ROW = BaseLocators.xpath(
         "//android.view.TextView[contains(@resource-id,'ContactPanel')]"
     )
+    # Every new profile has a request out to the support bot, so its panel
+    # can sit in either list; the peer's is the first panel that is not the bot's.
+    _PEER_PANEL = (
+        "//*[contains(@resource-id,'ContactPanel')"
+        f" and not(contains(@content-desc,'{SUPPORT_BOT_DISPLAY_NAME}'))"
+        f" and not(contains(@resource-id,'{SUPPORT_BOT_CHAT_KEY}'))]"
+    )
     FIRST_PENDING_ACCEPT_BUTTON = BaseLocators.xpath(
-        "(//*[contains(@resource-id,'ContactPanel')]//*[contains(@resource-id,'acceptBtn')])[1]"
+        f"({_PEER_PANEL}//*[contains(@resource-id,'acceptBtn')])[1]"
     )
     FIRST_CONTACT_CHAT_BUTTON = BaseLocators.xpath(
-        "(//*[contains(@resource-id,'ContactPanel')]//*[contains(@resource-id,'chatBtn')])[1]"
+        f"({_PEER_PANEL}//*[contains(@resource-id,'chatBtn')])[1]"
     )
     DISMISSED_TAB = BaseLocators.xpath(
         "//*[contains(@resource-id,'ContactsView_DismissedRequest_Button')]"

--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -1,6 +1,7 @@
 
 import time
 
+from constants.support_bot import SUPPORT_BOT_DISPLAY_NAME
 from locators.messaging.chat_locators import ChatLocators
 from utils.exceptions import ElementInteractionError
 
@@ -34,74 +35,78 @@ class ChatPage(BasePage):
         locator = self.locators.chat_list_item(display_name)
         return self.safe_click(locator, max_attempts=2)
 
-    def has_any_chat(self, timeout: int = 5) -> bool:
-        """Check if there are any chats in the chat list.
+    def _chat_rows(self) -> list[tuple[str, str, str]]:
+        """``(resource-id, name, label)`` for every listed chat row.
 
-        Returns:
-            bool: True if at least one chat exists.
+        Android exposes a row's chat name only as the resource-id segment
+        before ``.StatusDraggableListItem_``; ``text`` and ``content-desc``
+        are empty there and are kept as ``label`` for platforms that fill them.
         """
-        self._ensure_chat_list_visible()
-        return self.is_element_visible(self.locators.FIRST_CHAT_ITEM, timeout=timeout)
-
-    def get_first_chat_name(self, timeout: int = 5) -> str | None:
-        """Read the display text or content-desc of the first chat in the list.
-
-        Useful for capturing the actual name of a chat before opening it via
-        ``open_first_chat()`` so that later assertions (e.g. gone-from-list
-        checks) can use a meaningful identifier rather than a potentially
-        stale or unsynchronised name.
-
-        Returns:
-            The chat name string, or ``None`` if no chat is visible or the
-            name cannot be read.
-        """
-        self._ensure_chat_list_visible()
-        element = self.find_element_safe(self.locators.FIRST_CHAT_ITEM, timeout=timeout)
-        if not element:
-            return None
-        for attr in ("content-desc", "text"):
+        rows: list[tuple[str, str, str]] = []
+        try:
+            elements = self.driver.find_elements(*self.locators.CHAT_ROWS)
+        except Exception as exc:
+            self.logger.debug("Chat row listing failed: %s", exc)
+            return rows
+        for element in elements:
             try:
-                raw = element.get_attribute(attr)
-                if not raw or raw == "null":
-                    continue
-                value = raw.strip()
-                if " [tid:" in value:
-                    value = value.split(" [tid:")[0].strip()
-                if value:
-                    return value
+                resource_id = element.get_attribute("resource-id") or ""
+                label = " ".join(
+                    value
+                    for value in (
+                        element.get_attribute("content-desc"),
+                        element.get_attribute("text"),
+                    )
+                    if value and value != "null"
+                )
             except Exception:
                 continue
+            if ".StatusDraggableListItem_" not in resource_id:
+                continue
+            name = resource_id.split(".StatusDraggableListItem_", 1)[0].rsplit(".", 1)[-1]
+            rows.append((resource_id, name, label))
+        return rows
+
+    def _find_chat_row(
+        self, chat_identifier: str, display_name: str | None = None
+    ) -> tuple | None:
+        """Locator pinned to the peer's chat row, or None.
+
+        A row named with ``chat_identifier`` or ``display_name`` wins. Rows
+        are normally named with the peer's generated three-word name, which
+        the caller cannot know, so otherwise the peer is the one row that is
+        not the support bot's. Two or more such rows is no answer: the
+        caller fails instead of opening whichever comes first.
+        """
+        wanted = [value for value in (chat_identifier, display_name) if value]
+        peers = []
+        for resource_id, name, label in self._chat_rows():
+            if any(value in name or value in label for value in wanted):
+                return self.locators.chat_row(resource_id)
+            if SUPPORT_BOT_DISPLAY_NAME in name or SUPPORT_BOT_DISPLAY_NAME in label:
+                continue
+            peers.append(resource_id)
+        if len(peers) == 1:
+            return self.locators.chat_row(peers[0])
+        if peers:
+            self.logger.debug(
+                "%d chat rows besides the support bot's and none named %s",
+                len(peers), wanted,
+            )
         return None
 
-    def open_first_chat(self, timeout: int = 10) -> bool:
-        """Open the first chat in the chat list.
+    def wait_for_peer_rows(self, minimum: int, timeout: int = 60) -> bool:
+        """Wait until at least ``minimum`` rows other than the support bot's are listed."""
 
-        Useful for tests that need any available chat without knowing specific names.
+        def _enough() -> bool:
+            return sum(
+                1
+                for _, name, label in self._chat_rows()
+                if SUPPORT_BOT_DISPLAY_NAME not in name
+                and SUPPORT_BOT_DISPLAY_NAME not in label
+            ) >= minimum
 
-        Returns:
-            bool: True if a chat was opened successfully.
-        """
-        self._ensure_chat_list_visible()
-        if not self.is_element_visible(self.locators.FIRST_CHAT_ITEM, timeout=timeout):
-            self.logger.warning("No chats available in the list")
-            return False
-        return self.safe_click(self.locators.FIRST_CHAT_ITEM, timeout=timeout)
-
-    def _resolve_chat_locators(self, chat_identifier: str, display_name: str | None = None):
-        """Locators for a chat row, in priority order.
-
-        Status tags fresh-contact chat rows with an auto-generated 3-word
-        identity name (e.g. "Whopping Insecure Frilledlizard") in
-        ``resource-id`` on both sides, so identifier-specific locators
-        miss. ``FIRST_CHAT_ITEM`` is the load-bearing fallback in the
-        one-chat fixture scenario. Strict-uniqueness assertions are not
-        supported by these locators today.
-        """
-        locators = [self.locators.dm_row_button(chat_identifier)]
-        if display_name:
-            locators.append(self.locators.chat_list_item(display_name))
-        locators.append(self.locators.FIRST_CHAT_ITEM)
-        return locators
+        return self.wait_for_condition(_enough, timeout=timeout, poll_interval=1.0)
 
     def open_chat_by_suffix(
         self,
@@ -111,23 +116,27 @@ class ChatPage(BasePage):
         timeout: int | None = 15,
     ) -> bool:
         self._ensure_chat_list_visible()
-        primary, *fallbacks = self._resolve_chat_locators(chat_identifier, display_name)
+        deadline = time.time() + (timeout or 15)
+        locator = self._find_chat_row(chat_identifier, display_name)
+        while locator is None and time.time() < deadline:
+            time.sleep(1.0)
+            locator = self._find_chat_row(chat_identifier, display_name)
+        if locator is None:
+            self.dump_page_source(f"open_chat_by_suffix_failure_{chat_identifier}")
+            return False
         try:
-            return self.safe_click(
-                primary, fallback_locators=fallbacks, timeout=timeout, max_attempts=3,
-            )
+            self.safe_click(locator, timeout=5, max_attempts=3)
         except ElementInteractionError as exc:
-            self.logger.debug(
-                "Direct click chain failed (%s); attempting scroll in chat list", exc,
+            self.logger.warning(
+                "Chat row for %s did not take the tap: %s", chat_identifier, exc,
             )
-        for locator in (primary, *fallbacks):
-            if self.scroll_to_element(locator, max_swipes=3, timeout=3):
-                return self.safe_click(locator, timeout=timeout, max_attempts=3)
-        # Diagnostic: dump page source so we can tell whether the chat list
-        # is genuinely empty (status-go fresh-contact race) vs populated but
-        # using AT names our locators don't match.
-        self.dump_page_source(f"open_chat_by_suffix_failure_{chat_identifier}")
-        return False
+            return False
+        header = self._read_element_text(self.locators.CHAT_HEADER_NAME, timeout=10)
+        self.logger.info("Opened chat '%s' for peer %s", header, chat_identifier)
+        if header and SUPPORT_BOT_DISPLAY_NAME in header:
+            self.dump_page_source(f"open_chat_by_suffix_wrong_chat_{chat_identifier}")
+            return False
+        return True
 
     def chat_exists_in_list(
         self,
@@ -144,9 +153,8 @@ class ChatPage(BasePage):
             self.logger.debug(f"Failed to show chat list: {exc}")
             return False
 
-        locators = self._resolve_chat_locators(chat_identifier, display_name)
         return self.wait_for_condition(
-            lambda: any(self.find_element_safe(loc, timeout=1) for loc in locators),
+            lambda: self._find_chat_row(chat_identifier, display_name) is not None,
             timeout=timeout,
             poll_interval=0.5,
         )
@@ -309,19 +317,14 @@ class ChatPage(BasePage):
         self.dismiss_introduce_prompt(timeout=2)
         self.dismiss_backup_prompt(timeout=2)
         self._ensure_chat_list_visible()
-        locators = self._resolve_chat_locators(chat_identifier, display_name)
 
         deadline = time.time() + timeout
         last_refresh = time.time()
         app = App(self.driver)
 
         while time.time() < deadline:
-            # Check for the chat row
-            try:
-                if any(self.find_element_safe(loc, timeout=1) for loc in locators):
-                    return True
-            except Exception:
-                pass
+            if self._find_chat_row(chat_identifier, display_name) is not None:
+                return True
 
             # Periodically force a full nav refresh: switch to another
             # section and back so the chat list is re-built by the UI.
@@ -360,12 +363,8 @@ class ChatPage(BasePage):
         display_name: str | None = None,
         timeout: int | None = 4,
     ) -> bool:
-        locators = self._resolve_chat_locators(chat_identifier, display_name)
-        element = None
-        for locator in locators:
-            element = self.find_element_safe(locator, timeout=timeout)
-            if element:
-                break
+        locator = self._find_chat_row(chat_identifier, display_name)
+        element = self.find_element_safe(locator, timeout=timeout) if locator else None
         if not element:
             return False
         try:

--- a/test/e2e_appium/pages/settings/contacts_page.py
+++ b/test/e2e_appium/pages/settings/contacts_page.py
@@ -58,14 +58,11 @@ class ContactsSettingsPage(BasePage):
         return self.is_element_visible(self.locators.PENDING_REQUEST_ROW, timeout=timeout)
 
     def accept_contact_request(self, display_name: str) -> bool:
-        """Accept a pending contact request.
+        """Accept the pending request that is not the support bot's.
 
-        Primary is ``FIRST_PENDING_ACCEPT_BUTTON`` — the receiver's UI tags
-        the incoming request with an auto-generated identity name (e.g.
-        "Negligible Authorized Chafer"), not ``display_name``, so the
-        filtered xpath never matches in the one-pending-request flow. The
-        filtered xpath remains as a fallback for future multi-request
-        scenarios where the receiver knows the contact.
+        The list names a request with the sender's generated identity name
+        (e.g. "Negligible Authorized Chafer"), not ``display_name``, so the
+        filtered xpath is only a fallback for a receiver that knows the sender.
         """
         try:
             return self.safe_click(
@@ -79,14 +76,11 @@ class ContactsSettingsPage(BasePage):
             return False
 
     def open_chat_with(self, display_name: str) -> bool:
-        """Open chat with a specific contact.
+        """Open the chat of the contact that is not the support bot.
 
-        Primary is ``FIRST_CONTACT_CHAT_BUTTON`` — Status's ContactPanel
-        content-desc carries the auto-generated identity name (e.g.
+        The contact panel carries the generated identity name (e.g.
         "Unselfish Free Crocodile"), not the chat-key suffix, so the
-        filtered xpath misses. Mirrors ``accept_contact_request``. The
-        filtered locator stays as fallback for future scenarios where
-        the contact panel does carry the suffix or display_name.
+        filtered xpath is only a fallback. Mirrors ``accept_contact_request``.
         """
         return self.safe_click(
             self.locators.FIRST_CONTACT_CHAT_BUTTON,

--- a/test/e2e_appium/tests/messaging/test_message_context_menu.py
+++ b/test/e2e_appium/tests/messaging/test_message_context_menu.py
@@ -104,13 +104,6 @@ class _MessageContextMenuBase:
                     self.logger.info("Opened chat with secondary user")
                     return chat_page
 
-        # Fallback: try opening first available chat
-        self.logger.info("Attempting to open first available chat")
-        if chat_page.open_first_chat(timeout=self.UI_TIMEOUT):
-            if chat_page.wait_for_message_input(timeout=self.UI_TIMEOUT):
-                self.logger.info("Opened first chat successfully")
-                return chat_page
-
         raise AssertionError(
             "Could not navigate to a chat with message input. "
             "App may be in unexpected state."
@@ -165,10 +158,6 @@ class _MessageContextMenuBase:
                 if secondary_chat.wait_for_message_input(timeout=self.UI_TIMEOUT):
                     self.logger.info("Secondary opened chat with primary")
                     return secondary_chat
-
-        # Fallback: open first chat
-        if secondary_chat.open_first_chat(timeout=self.UI_TIMEOUT):
-            secondary_chat.wait_for_message_input(timeout=self.UI_TIMEOUT)
 
         return secondary_chat
 

--- a/test/e2e_appium/tests/messaging/test_z_chat_management.py
+++ b/test/e2e_appium/tests/messaging/test_z_chat_management.py
@@ -77,10 +77,6 @@ class TestChatManagement:
                 if chat_page.wait_for_message_input(timeout=self.UI_TIMEOUT):
                     return chat_page
 
-        if chat_page.open_first_chat(timeout=self.UI_TIMEOUT):
-            if chat_page.wait_for_message_input(timeout=self.UI_TIMEOUT):
-                return chat_page
-
         raise AssertionError(
             "Could not navigate to a chat with message input."
         )
@@ -109,9 +105,6 @@ class TestChatManagement:
             ):
                 if secondary_chat.wait_for_message_input(timeout=self.UI_TIMEOUT):
                     return secondary_chat
-
-        if secondary_chat.open_first_chat(timeout=self.UI_TIMEOUT):
-            secondary_chat.wait_for_message_input(timeout=self.UI_TIMEOUT)
 
         return secondary_chat
 

--- a/test/e2e_appium/tests/test_chat_row_selection.py
+++ b/test/e2e_appium/tests/test_chat_row_selection.py
@@ -1,0 +1,78 @@
+"""Chat rows are picked by identity, never by position.
+
+Android names a chat row only in its resource-id, with the peer's generated
+three-word name, so the fixture cannot match the row by chat key or display
+name. The support bot's row is on every new profile. These tests pin the
+selection rules without a device.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from constants.support_bot import SUPPORT_BOT_DISPLAY_NAME
+from pages.messaging.chat_page import ChatPage
+
+PREFIX = (
+    "QGuiApplication.mainWindow.StatusSectionLayoutPortrait_QMLTYPE_267_QML_273."
+    "BaseProxyPanel."
+)
+
+
+class _Row:
+    def __init__(self, name: str, ordinal: int, content_desc: str = ""):
+        self.resource_id = f"{PREFIX}{name}.StatusDraggableListItem_QMLTYPE_336_QML_{ordinal}"
+        self._attrs = {
+            "resource-id": self.resource_id,
+            "content-desc": content_desc,
+            "text": "",
+        }
+
+    def get_attribute(self, name: str):
+        return self._attrs.get(name)
+
+
+def _page(*rows: _Row) -> ChatPage:
+    driver = MagicMock()
+    driver.find_elements.return_value = list(rows)
+    return ChatPage(driver)
+
+
+BOT = _Row(SUPPORT_BOT_DISPLAY_NAME, 696)
+PEER = _Row("Burlywood Valuable Tayra", 697)
+OTHER = _Row("Feisty Oldfashioned Caterpillar", 698)
+
+
+@pytest.mark.gate
+@pytest.mark.component
+def test_peer_is_the_one_row_that_is_not_the_bot():
+    locator = _page(BOT, PEER)._find_chat_row("Lgrvz5", display_name="aVIVawpkfxhW")
+    assert locator == ("xpath", f'//*[@resource-id="{PEER.resource_id}"]')
+
+
+@pytest.mark.gate
+@pytest.mark.component
+def test_bot_alone_is_no_peer():
+    assert _page(BOT)._find_chat_row("Lgrvz5", display_name="aVIVawpkfxhW") is None
+
+
+@pytest.mark.gate
+@pytest.mark.component
+def test_two_unnamed_peers_is_no_answer():
+    assert _page(BOT, PEER, OTHER)._find_chat_row("Lgrvz5") is None
+
+
+@pytest.mark.gate
+@pytest.mark.component
+def test_a_row_named_after_the_peer_wins_over_exclusion():
+    named = _Row("aVIVawpkfxhW", 699)
+    locator = _page(BOT, PEER, named)._find_chat_row("Lgrvz5", display_name="aVIVawpkfxhW")
+    assert locator == ("xpath", f'//*[@resource-id="{named.resource_id}"]')
+
+
+@pytest.mark.gate
+@pytest.mark.component
+def test_peer_row_count_ignores_the_bot():
+    page = _page(BOT, PEER, OTHER)
+    assert page.wait_for_peer_rows(2, timeout=1) is True
+    assert page.wait_for_peer_rows(3, timeout=1) is False

--- a/test/e2e_appium/utils/contact_helpers.py
+++ b/test/e2e_appium/utils/contact_helpers.py
@@ -510,10 +510,9 @@ async def establish_contacts_admin_to_many(
     sender_chat.dismiss_backup_prompt(timeout=2)
     sender_chat.dismiss_introduce_prompt(timeout=2)
 
-    for rcv_suffix in receiver_suffixes:
-        assert sender_chat.wait_for_new_chat_to_arrive(
-            rcv_suffix, display_name=None, timeout=timeout,
-        ), f"Admin never saw chat from {rcv_suffix}"
+    assert sender_chat.wait_for_peer_rows(len(receivers), timeout=timeout), (
+        f"Admin never saw chat rows for all of {receiver_suffixes}"
+    )
 
     logger.info(
         "Contacts established admin↔[%s]",


### PR DESCRIPTION
### What does the PR do

Every new profile sends the support bot a contact request on first start, so its chat is row one of a fresh profile's chat list. The receiver's chat lookup has never matched the peer's row by name on Android (rows are named with the peer's generated three-word name, only in the resource-id) and fell back to the first row. That row is now the bot's, with a disabled composer, so the receiver's setup message was never sent and every messaging test in the nightly Android run errored in the session fixture.

- Read the chat rows and pick the peer by identity: a row named with the identifier or display name, else the one row that is not the support bot's. None or several fails with a page dump instead of opening whichever row is first; the opened chat's header is checked against the bot's name.
- Remove the positional helpers and the four test fallbacks that used them; exclude the bot's panel from the two contacts locators that took the first match.
- Five device-free tests pin the selection rules and run in the gate.

Not covered: the bot is recognised by its display name, which is what the app renders; the contacts-panel exclusion has no page-source evidence yet and is a no-op if the panel's accessibility name does not carry the bot's name. Should end-to-end builds disable the support-bot contact request at build time, as the status-go functional suite already does? Evidence is in the comment below. This closes the "Receiver failed to send setup message" cluster; the Settings-menu failures in `test_drawer_navigation_cycles` are a separate defect.
