### PR TITLE
fix(ci): pin e2e artifact copy to the build that produced it (#22110)

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -65,10 +65,11 @@ pipeline {
                   linux_e2e = build(
                     job: 'status-app/systems/linux/x86_64/tests-e2e',
                     parameters: jenkins.mapToParams([
-                      BUILD_SOURCE:       linux_x86_64.fullProjectName,
-                      TESTRAIL_RUN_NAME:  utils.pkgFilename(),
-                      TEST_SCOPE_FLAG:    utils.isReleaseBuild() ? '-m=critical' : '',
-                      GIT_REF:            env.BRANCH_NAME,
+                      BUILD_SOURCE:        linux_x86_64.fullProjectName,
+                      SOURCE_BUILD_NUMBER: linux_x86_64.number.toString(),
+                      TESTRAIL_RUN_NAME:   utils.pkgFilename(),
+                      TEST_SCOPE_FLAG:     utils.isReleaseBuild() ? '-m=critical' : '',
+                      GIT_REF:             env.BRANCH_NAME,
                     ]),
                   )
                 }
@@ -101,10 +102,11 @@ pipeline {
                   build(
                     job: 'status-app/systems/linux/x86_64/tests-e2e',
                     parameters: jenkins.mapToParams([
-                      BUILD_SOURCE:      linux_keycard.fullProjectName,
-                      TESTRAIL_RUN_NAME: utils.pkgFilename(),
-                      KEYCARD_TESTS:     true,
-                      GIT_REF:           env.BRANCH_NAME,
+                      BUILD_SOURCE:        linux_keycard.fullProjectName,
+                      SOURCE_BUILD_NUMBER: linux_keycard.number.toString(),
+                      TESTRAIL_RUN_NAME:   utils.pkgFilename(),
+                      KEYCARD_TESTS:       true,
+                      GIT_REF:             env.BRANCH_NAME,
                     ]),
                   )
                 }
@@ -130,10 +132,11 @@ pipeline {
                     windows_e2e = build(
                       job: 'status-app/systems/windows/x86_64/tests-e2e',
                       parameters: jenkins.mapToParams([
-                        BUILD_SOURCE:       windows_x86_64.fullProjectName,
-                        TESTRAIL_RUN_NAME:  utils.pkgFilename(),
-                        TEST_SCOPE_FLAG:    utils.isReleaseBuild() ? '-m=critical' : '',
-                        GIT_REF:            env.BRANCH_NAME,
+                        BUILD_SOURCE:        windows_x86_64.fullProjectName,
+                        SOURCE_BUILD_NUMBER: windows_x86_64.number.toString(),
+                        TESTRAIL_RUN_NAME:   utils.pkgFilename(),
+                        TEST_SCOPE_FLAG:     utils.isReleaseBuild() ? '-m=critical' : '',
+                        GIT_REF:             env.BRANCH_NAME,
                       ]),
                     )
                   }
@@ -152,10 +155,11 @@ pipeline {
                     benchmark_windows_e2e = build(
                       job: 'status-app/e2e/nightly-benchmark-windows-master',
                       parameters: jenkins.mapToParams([
-                        BUILD_SOURCE:      windows_x86_64.fullProjectName,
-                        TESTRAIL_RUN_NAME: utils.pkgFilename(),
-                        TEST_SCOPE_FLAG:   utils.isReleaseBuild() ? '-m=critical' : '',
-                        GIT_REF:           env.BRANCH_NAME
+                        BUILD_SOURCE:        windows_x86_64.fullProjectName,
+                        SOURCE_BUILD_NUMBER: windows_x86_64.number.toString(),
+                        TESTRAIL_RUN_NAME:   utils.pkgFilename(),
+                        TEST_SCOPE_FLAG:     utils.isReleaseBuild() ? '-m=critical' : '',
+                        GIT_REF:             env.BRANCH_NAME
                       ]),
                     )
                   }
@@ -189,10 +193,11 @@ pipeline {
                   build(
                     job: 'status-app/systems/windows/x86_64/tests-e2e',
                     parameters: jenkins.mapToParams([
-                      BUILD_SOURCE:      windows_keycard.fullProjectName,
-                      TESTRAIL_RUN_NAME: utils.pkgFilename(),
-                      KEYCARD_TESTS:     true,
-                      GIT_REF:           env.BRANCH_NAME,
+                      BUILD_SOURCE:        windows_keycard.fullProjectName,
+                      SOURCE_BUILD_NUMBER: windows_keycard.number.toString(),
+                      TESTRAIL_RUN_NAME:   utils.pkgFilename(),
+                      KEYCARD_TESTS:       true,
+                      GIT_REF:             env.BRANCH_NAME,
                     ]),
                   )
                 }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -64,7 +64,7 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
+      artifactNumToKeepStr: '10',
       artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */
@@ -168,6 +168,7 @@ pipeline {
           parameters: jenkins.mapToParams([
             GIT_REF: env.CHANGE_BRANCH ?: env.BRANCH_NAME,
             BUILD_SOURCE: env.JOB_NAME,
+            SOURCE_BUILD_NUMBER: env.BUILD_NUMBER,
           ]),
         )
       } }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -64,7 +64,7 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '10',
+      artifactNumToKeepStr: '1',
       artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -31,6 +31,11 @@ pipeline {
       defaultValue: getDefaultBuildSource()
     )
     string(
+      name: 'SOURCE_BUILD_NUMBER',
+      description: 'Build number of BUILD_SOURCE to copy from. Empty picks the latest.',
+      defaultValue: ''
+    )
+    string(
       name: 'TEST_NAME',
       description: 'Paste test name/part of test name to run specific test.',
       defaultValue: ''
@@ -179,7 +184,7 @@ pipeline {
         copyArtifacts(
           projectName: params.BUILD_SOURCE,
           filter:      'pkg/*-x86_64.tar.gz',
-          selector:    lastWithArtifacts(),
+          selector:    params.SOURCE_BUILD_NUMBER ? specific(params.SOURCE_BUILD_NUMBER) : lastWithArtifacts(),
           target:      './'
         )
         setBuildDescFromFile(utils.findFile('pkg/*tar.gz'))

--- a/ci/Jenkinsfile.tests-e2e.windows
+++ b/ci/Jenkinsfile.tests-e2e.windows
@@ -21,6 +21,11 @@ pipeline {
       defaultValue: getDefaultBuildSource()
     )
     string(
+      name: 'SOURCE_BUILD_NUMBER',
+      description: 'Build number of BUILD_SOURCE to copy from. Empty picks the latest.',
+      defaultValue: ''
+    )
+    string(
       name: 'TEST_NAME',
       description: 'Paste test name/part of test name to run specific test.',
       defaultValue: ''
@@ -164,7 +169,7 @@ pipeline {
         copyArtifacts(
           projectName: params.BUILD_SOURCE,
           filter:      'pkg/*-x86_64.7z',
-          selector:    lastWithArtifacts(),
+          selector:    params.SOURCE_BUILD_NUMBER ? specific(params.SOURCE_BUILD_NUMBER) : lastWithArtifacts(),
           target:      './'
         )
         setBuildDescFromFile(utils.findFile('pkg/*7z'))

--- a/ci/Jenkinsfile.tests-e2e.windows-benchmark
+++ b/ci/Jenkinsfile.tests-e2e.windows-benchmark
@@ -28,6 +28,11 @@ pipeline {
       defaultValue: 'status-app/systems/windows/x86_64/package'
     )
     string(
+      name: 'SOURCE_BUILD_NUMBER',
+      description: 'Build number of BUILD_SOURCE to copy from. Empty picks the latest.',
+      defaultValue: ''
+    )
+    string(
       name: 'CHANGE_ID',
       description: 'PR number. Set this for a pull-request run.',
       defaultValue: ''
@@ -195,7 +200,7 @@ pipeline {
         copyArtifacts(
           projectName: params.BUILD_SOURCE,
           filter:      'pkg/*-x86_64.7z',
-          selector:    lastWithArtifacts(),
+          selector:    params.SOURCE_BUILD_NUMBER ? specific(params.SOURCE_BUILD_NUMBER) : lastWithArtifacts(),
           target:      './'
         )
         setBuildDescFromFile(utils.findFile('pkg/*7z'))

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -61,7 +61,7 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '10',
+      artifactNumToKeepStr: '1',
       artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -61,7 +61,7 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
+      artifactNumToKeepStr: '10',
       artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */
@@ -185,6 +185,7 @@ pipeline {
           parameters: jenkins.mapToParams([
             GIT_REF: env.CHANGE_BRANCH ?: env.BRANCH_NAME,
             BUILD_SOURCE: env.JOB_NAME,
+            SOURCE_BUILD_NUMBER: env.BUILD_NUMBER,
           ]),
         )
       } }


### PR DESCRIPTION
Cherry-pick of #22110 to `release/2.39.x`.

### What does the PR do

1. Added an optional `SOURCE_BUILD_NUMBER` param to `Jenkinsfile.tests-e2e`, `.tests-e2e.windows` and `.tests-e2e.windows-benchmark`, and used it to select the artifact with `specific()` instead of `lastWithArtifacts()`. Empty keeps the old behaviour.
2. Passed it from every caller: `Jenkinsfile.combined` (5 sites) and the PR e2e triggers in `Jenkinsfile.linux` / `Jenkinsfile.windows`.

status-go passes it as of status-im/status-go#7770, backported in the matching `release/10.35.x` PR.

### Affected areas

CI only. No application code.

### Risk

Low. `artifactNumToKeepStr` stays at `1`, so when a newer package build has already rotated the artifact away, `specific()` fails the copy instead of silently testing that newer build's binary.
