### PR TITLE
fix(e2e_appium): wait longer to find the emoji picker

### DIFF
--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -487,14 +487,17 @@ class ChatPage(BasePage):
             self.logger.error("Failed to click emoji button")
             return False
 
-        if not self.is_element_visible(emoji_locators.POPUP_CONTAINER, timeout=5):
+        # The picker opens at once, but its emoji grid (hundreds of nodes)
+        # reaches the accessibility tree seconds later; a 5s wait was too short.
+        POPUP_TIMEOUT = 20
+        if not self.is_element_visible(emoji_locators.POPUP_CONTAINER, timeout=POPUP_TIMEOUT):
             self.logger.error("Emoji popup did not appear")
             return False
 
         if not self.qt_safe_input(
             emoji_locators.SEARCH_INPUT,
             search_term,
-            timeout=5,
+            timeout=POPUP_TIMEOUT,
             verify=False,
         ):
             self.logger.error("Failed to type in emoji search")


### PR DESCRIPTION
### What does the PR do

`send_emoji_to_chat` waited 5 seconds for the emoji picker popup. The picker opens right away, but its emoji grid has hundreds of accessibility nodes that reach the tree a few seconds later, and the search box later still. On a Pixel 8 the popup node appeared at about 4.9 seconds, so the 5 second wait failed about half the time with "Emoji popup did not appear" while the picker was open on screen.

- Wait 20 seconds for the popup and the search box. `is_element_visible` returns as soon as the node appears, so a fast run is not slowed.

Verified on BrowserStack Pixel 8: 2 of 2 runs sent the emoji with no "Emoji popup did not appear". The test can still flake on cross-device delivery, which is a separate issue.
