### PR TITLE
perf: Reduce community portal loading time

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -381,7 +381,7 @@ FetchContent_Declare(
   QtModelsToolkit
 
   GIT_REPOSITORY https://github.com/status-im/QtModelsToolkit.git
-  GIT_TAG d8b0542011425496b917b8b1e26ad568116d49ce
+  GIT_TAG 84d2433e8e869d75a3e3a8105510be1bc325d248
 )
 
 FetchContent_MakeAvailable(QtModelsToolkit)

--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
@@ -391,6 +391,9 @@ Rectangle {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.preferredHeight: 24
                 visible: active
+
+                // The tag row is the heaviest part of the card
+                asynchronous: true
                 active: root.categories.count > 0 || !!root.bottomRowComponent
                 sourceComponent: {
                     if (!!root.bottomRowComponent)
@@ -435,83 +438,86 @@ Rectangle {
         }
     } // End of content card
 
-    // Loading card
-    Rectangle {
-        visible: !root.loaded
+    // Loading card — behind a Loader so an already-loaded card never builds the skeleton
+    Loader {
+        active: !root.loaded
         anchors.top: parent.top
         anchors.topMargin: (root.cardSize === StatusCommunityCard.Size.Big) ? 40 : 23
         width: parent.width
         height: d.cardHeigth
-        color: d.cardColor
-        radius: d.cardRadius
-        clip: true
-        Rectangle {
-            anchors.top: parent.top
-            anchors.topMargin: 8
-            anchors.right: parent.right
-            anchors.rightMargin: anchors.topMargin
-            width: 48
-            height: 24
-            color: d.loadingColor2
-            radius: 200
-        }
-        ColumnLayout {
-            anchors.fill: parent
-            anchors.topMargin: 32
-            anchors.margins: d.margins
+
+        sourceComponent: Rectangle {
+            color: d.cardColor
+            radius: d.cardRadius
             clip: true
-            spacing: 9
             Rectangle {
-                width: 84
-                height: 16
-                color: d.loadingColor1
-                radius: 5
+                anchors.top: parent.top
+                anchors.topMargin: 8
+                anchors.right: parent.right
+                anchors.rightMargin: anchors.topMargin
+                width: 48
+                height: 24
+                color: d.loadingColor2
+                radius: 200
             }
-            Rectangle {
-                width: 311
-                height: 16
-                color: d.loadingColor1
-                radius: 5
-            }
-            Rectangle {
-                width: 271
-                height: 16
-                color: d.loadingColor1
-                radius: 5
-            }
-            Row {
-                Layout.topMargin: 22 - 9
-                spacing: 16
-                Repeater {
-                    model: 2
-                    delegate: Row {
-                        spacing: 4
-                        Rectangle {
-                            width: 14
-                            height: 14
-                            color: d.loadingColor1
-                            radius: width / 2
-                        }
-                        Rectangle {
-                            width: 50
-                            height: 12
-                            color: d.loadingColor2
-                            radius: 5
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.topMargin: 32
+                anchors.margins: d.margins
+                clip: true
+                spacing: 9
+                Rectangle {
+                    width: 84
+                    height: 16
+                    color: d.loadingColor1
+                    radius: 5
+                }
+                Rectangle {
+                    width: 311
+                    height: 16
+                    color: d.loadingColor1
+                    radius: 5
+                }
+                Rectangle {
+                    width: 271
+                    height: 16
+                    color: d.loadingColor1
+                    radius: 5
+                }
+                Row {
+                    Layout.topMargin: 22 - 9
+                    spacing: 16
+                    Repeater {
+                        model: 2
+                        delegate: Row {
+                            spacing: 4
+                            Rectangle {
+                                width: 14
+                                height: 14
+                                color: d.loadingColor1
+                                radius: width / 2
+                            }
+                            Rectangle {
+                                width: 50
+                                height: 12
+                                color: d.loadingColor2
+                                radius: 5
+                            }
                         }
                     }
                 }
-            }
-            Row {
-                Layout.topMargin: 21 - 9
-                spacing: 8
-                Repeater {
-                    model: 3
-                    delegate:
-                    Rectangle {
-                        width: 76
-                        height: 24
-                        color: d.loadingColor2
-                        radius: 20
+                Row {
+                    Layout.topMargin: 21 - 9
+                    spacing: 8
+                    Repeater {
+                        model: 3
+                        delegate:
+                        Rectangle {
+                            width: 76
+                            height: 24
+                            color: d.loadingColor2
+                            radius: 20
+                        }
                     }
                 }
             }

--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundedComponent.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundedComponent.qml
@@ -63,7 +63,9 @@ Rectangle {
     implicitHeight: 40
     color: "transparent"
     radius: width / 2
-    layer.enabled: true
+    // The mask is a ShaderEffectSource + OpacityMask + mask Rectangle per instance.
+    // Invisible instances (e.g. an unused badge) must not pay for it.
+    layer.enabled: root.visible
     layer.effect: OpacityMask {
         maskSource: Rectangle {
             x: root.x; y: root.y

--- a/ui/StatusQ/src/StatusQ/Controls/StatusCommunityTag.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusCommunityTag.qml
@@ -54,10 +54,13 @@ Rectangle {
             text: root.name
         }
 
-        StatusIcon {
-            visible: root.removable
-            color: root.enabled ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
-            icon: "close"
+        Loader {
+            active: root.removable
+
+            sourceComponent: StatusIcon {
+                color: root.enabled ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
+                icon: "close"
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -154,23 +154,35 @@ StatusSectionLayout {
                 tags: root.communitiesStore.communityTags
             }
 
-            CommunitiesGridView {
-                id: communitiesGrid
-
+            Loader {
+                id: communitiesGridLoader
+                asynchronous: true
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                Loader {
+                    id: loadingIndicator
+                    anchors.centerIn: parent
+                    active: communitiesGridLoader.status !== Loader.Ready
+                    sourceComponent: StatusLoadingIndicator {
+                        width: 40
+                        height: 40
+                    }
+                }
+                sourceComponent: CommunitiesGridView {
+                    id: communitiesGrid
+                    visible: communitiesGridLoader.status === Loader.Ready
+                    padding: 0
+                    bottomPadding: d.layoutBottomMargin
+                    compactMode: d.compactMode
 
-                padding: 0
-                bottomPadding: d.layoutBottomMargin
-                compactMode: d.compactMode
+                    model: filteredCommunitiesModel
+                    searchLayout: d.searchMode
 
-                model: filteredCommunitiesModel
-                searchLayout: d.searchMode
+                    assetsModel: root.assetsModel
+                    collectiblesModel: root.collectiblesModel
 
-                assetsModel: root.assetsModel
-                collectiblesModel: root.collectiblesModel
-
-                onCardClicked: (communityId) => root.communitiesStore.navigateToCommunity(communityId)
+                    onCardClicked: (communityId) => root.communitiesStore.navigateToCommunity(communityId)
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Communities/views/CommunitiesGridView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitiesGridView.qml
@@ -40,8 +40,15 @@ StatusScrollView {
         // Values from the design
         readonly property int scrollViewTopMargin: 20
         readonly property int subtitlePixelSize: root.Theme.fontSize(17)
-        readonly property int promotionalCardPosition: Math.max(gridLayout.delegateCountPerRow - 1, 1)
-        property int delegateWidth: root.compactMode ? 300 : 335
+        readonly property int targetDelegateWidth: root.compactMode ? 300 : 335
+        property int delegateWidth: targetDelegateWidth
+
+        readonly property int delegateCountPerRow:
+            root.availableWidth > 0
+            ? Math.max(1, Math.trunc(root.availableWidth / (targetDelegateWidth + root.Theme.padding)))
+            : 0
+
+        readonly property int promotionalCardPosition: Math.max(delegateCountPerRow - 1, 1)
 
         Behavior on delegateWidth {
             PropertyAnimation { duration: ThemeUtils.AnimationDuration.Fast }
@@ -58,6 +65,7 @@ StatusScrollView {
         sourceModel: root.model
 
         filters: ValueFilter {
+            enabled: !root.searchLayout
             roleName: "featured"
             value: true
         }
@@ -171,7 +179,7 @@ StatusScrollView {
         }
 
         Flow {
-            readonly property int delegateCountPerRow: Math.trunc(parent.width / (d.delegateWidth + spacing))
+            readonly property int delegateCountPerRow: d.delegateCountPerRow
             Layout.preferredWidth: (delegateCountPerRow * d.delegateWidth) + (spacing * (delegateCountPerRow - 1))
             Layout.alignment: Qt.AlignHCenter
 
@@ -184,7 +192,7 @@ StatusScrollView {
 
             Repeater {
                 id: featuredRepeater
-                model: root.searchLayout ? root.model : featuredModel
+                model: featuredModel
                 delegate: communityCardDelegate
             }
             move: FastXYTransition {}
@@ -204,7 +212,7 @@ StatusScrollView {
         Flow {
             id: gridLayout
 
-            readonly property int delegateCountPerRow: Math.trunc(parent.width / (d.delegateWidth + spacing))
+            readonly property int delegateCountPerRow: d.delegateCountPerRow
             Layout.preferredWidth: (delegateCountPerRow * d.delegateWidth) + (spacing * (delegateCountPerRow - 1))
             Layout.alignment: Qt.AlignHCenter
 


### PR DESCRIPTION
### What does the PR do

Closes #[22188](https://github.com/status-im/status-app/issues/22188)

- Reducing the component creation time from 1.8-3sec to 600ms
- Async loading for the gridview

### Affected areas

SFPM
community portal

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/3686ebe7-b8b6-4f63-ae91-44144d1942fe


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Better UX when navigating to community portal

### How to test

Navigate to community portal

### Risk 

Worst case scenario - some components might expect SFPM to be transparent before component completion event