### PR TITLE
fix(android): prevent notification vibration after inline replies

### DIFF
--- a/docs/adr/0002-android-push-notifications.md
+++ b/docs/adr/0002-android-push-notifications.md
@@ -110,9 +110,9 @@ No in-process conversation buffer is maintained. Instead, conversation state is 
 When the user sends a message, `status-go` emits a `local-notifications` signal with `isFromMe: true`. The Android layer uses this to:
 
 - **Skip** posting a notification if no incoming-message notification for this conversation is currently active (the user is the first sender; nothing to refresh).
-- **Refresh** an existing conversation notification by appending the sent message to the MessagingStyle thread, so the notification reflects the full conversation.
+- **Refresh** an existing conversation notification by appending the sent message to the MessagingStyle thread, so the notification reflects the full conversation. The repost uses `setOnlyAlertOnce(true)`, which preserves the notification without alerting or vibrating again.
 
-This prevents the user from seeing a notification for their own messages while still keeping an active notification up to date.
+This prevents the user from seeing a notification for their own messages while still keeping an active notification up to date. In particular, an inline reply appends to the active notification without triggering the notification channel's vibration again.
 
 ---
 
@@ -130,7 +130,7 @@ When the UI comes to the foreground, all active notifications are cancelled and 
 
 1. Extracts the reply text from `RemoteInput`.
 2. Calls `StatusGoService.callRpc("wakuext_sendChatMessage", ...)` directly (same process — no Binder round-trip needed).
-3. On success the notification is updated with the sent message via a new `local-notifications` signal from `status-go`.
+3. On success the notification is updated with the sent message via a new `local-notifications` signal from `status-go`; the update is configured to alert only once, so it does not vibrate again.
 4. On failure a "Reply failed" notification is shown.
 
 The send response is also forwarded to the UI process as an internal `notification.reply.sent`

--- a/mobile/android/qt6/src/app/status/mobile/ipc/notifications/NotificationBuilder.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/notifications/NotificationBuilder.java
@@ -106,7 +106,7 @@ public final class NotificationBuilder {
     public static void postMessageNotification(Context context, String title,
             String conversationId, int notificationId, String deepLink,
             Bitmap largeIcon, List<MessageEntry> messages,
-            boolean isOneToOne) {
+            boolean isOneToOne, boolean onlyAlertOnce) {
 
         Intent intent = buildTapIntent(context, deepLink);
         if (intent == null) return;
@@ -120,6 +120,7 @@ public final class NotificationBuilder {
                 .setContentTitle(title)
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(false)
+                .setOnlyAlertOnce(onlyAlertOnce)
                 .setContentIntent(pendingIntent);
         if (largeIcon != null) builder.setLargeIcon(largeIcon);
 

--- a/mobile/android/qt6/src/app/status/mobile/ipc/notifications/StatusNotificationManager.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/notifications/StatusNotificationManager.java
@@ -128,7 +128,6 @@ public final class StatusNotificationManager {
         final String communityIcon = eventWrap.optString("communityIcon", "");
         final String chatIcon = eventWrap.optString("chatIcon", "");
         final boolean isFromMe = eventWrap.optBoolean("isFromMe", false);
-
         String senderIcon = "";
         String senderName = "";
         final JSONObject author = eventWrap.optJSONObject("notificationAuthor");
@@ -236,7 +235,7 @@ public final class StatusNotificationManager {
                         ? activeVisual.largeIcon : largeIconFromEvent;
                 NotificationBuilder.postMessageNotification(
                         context, notificationTitle, conversationId, notifIdInt,
-                        deepLink, largeIcon, messages, isOneToOne);
+                        deepLink, largeIcon, messages, isOneToOne, isFromMe);
             } else {
                 String idBase = (notificationId != null ? notificationId
                         : (conversationId != null ? conversationId : title + message))


### PR DESCRIPTION
### What does the PR do

Fixes #22133

Keep outgoing messages in the active MessagingStyle notification thread, but mark their reposts as alert-once so replying from a push notification does not trigger vibration again. Incoming notifications keep their normal alert behavior.

### Affected areas

StatusNotificationManager.java

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Can't really show it, but I tested and it works

### Impact on end user

No more confusing vibrations

### How to test

0. Download the APK
1. Login
2. Background the app
3. Send a message to the mobile profile from another device
4. Receive the msg with the vibration
5. reply
6. No vibration :+1: 

### Risk 

Low
