### PR TITLE
fix(SignModals): narrow/portrait mode fixes

### DIFF
--- a/storybook/pages/AlertPopupPage.qml
+++ b/storybook/pages/AlertPopupPage.qml
@@ -32,7 +32,6 @@ SplitView {
             AlertPopup {
                 id: dialog
 
-                anchors.centerIn: parent
                 title: qsTr("Remotely destruct %n token(s)", "", 12)
                 acceptBtnText: qsTr("Remotely destruct")
                 alertText: qsTr("Continuing will destroy tokens held by members and revoke any perissions they given. To undo you will have to issue them new tokens.")
@@ -40,6 +39,10 @@ SplitView {
                 onAcceptClicked: logs.logEvent("AlertPopup::onAcceptClicked")
                 onCancelClicked: logs.logEvent("AlertPopup::onCancelClicked")
 
+                Binding on asset.name {
+                    when: ctrlIcon.checked
+                    value: "settings"
+                }
             }
         }
 
@@ -50,13 +53,14 @@ SplitView {
             SplitView.preferredHeight: 150
 
             logsView.logText: logs.logText
-        }
-    }
 
-    Pane {
-        SplitView.minimumWidth: 300
-        SplitView.preferredWidth: 300
+            CheckBox {
+                id: ctrlIcon
+                text: "With icon"
+            }
+        }
     }
 }
 
 // category: Popups
+// status: good

--- a/storybook/pages/DAppSignRequestModalPage.qml
+++ b/storybook/pages/DAppSignRequestModalPage.qml
@@ -19,7 +19,7 @@ SplitView {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        color: Theme.palette.background
+        color: "gray"
 
         Button {
             anchors.centerIn: parent
@@ -65,7 +65,8 @@ SplitView {
             requestPayload: controls.contentToSign[contentToSignComboBox.currentIndex]
             signingTransaction: signingTransaction.checked
 
-            expirationSeconds: !!ctrlExpiration.text && parseInt(ctrlExpiration.text) ? parseInt(ctrlExpiration.text) : 0
+            expirationSeconds: ctrlExpiration.value
+            hasExpiryDate: ctrlExpiration.value > 0
             onExpirationSecondsChanged: requestTimestamp = new Date()
 
             onAccepted: print ("Accepted")
@@ -171,10 +172,15 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce nibh. Etiam quis
                 ToolTip.text: "Replaces dappName with an HTML payload to verify "
                               + "textFormat: Text.PlainText renders literal markup, not styled text."
             }
-            TextField {
-                Layout.fillWidth: true
+            Label {
+                text: "Expiration"
+            }
+            SpinBox {
                 id: ctrlExpiration
-                placeholderText: "Expiration in seconds"
+                value: 0
+                from: 0
+                to: 120
+                editable: true
             }
         }
     }

--- a/storybook/pages/SendSignModalPage.qml
+++ b/storybook/pages/SendSignModalPage.qml
@@ -111,6 +111,7 @@ SplitView {
         PopupBackground {
             id: popupBg
             anchors.fill: parent
+            color: "gray"
 
             Button {
                 anchors.centerIn: parent
@@ -122,8 +123,6 @@ SplitView {
             Component {
                 id: dlgComponent
                 SendSignModal {
-                    closePolicy: Popup.CloseOnEscape
-                    anchors.centerIn: parent
                     destroyOnClose: true
                     modal: false
 
@@ -203,8 +202,8 @@ SplitView {
                         return 0
                     }
 
-                    fiatFees: formatBigNumber(42.542567, "EUR")
-                    cryptoFees: formatBigNumber(0.06, "ETH")
+                    fiatFees: formatBigNumber(42.542567)
+                    cryptoFees: formatBigNumber(0.06)
                     estimatedTime: qsTr("~60s")
 
                     isCollectibleLoading: isCollectibleLoadingCheckbox.checked
@@ -218,8 +217,7 @@ SplitView {
                                        + '<img src="https://placekitten.com/40/40">'
                                      : (!!collectibleComboBox.currentCollectible ?
                                             collectibleComboBox.currentCollectible.name: "")
-                    collectibleBackgroundColor: !!collectibleComboBox.currentCollectible ?
-                                                    collectibleComboBox.currentCollectible.backgroundColor: ""
+                    collectibleBackgroundColor: collectibleComboBox.currentCollectible?.backgroundColor ?? "transparent"
                     collectibleMediaUrl: !!collectibleComboBox.currentCollectible ?
                                              collectibleComboBox.currentCollectible.mediaUrl ?? "" : ""
                     collectibleMediaType: ""
@@ -231,7 +229,8 @@ SplitView {
 
                     feesLoading: ctrlLoading.checked
 
-                    expirationSeconds: !!ctrlExpiration.text && parseInt(ctrlExpiration.text) ? parseInt(ctrlExpiration.text) : 0
+                    expirationSeconds: ctrlExpiration.value
+                    hasExpiryDate: ctrlExpiration.value > 0
                     onExpirationSecondsChanged: requestTimestamp = new Date()
 
                     fnGetOpenSeaExplorerUrl: function(networkShortName) {
@@ -288,7 +287,7 @@ SplitView {
                 }
                 enabled: isCollectibleCheckbox.checked
             }
-            Text {
+            Label {
                 text: "Selected Send Amount"
             }
             TextField {
@@ -297,7 +296,7 @@ SplitView {
                 text: "100"
                 placeholderText: "From amount"
             }
-            Text {
+            Label {
                 text: "Selected From Account"
             }
             ComboBox {
@@ -309,7 +308,7 @@ SplitView {
                 currentIndex: 0
             }
 
-            Text {
+            Label {
                 text: "Selected Recipient"
             }
             ComboBox {
@@ -321,7 +320,7 @@ SplitView {
                 currentIndex: 0
             }
 
-            Text {
+            Label {
                 text: "Selected Network"
             }
             ComboBox {
@@ -338,7 +337,7 @@ SplitView {
                 text: "Fees loading"
             }
 
-            Text {
+            Label {
                 text: "Login Type"
             }
             ComboBox {
@@ -355,10 +354,16 @@ SplitView {
                 restoreMode: Binding.RestoreBindingOrValue
             }
 
-            TextField {
+            Label {
+                text: "Expiration"
+            }
+            SpinBox {
                 Layout.fillWidth: true
                 id: ctrlExpiration
-                placeholderText: "Expiration in seconds"
+                value: 0
+                from: 0
+                to: 120
+                editable: true
             }
         }
     }

--- a/storybook/pages/SwapSignModalPage.qml
+++ b/storybook/pages/SwapSignModalPage.qml
@@ -60,6 +60,7 @@ SplitView {
         PopupBackground {
             id: popupBg
             anchors.fill: parent
+            color: "gray"
 
             Button {
                 anchors.centerIn: parent
@@ -71,7 +72,6 @@ SplitView {
             Component {
                 id: dlgComponent
                 SwapSignModal {
-                    anchors.centerIn: parent
                     destroyOnClose: true
                     modal: false
 
@@ -122,7 +122,8 @@ SplitView {
 
                     feesLoading: ctrlLoading.checked
 
-                    expirationSeconds: !!ctrlExpiration.text && parseInt(ctrlExpiration.text) ? parseInt(ctrlExpiration.text) : 0
+                    expirationSeconds: ctrlExpiration.value
+                    hasExpiryDate: ctrlExpiration.value > 0
                     onExpirationSecondsChanged: requestTimestamp = new Date()
 
                     onAccepted: logs.logEvent("accepted")
@@ -174,7 +175,7 @@ SplitView {
                 placeholderText: "To amount"
             }
 
-            Text {
+            Label {
                 text: "Selected Account"
             }
             ComboBox {
@@ -186,7 +187,7 @@ SplitView {
                 currentIndex: 0
             }
 
-            Text {
+            Label {
                 text: "Selected Network"
             }
             ComboBox {
@@ -203,7 +204,7 @@ SplitView {
                 text: "Fees loading"
             }
 
-            Text {
+            Label {
                 text: "Login Type"
             }
             ComboBox {
@@ -220,10 +221,16 @@ SplitView {
                 restoreMode: Binding.RestoreBindingOrValue
             }
 
-            TextField {
+            Label {
+                text: "Expiration"
+            }
+            SpinBox {
                 Layout.fillWidth: true
                 id: ctrlExpiration
-                placeholderText: "Expiration in seconds"
+                value: 0
+                from: 0
+                to: 120
+                editable: true
             }
         }
     }

--- a/storybook/pages/TransferOwnershipAlertPopupPage.qml
+++ b/storybook/pages/TransferOwnershipAlertPopupPage.qml
@@ -33,7 +33,6 @@ SplitView {
             TransferOwnershipAlertPopup {
                 id: dialog
 
-                anchors.centerIn: parent                
                 closePolicy: Popup.NoAutoClose
                 visible: true
                 modal: false

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogHeader.qml
@@ -54,7 +54,7 @@ ToolBar {
                 margins: Theme.defaultPadding
             }
 
-            spacing: Theme.halfPadding
+            spacing: Theme.defaultSmallPadding
 
             Loader {
                 id: leftComponentLoader

--- a/ui/app/AppLayouts/Communities/popups/TransferOwnershipAlertPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TransferOwnershipAlertPopup.qml
@@ -49,9 +49,8 @@ StatusDialog {
     header: StatusDialogHeader {
         headline.title: d.headerTitle
         actions.closeButton.onClicked: root.close()
-        leftComponent: StatusSmartIdenticon {
-            asset.name: root.communityLogo
-            asset.isImage: !!asset.name
+        leftComponent: StatusRoundedImage {
+            image.source: root.communityLogo
         }
     }
 
@@ -63,7 +62,7 @@ StatusDialog {
 
                 onClicked: {
                     root.cancelClicked()
-                    close()
+                    root.close()
                 }
             }
 
@@ -72,7 +71,7 @@ StatusDialog {
 
                 onClicked: {
                     root.mintClicked()
-                    close()
+                    root.close()
                 }
             }
         }

--- a/ui/app/AppLayouts/Wallet/controls/SwapProvidersTermsAndConditionsText.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SwapProvidersTermsAndConditionsText.qml
@@ -7,7 +7,7 @@ import StatusQ.Core.Theme
 
 import utils
 
-RowLayout {
+StatusCenteredFlow {
     id: root
 
     required property string serviceProviderName
@@ -17,8 +17,8 @@ RowLayout {
     spacing: 4
 
     StatusIcon {
-        Layout.preferredWidth: 16
-        Layout.preferredHeight: 16
+        width: 16
+        height: 16
         icon: "external-link"
         color: Theme.palette.directColor1
     }
@@ -27,7 +27,6 @@ RowLayout {
         text: qsTr("Powered by")
     }
     StatusLinkText {
-        Layout.topMargin: 1 // compensate for the underline
         text: "%1.".arg(root.serviceProviderName)
         font.weight: Font.Normal
         textFormat: Text.PlainText
@@ -38,7 +37,6 @@ RowLayout {
         text: qsTr("View")
     }
     StatusLinkText {
-        Layout.topMargin: 1 // compensate for the underline
         text: qsTr("Terms & Conditions")
         font.weight: Font.Normal
         onClicked: root.termsAndConditionClicked()

--- a/ui/app/AppLayouts/Wallet/panels/SignInfoBox.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SignInfoBox.qml
@@ -40,6 +40,7 @@ ColumnLayout {
         statusListItemTitle.customColor: root.primaryTextCustomColor
         statusListItemTitle.textFormat: Text.PlainText
         subTitle: root.secondaryText
+        statusListItemSubTitle.font.family: Fonts.codeFont.family
         statusListItemSubTitle.font.pixelSize: Theme.additionalTextSize
         statusListItemSubTitle.textFormat: Text.PlainText
         asset.name: root.icon

--- a/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
@@ -10,7 +10,6 @@ import StatusQ.Core.Utils as SQUtils
 import StatusQ.Core.Theme
 import StatusQ.Controls
 import StatusQ.Components
-import StatusQ.Popups
 import StatusQ.Popups.Dialog
 
 import shared.controls
@@ -56,7 +55,6 @@ StatusDialog {
     property ObjectModel leftFooterContents
     property ObjectModel rightFooterContents: ObjectModel {
         RowLayout {
-            Layout.rightMargin: 4
             spacing: Theme.halfPadding
             StatusFlatButton {
                 objectName: "rejectButton"
@@ -109,7 +107,8 @@ StatusDialog {
     signal closeInternalPopup()
 
     width: 480
-    padding: 0
+    horizontalPadding: 0
+    verticalPadding: 0 // to have the gradient strech top-bottom
 
     closePolicy: Popup.NoAutoClose
 
@@ -136,6 +135,7 @@ StatusDialog {
 
     footer: StatusDialogFooter {
         dropShadowEnabled: true
+        bottomSheet: root.bottomSheet
 
         leftButtons: root.leftFooterContents
         rightButtons: root.rightFooterContents
@@ -145,33 +145,30 @@ StatusDialog {
         id: scrollView
         anchors.fill: parent
         contentWidth: availableWidth
-        contentHeight: content.implicitHeight
-        topPadding: 0
-        bottomPadding: countdownPill.height
+        padding: 0
 
         ColumnLayout {
             id: content
-            anchors.left: parent.left
-            anchors.leftMargin: 4
-            anchors.right: parent.right
-            anchors.rightMargin: 4
-            spacing: 0
+            width: scrollView.availableWidth
+            spacing: 12
 
             // header box with gradient
-            Rectangle {
+            Control {
                 Layout.fillWidth: true
-                Layout.leftMargin: -parent.anchors.leftMargin - scrollView.leftPadding
-                Layout.rightMargin: -parent.anchors.rightMargin - scrollView.rightPadding
-                Layout.preferredHeight: childrenRect.height + 80 - countdownPill.height // 40 + 40 top/bottomMargin
-                gradient: Gradient {
-                    GradientStop { position: 0.0; color: Utils.setColorAlpha(root.gradientColor, 0.05) }
-                    GradientStop { position: 1.0; color: root.backgroundColor }
-                }
+                Layout.alignment: Qt.AlignHCenter
+                verticalPadding: Theme.bigPadding // for top/bottom margin
+                horizontalPadding: Theme.defaultPadding // for scrollbars
 
-                ColumnLayout {
-                    width: 336 // by design
-                    spacing: 12
-                    anchors.centerIn: parent
+                background: Rectangle {
+                    gradient: Gradient {
+                        GradientStop { position: 0.0; color: StatusColors.alphaColor(root.gradientColor, 0.25) }
+                        GradientStop { position: 1.0; color: root.backgroundColor }
+                    }
+                }
+                contentItem: ColumnLayout {
+                    Layout.fillWidth: true
+                    Layout.maximumWidth: 336
+                    spacing: 20
 
                     RowLayout {
                         Layout.alignment: Qt.AlignHCenter
@@ -298,23 +295,23 @@ StatusDialog {
 
                     InformationTag {
                         id: infoTag
+                        Layout.maximumWidth: parent.width
                         Layout.alignment: Qt.AlignHCenter
                         asset.name: "info"
                         tagPrimaryLabel.text: root.infoTagText
                         visible: !!root.infoTagText
                     }
                 }
+            }
 
-                CountdownPill {
-                    id: countdownPill
-                    objectName: "countdownPill"
-                    anchors.right: parent.right
-                    anchors.top: parent.top
-                    anchors.margins: Theme.padding
-                    timestamp: root.requestTimestamp
-                    expirationSeconds: root.expirationSeconds
-                    visible: !!root.hasExpiryDate
-                }
+            CountdownPill {
+                id: countdownPill
+                objectName: "countdownPill"
+                anchors.right: parent.right
+                anchors.top: parent.top
+                timestamp: root.requestTimestamp
+                expirationSeconds: root.expirationSeconds
+                visible: !!root.hasExpiryDate
             }
 
             StatusDialogDivider {
@@ -325,6 +322,11 @@ StatusDialog {
 
             ColumnLayout {
                 Layout.fillWidth: true
+                // for scrollbars
+                Layout.leftMargin: Theme.defaultPadding
+                Layout.rightMargin: Theme.defaultPadding
+                // for bottom margin
+                Layout.bottomMargin: Theme.defaultPadding
                 id: contentsLayout
             }
         }

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
@@ -86,7 +86,7 @@ SignTransactionModalBase {
     required property var fnGetOpenSeaExplorerUrl
 
     /** Transaction settings related parameters **/
-    required property int selectedFeeMode
+    required property int selectedFeeMode // Constants.FeePriorityModeType.XXX
 
     required property bool fromChainEIP1559Compliant
     required property bool fromChainNoBaseFee
@@ -149,9 +149,7 @@ SignTransactionModalBase {
         const tokenToSend = root.isCollectible ? root.collectibleName:
                               "%1 %2".arg(root.tokenAmount).arg(root.tokenSymbol)
         //: e.g. (Send) 100 DAI to batista.eth
-        return qsTr("%1 to %2").
-        arg(tokenToSend).
-        arg(SQUtils.Utils.elideAndFormatWalletAddress(root.recipientAddress))
+        return qsTr("%1 to %2").arg(tokenToSend).arg(SQUtils.Utils.elideAndFormatWalletAddress(root.recipientAddress))
     }
 
     headerActionsCloseButtonVisible: true
@@ -207,12 +205,17 @@ SignTransactionModalBase {
 
     leftFooterContents: ObjectModel {
         RowLayout {
-            Layout.leftMargin: 4
+            Layout.fillWidth: true
+            id: leftFeesContent
             spacing: Theme.padding
+            visible: root.width > ThemeUtils.portraitBreakpoint.width / 2
             ColumnLayout {
+                Layout.fillWidth: true
                 spacing: 2
                 RowLayout {
+                    Layout.fillWidth: true
                     StatusBaseText {
+                        Layout.fillWidth: true
                         objectName: "footerEstTimeLabel"
                         text: WalletUtils.getFeeTextForFeeMode(root.selectedFeeMode)
                         color: Theme.palette.baseColor1
@@ -221,47 +224,51 @@ SignTransactionModalBase {
                     StatusImage {
                         objectName: "footerEstTimeIcon"
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.preferredWidth: 22
-                        Layout.preferredHeight: 22
+                        Layout.preferredWidth: 16
+                        Layout.preferredHeight: 16
                         source: WalletUtils.getIconForFeeMode(root.selectedFeeMode)
                     }
                 }
                 StatusTextWithLoadingState {
+                    Layout.fillWidth: true
                     objectName: "footerEstTimeText"
                     text: loading ? Constants.dummyText : root.estimatedTime
                     loading: root.feesLoading
+                    font.pixelSize: Theme.additionalTextSize
                 }
             }
             ColumnLayout {
+                Layout.fillWidth: true
                 spacing: 2
                 StatusBaseText {
+                    Layout.fillWidth: true
                     objectName: "footerFiatFeesLabel"
                     text: qsTr("Max fees")
                     color: Theme.palette.baseColor1
                     font.pixelSize: Theme.additionalTextSize
                 }
                 StatusTextWithLoadingState {
+                    Layout.fillWidth: true
                     objectName: "footerFiatFeesText"
                     text: loading ? Constants.dummyText : root.fiatFees
                     loading: root.feesLoading
+                    font.pixelSize: Theme.additionalTextSize
                 }
             }
-            StatusFlatButton {
-                Layout.preferredWidth: 44
-                Layout.preferredHeight: 44
-                tooltip.text: qsTr("Edit transaction settings")
-                icon.name: "settings-advance"
-                textColor: hovered? Theme.palette.directColor1 : Theme.palette.baseColor1
-                size: StatusBaseButton.Size.Small
-                onClicked: {
-                    root.internalPopupActive = true
-                }
+        }
+        StatusFlatButton {
+            tooltip.text: qsTr("Edit transaction settings")
+            icon.name: "settings-advance"
+            textColor: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
+            size: StatusBaseButton.Size.Small
+            text: leftFeesContent.visible ? "" : qsTr("Edit")
+            onClicked: {
+                root.internalPopupActive = true
             }
         }
     }
 
     property Component internalPopup: TransactionSettings {
-
         fnGetPriceInCurrencyForFee: root.fnGetPriceInCurrencyForFee
         fnGetPriceInNativeTokenForFee: root.fnGetPriceInNativeTokenForFee
         fnGetEstimatedTime: root.fnGetEstimatedTime
@@ -520,7 +527,6 @@ SignTransactionModalBase {
     // Fees
     SignInfoBox {
         Layout.fillWidth: true
-        Layout.bottomMargin: Theme.bigPadding
         objectName: "feesBox"
         caption: qsTr("Fees")
         primaryText: qsTr("Max. fees on %1").arg(root.networkName)

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
@@ -49,6 +49,8 @@ SignTransactionModalBase {
     //: e.g. (swap) 100 DAI to 100 USDT
     subtitle: qsTr("%1 to %2").arg(formatBigNumber(fromTokenAmount, fromTokenSymbol)).arg(formatBigNumber(toTokenAmount, toTokenSymbol))
 
+    headerActionsCloseButtonVisible: true
+
     gradientColor: root.accountColor
     fromImageSource: Constants.tokenIcon(root.fromTokenSymbol)
     toImageSource: Constants.tokenIcon(root.toTokenSymbol)
@@ -58,6 +60,7 @@ SignTransactionModalBase {
         .arg(formatBigNumber(root.toTokenAmount, root.toTokenSymbol)).arg(root.accountName).arg(root.networkName)
     headerSubTextLayout: [
         SwapProvidersTermsAndConditionsText {
+            Layout.fillWidth: true
             serviceProviderName: root.serviceProviderName
             onLinkClicked: root.requestOpenLink(root.serviceProviderURL)
             onTermsAndConditionClicked: root.requestOpenLink(root.serviceProviderTandCUrl)
@@ -81,31 +84,43 @@ SignTransactionModalBase {
 
     leftFooterContents: ObjectModel {
         RowLayout {
-            Layout.leftMargin: 4
-            spacing: Theme.bigPadding
+            Layout.fillWidth: true
+            spacing: Theme.padding
             ColumnLayout {
+                Layout.fillWidth: true
                 spacing: 2
                 StatusBaseText {
+                    Layout.fillWidth: true
                     text: qsTr("Max fees:")
                     color: Theme.palette.baseColor1
                     font.pixelSize: Theme.additionalTextSize
+                    elide: Text.ElideRight
                 }
                 StatusTextWithLoadingState {
+                    Layout.fillWidth: true
                     objectName: "footerFiatFeesText"
                     text: loading ? Constants.dummyText : root.fiatFees
                     loading: root.feesLoading
+                    font.pixelSize: Theme.additionalTextSize
+                    elide: Text.ElideRight
                 }
             }
             ColumnLayout {
+                Layout.fillWidth: true
                 spacing: 2
                 StatusBaseText {
+                    Layout.fillWidth: true
                     text: qsTr("Max slippage:")
                     color: Theme.palette.baseColor1
                     font.pixelSize: Theme.additionalTextSize
+                    elide: Text.ElideRight
                 }
                 StatusBaseText {
+                    Layout.fillWidth: true
                     objectName: "footerMaxSlippageText"
                     text: "%1%".arg(LocaleUtils.numberToLocaleString(root.slippage))
+                    font.pixelSize: Theme.additionalTextSize
+                    elide: Text.ElideRight
                 }
             }
         }

--- a/ui/app/AppLayouts/Wallet/views/TransactionSettings.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionSettings.qml
@@ -15,8 +15,6 @@ import shared.controls
 import shared.popups
 import utils
 
-import AppLayouts.Wallet
-
 Rectangle {
     id: root
 
@@ -182,6 +180,7 @@ Rectangle {
             width: root.width - 2 * 20
 
             acceptBtnText: qsTr("Got it")
+            acceptBtnType: StatusBaseButton.Type.Normal
             cancelBtn.text: !!infoBox.url? qsTr("Read more") : ""
             cancelBtn.icon.name: "external-link"
             cancelBtn.visible: !!infoBox.url

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -15307,6 +15307,10 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -15391,6 +15391,10 @@ selhalo</translation>
         <translation>Upravit nastavení transakce</translation>
     </message>
     <message>
+        <source>Edit</source>
+        <translation type="unfinished">Upravit</translation>
+    </message>
+    <message>
         <source>Send</source>
         <translation>Odeslat</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -15322,6 +15322,10 @@ al cargar</translation>
         <translation>Editar configuración de transacción</translation>
     </message>
     <message>
+        <source>Edit</source>
+        <translation type="unfinished">Editar</translation>
+    </message>
+    <message>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -15321,6 +15321,10 @@ Seul le détenteur du jeton Owner peut distribuer des jetons TokenMaster. Ces je
         <translation>Modifier les paramètres de la transaction</translation>
     </message>
     <message>
+        <source>Edit</source>
+        <translation type="unfinished">Modifier</translation>
+    </message>
+    <message>
         <source>Send</source>
         <translation>Envoyer</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -15254,6 +15254,10 @@ to load</source>
         <translation>트랜잭션 설정 편집</translation>
     </message>
     <message>
+        <source>Edit</source>
+        <translation type="unfinished">편집</translation>
+    </message>
+    <message>
         <source>Send</source>
         <translation>보내기</translation>
     </message>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -15394,6 +15394,10 @@ to load</source>
         <translation>Змінити налаштування транзакції</translation>
     </message>
     <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Send</source>
         <translation>Надіслати</translation>
     </message>

--- a/ui/imports/shared/popups/AlertPopup.qml
+++ b/ui/imports/shared/popups/AlertPopup.qml
@@ -62,10 +62,12 @@ StatusDialog {
         headline.title: root.title
         headline.subtitle: root.subtitle
         actions.closeButton.onClicked: root.close()
-        leftComponent: StatusRoundIcon {
-            width: visible?  implicitWidth: 0
-            visible: !!root.asset.name
-            asset: root.asset
+        leftComponent: !!root.asset.name ? leftIconComponent : undefined
+        Component {
+            id: leftIconComponent
+            StatusRoundIcon {
+                asset: root.asset
+            }
         }
     }
 

--- a/ui/imports/shared/popups/KeycardStateDisplay.qml
+++ b/ui/imports/shared/popups/KeycardStateDisplay.qml
@@ -59,7 +59,7 @@ Item {
             Layout.topMargin: Theme.padding
             horizontalAlignment: Text.AlignHCenter
             text: root.title
-            font.pixelSize: Theme.fontSize25
+            font.pixelSize: Theme.fontSize(25)
             font.bold: true
             color: root.isError ? Theme.palette.dangerColor1 : Theme.palette.directColor1
             wrapMode: Text.WordWrap

--- a/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
@@ -89,14 +89,17 @@ SignTransactionModalBase {
 
     leftFooterContents: ObjectModel {
         RowLayout {
-            Layout.leftMargin: 4
-            spacing: Theme.bigPadding
+            Layout.fillWidth: true
+            spacing: Theme.padding
             ColumnLayout {
+                Layout.fillWidth: true
                 spacing: 2
                 StatusBaseText {
+                    Layout.fillWidth: true
                     text: qsTr("Max fees:")
                     color: Theme.palette.baseColor1
                     font.pixelSize: Theme.additionalTextSize
+                    elide: Text.ElideRight
                 }
                 StatusTextWithLoadingState {
                     id: maxFees
@@ -104,7 +107,8 @@ SignTransactionModalBase {
                     objectName: "footerFiatFeesText"
                     text: root.hasFees ? formatBigNumber(root.fiatFees, root.fiatSymbol) : qsTr("No fees")
                     loading: root.feesLoading && root.hasFees
-                    elide: Qt.ElideMiddle
+                    font.pixelSize: Theme.additionalTextSize
+                    elide: Text.ElideRight
                     customColor: !root.hasFees || root.enoughFundsForFees ? Theme.palette.directColor1 : Theme.palette.dangerColor1
                     ColorTransition on customColor {}
                 }
@@ -113,15 +117,20 @@ SignTransactionModalBase {
                 spacing: 2
                 visible: root.hasFees
                 StatusBaseText {
+                    Layout.fillWidth: true
                     text: qsTr("Est. time:")
                     color: Theme.palette.baseColor1
                     font.pixelSize: Theme.additionalTextSize
+                    elide: Qt.ElideRight
                 }
                 StatusTextWithLoadingState {
+                    Layout.fillWidth: true
                     id: estimatedTime
                     objectName: "footerEstimatedTime"
                     text: root.estimatedTime
                     loading: root.estimatedTimeLoading
+                    font.pixelSize: Theme.additionalTextSize
+                    elide: Qt.ElideRight
                     ColorTransition on customColor {}
                 }
             }
@@ -164,7 +173,6 @@ SignTransactionModalBase {
     // Fees
     SignInfoBox {
         Layout.fillWidth: true
-        Layout.bottomMargin: Theme.bigPadding
         objectName: "feesBox"
         caption: qsTr("Fees")
         primaryText: qsTr("Max. fees on %1").arg(root.networkName)


### PR DESCRIPTION
### What does the PR do

- various fixes to prevent overflowing contents on mobile/narrow/portrait views
- fix the background gradient not stretching edge-to-edge
- hide/move some footer contents/buttons when little space left
- properly limit the width of texts and layouts, add wrapping and elide where needed
- apply consistent paddings
- update SB pages and TS files
    
Fixes #22123

### Affected areas

Sign modals (SendSignModal, SwapSignModal, DAppSignRequestModal)

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Sign send bottom sheet:
<img width="1114" height="2116" alt="Snímek obrazovky z 2026-08-28 21-45-35" src="https://github.com/user-attachments/assets/a4749278-e1f1-424f-9033-ccaf9fbb90d0" />

Sign send very narrow view:
<img width="658" height="2116" alt="Snímek obrazovky z 2026-08-28 21-45-59" src="https://github.com/user-attachments/assets/b7acc4af-a40e-40da-a5b2-1be1bc81ea0f" />

DApp sign request:
<img width="592" height="1800" alt="Snímek obrazovky z 2026-08-28 21-06-19" src="https://github.com/user-attachments/assets/a5b88bb5-e08e-4c2f-827e-b8a3c80f6dc2" />

Sign Swap:
<img width="632" height="1800" alt="Snímek obrazovky z 2026-08-28 20-34-56" src="https://github.com/user-attachments/assets/e9764f01-0a0f-4d4f-9832-3b66d5d2a7a3" />


### Impact on end user

Better mobile UX

### How to test

- open sign modals on mobile (or narrow desktop view)
- observe nothing overflowing horizontally

### Risk 

low
