### PR TITLE
MyProfileView: Skip the community dupe check for ENS users

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -363,7 +363,9 @@ SettingsContentBase {
 
                         Backpressure.debounce(root, 500, () => {
                             const displayName = descriptionPanel.displayName.text
-                            if (!root.communitiesStore || displayName === root.profileStore.name) {
+
+                            if (!root.communitiesStore || descriptionPanel.isEnsName
+                                    || displayName === root.profileStore.displayName) {
                                 descriptionPanel.setDisplayNameValidityAndErrorMessage(true, "")
                                 return
                             }


### PR DESCRIPTION
### What does the PR do

Skip the community dupe check for ENS users (the field is read-only for them) and when the value is unchanged from the stored display name.

Closes: #22117

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`MyProfileView`

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Impact on end user

Low

### How to test

With ENS name in use and being a community member, go to settings. The read only name should be presented without any error.

### Risk 
Low
