### PR TITLE
chore(ci): skip windows e2e when in release for now

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -126,6 +126,10 @@ pipeline {
               }
             }
             stage('Windows E2E Tests') {
+              /* Temporarily skip Windows E2E tests for release builds. */
+              when {
+                expression { !utils.isReleaseBuild() }
+              }
               steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                   script {


### PR DESCRIPTION
There is no CI machine currently for running Windows e2e on Release jobs. So Release jobs all fail at that step with:
```
ERROR: Failed to trigger build of status-app/systems/windows/x86_64/tests-e2e; Setting overall build result to FAILURE
```