### PR TITLE
Contacts: ensure 3-word alias generation

### DIFF
--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -375,13 +375,16 @@ QtObject:
 
   proc constructContactDetails(self: Service, contactDto: ContactsDto, isCurrentUser: bool = false): ContactDetails =
     result = ContactDetails()
-    let (name, optionalName, icon, _) = self.getContactNameAndImageInternal(contactDto)
+    var dto = contactDto
+    if dto.alias.len == 0 and dto.id.len > 0:
+      dto.alias = self.generateAlias(dto.id)
+    let (name, optionalName, icon, _) = self.getContactNameAndImageInternal(dto)
     result.defaultDisplayName = name
     result.optionalName = optionalName
     result.icon = icon
-    result.colorId = contactDto.colorId
+    result.colorId = dto.colorId
     result.isCurrentUser = isCurrentUser
-    result.dto = contactDto
+    result.dto = dto
 
   proc getContactDetails*(self: Service, id: string): ContactDetails =
     var pubkey = id

--- a/ui/imports/utils/ProfileUtils.qml
+++ b/ui/imports/utils/ProfileUtils.qml
@@ -10,7 +10,7 @@ QtObject {
 
     function displayName(nickName: string, ensName: string, displayName: string, aliasName: string) : string
     {
-        return nickName || ensName || displayName || aliasName
+        return nickName || ensName || displayName || aliasName || ""
     }
 
     // social links utils


### PR DESCRIPTION
### What does the PR do

Adds 3-word alias to contact Dto if not present. It prevents displaying `undefined` as a contact name.

Closes: #22136

### Affected areas
`src/app_service/service/contacts/service.nim`

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Low

### How to test

Invoke `Send contact request` dialog for a community contact with 3-word name, check if name is populated correctly with 3-words name instead of `undefined`.

### Risk
 
Low
