### PR TITLE
fix(chat): prevent empty and unstable community section loading states

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -413,6 +413,10 @@ method onChatsLoaded*(
       if chatId == activeChatId:
         cModule.onMadeActive()
 
+  # The QML section chrome may have finished incubating before this deferred
+  # build. Only now is its model safe to reveal.
+  self.view.setChatsLoaded()
+
 proc checkIfModuleDidLoad(self: Module) =
   if self.moduleLoaded:
     return

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -21,6 +21,7 @@ QtObject:
       editCategoryChannelsModel: chats_model.Model
       editCategoryChannelsVariant: QVariant
       loadingHistoryMessagesInProgress: bool
+      chatsLoaded: bool
       tokenPermissionsModel: TokenPermissionsModel
       tokenPermissionsVariant: QVariant
       allTokenRequirementsMet: bool
@@ -54,6 +55,7 @@ QtObject:
     result.contactRequestsModel = user_model.newModel()
     result.contactRequestsModelVariant = newQVariant(result.contactRequestsModel)
     result.loadingHistoryMessagesInProgress = false
+    result.chatsLoaded = false
     result.tokenPermissionsModel = newTokenPermissionsModel()
     result.tokenPermissionsVariant = newQVariant(result.tokenPermissionsModel)
     result.amIMember = false
@@ -84,6 +86,25 @@ QtObject:
 
   QtProperty[QVariant] model:
     read = getModel
+
+  proc chatsLoadedChanged*(self: View) {.signal.}
+
+  # This is deliberately separate from the module's internal `chatsLoaded`
+  # flag. The latter lets the backend build the section; this property only
+  # rises once that build has populated the model and selected its active item,
+  # so QML never renders an intermediate empty section.
+  proc setChatsLoaded*(self: View) =
+    if self.chatsLoaded:
+      return
+    self.chatsLoaded = true
+    self.chatsLoadedChanged()
+
+  proc getChatsLoaded*(self: View): bool {.slot.} =
+    return self.chatsLoaded
+
+  QtProperty[bool] chatsLoaded:
+    read = getChatsLoaded
+    notify = chatsLoadedChanged
 
   proc editCategoryChannelsModel*(self: View): chats_model.Model =
     return self.editCategoryChannelsModel

--- a/storybook/qmlTests/tests/tst_CommunityChatLoaderSection.qml
+++ b/storybook/qmlTests/tests/tst_CommunityChatLoaderSection.qml
@@ -115,6 +115,7 @@ Item {
             mock.messagesPerChannel = 150
             mock.canViewPrivateChannels = true
             mock.canPostInPrivateChannels = true
+            mock.chatsLoaded = true
             mock.install()
         }
 
@@ -181,6 +182,31 @@ Item {
             const rows = mock.uncategorizedChannelsCount + mock.categoriesCount
                        + mock.categoriesCount * mock.channelsPerCategory
             tryCompare(chatList, "count", rows)
+        }
+
+        // The model build is intentionally deferred until section navigation
+        // settles. Its real QML panels may finish incubating first, but must
+        // remain behind the loader-owned skeleton instead of exposing
+        // ChatColumnView's EmptyChatPanel for that interval.
+        function test_skeletonWaitsForDeferredCommunityModel() {
+            mock.chatsLoaded = false
+            harness.active = true
+            const loader = harness.item
+            verify(!!loader)
+
+            tryVerify(() => loader.status === Loader.Ready, 10000)
+            const chrome = findChild(loader, "sectionChrome")
+            const skeleton = findChild(loader, "centerPanelSkeleton")
+            verify(!!chrome)
+            verify(!!skeleton)
+            tryVerify(() => loader.item.centerPanelReady, 10000,
+                      "the QML center panel should finish while data remains deferred")
+            verify(chrome.centerPanel === skeleton,
+                   "the center skeleton must cover the deferred model build")
+
+            mock.chatsLoaded = true
+            tryVerify(() => chrome.centerPanel === loader.item.centerPanel, 10000,
+                      "the real center panel should replace the skeleton once data is ready")
         }
 
         // The channels column and the message view incubate off the critical

--- a/storybook/qmlTests/tests/tst_SectionLoaderChrome.qml
+++ b/storybook/qmlTests/tests/tst_SectionLoaderChrome.qml
@@ -23,17 +23,19 @@ Item {
         id: sectionStubComp
 
         Item {
+            property bool sectionDataReady: true
             property bool headerReady: false
             property bool leftPanelReady: false
             property bool centerPanelReady: false
             property bool rightPanelReady: false
+            property bool rightPanelDecisionReady: false
 
             readonly property Item headerContent: Item {}
             readonly property Item leftPanel: Item {}
             readonly property Item centerPanel: Item {}
             readonly property Item rightPanel: Item {}
 
-            readonly property bool showRightPanel: true
+            property bool showRightPanel: false
             readonly property var viewSubsectionHistory: null
             readonly property bool ownsFullPage: false
             property bool navToMsgDetails: false
@@ -208,6 +210,55 @@ Item {
             verify(chrome.leftPanel === findChild(loader, "leftPanelSkeleton"))
             verify(chrome.centerPanel === findChild(loader, "centerPanelSkeleton"))
             verify(chrome.rightPanel === findChild(loader, "rightPanelSkeleton"))
+        }
+
+        function test_rightPanelVisibilityWaitsForDecision_data() { return loaderCases() }
+
+        // While ChatView is still obtaining the active chat, its false
+        // showRightPanel value means “unknown”. The chrome must retain the
+        // user's members-panel preference until the decision becomes final.
+        function test_rightPanelVisibilityWaitsForDecision(data) {
+            appAccountSettingsStore.showUsersList = true
+            const loader = createLoaderWithStub(data.comp)
+            const stub = loader.item
+            const chrome = findChild(loader, "sectionChrome")
+
+            verify(chrome.showRightPanel,
+                   "pending chat data must not hide the requested members column")
+
+            stub.rightPanelDecisionReady = true
+            verify(!chrome.showRightPanel,
+                   "the final chat decision must still be able to hide the members column")
+
+            appAccountSettingsStore.showUsersList = false
+        }
+
+        // QML panel incubation alone is insufficient while the backend's
+        // deferred first chat/channel build is still in progress. Both
+        // section loaders must keep every slot on its skeleton until the
+        // model is safe to render.
+        function test_sectionDataReadiness_data() { return loaderCases() }
+
+        function test_sectionDataReadiness(data) {
+            const loader = createLoaderWithStub(data.comp)
+            const stub = loader.item
+            const chrome = findChild(loader, "sectionChrome")
+            verify(!!chrome)
+
+            stub.sectionDataReady = false
+            for (const spec of slotSpecs)
+                stub[spec.flag] = true
+
+            for (const spec of slotSpecs) {
+                verify(chrome[spec.slot] === findChild(loader, spec.skeleton),
+                       spec.slot + " must stay on its skeleton until section data is ready")
+            }
+
+            stub.sectionDataReady = true
+            for (const spec of slotSpecs) {
+                verify(chrome[spec.slot] === stub[spec.slot],
+                       spec.slot + " must promote after section data is ready")
+            }
         }
     }
 }

--- a/storybook/src/Models/CommunitySectionMock.qml
+++ b/storybook/src/Models/CommunitySectionMock.qml
@@ -68,6 +68,8 @@ QtObject {
     property bool allChannelsAreHiddenBecauseNotPermitted: false
 
     property string activeChatId: ""
+    // Lets loader tests hold the backend model in its deferred-build state.
+    property bool chatsLoaded: true
 
     // Built models
     // Wallet models resolving permission holdings to symbols/icons; the
@@ -146,7 +148,7 @@ QtObject {
         readonly property bool isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin: root.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin
         readonly property int requestToJoinState: root.requestToJoinState
         readonly property bool loadingHistoryMessagesInProgress: false
-        readonly property bool chatsLoaded: true
+        readonly property bool chatsLoaded: root.chatsLoaded
         readonly property var membersModel: root.membersModel
         readonly property var contactRequestsModel: null
         readonly property string emoji: ""

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -48,6 +48,7 @@ StackLayout {
     readonly property Item rightPanel: mainViewLoader.item?.rightPanel ?? null
     readonly property Item headerContent: mainViewLoader.item?.headerContent ?? null
     readonly property bool showRightPanel: mainViewLoader.item?.showRightPanel ?? false
+    readonly property bool rightPanelDecisionReady: mainViewLoader.item?.rightPanelDecisionReady ?? false
     readonly property var viewSubsectionHistory: mainViewLoader.item?.subsectionHistory ?? null
 
     // Per-panel readiness of those panels, so the loader can retire each
@@ -56,6 +57,12 @@ StackLayout {
     readonly property bool leftPanelReady: mainViewLoader.item?.leftPanelReady ?? false
     readonly property bool centerPanelReady: mainViewLoader.item?.centerPanelReady ?? false
     readonly property bool rightPanelReady: mainViewLoader.item?.rightPanelReady ?? false
+
+    // Panel loaders can finish before the deferred first chat/channel build.
+    // Keep the section chrome's skeletons until the backing model has an
+    // active, renderable state. The true fallback preserves standalone and
+    // legacy mock consumers which do not expose the new backend property.
+    readonly property bool sectionDataReady: root.rootStore?.chatCommunitySectionModule?.chatsLoaded ?? true
 
     // True while a full-page view (join/banned/offline community view or the
     // community settings page) replaces the paneled chat view; the loader hides

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -290,6 +290,16 @@ Item {
         return root.chatContentModule.chatDetails.isUsersListAvailable
     }
 
+    // Until the active chat/content module exists, `showRightPanel` is false
+    // only because its answer is not known yet. Let the section chrome keep
+    // the user-requested members column in that interval instead of resizing
+    // from shown → hidden → shown as this view initializes.
+    readonly property bool rightPanelDecisionReady: !root.showUsersList
+                                                  || root.contentLocked
+                                                  || root.rootStore.openCreateChat
+                                                  || root.allChannelsAreHiddenBecauseNotPermitted
+                                                  || !!root.chatContentModule
+
     onNavToMsgDetailsChanged: {
         if (root.navToMsgDetails) {
             d.requestCenterPanel()

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -68,6 +68,16 @@ Loader {
 
     asynchronous: true
 
+    // See CommunityChatLoader: before ChatView has an active chat/content
+    // module, false means “not decided” rather than “hide the members panel”.
+    readonly property bool rightPanelDecisionReady: root.item?.rightPanelDecisionReady ?? false
+    readonly property bool showRightPanel: root.rightPanelDecisionReady
+                                         ? (root.item?.showRightPanel ?? false)
+                                         : root.accountSettingsStore.showUsersList
+
+
+    readonly property bool panelSwapGateReady: root.item?.sectionDataReady ?? true
+
     // The section chrome is owned by the loader: it shows instantly with
     // skeleton panels and swaps in the real panels produced by ChatView
     // (LayoutItemProxy retarget) as each one finishes incubating. Each slot is
@@ -85,7 +95,7 @@ Loader {
         leftPanel: leftPanelGate.up ? root.item.leftPanel : listSkeleton
         centerPanel: centerPanelGate.up ? root.item.centerPanel : chatSkeleton
         rightPanel: rightPanelGate.up ? root.item.rightPanel : membersSkeleton
-        showRightPanel: root.item?.showRightPanel ?? root.accountSettingsStore.showUsersList
+        showRightPanel: root.showRightPanel
         subsectionHistory: root.item?.viewSubsectionHistory ?? null
 
         leftPanelWidthOverride: root.leftPanelWidthOverride
@@ -98,25 +108,25 @@ Loader {
     // chrome's panel-switch animation.
     PanelSwapGate {
         id: headerGate
-        ready: root.item?.headerReady ?? false
+        ready: root.panelSwapGateReady && (root.item?.headerReady ?? false)
         switchOngoing: d.panelSwitchOngoing
     }
 
     PanelSwapGate {
         id: leftPanelGate
-        ready: root.item?.leftPanelReady ?? false
+        ready: root.panelSwapGateReady && (root.item?.leftPanelReady ?? false)
         switchOngoing: d.panelSwitchOngoing
     }
 
     PanelSwapGate {
         id: centerPanelGate
-        ready: root.item?.centerPanelReady ?? false
+        ready: root.panelSwapGateReady && (root.item?.centerPanelReady ?? false)
         switchOngoing: d.panelSwitchOngoing
     }
 
     PanelSwapGate {
         id: rightPanelGate
-        ready: root.item?.rightPanelReady ?? false
+        ready: root.panelSwapGateReady && (root.item?.rightPanelReady ?? false)
         switchOngoing: d.panelSwitchOngoing
     }
 

--- a/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
@@ -83,6 +83,17 @@ Loader {
     // instance behaves like a plain, always-chromed loader.
     property bool chromeNeeded: true
 
+    // `ChatView.showRightPanel` is temporarily false before it has an active
+    // chat/content module. Keep the column at the persisted user preference
+    // until that decision is meaningful; otherwise the loading chrome visibly
+    // resizes true → false → true while a community starts.
+    readonly property bool rightPanelDecisionReady: root.item?.rightPanelDecisionReady ?? false
+    readonly property bool showRightPanel: root.rightPanelDecisionReady
+                                         ? (root.item?.showRightPanel ?? false)
+                                         : root.accountSettingsStore.showUsersList
+
+    readonly property bool panelSwapGateReady: root.item?.sectionDataReady ?? true
+
     // The section chrome is owned by the loader: it shows instantly with
     // skeleton panels and swaps in the real panels produced by ChatView
     // (LayoutItemProxy retarget) as each one finishes incubating. Each slot is
@@ -107,7 +118,7 @@ Loader {
             leftPanel: leftPanelGate.up ? root.item.leftPanel : channelsSkeleton
             centerPanel: centerPanelGate.up ? root.item.centerPanel : chatSkeleton
             rightPanel: rightPanelGate.up ? root.item.rightPanel : membersSkeleton
-            showRightPanel: root.item?.showRightPanel ?? root.accountSettingsStore.showUsersList
+            showRightPanel: root.showRightPanel
             subsectionHistory: root.item?.viewSubsectionHistory ?? null
 
             leftPanelWidthOverride: root.leftPanelWidthOverride
@@ -121,25 +132,25 @@ Loader {
     // chrome's panel-switch animation.
     PanelSwapGate {
         id: headerGate
-        ready: root.item?.headerReady ?? false
+        ready: root.panelSwapGateReady && (root.item?.headerReady ?? false)
         switchOngoing: d.panelSwitchOngoing
     }
 
     PanelSwapGate {
         id: leftPanelGate
-        ready: root.item?.leftPanelReady ?? false
+        ready: root.panelSwapGateReady && (root.item?.leftPanelReady ?? false)
         switchOngoing: d.panelSwitchOngoing
     }
 
     PanelSwapGate {
         id: centerPanelGate
-        ready: root.item?.centerPanelReady ?? false
+        ready: root.panelSwapGateReady && (root.item?.centerPanelReady ?? false)
         switchOngoing: d.panelSwitchOngoing
     }
 
     PanelSwapGate {
         id: rightPanelGate
-        ready: root.item?.rightPanelReady ?? false
+        ready: root.panelSwapGateReady && (root.item?.rightPanelReady ?? false)
         switchOngoing: d.panelSwitchOngoing
     }
 


### PR DESCRIPTION
### What does the PR do

Fixes #22116

Keep the section skeleton visible until the backend has built the initial chat/community model, preventing `EmptyChatPanel` from briefly rendering during section switches. The loader now waits for both QML panel incubation and data readiness before replacing the skeleton.

Stabilize the members-panel visibility while the active chat is still unknown, avoiding a true → false → true right-column resize and the resulting staggered skeleton transition. Add focused loader and community-section regression coverage.

### Affected areas

- chat_section module and view
- Chat and Community Loaders

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring

### Screencapture of the functionality

[fixed-loading-chromes.webm](https://github.com/user-attachments/assets/da445cde-15f2-47fb-8131-d5d35214033c)

### Impact on end user

Makes the loading states more consistent with no "bouncing around"

### How to test

0. Have multiple communities
1. Change section (only first load does the full loadind)

### Risk 

Low
