### PR TITLE
chore(SendButton): replace zoom animation with ripple effect

### DIFF
--- a/ui/imports/shared/status/StatusChatInputSendButton.qml
+++ b/ui/imports/shared/status/StatusChatInputSendButton.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 
 import StatusQ.Core
 import StatusQ.Core.Theme
+import StatusQ.Controls
 
 Control {
     id: root
@@ -17,8 +18,6 @@ Control {
         id: d
 
         readonly property int implicitHeight: 36
-        readonly property real hoverExpandFactor: 1.2
-        readonly property real pressedExpandFactor: 1.1
         readonly property int cornerRadius: 8
     }
 
@@ -86,28 +85,6 @@ Control {
         }
 
         Rectangle {
-            anchors.centerIn: baseBackgroundRectangle
-
-            property real factor: mouseArea.pressed
-                                  ? d.pressedExpandFactor
-                                  : (mouseArea.containsMouse
-                                     ? d.hoverExpandFactor : 1)
-
-            width: baseBackgroundRectangle.width * factor
-            height: width
-            radius: d.cornerRadius
-
-            color: baseBackgroundRectangle.color
-
-            Behavior on factor {
-                NumberAnimation {
-                    duration: ThemeUtils.AnimationDuration.Fast
-                    easing.type: Easing.InOutQuad
-                }
-            }
-        }
-
-        Rectangle {
             id: baseBackgroundRectangle
 
             width: parent.height
@@ -124,6 +101,16 @@ Control {
                 ColorAnimation {
                     duration: ThemeUtils.AnimationDuration.Fast
                 }
+            }
+
+            StatusRipple {
+                id: ripple
+
+                objectName: "statusChatInputSendButtonRipple"
+                anchors.fill: parent
+                enabled: root.enabled && mouseArea.enabled
+                color: Theme.palette.white
+                radius: parent.radius
             }
 
             StatusIcon {
@@ -143,6 +130,9 @@ Control {
 
                 cursorShape: Qt.PointingHandCursor
 
+                onPressed: mouse => ripple.press(mouse.x, mouse.y)
+                onReleased: ripple.release()
+                onCanceled: ripple.release()
                 onClicked: root.clicked()
             }
         }


### PR DESCRIPTION
### What does the PR do

Fixes #22093

Replace the chat send button’s hover and press scaling animations with the new `StatusRipple` press feedback.

### Affected areas

StatusChatInputSendButton

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction

### Screencapture of the functionality

[new-button-animation.webm](https://github.com/user-attachments/assets/b1e00a9d-890c-4187-b7ed-bfc5a7550925)

[send-button-zoom-in-app.webm](https://github.com/user-attachments/assets/03f24eed-809a-4e88-b8e6-dba53b26ad46)

### Impact on end user

Better animation

### How to test

Type in the field and hover the button

### Risk 

Low
