### PR TITLE
chore(@e2e): fix for port range and image dialog

### DIFF
--- a/test/e2e/configs/squish.py
+++ b/test/e2e/configs/squish.py
@@ -1,6 +1,6 @@
 import os
 
-# Below the OS ephemeral range so the second AUT hook is not stolen by the first instance.
-AUT_PORT = 35100 + int(os.getenv('EXECUTOR_NUMBER', 0))
+# Below OS ephemeral ranges (Linux from 32768, macOS/Windows from 49152).
+AUT_PORT = 25000 + int(os.getenv('EXECUTOR_NUMBER', 0))
 SERVER_PORT = 4322 + int(os.getenv('EXECUTOR_NUMBER', 0))
 CURSOR_ANIMATION = False

--- a/test/e2e/driver/aut.py
+++ b/test/e2e/driver/aut.py
@@ -8,7 +8,6 @@ import configs
 import driver
 import shortuuid
 from tests import test_data
-from datetime import datetime
 from configs.system import get_platform
 from driver import context
 from driver.server import SquishServer
@@ -34,7 +33,7 @@ class AUT:
         self.ctx = None
         self.pid = None
         self.port = None
-        self.aut_id = f'AUT_{datetime.now():%H%M%S}'
+        self.aut_id = f'AUT_{shortuuid.ShortUUID().random(length=8)}'
         self.app_data = configs.testpath.STATUS_DATA / f'app_{shortuuid.ShortUUID().random(length=10)}'
         if user_data is not None:
             user_data.copy_to(self.app_data / 'data')
@@ -68,7 +67,7 @@ class AUT:
 
     @allure.step('Attach Squish to Test Application')
     def attach(self):
-        LOG.info('Attaching to AUT: localhost:%d', self.port)
+        LOG.info('Attaching to AUT: 127.0.0.1:%d', self.port)
 
         try:
             SquishServer().add_attachable_aut(self.aut_id, self.port)
@@ -171,9 +170,9 @@ class AUT:
         if retries is None:
             retries = 20 if get_platform() == "Windows" else 10
         
-        LOG.info('Waiting for AUT port localhost:%d... (timeout=%ds, retries=%d)', self.port, timeout, retries)
+        LOG.info('Waiting for AUT port 127.0.0.1:%d... (timeout=%ds, retries=%d)', self.port, timeout, retries)
         try:
-            wait_for_port('localhost', self.port, timeout, retries)
+            wait_for_port('127.0.0.1', self.port, timeout, retries)
         except TimeoutError as err:
             LOG.error('Wait for AUT port timed out: %s', err)
             # Check if process is still running

--- a/test/e2e/driver/context.py
+++ b/test/e2e/driver/context.py
@@ -7,25 +7,37 @@ import squish
 import configs
 import driver
 from driver.server import SquishServer
-from configs.system import get_platform
 
 LOG = logging.getLogger(__name__)
+
+_ALREADY_ATTACHED = 'another test is currently attached'
+_ATTACH_RETRIES = 3
+_ATTACH_RETRY_DELAY_SEC = 1.0
+
+
+def _existing_context(aut_id: str):
+    for ctx in driver.applicationContextList():
+        name = getattr(ctx, 'name', None)
+        if name == aut_id or str(ctx) == aut_id:
+            return ctx
+    return None
 
 
 @allure.step('Get application context of "{0}"')
 def get_context(aut_id: str):
     """
-    Get application context with retry logic for slow first startup on Windows VMs.
-    On Windows, the first app start after install can be slow, so we retry a few times.
+    Get application context with retry logic for slow AUT hook handshake.
+    Do not retry 'already attached': the AUT is bound to this test; reuse the context.
     """
-    is_windows = get_platform() == "Windows"
-    max_retries = 3 if is_windows else 1
-    retry_delay = 1.0 if is_windows else 0.0
-    
     LOG.info('Attaching to: %s', aut_id)
-    
+
+    existing = _existing_context(aut_id)
+    if existing is not None:
+        LOG.info('AUT %s already has an application context, reusing it', aut_id)
+        return existing
+
     last_error = None
-    for attempt in range(max_retries):
+    for attempt in range(_ATTACH_RETRIES):
         try:
             context = driver.attachToApplication(aut_id, SquishServer().host, SquishServer().port)
             if context is not None:
@@ -34,13 +46,20 @@ def get_context(aut_id: str):
                 return context
         except RuntimeError as error:
             last_error = error
-            if attempt < max_retries - 1:
-                LOG.warning('AUT %s not ready (attempt %d/%d), retrying in %.1fs...', 
-                           aut_id, attempt + 1, max_retries, retry_delay)
-                time.sleep(retry_delay)
+            existing = _existing_context(aut_id)
+            if existing is not None:
+                LOG.info('AUT %s attached despite error (%s); reusing context', aut_id, error)
+                return existing
+            if _ALREADY_ATTACHED in str(error).lower():
+                LOG.error('AUT %s is attached to another test: %s', aut_id, error)
+                raise
+            if attempt < _ATTACH_RETRIES - 1:
+                LOG.warning('AUT %s not ready (attempt %d/%d), retrying in %.1fs...',
+                           aut_id, attempt + 1, _ATTACH_RETRIES, _ATTACH_RETRY_DELAY_SEC)
+                time.sleep(_ATTACH_RETRY_DELAY_SEC)
             else:
-                LOG.error('AUT %s context not found after %d attempts', aut_id, max_retries)
-    
+                LOG.error('AUT %s context not found after %d attempts', aut_id, _ATTACH_RETRIES)
+
     raise last_error
 
 

--- a/test/e2e/driver/server.py
+++ b/test/e2e/driver/server.py
@@ -68,4 +68,4 @@ class SquishServer:
 
     @classmethod
     def add_attachable_aut(cls, aut_id: str, port: int):
-        cls.configuring('addAttachableAUT', [aut_id, f'localhost:{port}'])
+        cls.configuring('addAttachableAUT', [aut_id, f'127.0.0.1:{port}'])

--- a/test/e2e/gui/elements/window.py
+++ b/test/e2e/gui/elements/window.py
@@ -14,7 +14,7 @@ class Window(QObject):
     def prepare(self) -> 'Window':
         self.maximize()
         self.set_focus()
-        # self.on_top_level()
+        self.on_top_level()
         return self
 
     @property

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -628,9 +628,6 @@ authenticate_keycardPasswordInput = {"container": statusDesktop_mainWindow_overl
 # auth_sign_base/PopupBase.qml footer submit button
 authenticate_StatusButton = {"container": statusDesktop_mainWindow_overlay,
                              "objectName": "keycardPopupBaseSubmitButton", "type": "StatusButton", "visible": True}
-signPopup = {"container": statusDesktop_mainWindow_overlay, "type": "SignPopup", "visible": True}
-keycardAuthPinInput = {"container": statusDesktop_mainWindow_overlay,
-                       "objectName": "keycardAuthPinInput", "type": "StatusPinInput", "visible": True}
 headerCloseButton_StatusFlatRoundButton = {"container": statusDesktop_mainWindow_overlay,
                                            "objectName": "headerCloseButton", "type": "StatusFlatRoundButton",
                                            "visible": True}

--- a/test/e2e/scripts/utils/local_system.py
+++ b/test/e2e/scripts/utils/local_system.py
@@ -26,15 +26,34 @@ def find_process_by_port(port: int) -> typing.List[int]:
     return pid_list
 
 
-def _port_is_listening(port: int) -> bool:
+def _port_is_listening(host: str, port: int, family: int = socket.AF_INET) -> bool:
+    try:
+        with socket.socket(family, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.2)
+            return sock.connect_ex((host, port)) == 0
+    except OSError:
+        return False
+
+
+def _port_can_bind(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.settimeout(0.2)
-        return sock.connect_ex(('127.0.0.1', port)) == 0
+        exclusive = getattr(socket, 'SO_EXCLUSIVEADDRUSE', None)
+        if exclusive is not None:
+            sock.setsockopt(socket.SOL_SOCKET, exclusive, 1)
+        try:
+            sock.bind(('127.0.0.1', port))
+            return True
+        except OSError:
+            return False
 
 
 def find_free_port(start: int, step: int) -> int:
     for port in range(start, start + step * 100, step):
-        if not _port_is_listening(port):
+        if _port_is_listening('127.0.0.1', port):
+            continue
+        if _port_is_listening('::1', port, socket.AF_INET6):
+            continue
+        if _port_can_bind(port):
             return port
     raise RuntimeError(f'No free TCP port found from {start}')
 

--- a/ui/imports/shared/popups/ImageCropWorkflow.qml
+++ b/ui/imports/shared/popups/ImageCropWorkflow.qml
@@ -36,6 +36,15 @@ Item {
         imageCropperModal.open()
     }
 
+    // Native FileDialog is still closing; opening a Popup here becomes a new window on Linux.
+    Timer {
+        id: openCropperTimer
+        interval: 1
+        repeat: false
+        property url pendingImage
+        onTriggered: root.cropImage(pendingImage)
+    }
+
     StatusFileDialog {
         id: fileDialog
 
@@ -47,15 +56,16 @@ Item {
         onAccepted: {
             if (fileDialog.selectedFiles.length > 0) {
                 const url = fileDialog.selectedFile
-                if (Utils.isValidDragNDropImage(url))
-                    cropImage(url)
-                else {
+                if (Utils.isValidDragNDropImage(url)) {
+                    openCropperTimer.pendingImage = url
+                    openCropperTimer.restart()
+                } else {
                     errorDialog.fileOpened = url
                     errorDialog.open()
                 }
             }
         }
-    } // FileDialog
+    }
 
     StatusDialog {
         id: errorDialog
@@ -77,7 +87,7 @@ Item {
             }
         }
         standardButtons: Dialog.Ok
-    } // StatusDialog
+    }
 
     StatusModal {
         id: imageCropperModal
@@ -127,5 +137,5 @@ Item {
             }
         ]
         onClosed: root.done()
-    } // StatusModal
-} // Item
+    }
+}


### PR DESCRIPTION
### What does the PR do

- Squish waits for a fixed TCP port opened by `startaut`. On Linux the ephemeral range starts at 32768, so `AUT_PORT=35100` was still inside it. This PR moves hook ports to 25000 (below ephemeral on Linux, macOS, and Windows), reserves ports via `bind()` instead of a connect probe, and waits on `127.0.0.1`.

- `popupType: Popup.Item` on `StatusDialog` (https://github.com/status-im/status-app/pull/22135) was not enough for the nested crop flow: `ImageCropWorkflow` opened a `StatusModal` on top of Create Community, which still became a separate X11 window at (0,0). The crop editor is now an overlay `Item`

<img width="2560" height="1393" alt="image" src="https://github.com/user-attachments/assets/3c260657-35c1-4966-9874-ed1bb497b426" />


<img width="752" height="846" alt="{2334148F-36D4-45D3-A56B-E2058C11BA6A}" src="https://github.com/user-attachments/assets/5d3ed277-0e68-4672-9a1b-1bfc356ed89d" />

