### PR TITLE
fix(android): reconcile notification replies with frontend

### DIFF
--- a/docs/adr/0002-android-push-notifications.md
+++ b/docs/adr/0002-android-push-notifications.md
@@ -133,6 +133,11 @@ When the UI comes to the foreground, all active notifications are cancelled and 
 3. On success the notification is updated with the sent message via a new `local-notifications` signal from `status-go`.
 4. On failure a "Reply failed" notification is shown.
 
+The send response is also forwarded to the UI process as an internal `notification.reply.sent`
+signal. It is queued while the UI is backgrounded, then processed through the same messenger
+response path as a normal in-app send when the UI returns. `local-notifications` continues to
+update only the Android notification thread.
+
 ---
 
 ## What was considered

--- a/mobile/android/qt6/src/app/status/mobile/ipc/NotificationReplyReceiver.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/NotificationReplyReceiver.java
@@ -115,20 +115,34 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
                 String result = StatusGoService.callRpc("CallPrivateRPC", argsJson);
                 boolean failed = false;
                 String errorMsg = null;
-                if (result != null) {
-                    try {
-                        JSONObject resp = new JSONObject(result);
-                        if (resp.has("error") && !resp.isNull("error")) {
-                            Object err = resp.get("error");
-                            failed = true;
-                            errorMsg = err instanceof JSONObject
-                                    ? ((JSONObject) err).optString("message", "rpc error")
-                                    : err.toString();
-                        }
-                    } catch (Exception ignored) {
-                        failed = true;
-                        errorMsg = "unparseable response";
+                try {
+                    if (result == null || result.isEmpty()) {
+                        throw new IllegalStateException("empty response");
                     }
+
+                    JSONObject response = new JSONObject(result);
+                    if (response.has("error") && !response.isNull("error")) {
+                        Object err = response.get("error");
+                        failed = true;
+                        errorMsg = err instanceof JSONObject
+                                ? ((JSONObject) err).optString("message", "rpc error")
+                                : err.toString();
+                    } else {
+                        JSONObject sendResult = response.optJSONObject("result");
+                        if (sendResult == null
+                                || !(sendResult.opt("chats") instanceof JSONArray)
+                                || !(sendResult.opt("messages") instanceof JSONArray)) {
+                            failed = true;
+                            errorMsg = "missing send result";
+                        } else if (!StatusGoService.publishNotificationReplyResult(response.toString())) {
+                            // The message has already been persisted and sent. A later cold start
+                            // will reload it from status-go, so this is not a send failure.
+                            Log.w(TAG, "sent reply but could not queue frontend update");
+                        }
+                    }
+                } catch (Exception ignored) {
+                    failed = true;
+                    errorMsg = "unparseable response";
                 }
 
                 StatusNotificationManager mgr = StatusNotificationManager.getInstance();

--- a/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
@@ -24,6 +24,8 @@ import androidx.core.app.NotificationCompat;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -69,6 +71,14 @@ public final class StatusGoService extends Service {
     private static final int NOTIFICATION_SMALL_ICON = R.drawable.ic_notification_status_logo;
 
     private final RemoteCallbackList<IStatusGoSignalListener> listeners = new RemoteCallbackList<>();
+    /** RemoteCallbackList broadcasts must never overlap. */
+    private final Object signalDispatchLock = new Object();
+    /**
+     * Successful inline replies are initiated outside the UI process. Preserve their normal
+     * send-response update until that process is visible and can consume it.
+     */
+    private final Object notificationReplyLock = new Object();
+    private final Deque<String> pendingNotificationReplySignals = new ArrayDeque<>();
     private volatile boolean foregroundStarted = false;
     private volatile boolean uiVisible = false;
 
@@ -143,6 +153,18 @@ public final class StatusGoService extends Service {
     }
 
     /**
+     * Queues the successful sendChatMessage JSON-RPC response from an Android
+     * notification reply for normal frontend processing. The frontend's regular send path
+     * consumes this response to update chat state; status-go does not emit messages.new for
+     * locally initiated sends.
+     */
+    public static boolean publishNotificationReplyResult(String rpcResponseJson) {
+        final StatusGoService service = sInstance;
+        if (service == null || rpcResponseJson == null || rpcResponseJson.isEmpty()) return false;
+        return service.publishNotificationReplyResultInternal(rpcResponseJson);
+    }
+
+    /**
      * Defense-in-depth: ensure only our own app UID can invoke Binder methods.
      *
      * Note: this service is also declared with android:exported="false" and a signature-level
@@ -171,35 +193,83 @@ public final class StatusGoService extends Service {
         maybeStartForegroundFromSignal(jsonSignal);
         notificationManager.handleSignal(jsonSignal);
 
-        final int n = listeners.beginBroadcast();
+        dispatchSignalToListeners(jsonSignal);
+    }
+
+    /**
+     * Sends a signal over the existing Binder transport. Returns how many listeners accepted
+     * delivery, which lets notification replies remain queued until a UI listener is reachable.
+     */
+    private int dispatchSignalToListeners(String jsonSignal) {
+        final int signalSizeBytes = jsonSignal != null
+                ? jsonSignal.getBytes(StandardCharsets.UTF_8).length
+                : 0;
         final boolean useSharedMemorySignal = signalSizeBytes >= SIGNAL_SHARED_MEMORY_THRESHOLD_BYTES;
         final byte[] signalBytes = useSharedMemorySignal
                 ? (jsonSignal != null ? jsonSignal.getBytes(StandardCharsets.UTF_8) : new byte[0])
                 : null;
-        try {
-            for (int i = 0; i < n; i++) {
-                try {
-                    final IStatusGoSignalListener listener = listeners.getBroadcastItem(i);
-                    if (useSharedMemorySignal) {
-                        try (RpcResponse signalResponse = sharedPayload(signalBytes, "statusgo-signal")) {
-                            listener.onSignalShm(signalResponse);
+        int delivered = 0;
+        synchronized (signalDispatchLock) {
+            final int n = listeners.beginBroadcast();
+            try {
+                for (int i = 0; i < n; i++) {
+                    try {
+                        final IStatusGoSignalListener listener = listeners.getBroadcastItem(i);
+                        if (useSharedMemorySignal) {
+                            try (RpcResponse signalResponse = sharedPayload(signalBytes, "statusgo-signal")) {
+                                listener.onSignalShm(signalResponse);
+                            }
+                        } else {
+                            listener.onSignal(jsonSignal);
                         }
-                    } else {
-                        listener.onSignal(jsonSignal);
+                        delivered++;
+                    } catch (RemoteException e) {
+                        Log.w(TAG, "failed to deliver signal to UI listener type=" + getSignalType(jsonSignal)
+                                + " sizeBytes=" + signalSizeBytes, e);
+                    } catch (RuntimeException e) {
+                        Log.w(TAG, "runtime failure delivering signal to UI listener type=" + getSignalType(jsonSignal)
+                                + " sizeBytes=" + signalSizeBytes, e);
+                    } catch (Throwable e) {
+                        Log.w(TAG, "unexpected failure delivering signal to UI listener type=" + getSignalType(jsonSignal)
+                                + " sizeBytes=" + signalSizeBytes, e);
                     }
-                } catch (RemoteException e) {
-                    Log.w(TAG, "failed to deliver signal to UI listener type=" + getSignalType(jsonSignal)
-                            + " sizeBytes=" + signalSizeBytes, e);
-                } catch (RuntimeException e) {
-                    Log.w(TAG, "runtime failure delivering signal to UI listener type=" + getSignalType(jsonSignal)
-                            + " sizeBytes=" + signalSizeBytes, e);
-                } catch (Throwable e) {
-                    Log.w(TAG, "unexpected failure delivering signal to UI listener type=" + getSignalType(jsonSignal)
-                            + " sizeBytes=" + signalSizeBytes, e);
                 }
+            } finally {
+                listeners.finishBroadcast();
             }
-        } finally {
-            listeners.finishBroadcast();
+        }
+        return delivered;
+    }
+
+    private boolean publishNotificationReplyResultInternal(String rpcResponseJson) {
+        final String signal;
+        try {
+            JSONObject envelope = new JSONObject();
+            envelope.put("type", "notification.reply.sent");
+            envelope.put("event", new JSONObject(rpcResponseJson));
+            signal = envelope.toString();
+        } catch (Throwable t) {
+            Log.w(TAG, "failed to create notification reply frontend signal", t);
+            return false;
+        }
+
+        synchronized (notificationReplyLock) {
+            if (!uiVisible || dispatchSignalToListeners(signal) == 0) {
+                pendingNotificationReplySignals.addLast(signal);
+            }
+        }
+        return true;
+    }
+
+    /** Flushes queued notification replies in FIFO order once the frontend is usable. */
+    private void flushPendingNotificationReplySignals() {
+        synchronized (notificationReplyLock) {
+            while (uiVisible && !pendingNotificationReplySignals.isEmpty()) {
+                if (dispatchSignalToListeners(pendingNotificationReplySignals.peekFirst()) == 0) {
+                    return;
+                }
+                pendingNotificationReplySignals.removeFirst();
+            }
         }
     }
 
@@ -450,6 +520,7 @@ public final class StatusGoService extends Service {
         mainHandler.removeCallbacks(repauseMessagingRunnable);
         notificationManager.setUiVisible(visible);
         scheduleBackendLifecycleUpdate(visible);
+        if (visible) flushPendingNotificationReplySignals();
     }
 
     private final IStatusGoService.Stub binder = new IStatusGoService.Stub() {
@@ -492,6 +563,7 @@ public final class StatusGoService extends Service {
             enforceCallerIsSameApp();
             if (listener == null) return;
             listeners.register(listener);
+            if (uiVisible) flushPendingNotificationReplySignals();
             // Reset uiVisible if the UI process dies unexpectedly (crash, OOM, force-stop).
             // RemoteCallbackList.unregister() calls unlinkToDeath internally, so clean
             // unregistration does not trigger this callback.

--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -46,11 +46,20 @@ type MessageDeliveredSignal* = ref object of Signal
   chatId*: string
   messageId*: string
 
+type NotificationReplySentSignal* = ref object of Signal
+  ## Full successful JSON-RPC response from an Android notification reply.
+  response*: JsonNode
+
 proc fromEvent*(T: type MessageDeliveredSignal, event: JsonNode): MessageDeliveredSignal =
   result = MessageDeliveredSignal()
   result.signalType = SignalType.MessageDelivered
   result.chatId = event["event"]["chatID"].getStr
   result.messageId = event["event"]["messageID"].getStr
+
+proc fromEvent*(T: type NotificationReplySentSignal, event: JsonNode): NotificationReplySentSignal =
+  result = NotificationReplySentSignal()
+  result.signalType = SignalType.NotificationReplySent
+  result.response = if event.contains("event"): event["event"] else: newJNull()
 
 proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   var signal:MessageSignal = MessageSignal()
@@ -169,4 +178,3 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
     for contactId in e["updatedProfileShowcaseContactIDs"]:
       signal.updatedProfileShowcaseContactIDs.add(contactId.getStr())
   result = signal
-

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -3,6 +3,7 @@
 type SignalType* {.pure.} = enum
   Message = "messages.new"
   MessageDelivered = "message.delivered"
+  NotificationReplySent = "notification.reply.sent"
   ## Wallet Signals
   Wallet = "wallet"
   WalletSignTransactions = "wallet.sign.transactions"

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -78,6 +78,7 @@ QtObject:
     result = case signalType:
       of SignalType.Message: MessageSignal.fromEvent(jsonSignal)
       of SignalType.MessageDelivered: MessageDeliveredSignal.fromEvent(jsonSignal)
+      of SignalType.NotificationReplySent: NotificationReplySentSignal.fromEvent(jsonSignal)
       of SignalType.EnvelopeSent: EnvelopeSentSignal.fromEvent(jsonSignal)
       of SignalType.EnvelopeExpired: EnvelopeExpiredSignal.fromEvent(jsonSignal)
       of SignalType.WhisperFilterAdded: WhisperFilterSignal.fromEvent(jsonSignal)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -182,6 +182,18 @@ QtObject:
         for clearedHistoryDto in receivedData.clearedHistories:
           self.events.emit(SIGNAL_CHAT_HISTORY_CLEARED, ChatArgs(chatId: clearedHistoryDto.chatId))
 
+    self.events.on(SignalType.NotificationReplySent.event) do(e: Args):
+      let receivedData = NotificationReplySentSignal(e)
+      try:
+        let response = Json.decode($receivedData.response, RpcResponse[JsonNode])
+        if not response.error.isNil:
+          raise newException(CatchableError, response.error.message)
+        let (chats, messages) = self.processMessengerResponse(response)
+        if chats.len == 0 or messages.len == 0:
+          raise newException(CatchableError, "no chat or message returned")
+      except CatchableError as ex:
+        error "failed to process notification reply response", msg = ex.msg
+
   proc asyncGetActiveChats*(self: Service) =
     let arg = AsyncGetActiveChatsTaskArg(
       tptr: asyncGetActiveChatsTask,
@@ -741,4 +753,3 @@ QtObject:
 
   proc delete*(self: Service) =
     self.QObject.delete
-

--- a/test/nim/signals_manager_test.nim
+++ b/test/nim/signals_manager_test.nim
@@ -6,6 +6,7 @@ import app/core/signals/signals_manager
 import app/core/signals/signal_type_scan
 import app/core/signals/remote_signals/signal_type
 import app/core/signals/remote_signals/mediaserver
+import app/core/signals/remote_signals/messages
 import app/core/signals/remote_signals/storage_stats
 
 # Exercises the real ManageSignals dispatch path (`processSignal`) to prove that
@@ -85,6 +86,18 @@ suite "SignalsManager - unhandled signal-type skipping":
 
     check dispatched
     check receivedPort == 0
+
+  test "notification.reply.sent carries the full successful send response":
+    let emitter = createEventEmitter()
+    var response: JsonNode
+    emitter.on(SignalType.NotificationReplySent.event) do(a: Args):
+      response = NotificationReplySentSignal(a).response
+
+    let manager = newSignalsManager(emitter)
+    manager.processSignal("""{"type":"notification.reply.sent","event":{"jsonrpc":"2.0","id":1,"result":{"chats":[{"id":"chat-id"}],"messages":[{"id":"message-id"}]}}}""")
+
+    check response["result"]["chats"][0]["id"].getStr == "chat-id"
+    check response["result"]["messages"][0]["id"].getStr == "message-id"
 
   test "a handled type in a whitespaced envelope still dispatches (scan-miss fallback)":
     # The fast substring scan assumes status-go's compact `"type":"` byte token.


### PR DESCRIPTION
### What does the PR do

Fixes #22134

Inline notification replies now forward their successful send response to the frontend instead of discarding it. While the UI is backgrounded, the status-go service queues these responses and replays them on resume through a new internal notification.reply.sent signal. This updates the local chat model using the same path as normal in-app sends, so replied messages appear locally without restarting the app.

### Affected areas

- java android code
- message service

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring

### Screencapture of the functionality

https://github.com/user-attachments/assets/eca0b187-9420-482b-ba13-23c93da0873d

### Impact on end user

Fixes the sisue

### How to test

1. Open the app on Android
2. Login and then background
3. Send a message to the android profile
4. Receive the message
5. Reply using the Push notif
6. Open the app
7. See that the reply is there in the chat

### Risk 

Low
