### PR TITLE
fix(e2e_appium): wait for the profile sheet before tapping Settings

### DIFF
--- a/test/e2e_appium/locators/app_locators.py
+++ b/test/e2e_appium/locators/app_locators.py
@@ -45,8 +45,9 @@ class AppLocators(BaseLocators):
     SETTINGS_ACTION = BaseLocators.xpath(
         "//*[contains(@resource-id,'userStatusSettingsAction')]"
     )
+    # The profile sheet's QML type name; there is no 'ProfileMenu' objectName.
     PROFILE_MENU_CONTAINER = BaseLocators.xpath(
-        "//*[contains(@resource-id,'ProfileMenu')]"
+        "//*[contains(@resource-id,'UserStatusContextMenu')]"
     )
 
     # Toolbar

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -269,35 +269,110 @@ class App(BasePage):
 
     def click_settings_button(self) -> bool:
         self.logger.info("Opening Settings from the profile menu")
-        from utils.screen_identity import SCREEN_ANCHORS
+        from utils.screen_identity import SCREEN_ANCHORS, dismiss_backup_modal
         if self.is_element_visible(SCREEN_ANCHORS["settings"], timeout=1):
             self.logger.info("Already in Settings section — skipping nav")
             return True
 
-        for attempt in range(1, 4):
+        strategies = ["w3c", "native", "w3c"]
+        for attempt, strategy in enumerate(strategies, start=1):
+            if attempt > 1:
+                self._reset_profile_menu_state()
+            if dismiss_backup_modal(self, timeout=1):
+                self.logger.warning(
+                    "click_settings_button: dismissed backup modal on attempt %d",
+                    attempt,
+                )
             if not self._ensure_main_nav_visible():
                 self.logger.warning(
                     "Nav not visible on Settings attempt %d", attempt
                 )
                 continue
-            if not self.safe_click(self.locators.PROFILE_NAV_BUTTON, timeout=5):
+            # The drawer is still sliding in when its items reach the a11y
+            # tree; a tap during the slide closes it instead of opening the menu.
+            time.sleep(0.6)
+            if not self.try_click(
+                self.locators.PROFILE_NAV_BUTTON, timeout=5, max_attempts=1
+            ):
                 self.logger.warning(
                     "Profile nav button tap failed on Settings attempt %d", attempt
                 )
                 continue
-            if not self.safe_click(self.locators.SETTINGS_ACTION, timeout=5):
+            action = self._wait_for_profile_menu(timeout=5)
+            if action is None:
                 self.logger.warning(
-                    "Settings menu item tap failed on attempt %d", attempt
+                    "Profile menu did not open on Settings attempt %d", attempt
+                )
+                self.dump_page_source(f"settings_menu_not_open_a{attempt}_{strategy}")
+                continue
+            if not self._tap_element(action, strategy):
+                self.logger.warning(
+                    "Settings menu item tap failed on attempt %d (strategy=%s)",
+                    attempt, strategy,
                 )
                 continue
             if self.is_element_visible(SCREEN_ANCHORS["settings"], timeout=15):
+                if attempt > 1:
+                    self.logger.warning(
+                        "click_settings_button: rescued on attempt %d (strategy=%s)",
+                        attempt, strategy,
+                    )
                 return True
             self.logger.warning(
-                "Settings screen anchor not visible after attempt %d", attempt
+                "Settings screen anchor not visible after attempt %d (strategy=%s)",
+                attempt, strategy,
             )
+            self.dump_page_source(f"settings_nav_no_page_a{attempt}_{strategy}")
 
         self.dump_page_source("settings_nav_failed")
         return False
+
+    def _wait_for_profile_menu(self, timeout: int = 5):
+        """The Settings menu item once the profile sheet is open, or None.
+
+        The sheet slides up from the bottom. Its items are in the a11y tree
+        from the first frame, so a tap during the slide lands on the dimmed
+        background and closes the sheet. Wait for the sheet container, then
+        let the slide finish before returning the item to tap.
+        """
+        if not self.is_element_visible(self.locators.PROFILE_MENU_CONTAINER, timeout=timeout):
+            return None
+        # The sheet keeps animating for ~200-400ms after it is in the tree,
+        # matching the drawer settle in _click_drawer_nav_with_verify.
+        time.sleep(0.6)
+        return self.wait_for_painted(self.locators.SETTINGS_ACTION, timeout=2)
+
+    def _tap_element(self, element, strategy: str) -> bool:
+        try:
+            if strategy == "native":
+                self.driver.execute_script(
+                    "mobile: clickGesture", {"elementId": element.id},
+                )
+                return True
+            rect = element.rect
+            return self.gestures.tap(
+                int(rect["x"] + rect["width"] / 2),
+                int(rect["y"] + rect["height"] / 2),
+            )
+        except Exception as exc:
+            self.logger.debug("%s tap failed: %s", strategy, exc)
+            return False
+
+    def _reset_profile_menu_state(self) -> None:
+        """Close an open profile sheet or drawer, then re-foreground the app."""
+        for open_locator in (self.locators.SETTINGS_ACTION, self.locators.LEFT_NAV_ANY):
+            if self.is_element_visible(open_locator, timeout=1):
+                try:
+                    self.driver.press_keycode(4)  # KEYCODE_BACK
+                except Exception as exc:
+                    self.logger.debug("press_keycode(BACK) suppressed: %s", exc)
+                time.sleep(0.5)
+        pkg = self.driver.capabilities.get("appPackage") or "app.status.mobile"
+        try:
+            self.driver.activate_app(pkg)
+        except Exception as exc:
+            self.logger.debug("activate_app suppressed: %s", exc)
+        time.sleep(1.0)
 
     def _click_drawer_nav_with_verify(
         self,

--- a/test/e2e_appium/tests/test_settings_nav_ladder.py
+++ b/test/e2e_appium/tests/test_settings_nav_ladder.py
@@ -1,0 +1,68 @@
+"""The Settings navigation ladder retries, and only taps an open menu.
+
+Settings is reached through the profile sheet. These tests drive
+``click_settings_button`` with stubs so the sequence is pinned without a
+device: no tap before the sheet has arrived, a different tap on the next
+attempt, and a page dump when every attempt fails.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import pages.app as app_module
+from pages.app import App
+
+
+def _app(monkeypatch, menu_outcomes, arrive_after_tap=True):
+    app = App(MagicMock())
+    calls = {"taps": [], "resets": 0, "dumps": [], "anchor_checks": 0}
+    outcomes = list(menu_outcomes)
+
+    def anchor_visible(locator, timeout=None):
+        calls["anchor_checks"] += 1
+        return arrive_after_tap and bool(calls["taps"])
+
+    monkeypatch.setattr(app_module.time, "sleep", lambda *_: None)
+    monkeypatch.setattr("utils.screen_identity.dismiss_backup_modal", lambda *a, **k: False)
+    monkeypatch.setattr(app, "is_element_visible", anchor_visible)
+    monkeypatch.setattr(app, "_ensure_main_nav_visible", lambda: True)
+    monkeypatch.setattr(app, "try_click", lambda *a, **k: True)
+    monkeypatch.setattr(app, "_wait_for_profile_menu", lambda timeout=5: outcomes.pop(0))
+    monkeypatch.setattr(app, "_tap_element", lambda el, strategy: calls["taps"].append(strategy) or True)
+    monkeypatch.setattr(app, "_reset_profile_menu_state", lambda: calls.__setitem__("resets", calls["resets"] + 1))
+    monkeypatch.setattr(app, "dump_page_source", lambda name=None: calls["dumps"].append(name))
+    return app, calls
+
+
+@pytest.mark.gate
+@pytest.mark.component
+def test_menu_item_is_not_tapped_until_the_sheet_arrives(monkeypatch):
+    app, calls = _app(monkeypatch, menu_outcomes=[None, MagicMock()])
+
+    assert app.click_settings_button() is True
+    assert calls["taps"] == ["native"], "the tap must wait for attempt 2, with the other strategy"
+    assert calls["resets"] == 1
+    assert calls["dumps"] == ["settings_menu_not_open_a1_w3c"]
+
+
+@pytest.mark.gate
+@pytest.mark.component
+def test_every_attempt_failing_leaves_the_dump(monkeypatch):
+    app, calls = _app(monkeypatch, menu_outcomes=[None, None, None])
+
+    assert app.click_settings_button() is False
+    assert calls["taps"] == []
+    assert calls["resets"] == 2
+    assert calls["dumps"][-1] == "settings_nav_failed"
+
+
+@pytest.mark.gate
+@pytest.mark.component
+def test_tap_without_arrival_is_retried_with_another_strategy(monkeypatch):
+    sheet = MagicMock()
+    app, calls = _app(monkeypatch, menu_outcomes=[sheet, sheet, sheet], arrive_after_tap=False)
+
+    assert app.click_settings_button() is False
+    assert calls["taps"] == ["w3c", "native", "w3c"]
+    assert calls["dumps"][-1] == "settings_nav_failed"


### PR DESCRIPTION
### What does the PR do

`click_settings_button` tapped the profile button and the Settings menu item back to back. The profile sheet slides up, so the item is in the accessibility tree at moving bounds before it can take a tap; on a Pixel 8 the tap lands on the dimmed background or the item is not there yet, `safe_click` raises, and the `for attempt in range(1, 4)` loop never ran a second attempt. The nightly Android run lost `test_drawer_navigation_cycles` to it, and on some nights both devices of every messaging fixture.

- Wait until the Settings item is painted and has stopped moving before tapping it; verify the Settings landmark afterwards.
- Make the loop real: `try_click` for the profile button, a reset of sheet and drawer state between attempts, a different tap gesture on the next attempt, page dumps on each failed step and after the last.
- Three device-free tests pin the sequence.

`AppLocators.PROFILE_MENU_CONTAINER` is left as is: no objectName under `ui/` contains `ProfileMenu`, so it never resolves, which is why the wait is on the menu item itself. Not covered: the stationary-bounds check is read from the accessibility tree, and one device run per platform. Evidence is in the comment below. This closes the `userStatusSettingsAction` cluster; the `LEFT_NAV_SETTINGS` line in the same test is #22148, and the "Receiver failed to send setup message" cluster is #22154.
