### PR TITLE
fix(LogosNetworkView): fix Logos Network peer polling for StackView

### DIFF
--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -657,7 +657,7 @@ StatusSectionLayout {
                 peerCount: root.logosNetworkStore.peerCount
                 peerCountLoading: root.logosNetworkStore.peerCountLoading
                 peerCountError: root.logosNetworkStore.peerCountError
-                pollingActive: profileContainer.currentIndex === Constants.settingsSubsection.logosNetworkSettings
+                pollingActive: StackView.visible
                 onRefreshPeerCountRequested: root.logosNetworkStore.refreshPeerCount()
             }
         }


### PR DESCRIPTION
### What does the PR do

Fixes #22138

Use the active `currentItem` and visibility state instead of comparing incompatible indexes.

### Affected areas

ProfileLayout

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review

### Screencapture of the functionality

[logos-network-settings-fix.webm](https://github.com/user-attachments/assets/73a60814-1f0d-4bf4-8739-8576206f40af)


### Impact on end user

Fixes the polling in the settings

### How to test

Go to the settings

### Risk 

Low
