### PR TITLE
Chat input: prevent switching chat on backspace with incomplete mention on Windows

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -3426,8 +3426,15 @@ Item {
     // is consulted before the key event reaches the focus chain, which is the only
     // route that works in the Browser — a focused WebEngineView accepts every key
     // event and nothing bubbles out of it.
+    //
+    // On Windows StandardKey.Back also binds plain Backspace. That normally edits
+    // the focused text field, but when a non-editable item has focus (e.g. the open
+    // mention-suggestion list) the unconsumed Backspace reaches this shortcut and
+    // hijacks a chat/subsection switch. Bind the explicit Alt+Left there instead so
+    // Backspace never navigates; other platforms keep StandardKey.Back unchanged.
     Shortcut {
-        sequences: [StandardKey.Back]
+        sequences: Qt.platform.os === SQUtils.Utils.windows
+                   ? ["Alt+Left"] : [StandardKey.Back]
         enabled: !SQUtils.Utils.isMobile && appMain.canGoBackAnywhere
         onActivated: appMain.tryGoBack()
     }


### PR DESCRIPTION
### What does the PR do

Excludes bare `Backspace` key from back shortcut on `Windows`

Closes: #22140

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`AppMain.qml`

### Impact on end user
Important on Windows

### How to test

Go to some chat, switch chat to another one, type @ and few letters (suggestion list should be open). Then use backspace to remove inserted characters.

### Risk 
Low