### PR TITLE
fix: missing view to insert the Keycard when logging in

### DIFF
--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -371,6 +371,7 @@ method onNodeLogin*[T](self: Module[T], err: string, account: AccountDto, settin
   if err.len != 0:
     self.onAccountLoginError(err)
     return
+  info "account logged in", keyUid = account.keyUid
   self.controller.setLoggedInAccount(account)
   discard self.delegate.userLoggedIn()
 

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -461,7 +461,7 @@ QtObject:
       self.events.emit(SIGNAL_LOGIN_ERROR, LoginErrorArgs(error: response.result{"error"}.getStr))
       return
 
-    debug "account logged in"
+    debug "login request accepted, waiting for node.login signal"
     self.setLocalAccountSettingsFile()
 
   proc login*(self: Service, account: AccountDto, hashedPassword: string, chatPrivateKey: string = "", mnemonic: string = "",

--- a/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
+++ b/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
@@ -93,7 +93,10 @@ Item {
 
             onKeycardStateChanged: {
                 if (onboardingStore.loginRequestSent && keycardState === Onboarding.KeycardState.NotEmpty) {
-                    onboardingLayout.stack.push(splashScreenV2, { runningProgressAnimation: true }, StackView.Immediate)
+                    // Show the splash screen if it's not already on top (on mobile it's pushed as soon as the login is requested)
+                    const currentItem = onboardingLayout.stack.currentItem
+                    if (!currentItem || currentItem.objectName !== "splashScreenV2")
+                        onboardingLayout.stack.push(splashScreenV2, { runningProgressAnimation: true }, StackView.Immediate)
                 } else if(keycardState === Onboarding.KeycardState.Cancelled) {
                     onboardingLayout.unwindToLoginScreen()
                 }
@@ -137,7 +140,10 @@ Item {
                 return
             }
 
-            onboardingLayout.stack.push(splashScreenV2, { runningProgressAnimation: true }, StackView.Immediate)
+            // Keycard login on desktop blocks until a card is inserted. The splash screen is pushed from onKeycardStateChanged
+            // once the card is read. On mobile the OS NFC prompts for the card, so the splash is pushed right away.
+            if (method !== Onboarding.LoginMethod.Keycard || SQUtils.Utils.isMobile)
+                onboardingLayout.stack.push(splashScreenV2, { runningProgressAnimation: true }, StackView.Immediate)
 
             onboardingStore.loginRequestSent = true
             onboardingStore.loginRequested(keyUid, method, data)


### PR DESCRIPTION
What's changed:
- updated the debug messages to depict a real processing state
- In onLoginRequested, skip the splash screen push on desktop, keep the user on the login screen and let the onKeycardStateChanged handler push the splash once the card reports a ready state
- In that onKeycardStateChanged handler, only push the splash if it isn't already displayed

Fixes #22175