### PR TITLE
fix: the success screen lacks copy - lost keycard flow

### DIFF
--- a/ui/app/AppLayouts/Onboarding/pages/ConvertKeycardAccountPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/ConvertKeycardAccountPage.qml
@@ -47,18 +47,13 @@ OnboardingPage {
                 when: root.convertKeycardAccountState === Onboarding.ProgressState.Success
 
                 PropertyChanges {
-                    target: root
-                    root.title: root.restartRequired ? qsTr("Re-encryption complete")
-                                                     : qsTr("Profile migration complete")
+                    root.title: qsTr("Re-encryption complete")
                 }
                 PropertyChanges {
                     iconLoader.sourceComponent: successIcon
                 }
                 PropertyChanges {
-                    target: subtitle
-                    subtitle.text: root.restartRequired
-                                   ? qsTr("Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.")
-                                   : qsTr("Your profile no longer uses Keycard. You can now log in using the password you just created.")
+                    subtitle.text: qsTr("Your profile data was re-encrypted successfully.\nLog in with your new password.")
                 }
                 PropertyChanges {
                     warningText.visible: false

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -4583,15 +4583,8 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Profile migration complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
+        <source>Your profile data was re-encrypted successfully.
+Log in with your new password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -4607,15 +4607,8 @@ Zůstanete přihlášeni a vaše obnovovací fráze bude zcela ve vašich rukou.
         <translation>Přešifrování dokončeno</translation>
     </message>
     <message>
-        <source>Profile migration complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
-        <translation>Vaše data byla úspěšně přešifrována vaším novým heslem. Nyní můžete restartovat Status a přihlásit se ke svému profilu pomocí hesla, které jste právě vytvořili.</translation>
-    </message>
-    <message>
-        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
+        <source>Your profile data was re-encrypted successfully.
+Log in with your new password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -4588,15 +4588,8 @@ Permanecerás conectado y tu frase de recuperación estará completamente en tus
         <translation>Re-cifrado completado</translation>
     </message>
     <message>
-        <source>Profile migration complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
-        <translation>Tus datos se volvieron a cifrar exitosamente con tu nueva contraseña. Ahora puedes reiniciar Status e iniciar sesión en tu perfil usando la contraseña que acabas de crear.</translation>
-    </message>
-    <message>
-        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
+        <source>Your profile data was re-encrypted successfully.
+Log in with your new password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -4586,16 +4586,9 @@ Vous resterez connecté et votre phrase de récupération sera entièrement entr
         <translation>Réencryption terminée</translation>
     </message>
     <message>
-        <source>Profile migration complete</source>
-        <translation>Migration du profil terminée</translation>
-    </message>
-    <message>
-        <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
-        <translation>Vos données ont été re-chiffrées avec succès à l’aide de votre nouveau mot de passe. Vous pouvez maintenant redémarrer Status et vous connecter à votre profil en utilisant le mot de passe que vous venez de créer.</translation>
-    </message>
-    <message>
-        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
-        <translation>Votre profil n&apos;utilise plus de Keycard. Vous pouvez maintenant vous connecter avec le mot de passe que vous venez de créer.</translation>
+        <source>Your profile data was re-encrypted successfully.
+Log in with your new password.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Re-encryption failed</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -4568,15 +4568,8 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation>재암호화 완료</translation>
     </message>
     <message>
-        <source>Profile migration complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
-        <translation>데이터가 새 비밀번호로 성공적으로 재암호화되었습니다. 이제 Status를 다시 시작하고, 방금 만든 비밀번호로 프로필에 로그인할 수 있어요.</translation>
-    </message>
-    <message>
-        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
+        <source>Your profile data was re-encrypted successfully.
+Log in with your new password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -4607,16 +4607,9 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation>Повторне шифрування завершено</translation>
     </message>
     <message>
-        <source>Profile migration complete</source>
-        <translation>Міграцію профілю завершено</translation>
-    </message>
-    <message>
-        <source>Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.</source>
-        <translation>Ваші дані успішно повторно зашифровано новим паролем. Тепер перезапустіть Status і ввійдіть у профіль за допомогою щойно створеного пароля.</translation>
-    </message>
-    <message>
-        <source>Your profile no longer uses Keycard. You can now log in using the password you just created.</source>
-        <translation>Ваш профіль більше не використовує Keycard. Тепер ви можете ввійти за допомогою щойно створеного пароля.</translation>
+        <source>Your profile data was re-encrypted successfully.
+Log in with your new password.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Re-encryption failed</source>


### PR DESCRIPTION
Following the "Lost Keycard" -> "Start using profile without Keycard" flow the user at some step ends up on an almost empty screen. Now updated with some meaningful copy.

Fixes #22158

<img width="898" height="862" alt="ReEncCompleted" src="https://github.com/user-attachments/assets/dec8e09f-bd5e-437f-a4cf-9eeecafea1c8" />
