### PR TITLE
fix: allow letters and digits of any script in name/text inputs

### DIFF
--- a/storybook/qmlTests/tests/tst_AccountAndKeypairNameValidators.qml
+++ b/storybook/qmlTests/tests/tst_AccountAndKeypairNameValidators.qml
@@ -83,5 +83,44 @@ Item {
             setAndValidate(input, "a")
             verify(input.valid, "a 1-character key pair name must be valid")
         }
+
+        function test_keypairName_acceptsAnyScript_data() {
+            return [
+                { tag: "serbian cyrillic", name: "Кључ Ђорђе-1" },
+                { tag: "serbian latin",    name: "Ključ Đorđe_1" },
+                { tag: "ukrainian",        name: "Ключ Їжак" },
+                { tag: "german",           name: "Schlüssel Straße" },
+                { tag: "chinese",          name: "我的密钥" },
+                { tag: "japanese",         name: "キーペア さいふ" },
+                { tag: "korean",           name: "내 키" },
+                { tag: "arabic",           name: "مفتاحي" },
+                { tag: "hindi",            name: "मेरी कुंजी" },
+            ]
+        }
+
+        function test_keypairName_acceptsAnyScript(data) {
+            const state = createTemporaryObject(enterKeyPairNameStateComponent, root)
+            verify(!!state)
+            waitForRendering(state)
+
+            const input = findChild(state, "keycardKeyPairNameInput")
+            verify(!!input)
+
+            setAndValidate(input, data.name)
+            verify(input.valid, `"${data.name}" must be a valid key pair name (error: "${input.errorMessageCmp.text}")`)
+        }
+
+        function test_keypairName_rejectsPunctuation() {
+            const state = createTemporaryObject(enterKeyPairNameStateComponent, root)
+            verify(!!state)
+            waitForRendering(state)
+
+            const input = findChild(state, "keycardKeyPairNameInput")
+            verify(!!input)
+
+            setAndValidate(input, "Кључ!")
+            verify(!input.valid)
+            compare(input.errorMessageCmp.text, Constants.errorMessages.alphanumericalExpandedRegExp)
+        }
     }
 }

--- a/storybook/qmlTests/tests/tst_AddEditSavedAddressPopupNameValidator.qml
+++ b/storybook/qmlTests/tests/tst_AddEditSavedAddressPopupNameValidator.qml
@@ -1,0 +1,112 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Wallet.popups
+
+import utils
+
+Item {
+    id: root
+
+    width: 600
+    height: 700
+
+    Component {
+        id: popupComponent
+
+        AddEditSavedAddressPopup {
+            destroyOnClose: false
+            modal: false
+
+            isChecksumValidForAddress: () => true
+            getWalletAccount: () => ({})
+            getSavedAddress: () => ({})
+            remainingCapacityForSavedAddresses: () => 10
+            savedAddressNameExists: (name) => name.toLowerCase() === "taken"
+
+            Component.onCompleted: initWithParams({edit: false, name: "", address: "", colorId: ""})
+        }
+    }
+
+    TestCase {
+        name: "AddEditSavedAddressPopupNameValidator"
+        when: windowShown
+
+        function setAndValidate(input, text) {
+            input.text = text
+            input.validate(true)
+        }
+
+        function openPopup() {
+            const popup = createTemporaryObject(popupComponent, root)
+            verify(!!popup)
+            popup.open()
+            tryCompare(popup, "opened", true)
+
+            const input = findChild(popup, "savedAddressNameStatusInput")
+            verify(!!input)
+            return input
+        }
+
+        function test_nameAcceptsLettersAndDigitsOfAnyScript_data() {
+            return [
+                { tag: "latin",              name: "My Wallet-1_a" },
+                { tag: "serbian cyrillic",   name: "Саша Ђенић-ЂЂЧчЋћЖжЉљЊњШш" },
+                { tag: "serbian latin",      name: "Saša Đenić-ĐđČčĆćŽžŠš" },
+                { tag: "ukrainian",          name: "Ґудзик Їжак Євген" },
+                { tag: "german",             name: "Straße Ärger Öl Über" },
+                { tag: "french",             name: "Élodie Ça Noël" },
+                { tag: "greek",              name: "Αλέξανδρος" },
+                { tag: "chinese",            name: "我的钱包" },
+                { tag: "japanese",           name: "財布 ワレット さいふ" },
+                { tag: "korean",             name: "내 지갑" },
+                { tag: "arabic",             name: "محفظتي" },
+                { tag: "hebrew",             name: "הארנק שלי" },
+                { tag: "hindi (with marks)", name: "मेरा बटुआ" },
+                { tag: "thai (with marks)",  name: "กระเป๋า" },
+                { tag: "vietnamese",         name: "Ví của tôi" },
+                { tag: "unicode digits",     name: "Саша ٣٤٥" },
+            ]
+        }
+
+        function test_nameAcceptsLettersAndDigitsOfAnyScript(data) {
+            const input = openPopup()
+            setAndValidate(input, data.name)
+            verify(input.valid, `"${data.name}" must be a valid saved address name (error: "${input.errorMessageCmp.text}")`)
+            compare(input.errorMessageCmp.text, "")
+        }
+
+        function test_nameRejectsPunctuationAndEmojis_data() {
+            return [
+                { tag: "ascii punctuation", name: "Саша!",  expectedError: Constants.errorMessages.alphanumericalExpanded1RegExp },
+                { tag: "dot",               name: "wallet.1", expectedError: Constants.errorMessages.alphanumericalExpanded1RegExp },
+                { tag: "double space",      name: "Саша  Ђ", expectedError: Constants.errorMessages.alphanumericalExpanded1RegExp },
+                { tag: "cjk punctuation",   name: "我的钱包。", expectedError: Constants.errorMessages.alphanumericalExpanded1RegExp },
+                { tag: "emoji",             name: "Саша 🙂", expectedError: Constants.errorMessages.emojRegExp },
+            ]
+        }
+
+        function test_nameRejectsPunctuationAndEmojis(data) {
+            const input = openPopup()
+            setAndValidate(input, data.name)
+            verify(!input.valid, `"${data.name}" must be an invalid saved address name`)
+            compare(input.errorMessageCmp.text, data.expectedError)
+        }
+
+        function test_emojiCheckIsStatelessAcrossValidations() {
+            const input = openPopup()
+
+            // The emoji regex carries the 'g' flag; consecutive checks must not depend on lastIndex.
+            setAndValidate(input, "🙂")
+            verify(!input.valid)
+            compare(input.errorMessageCmp.text, Constants.errorMessages.emojRegExp)
+
+            setAndValidate(input, "🙂 Саша")
+            verify(!input.valid)
+            compare(input.errorMessageCmp.text, Constants.errorMessages.emojRegExp)
+
+            setAndValidate(input, "Саша")
+            verify(input.valid)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_UnicodeNameRegularExpressions.qml
+++ b/storybook/qmlTests/tests/tst_UnicodeNameRegularExpressions.qml
@@ -1,0 +1,163 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Controls
+import StatusQ.Controls.Validators
+
+import shared.validators
+import utils
+
+// Guards the app-wide "names in any language" rules from Constants.regularExpressions:
+// the expressions use Unicode property classes (\p{L}, \p{M}, \p{N}, ...) and are evaluated by
+// PCRE2 through StatusRegularExpressionValidator. Each case lists what every rule must accept
+// and reject.
+Item {
+    id: root
+
+    width: 400
+    height: 200
+
+    Component {
+        id: inputComponent
+
+        StatusInput {
+            property alias regularExpression: regexValidator.regularExpression
+
+            width: 300
+            validationMode: StatusInput.ValidationMode.Always
+            validators: [
+                StatusRegularExpressionValidator {
+                    id: regexValidator
+                    errorMessage: "invalid"
+                }
+            ]
+        }
+    }
+
+    TestCase {
+        name: "UnicodeNameRegularExpressions"
+        when: windowShown
+
+        // the regex rule of the real display name validator list (the other rules need stores)
+        readonly property var displayNameRegexValidator: displayNameValidators.validators.find(v => v.name === "regex")
+
+        DisplayNameValidators { id: displayNameValidators }
+
+        readonly property var anyScriptWords: [
+            "Latin", "Саша", "Saša", "Їжак", "Straße", "Élodie", "Αλέξανδρος",
+            "我的钱包", "ワレット", "지갑", "محفظتي", "שלי", "मेरा", "กระเป๋า", "tôi", "٣٤٥"
+        ]
+
+        function isValid(regularExpression, text) {
+            const input = createTemporaryObject(inputComponent, root, { regularExpression })
+            verify(!!input)
+            input.text = text
+            input.validate(true)
+            return input.valid
+        }
+
+        function verifyAll(regularExpression, texts, expectedValid, ruleName) {
+            for (const text of texts) {
+                compare(isValid(regularExpression, text), expectedValid,
+                        `${ruleName}: "${text}" expected ${expectedValid ? "valid" : "invalid"}`)
+            }
+        }
+
+        function test_rules_data() {
+            const re = Constants.regularExpressions
+            return [
+                {
+                    tag: "alphanumerical",
+                    re: re.alphanumerical,
+                    valid: anyScriptWords.concat(["abc123", ""]),
+                    invalid: ["a b", "a-b", "a_b", "a.b", "a!", "🙂"]
+                },
+                {
+                    tag: "alphanumericalExpanded (community/channel/category/token name)",
+                    re: re.alphanumericalExpanded,
+                    valid: anyScriptWords.concat(["Саша Ђенић", "my-community_1.0", " leading", "trailing ", ""]),
+                    invalid: ["a&b", "a,b", "a!", "我的钱包。", "🙂"]
+                },
+                {
+                    tag: "alphanumericalExpanded1 (saved address name, search)",
+                    re: re.alphanumericalExpanded1,
+                    valid: anyScriptWords.concat(["Саша Ђенић", "my-name_1"]),
+                    invalid: ["", " leading", "trailing ", "double  space", "a.b", "a!", "🙂"]
+                },
+                {
+                    tag: "alphanumericalExpanded2 (group chat name)",
+                    re: re.alphanumericalExpanded2,
+                    valid: anyScriptWords.concat(["Саша & Ђенић", "a-b_c.d", ""]),
+                    invalid: ["a,b", "a!", "🙂"]
+                },
+                {
+                    tag: "alphanumericalExpanded3 (channel description)",
+                    re: re.alphanumericalExpanded3,
+                    valid: anyScriptWords.concat(["Саша, Ђенић & co.", ""]),
+                    invalid: ["a!", "line\nbreak", "🙂"]
+                },
+                {
+                    tag: "alphanumericalExpanded4 (community description)",
+                    re: re.alphanumericalExpanded4,
+                    valid: anyScriptWords.concat(["Саша, Ђенић & co.", "line\nbreak", "crlf\r\nbreak", ""]),
+                    invalid: ["a!", "🙂"]
+                },
+                {
+                    tag: "alphanumericalWithSpace (wallet account name)",
+                    re: re.alphanumericalWithSpace,
+                    valid: anyScriptWords.concat(["Саша Ђенић", "Straße Ärger Öl", "財布 ワレット", "Account 1", ""]),
+                    invalid: ["a-b", "a_b", "a.b", "Саша!", "我的钱包。", "🙂"]
+                },
+                {
+                    tag: "textWithEmoji (profile bio, token description)",
+                    re: re.textWithEmoji,
+                    valid: anyScriptWords.concat(["Hello, world! #1 (ok) - 100% <b>", "Саша!? 我的钱包。 ¿Qué?",
+                                                  "🙂", "👨‍👩‍👧‍👦 🇷🇸 👍🏽", "line\nbreak", ""]),
+                    invalid: ["", "￾"]
+                },
+                {
+                    tag: "ascii (unchanged, ASCII-only)",
+                    re: re.ascii,
+                    valid: ["abc 123 !@#", ""],
+                    invalid: ["Саша", "Straße", "我"]
+                },
+                {
+                    tag: "capitalOnly (token symbol, unchanged)",
+                    re: re.capitalOnly,
+                    valid: ["ABC", ""],
+                    invalid: ["abc", "САША", "A1"]
+                },
+                {
+                    tag: "numerical (unchanged, ASCII digits only)",
+                    re: re.numerical,
+                    valid: ["0123", ""],
+                    invalid: ["١٢٣", "1a", "1.0"]
+                },
+                {
+                    tag: "keypairName validator",
+                    re: /^[\p{L}\p{M}\p{N}\-_ ]+$/,
+                    valid: anyScriptWords.concat(["Кључ-1 main_key"]),
+                    invalid: ["", "a.b", "Саша!", "🙂"]
+                },
+                {
+                    tag: "displayName validator",
+                    re: displayNameRegexValidator.regularExpression,
+                    valid: anyScriptWords.concat(["Саша Ђенић", "Straße Ärger Öl", "財布 ワレット", "my_name-1", ""]),
+                    invalid: ["a.b", "Саша!", "我的钱包。", "🙂"]
+                },
+            ]
+        }
+
+        function test_rules(data) {
+            verifyAll(data.re, data.valid, true, data.tag)
+            verifyAll(data.re, data.invalid, false, data.tag)
+        }
+
+        function test_keypairNameValidatorMatchesConstants() {
+            // Constants.validators.keypairName is a validator list; make sure its regex rule is the one tested above
+            const regexValidators = Constants.validators.keypairName.filter(v => v.name === "regex")
+            compare(regexValidators.length, 1)
+            compare(regexValidators[0].regularExpression.toString(), (/^[\p{L}\p{M}\p{N}\-_ ]+$/).toString())
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Controls/Validators/StatusRegularExpressionValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/Validators/StatusRegularExpressionValidator.qml
@@ -1,5 +1,6 @@
 import QtQuick
 
+import StatusQ
 import StatusQ.Controls
 
 /*!
@@ -11,14 +12,17 @@ import StatusQ.Controls
 
    The \c StatusRegularExpressionValidator type provides a validator, that counts as valid any string which matches a specified regular expression.
 
-   It is a wrapper of QML type \l{https://doc.qt.io/qt-5/qml-qtquick-regularexpressionvalidator.html}{RegularExpressionValidator}.
+   It is a wrapper of \l RXValidator, a \c QValidator built on \c QRegularExpression (PCRE2) with Unicode
+   support enabled. Validation is NOT performed by the JS regex engine: QML's JS engine has no support
+   for Unicode property escapes (\c {\p{L}}) and its \c {\w} / \c {\d} classes are ASCII-only, which makes it
+   unsuitable for validating user input in non-Latin scripts.
 
    Example of how to use it:
 
    \qml
         StatusRegularExpressionValidator {
-            regularExpression: /[0-9A-Za-z@]+/
-            errorMessage: qsTr("Please enter a valid regular expression.")
+            regularExpression: /^[\p{L}\p{M}\p{N} ]+$/
+            errorMessage: qsTr("Only letters, numbers and spaces allowed")
         }
    \endqml
 
@@ -31,30 +35,42 @@ StatusValidator {
        \qmlproperty var StatusRegularExpressionValidator::regularExpression
         This property holds the regular expression used for validation.
 
-        Note that this property should be a regular expression in JS syntax, e.g /a/ for the regular expression matching "a".
+        The value is written as a JS regular expression literal (e.g. \c {/^[0-9]+$/}), but the pattern text is
+        handed over verbatim to \c QRegularExpression and evaluated by PCRE2 with
+        \c QRegularExpression::UseUnicodePropertiesOption. Consequently:
 
-        By default, this property contains a regular expression with the pattern .* that matches any string.
+        \list
+        \li Unicode property classes are available: \c {\p{L}} (letters of any script), \c {\p{M}} (combining
+            marks), \c {\p{N}} (digits of any script), \c {\p{P}} (punctuation), \c {\p{S}} (symbols, incl. emoji)...
+        \li \c {\w}, \c {\d}, \c {\s} and \c {\b} are Unicode-aware (unlike in JS). Use explicit ranges such as
+            \c {[0-9]} or \c {[A-Z]} when ASCII-only semantics are required.
+        \li The pattern is anchored: the whole input has to match.
+        \li Do not use the JS \c u flag (the JS parser would reject \c {\p{...}}), \c {\uXXXX} escapes or
+            surrogate pair escapes (not supported by PCRE2 - use \c {\p{...}} classes instead), nor a class
+            range ending with a class escape (e.g. \c {[$-\s]}).
+        \endlist
 
-        Some more examples of regular expressions:
+        Only the \c i (case insensitive) and \c m (multiline) JS flags are carried over.
+
+        Some examples of regular expressions:
 
         > A list of numbers with one to three positions separated by a comma:
         \qml
-        /\d{1,3}(?:,\d{1,3})+$/
+        /^\d{1,3}(?:,\d{1,3})+$/
         \endqml
 
         > An amount consisting of up to 3 numbers before the decimal point, and 1 to 2 after the decimal point:
         \qml
-        /(\d{1,3})([.,]\d{1,2})?$/
+        /^(\d{1,3})([.,]\d{1,2})?$/
        \endqml
     */
     property var regularExpression
 
     name: "regex"
     errorMessage: `Must match regex(${regularExpression.toString()})`
-    validatorObj: RegularExpressionValidator { regularExpression: root.regularExpression }
+    validatorObj: RXValidator { regularExpression: root.regularExpression }
 
     validate: function (value) {
-        // Basic validation management
-        return root.regularExpression.test(value)
+        return root.validatorObj.test(value)
     }
 }

--- a/ui/StatusQ/tests/TestControls/tst_StatusInput.qml
+++ b/ui/StatusQ/tests/TestControls/tst_StatusInput.qml
@@ -42,7 +42,7 @@ Item {
 
                 validators: [
                     StatusRegularExpressionValidator {
-                        regularExpression: /^[0-9A-Za-z_\$-\s]*$/
+                        regularExpression: /^[0-9A-Za-z_$\-\s]*$/
                     }
                 ]
             }
@@ -69,6 +69,27 @@ Item {
             verify(regexTC.testControl.valid, "Expected valid input")
             TestUtils.pressKeyAndWait(regexTC, regexTC.testControl, Qt.Key_Ampersand)
             verify(!regexTC.testControl.valid, "Expected invalid input")
+
+            verify(qtOuput.qtOuput().length === 0, `No output expected. Found:\n"${qtOuput.qtOuput()}"\n`)
+        }
+
+        function test_regex_validation_unicode() {
+            // StatusRegularExpressionValidator evaluates through PCRE2 (RXValidator), so Unicode
+            // property classes work and match letters/digits of any script
+            regexTC.testControl.validators[0].regularExpression = /^[\p{L}\p{M}\p{N}\s]+$/
+            regexTC.testControl.validationMode = StatusInput.ValidationMode.Always
+
+            // (no Indic samples here: font shaping logs "OpenType support missing" and trips the no-output guard)
+            for (const text of ["Ђорђе Ћурчић", "Straße", "我的钱包", "ワレット", "Ђорђе ٣٤٥"]) {
+                regexTC.testControl.text = text
+                regexTC.testControl.validate(true)
+                verify(regexTC.testControl.valid, `"${text}" expected to be valid`)
+            }
+            for (const text of ["Ђорђе!", "我的钱包。", "🙂", "a_b"]) {
+                regexTC.testControl.text = text
+                regexTC.testControl.validate(true)
+                verify(!regexTC.testControl.valid, `"${text}" expected to be invalid`)
+            }
 
             verify(qtOuput.qtOuput().length === 0, `No output expected. Found:\n"${qtOuput.qtOuput()}"\n`)
         }

--- a/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
@@ -152,10 +152,10 @@ StatusScrollView {
             charLimit: 15
             placeholderText: qsTr("Name")
             validationMode: root.validationMode
-            minLengthValidator.errorMessage: qsTr("Please name your token name (use A-Z and 0-9, hyphens and underscores only)")
+            minLengthValidator.errorMessage: qsTr("Please name your token name (use letters and numbers, hyphens and underscores only)")
             regexValidator.errorMessage: d.hasEmoji(text) ?
-                                             qsTr("Your token name is too cool (use A-Z and 0-9, hyphens and underscores only)") :
-                                             qsTr("Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)")
+                                             qsTr("Your token name is too cool (use letters and numbers, hyphens and underscores only)") :
+                                             qsTr("Your token name contains invalid characters (use letters and numbers, hyphens and underscores only)")
             extraValidator.validate: function (value) {
                 // If minting failed, we can retry same deployment, so same name allowed
                 const allowRepeatedName = root.token.deployState === Constants.ContractTransactionStatus.Failed
@@ -191,8 +191,8 @@ StatusScrollView {
             maximumHeight: minimumHeight
             validationMode: root.validationMode
             minLengthValidator.errorMessage: qsTr("Please enter a token description")
-            regexValidator.regularExpression: Constants.regularExpressions.ascii
-            regexValidator.errorMessage: qsTr("Only A-Z, 0-9 and standard punctuation allowed")
+            regexValidator.regularExpression: Constants.regularExpressions.textWithEmoji
+            regexValidator.errorMessage: qsTr("Only letters, numbers, standard punctuation and emojis allowed")
             input.tabNavItem: symbolInput
             onTextChanged: root.token.description = text
         }

--- a/ui/app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml
@@ -62,11 +62,8 @@ Item {
                     errorMessage: qsTr("Bio can't be longer than %n character(s)", "", bioInput.charLimit)
                 },
                 StatusRegularExpressionValidator {
-                    regularExpression: Constants.regularExpressions.asciiWithEmoji
+                    regularExpression: Constants.regularExpressions.textWithEmoji
                     errorMessage: qsTr("Invalid characters. Standard keyboard characters and emojis only.")
-                    validate: function (value) {
-                        return (regularExpression.test(value) || (value.length === 0));
-                    }
                 }
             ]
             input.tabNavItem: displayNameInput.input.edit

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls // for Popup.xxx
 
+import StatusQ // for RXValidator
 import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Controls.Validators
@@ -376,6 +377,7 @@ StatusDialog {
 
             StatusInput {
                 id: nameInput
+                objectName: "savedAddressNameStatusInput"
                 width: parent.width
                 anchors.horizontalCenter: parent.horizontalCenter
                 charLimit: 24
@@ -394,18 +396,20 @@ StatusDialog {
                         property bool isEmoji: false
 
                         name: "check-for-no-emojis"
+                        validatorObj: RXValidator { regularExpression: Constants.regularExpressions.alphanumericalExpanded1 }
                         validate: (value) => {
                                       const normalizedValue = value.trim()
                                       if (!normalizedValue) {
                                           return true
                                       }
 
+                                      Constants.regularExpressions.emoji.lastIndex = 0
                                       isEmoji = Constants.regularExpressions.emoji.test(normalizedValue)
                                       if (isEmoji){
                                           return false
                                       }
 
-                                      return Constants.regularExpressions.alphanumericalExpanded1.test(normalizedValue)
+                                      return validatorObj.test(normalizedValue)
                                   }
                         errorMessage: isEmoji?
                                           Constants.errorMessages.emojRegExp

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -4293,10 +4293,6 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4309,7 +4305,11 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <source>Invalid characters (letters and numbers, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name is too cool (use letters and numbers, single whitespace, hyphens and underscores only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6311,7 +6311,7 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)</source>
+        <source>Invalid characters (use letters and numbers, hyphens, underscores and spaces only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -6578,18 +6578,6 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please name your token name (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your token name is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Asset name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6614,7 +6602,19 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Only A-Z, 0-9 and standard punctuation allowed</source>
+        <source>Please name your token name (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name is too cool (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name contains invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, standard punctuation and emojis allowed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12205,7 +12205,7 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
+        <source>Invalid characters (use letters and numbers, hyphens and underscores only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -4317,10 +4317,6 @@ Zůstanete přihlášeni a vaše obnovovací fráze bude zcela ve vašich rukou.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4333,7 +4329,11 @@ Zůstanete přihlášeni a vaše obnovovací fráze bude zcela ve vašich rukou.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <source>Invalid characters (letters and numbers, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name is too cool (use letters and numbers, single whitespace, hyphens and underscores only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6346,7 +6346,7 @@ key pair. Keycard will be required for signing</source>
         <translation>Zobrazovaná jména nesmí začínat ani končit mezerou</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)</source>
+        <source>Invalid characters (use letters and numbers, hyphens, underscores and spaces only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -6617,18 +6617,6 @@ key pair. Keycard will be required for signing</source>
         <translation>Název</translation>
     </message>
     <message>
-        <source>Please name your token name (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Pojmenujte prosím svůj token (použijte pouze A-Z a 0-9, pomlčky a podtržítka)</translation>
-    </message>
-    <message>
-        <source>Your token name is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Název vašeho tokenu je příliš cool (použijte pouze A-Z a 0-9, pomlčky a podtržítka)</translation>
-    </message>
-    <message>
-        <source>Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Název vašeho tokenu obsahuje neplatné znaky (používejte pouze A-Z a 0-9, pomlčky a podtržítka)</translation>
-    </message>
-    <message>
         <source>Asset name already exists</source>
         <translation>Název aktiva již existuje</translation>
     </message>
@@ -6653,8 +6641,20 @@ key pair. Keycard will be required for signing</source>
         <translation>Zadejte prosím popis tokenu</translation>
     </message>
     <message>
-        <source>Only A-Z, 0-9 and standard punctuation allowed</source>
-        <translation>Povoleno pouze A-Z, 0-9 a standardní interpunkce</translation>
+        <source>Please name your token name (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name is too cool (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name contains invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, standard punctuation and emojis allowed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Symbol</source>
@@ -12278,8 +12278,8 @@ selhalo</translation>
         <translation>Přezdívka</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Neplatné znaky (používejte pouze A-Z a 0-9, pomlčky a podtržítka)</translation>
+        <source>Invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>Nicknames must be at least %n character(s) long</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -4298,10 +4298,6 @@ Permanecerás conectado y tu frase de recuperación estará completamente en tus
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4314,7 +4310,11 @@ Permanecerás conectado y tu frase de recuperación estará completamente en tus
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <source>Invalid characters (letters and numbers, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name is too cool (use letters and numbers, single whitespace, hyphens and underscores only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6322,7 +6322,7 @@ key pair. Keycard will be required for signing</source>
         <translation>Los nombres públicos no pueden comenzar ni terminar con un espacio</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)</source>
+        <source>Invalid characters (use letters and numbers, hyphens, underscores and spaces only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -6589,18 +6589,6 @@ key pair. Keycard will be required for signing</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <source>Please name your token name (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Por favor nombra tu token (usa solo A-Z y 0-9, guiones y guiones bajos)</translation>
-    </message>
-    <message>
-        <source>Your token name is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>El nombre de tu token es demasiado cool (usa solo A-Z y 0-9, guiones y guiones bajos)</translation>
-    </message>
-    <message>
-        <source>Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>El nombre de tu token contiene caracteres inválidos (usa solo A-Z y 0-9, guiones y guiones bajos)</translation>
-    </message>
-    <message>
         <source>Asset name already exists</source>
         <translation>El nombre del activo ya existe</translation>
     </message>
@@ -6625,8 +6613,20 @@ key pair. Keycard will be required for signing</source>
         <translation>Por favor escribe una descripción del token</translation>
     </message>
     <message>
-        <source>Only A-Z, 0-9 and standard punctuation allowed</source>
-        <translation>Solo se permiten A-Z, 0-9 y puntuación estándar</translation>
+        <source>Please name your token name (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name is too cool (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name contains invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, standard punctuation and emojis allowed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Symbol</source>
@@ -12218,8 +12218,8 @@ al cargar</translation>
         <translation>Apodo</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Caracteres inválidos (usa solo A-Z y 0-9, guiones y guiones bajos)</translation>
+        <source>Invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>Nicknames must be at least %n character(s) long</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -4296,10 +4296,6 @@ Vous resterez connecté et votre phrase de récupération sera entièrement entr
         <translation>Seules les lettres, les chiffres, les tirets bas, les points, les espaces et les tirets sont autorisés.</translation>
     </message>
     <message>
-        <source>Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Caractères non valides (seules les lettres A-Z et les chiffres 0-9, les espaces, les tirets et les tirets bas sont autorisés).</translation>
-    </message>
-    <message>
         <source>Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed</source>
         <translation>Seules les lettres, les chiffres, les tirets bas, les points, les virgules, les espaces et les tirets sont autorisés.</translation>
     </message>
@@ -4312,8 +4308,12 @@ Vous resterez connecté et votre phrase de récupération sera entièrement entr
         <translation>Seules les lettres, les chiffres et les caractères ASCII sont autorisés.</translation>
     </message>
     <message>
-        <source>Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Le nom est trop cool (utilisez uniquement les lettres majuscules A-Z et les chiffres 0-9, un seul espace, des tirets et des tirets bas).</translation>
+        <source>Invalid characters (letters and numbers, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name is too cool (use letters and numbers, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Whole numbers only</source>
@@ -6320,8 +6320,8 @@ key pair. Keycard will be required for signing</source>
         <translation>Les noms publics ne peuvent pas commencer ou se terminer par un espace</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)</source>
-        <translation>Caractères non valides (utilisez uniquement les lettres A à Z et les chiffres de 0 à 9, ainsi que les tirets, les traits de soulignement et les espaces)</translation>
+        <source>Invalid characters (use letters and numbers, hyphens, underscores and spaces only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>Display Names must be at least %n character(s) long</source>
@@ -6587,18 +6587,6 @@ key pair. Keycard will be required for signing</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <source>Please name your token name (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Veuillez donner un nom à votre jeton (utilisez uniquement les lettres A-Z et les chiffres 0-9, ainsi que les tirets et les traits de soulignement)</translation>
-    </message>
-    <message>
-        <source>Your token name is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Le nom de votre jeton est trop original (utilisez uniquement les lettres A-Z et les chiffres 0-9, ainsi que les tirets et les traits de soulignement)</translation>
-    </message>
-    <message>
-        <source>Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Le nom de votre jeton contient des caractères non valides (utilisez uniquement les lettres A-Z et les chiffres 0-9, ainsi que les tirets et les traits de soulignement)</translation>
-    </message>
-    <message>
         <source>Asset name already exists</source>
         <translation>Ce nom d&apos;actif existe déjà</translation>
     </message>
@@ -6623,8 +6611,20 @@ key pair. Keycard will be required for signing</source>
         <translation>Veuillez saisir une description du jeton</translation>
     </message>
     <message>
-        <source>Only A-Z, 0-9 and standard punctuation allowed</source>
-        <translation>Seules les lettres A-Z, les chiffres 0-9 et la ponctuation standard sont autorisées</translation>
+        <source>Please name your token name (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name is too cool (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name contains invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, standard punctuation and emojis allowed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Symbol</source>
@@ -12215,8 +12215,8 @@ chargement</translation>
         <translation>Pseudonyme</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Caractères non valides (utilisez uniquement les lettres A à Z, les chiffres de 0 à 9, les tirets et les traits de soulignement)</translation>
+        <source>Invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>Nicknames must be at least %n character(s) long</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -4278,10 +4278,6 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4294,7 +4290,11 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <source>Invalid characters (letters and numbers, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name is too cool (use letters and numbers, single whitespace, hyphens and underscores only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6297,7 +6297,7 @@ key pair. Keycard will be required for signing</source>
         <translation>표시 이름은 공백으로 시작하거나 끝날 수 없습니다</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)</source>
+        <source>Invalid characters (use letters and numbers, hyphens, underscores and spaces only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -6560,18 +6560,6 @@ key pair. Keycard will be required for signing</source>
         <translation>이름</translation>
     </message>
     <message>
-        <source>Please name your token name (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>토큰 이름을 입력하세요 (A-Z와 0-9, 하이픈과 밑줄만 사용)</translation>
-    </message>
-    <message>
-        <source>Your token name is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>토큰 이름이 너무 멋져요 (A-Z와 0-9, 하이픈, 밑줄만 사용하세요)</translation>
-    </message>
-    <message>
-        <source>Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>토큰 이름에 잘못된 문자가 포함되어 있습니다(A-Z, 0-9, 하이픈(-), 밑줄(_)만 사용하세요)</translation>
-    </message>
-    <message>
         <source>Asset name already exists</source>
         <translation>자산 이름이 이미 존재합니다</translation>
     </message>
@@ -6596,8 +6584,20 @@ key pair. Keycard will be required for signing</source>
         <translation>토큰 설명을 입력하세요</translation>
     </message>
     <message>
-        <source>Only A-Z, 0-9 and standard punctuation allowed</source>
-        <translation>A-Z, 0-9, 그리고 표준 문장 부호만 사용할 수 있습니다</translation>
+        <source>Please name your token name (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name is too cool (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name contains invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, standard punctuation and emojis allowed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Symbol</source>
@@ -12159,8 +12159,8 @@ to load</source>
         <translation>닉네임</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>유효하지 않은 문자입니다 (A-Z, 0-9, 하이픈과 언더스코어만 사용하세요)</translation>
+        <source>Invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>Nicknames must be at least %n character(s) long</source>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -4317,10 +4317,6 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation>Дозволено лише літери, цифри, підкреслення, крапки, пробіли й дефіси</translation>
     </message>
     <message>
-        <source>Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Недійсні символи (дозволено лише A-Z, 0-9, одинарні пробіли, дефіси й підкреслення)</translation>
-    </message>
-    <message>
         <source>Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed</source>
         <translation>Дозволено лише літери, цифри, підкреслення, крапки, коми, пробіли й дефіси</translation>
     </message>
@@ -4333,8 +4329,12 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation>Дозволено лише літери, цифри й символи ASCII</translation>
     </message>
     <message>
-        <source>Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Ім’я надто круте (використовуйте лише A-Z, 0-9, одинарні пробіли, дефіси й підкреслення)</translation>
+        <source>Invalid characters (letters and numbers, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name is too cool (use letters and numbers, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Whole numbers only</source>
@@ -6347,8 +6347,8 @@ key pair. Keycard will be required for signing</source>
         <translation>Ім’я профілю не може починатися або закінчуватися пробілом</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)</source>
-        <translation>Недійсні символи (використовуйте лише A-Z, 0-9, дефіси, підкреслення та пробіли)</translation>
+        <source>Invalid characters (use letters and numbers, hyphens, underscores and spaces only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>Display Names must be at least %n character(s) long</source>
@@ -6618,18 +6618,6 @@ key pair. Keycard will be required for signing</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <source>Please name your token name (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Введіть назву токена (лише A-Z, 0-9, дефіси та підкреслення)</translation>
-    </message>
-    <message>
-        <source>Your token name is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Назва токена надто крута (лише A-Z, 0-9, дефіси та підкреслення)</translation>
-    </message>
-    <message>
-        <source>Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Назва токена містить неприпустимі символи (лише A-Z, 0-9, дефіси та підкреслення)</translation>
-    </message>
-    <message>
         <source>Asset name already exists</source>
         <translation>Назва активу вже існує</translation>
     </message>
@@ -6654,8 +6642,20 @@ key pair. Keycard will be required for signing</source>
         <translation>Введіть опис токена</translation>
     </message>
     <message>
-        <source>Only A-Z, 0-9 and standard punctuation allowed</source>
-        <translation>Дозволено лише A-Z, 0-9 і стандартні розділові знаки</translation>
+        <source>Please name your token name (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name is too cool (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your token name contains invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only letters, numbers, standard punctuation and emojis allowed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Symbol</source>
@@ -12281,8 +12281,8 @@ to load</source>
         <translation>Псевдонім</translation>
     </message>
     <message>
-        <source>Invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Недопустимі символи (використовуйте лише A-Z, 0-9, дефіси та підкреслення)</translation>
+        <source>Invalid characters (use letters and numbers, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>Nicknames must be at least %n character(s) long</source>

--- a/ui/imports/shared/popups/NicknamePopup.qml
+++ b/ui/imports/shared/popups/NicknamePopup.qml
@@ -42,7 +42,7 @@ CommonContactDialog {
             StatusValidator {
                 validatorObj: RXValidator { regularExpression: /^[\w\d_ -\.]*$/u }
                 validate: (value) => validatorObj.test(value)
-                errorMessage: qsTr("Invalid characters (use A-Z and 0-9, hyphens and underscores only)")
+                errorMessage: qsTr("Invalid characters (use letters and numbers, hyphens and underscores only)")
             },
             StatusMinLengthValidator {
                 minLength: Constants.displayName.nameLengthMin

--- a/ui/imports/shared/validators/DisplayNameValidators.qml
+++ b/ui/imports/shared/validators/DisplayNameValidators.qml
@@ -24,8 +24,8 @@ QtObject {
             errorMessage: qsTr("Display Names can’t start or end with a space")
         },
         StatusRegularExpressionValidator {
-            regularExpression: /^$|^[a-zA-Z0-9\-_\u0020]+$/
-            errorMessage: qsTr("Invalid characters (use A-Z and 0-9, hyphens, underscores and spaces only)")
+            regularExpression: /^$|^[\p{L}\p{M}\p{N}\-_ ]+$/
+            errorMessage: qsTr("Invalid characters (use letters and numbers, hyphens, underscores and spaces only)")
         },
         StatusMinLengthValidator {
             minLength: Constants.displayName.nameLengthMin

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -418,7 +418,7 @@ QtObject {
                 errorMessage: qsTr("Key pair must be at least %n character(s)", "", keypair.nameLengthMin)
             },
             StatusRegularExpressionValidator {
-                regularExpression: /^[a-zA-Z0-9\-_ ]+$/
+                regularExpression: /^[\p{L}\p{M}\p{N}\-_ ]+$/
                 errorMessage: errorMessages.alphanumericalExpandedRegExp
             }
         ]
@@ -570,24 +570,24 @@ QtObject {
     }
 
     readonly property QtObject regularExpressions: QtObject {
-        readonly property var alphanumerical: /^$|^[a-zA-Z0-9]+$/
+        readonly property var alphanumerical: /^$|^[\p{L}\p{M}\p{N}]+$/
         // Adds space, dash, underscore and dot
-        readonly property var alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_\.\u0020]+$/
-        // Adds dash and underscore
-        readonly property var alphanumericalExpanded1: /^[a-zA-Z0-9\-_]+(?: [a-zA-Z0-9\-_]+)*$/
+        readonly property var alphanumericalExpanded: /^$|^[\p{L}\p{M}\p{N}\-_. ]+$/
+        // Adds dash and underscore; words separated by a single space
+        readonly property var alphanumericalExpanded1: /^[\p{L}\p{M}\p{N}\-_]+(?: [\p{L}\p{M}\p{N}\-_]+)*$/
         // Adds dash, underscore, dot space and ampersand
-        readonly property var alphanumericalExpanded2: /^$|^[a-zA-Z0-9\-_\.\u0020\&]+$/
+        readonly property var alphanumericalExpanded2: /^$|^[\p{L}\p{M}\p{N}\-_. &]+$/
         // Adds dash, underscore, dot, space, comma and ampersand
-        readonly property var alphanumericalExpanded3: /^$|^[a-zA-Z0-9\-_\.\,\u0020\&]+$/
+        readonly property var alphanumericalExpanded3: /^$|^[\p{L}\p{M}\p{N}\-_., &]+$/
         // Adds a newline (e.g. community description)
-        readonly property var alphanumericalExpanded4: /^$|^[a-zA-Z0-9\-_\.\,\u0020\&\r?\n]+$/
-        readonly property var alphanumericalWithSpace: /^$|^[a-zA-Z0-9\s]+$/
+        readonly property var alphanumericalExpanded4: /^$|^[\p{L}\p{M}\p{N}\-_., &\r?\n]+$/
+        readonly property var alphanumericalWithSpace: /^$|^[\p{L}\p{M}\p{N}\s]+$/
+        readonly property var textWithEmoji: /^$|^[\x00-\x7F\p{L}\p{M}\p{N}\p{P}\p{S}\p{Z}\p{Cf}]+$/
         readonly property var asciiPrintable:         /^$|^[!-~]+$/
         readonly property var ascii:                  /^$|^[\x00-\x7F]+$/
         readonly property var capitalOnly: /^$|^[A-Z]+$/
         readonly property var numerical: /^$|^[0-9]+$/
         readonly property var emoji: /\ud83c\udff4(\udb40[\udc61-\udc7a])+\udb40\udc7f|(\ud83c[\udde6-\uddff]){2}|([\#\*0-9]\ufe0f?\u20e3)|(\u00a9|\u00ae|[\u203c\u2049\u20e3\u2122\u2139\u2194-\u2199\u21a9\u21aa\u231a\u231b\u2328\u23cf\u23e9-\u23fa\u24c2\u25aa\u25ab\u25b6\u25c0\u25fb-\u25fe\u2600-\u2604\u260e\u2611\u2614\u2615\u2618\u261d\u2620\u2622\u2623\u2626\u262a\u262e\u262f\u2638-\u263a\u2640\u2642\u2648-\u2653\u265f\u2660\u2663\u2665\u2666\u2668\u267b\u267e\u267f\u2692-\u2697\u2699\u269b\u269c\u26a0\u26a1\u26a7\u26aa\u26ab\u26b0\u26b1\u26bd\u26be\u26c4\u26c5\u26c8\u26ce\u26cf\u26d1\u26d3\u26d4\u26e9\u26ea\u26f0-\u26f5\u26f7-\u26fa\u26fd\u2702\u2705\u2708-\u270d\u270f\u2712\u2714\u2716\u271d\u2721\u2728\u2733\u2734\u2744\u2747\u274c\u274e\u2753-\u2755\u2757\u2763\u2764\u2795-\u2797\u27a1\u27b0\u27bf\u2934\u2935\u2b05-\u2b07\u2b1b\u2b1c\u2b50\u2b55\u3030\u303d\u3297\u3299]|\ud83c[\udc04\udccf\udd70\udd71\udd7e\udd7f\udd8e\udd91-\udd9a\udde6-\uddff\ude01\ude02\ude1a\ude2f\ude32-\ude3a\ude50\ude51\udf00-\udf21\udf24-\udf93\udf96\udf97\udf99-\udf9b\udf9e-\udff0\udff3-\udff5\udff7-\udfff]|\ud83d[\udc00-\udcfd\udcff-\udd3d\udd49-\udd4e\udd50-\udd67\udd6f\udd70\udd73-\udd7a\udd87\udd8a-\udd8d\udd90\udd95\udd96\udda4\udda5\udda8\uddb1\uddb2\uddbc\uddc2-\uddc4\uddd1-\uddd3\udddc-\uddde\udde1\udde3\udde8\uddef\uddf3\uddfa-\ude4f\ude80-\udec5\udecb-\uded2\uded5-\uded7\udedc-\udee5\udee9\udeeb\udeec\udef0\udef3-\udefc\udfe0-\udfeb\udff0]|\ud83e[\udd0c-\udd3a\udd3c-\udd45\udd47-\ude7c\ude80-\ude88\ude90-\udebd\udebf-\udec5\udece-\udedb\udee0-\udee8\udef0-\udef8])((\ud83c[\udffb-\udfff])?(\ud83e[\uddb0-\uddb3])?(\ufe0f?\u200d([\u2000-\u3300]|[\ud83c-\ud83e][\ud000-\udfff])\ufe0f?)?)*/g;
-        readonly property var asciiWithEmoji: /^[\u00a9\u00ae\u2000-\u3300\ud83c\ud000-\udfff\ud83d\ud000-\udfff\ud83e\ud000-\udfff\u0000-\u007F]+$/
         readonly property var wholeNumbers: /^(0|[1-9][0-9]*)$/
         readonly property var positiveRealNumbers: /^(0|[1-9][0-9]*)([.,][0-9]+)?$/
     }
@@ -595,11 +595,11 @@ QtObject {
     readonly property QtObject errorMessages: QtObject {
         readonly property string alphanumericalRegExp: qsTr("Only letters and numbers allowed")
         readonly property string alphanumericalExpandedRegExp: qsTr("Only letters, numbers, underscores, periods, whitespaces and hyphens allowed")
-        readonly property string alphanumericalExpanded1RegExp: qsTr("Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)")
+        readonly property string alphanumericalExpanded1RegExp: qsTr("Invalid characters (letters and numbers, single whitespace, hyphens and underscores only)")
         readonly property string alphanumericalExpanded3RegExp: qsTr("Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed")
         readonly property string alphanumericalWithSpaceRegExp: qsTr("Special characters are not allowed")
         readonly property string asciiRegExp: qsTr("Only letters, numbers and ASCII characters allowed")
-        readonly property string emojRegExp: qsTr("Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)")
+        readonly property string emojRegExp: qsTr("Name is too cool (use letters and numbers, single whitespace, hyphens and underscores only)")
         readonly property string wholeNumbers: qsTr("Whole numbers only")
         readonly property string positiveRealNumbers: qsTr("Positive real numbers only")
     }


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/7773

Typing a character specific to a non-English keyboard layout (e.g. Serbian, Cyrillic/Latin, German, Ukrainian...) into name fields showed "Special characters are not allowed" / "Invalid characters", every rule in Constants.regularExpressions was an ASCII `[a-zA-Z0-9...]` regex evaluated by JS RegExp.test().

QML's JS engine cannot express Unicode letter classes at all (V4 ships a stub Unicode-property table, so `\p{L}` with the `u` flag is a SyntaxError and `\w` is ASCII-only), so validation now runs through PCRE2.

Fixes #22143