### PR TITLE
fix(chat): fix sending payment requests alone

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -1,4 +1,4 @@
-import nimqml, sets
+import nimqml, sets, std/strutils
 import app/global/html_utils
 import ./io_interface
 import ./preserved_properties
@@ -45,11 +45,14 @@ QtObject:
       self: View,
       msg: string,
       replyTo: string,
-      contentType: int) {.slot.} =
+      contentType: int): bool {.slot.} =
     # FIXME: Update this when `setText` is async.
+    if msg.strip().len == 0 and self.paymentRequestModel.isEmpty():
+      return false
     self.setSendingInProgress(true)
     self.delegate.setText(msg, false)
     self.delegate.sendChatMessage(msg, replyTo, contentType, self.linkPreviewModel.getUnfuledLinkPreviews(), self.payment_request_model.getPaymentRequests())
+    return true
 
   proc sendImages*(self: View, imagePathsJson: string, msg: string, replyTo: string) {.slot.} =
     # FIXME: Update this when `setText` is async.

--- a/src/app/modules/shared_models/payment_request_model.nim
+++ b/src/app/modules/shared_models/payment_request_model.nim
@@ -38,6 +38,9 @@ QtObject:
   method rowCount(self: Model, index: QModelIndex = nil): int =
     return self.items.len
 
+  proc isEmpty*(self: Model): bool =
+    return self.items.len == 0
+
   method roleNames(self: Model): Table[int, string] =
     {
       ModelRole.TokenKey.int: "tokenKey",

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -297,14 +297,10 @@ QtObject {
             chatContentModule.inputAreaModule.sendImages(JSON.stringify(convertedImagePaths), textMsg.trim(), replyMessageId)
             result = true
         } else {
-            if (textMsg.trim() !== "") {
-                chatContentModule.inputAreaModule.sendMessage(
-                            textMsg,
-                            replyMessageId,
-                            Utils.isOnlyEmoji(textMsg) ? Constants.messageContentType.emojiType : Constants.messageContentType.messageType)
-
-                result = true
-            }
+            result = chatContentModule.inputAreaModule.sendMessage(
+                        textMsg,
+                        replyMessageId,
+                        Utils.isOnlyEmoji(textMsg) ? Constants.messageContentType.emojiType : Constants.messageContentType.messageType)
         }
 
         return result


### PR DESCRIPTION
### What does the PR do

Fixes #22124

We enabled the button when payment requests were filled, but still the sending failed because the root store function required text.

I moved the condition check to the Nim view, since it has access to the text and the payment request model.

### Affected areas

- input_area/view
- chat's RootStore

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review

Also ask Copilot to align feedback with repository architecture boundaries:

- Nim (`src/`): orchestration, signals, module wiring

### Screencapture of the functionality

[payment-request-only.webm](https://github.com/user-attachments/assets/f1209bb7-4e51-48c5-9541-e02d1c8ceb3f)

### Impact on end user

Fixes the weird issue of the payment request not being sent even when the button is available

### How to test

Send a payment request alone

### Risk 

Low
