### PR TITLE
fix(StatusGifPopup): fix the enable overlay

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -124,7 +124,7 @@ QC.Popup {
             parent: root.QC.Overlay.overlay || parent
             modal: true
             dim: true
-            closePolicy: QC.Popup.CloseOnPressOutside
+            closePolicy: QC.Popup.CloseOnEscape | QC.Popup.CloseOnPressOutside
 
             x: 0
             y: d.windowHeight - height

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -422,9 +422,9 @@ StackLayout {
             onTokenPaymentRequested: root.tokenPaymentRequested(recipientAddress, tokenKey, rawAmount)
 
             // Unfurling related requests:
-            onSetNeverAskAboutUnfurlingAgain: root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+            onSetNeverAskAboutUnfurlingAgain: neverAskAgain => root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
 
-            onOpenGifPopupRequest: root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
+            onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) => root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
 
             // Contacts related requests:
             onChangeContactNicknameRequest: (pubKey, nickname, displayName, isEdit ) => {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -517,9 +517,9 @@ Item {
                         }
 
                         // Unfurling related requests:
-                        onSetNeverAskAboutUnfurlingAgain: root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+                        onSetNeverAskAboutUnfurlingAgain: neverAskAgain => root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
 
-                        onOpenGifPopupRequest: root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
+                        onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) => root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
 
                         // Contacts related requests:
                         onChangeContactNicknameRequest: (pubKey, nickname, displayName, isEdit) => {

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -169,9 +169,9 @@ ColumnLayout {
             }
 
             // Unfurling related requests:
-            onSetNeverAskAboutUnfurlingAgain: root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+            onSetNeverAskAboutUnfurlingAgain: neverAskAgain => root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
 
-            onOpenGifPopupRequest: root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
+            onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) => root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
 
             // Contacts related requests:
             onChangeContactNicknameRequest: root.changeContactNicknameRequest(pubKey, nickname, displayName, isEdit)

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -463,9 +463,9 @@ Item {
             }
 
             // Unfurling related requests:
-            onSetNeverAskAboutUnfurlingAgain: root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+            onSetNeverAskAboutUnfurlingAgain: neverAskAgain => root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
 
-            onOpenGifPopupRequest: root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
+            onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) => root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
 
             // Contacts related requests:
             onChangeContactNicknameRequest: root.changeContactNicknameRequest(pubKey, nickname, displayName, isEdit)

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -515,9 +515,9 @@ Item {
             onTokenPaymentRequested: root.tokenPaymentRequested(recipientAddress, tokenKey, rawAmount)
 
             // Unfurling related requests:
-            onSetNeverAskAboutUnfurlingAgain: root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+            onSetNeverAskAboutUnfurlingAgain: neverAskAgain => root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
 
-            onOpenGifPopupRequest: root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
+            onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) => root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
 
             // Contacts related requests:
             onChangeContactNicknameRequest: root.changeContactNicknameRequest(pubKey, nickname, displayName, isEdit)

--- a/ui/app/mainui/Handlers/StatusGifPopupHandler.qml
+++ b/ui/app/mainui/Handlers/StatusGifPopupHandler.qml
@@ -16,6 +16,7 @@ QtObject {
     signal enableThirdpartyServicesRequested
 
     property QtObject _d: QtObject {
+        id: _d
         property var cbOnGifSelected: function () {} // It stores callback for gifSelected
         property var cbOnClose: function () {} // It stores callback for popup closed
         property var popupParent: null // Gifs button object type

--- a/ui/imports/shared/status/StatusGifPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup.qml
@@ -51,14 +51,14 @@ StatusDropdown {
     property var gifColumnB: null
     property var gifColumnC: null
 
-    property var isFavorite: function () {}
-    property var addToRecentsGif: function () {}
-    property var searchGifsRequest: function () {}
+    property var isFavorite: function (id) {}
+    property var addToRecentsGif: function (id) {}
+    property var searchGifsRequest: function (query) {}
     property var getTrendingsGifs: function () {}
     property var getFavoritesGifs: function () {}
     property var getRecentsGifs: function () {}
-    property var toggleFavoriteGif: function () {}
-    property var setGifUnfurlingEnabled: function () {}
+    property var toggleFavoriteGif: function (id, reload) {}
+    property var setGifUnfurlingEnabled: function (value) {}
 
     signal gifSelected(string url)
     signal enableThirdpartyServicesRequested
@@ -67,20 +67,6 @@ StatusDropdown {
     implicitWidth: 360
 
     fillHeightOnBottomSheet: true
-
-    background: Rectangle {
-        radius: Theme.radius
-        color: Theme.palette.background
-        border.color: Theme.palette.border
-        layer.enabled: true
-        layer.effect: DropShadow {
-            verticalOffset: 3
-            radius: 8
-            samples: 15
-            cached: true
-            color: "#22000000"
-        }
-    }
 
     onAboutToShow: {
         searchBox.clear()
@@ -103,24 +89,23 @@ StatusDropdown {
         id: d
 
         readonly property int minimumContentHeight: 440
-        readonly property int headerMargin: root.Theme.halfPadding
+        readonly property int headerMargin: root.Theme.defaultHalfPadding
     }
 
     contentItem: Item {
-        implicitHeight: Math.max(d.minimumContentHeight, contentColumn.implicitHeight)
+        implicitHeight: Math.max(d.minimumContentHeight, childrenRect.height)
 
         ColumnLayout {
             id: contentColumn
 
             anchors.fill: parent
-            spacing: 0
+            visible: root.gifUnfurlingEnabled
 
             SearchBox {
                 id: searchBox
 
                 visible: root.thirdpartyServicesEnabled
                 placeholderText: qsTr("Search KLIPY")
-                enabled: root.gifUnfurlingEnabled
 
                 Layout.fillWidth: true
                 Layout.topMargin: d.headerMargin
@@ -164,7 +149,7 @@ StatusDropdown {
                 id: gifsLoader
 
                 active: root.thirdpartyServicesEnabled && root.opened && root.gifUnfurlingEnabled
-                visible: root.thirdpartyServicesEnabled && root.gifUnfurlingEnabled
+                visible: active
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
@@ -188,7 +173,6 @@ StatusDropdown {
                     onClicked: {
                         toggleCategory(GifPopupDefinitions.Category.Trending)
                     }
-                    enabled: root.gifUnfurlingEnabled
                 }
 
                 StatusTabBarIconButton {
@@ -197,7 +181,6 @@ StatusDropdown {
                     onClicked: {
                         toggleCategory(GifPopupDefinitions.Category.Recent)
                     }
-                    enabled: root.gifUnfurlingEnabled
                 }
 
                 StatusTabBarIconButton {
@@ -206,7 +189,6 @@ StatusDropdown {
                     onClicked: {
                         toggleCategory(GifPopupDefinitions.Category.Favorite)
                     }
-                    enabled: root.gifUnfurlingEnabled
                 }
             }
 
@@ -240,14 +222,6 @@ StatusDropdown {
             }
         }
 
-        Rectangle {
-            color: 'black'
-            opacity: 0.4
-            radius: Theme.radius
-            anchors.fill: parent
-            visible: confirmationPopupLoader.active
-        }
-
         Loader {
             id: confirmationPopupLoader
 
@@ -270,57 +244,52 @@ StatusDropdown {
 
         StatusScrollView {
             id: scrollView
+            anchors.fill: parent
             contentWidth: availableWidth
 
             Row {
                 id: gifs
                 width: scrollView.availableWidth
-                spacing: Theme.halfPadding
+                spacing: Theme.defaultHalfPadding
 
                 property string lastHoveredId
 
                 StatusGifColumn {
                     gifList.model: root.gifColumnA
-                    gifWidth: (root.width / 3) - Theme.padding
+                    gifWidth: (parent.width - 2 * parent.spacing) / 3
                     lastHoveredId: gifs.lastHoveredId
 
                     toggleFavorite: root.toggleFavorite
                     isFavorite: root.isFavorite
                     addToRecentsGif: root.addToRecentsGif
 
-                    onGifHovered: {
-                        gifs.lastHoveredId = id
-                    }
+                    onGifHovered: id => gifs.lastHoveredId = id
                     onGifSelected: url => root.gifSelected(url)
                 }
 
                 StatusGifColumn {
                     gifList.model: root.gifColumnB
-                    gifWidth: (root.width / 3) - Theme.padding
+                    gifWidth: (parent.width - 2 * parent.spacing) / 3
                     lastHoveredId: gifs.lastHoveredId
 
                     toggleFavorite: root.toggleFavorite
                     isFavorite: root.isFavorite
                     addToRecentsGif: root.addToRecentsGif
 
-                    onGifHovered: {
-                        gifs.lastHoveredId = id
-                    }
+                    onGifHovered: id => gifs.lastHoveredId = id
                     onGifSelected: url => root.gifSelected(url)
                 }
 
                 StatusGifColumn {
                     gifList.model: root.gifColumnC
-                    gifWidth: (root.width / 3) - Theme.padding
+                    gifWidth: (parent.width - 2 * parent.spacing) / 3
                     lastHoveredId: gifs.lastHoveredId
 
                     toggleFavorite: root.toggleFavorite
                     isFavorite: root.isFavorite
                     addToRecentsGif: root.addToRecentsGif
 
-                    onGifHovered: {
-                        gifs.lastHoveredId = id
-                    }
+                    onGifHovered: id => gifs.lastHoveredId = id
                     onGifSelected: url => root.gifSelected(url)
                 }
             }
@@ -336,7 +305,7 @@ StatusDropdown {
             loading: root.loading
             onDoRetry: searchBox.text === ""
                         ? root.getTrendingsGifs()
-                        : searchGif(searchBox.text)
+                        : root.searchGif(searchBox.text)
         }
     }
 }

--- a/ui/imports/shared/status/StatusGifPopup/StatusGifColumn.qml
+++ b/ui/imports/shared/status/StatusGifPopup/StatusGifColumn.qml
@@ -12,15 +12,15 @@ import shared.stores
 
 Column {
     id: root
-    spacing: 8
+    spacing: Theme.defaultHalfPadding
 
     property alias gifList: repeater
     property int gifWidth: 0
     property string lastHoveredId
 
-    property var toggleFavorite: function () {}
-    property var isFavorite: function () {}
-    property var addToRecentsGif: function () {}
+    property var toggleFavorite: function (item) {}
+    property var isFavorite: function (id) {}
+    property var addToRecentsGif: function (id) {}
 
     signal gifHovered(string id)
     signal gifSelected(string url)
@@ -58,19 +58,16 @@ Column {
                 id: starButton
                 property bool favorite: root.isFavorite(model.id)
 
-                type: StatusFlatRoundButton.Type.Secondary
-                textColor: hovered || favorite ? Theme.palette.miscColor7 : Theme.palette.secondaryText
+                type: StatusBaseButton.Type.Normal
+                size: StatusBaseButton.Size.Tiny
+                textColor: hovered || favorite ? Theme.palette.miscColor7 : StatusColors.grey4
                 icon.name: favorite ? "star-icon" : "star-icon-outline"
-                icon.width:  (14/104) * thumb.width
-                icon.height: (13/104) * thumb.width
-                topPadding: (6/104) * thumb.width
-                rightPadding: (6/104) * thumb.width
-                bottomPadding: (6/104) * thumb.width
-                leftPadding: (6/104) * thumb.width
-                normalColor: "transparent"
-                visible: !loader.visible && model.id === root.lastHoveredId
+                normalColor: StatusColors.alphaColor(StatusColors.black, 0.4)
+                hoverColor: Theme.palette.hoverColor(normalColor)
+                visible: !loader.visible
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
+                anchors.margins: 2
                 z: 1
                 onClicked: {
                     root.toggleFavorite(model)
@@ -81,13 +78,8 @@ Column {
                         root.gifHovered(model.id)
                     }
                 }
-                StatusToolTip {
-                    id: statusToolTip
-                    text: starButton.favorite ?
-                        qsTr("Remove from favorites") :
-                        qsTr("Add to favorites")
-                    visible: starButton.hovered
-                }
+                tooltip.text: favorite ? qsTr("Remove from favorites")
+                                       : qsTr("Add to favorites")
             }
 
             AnimatedImage {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1172,7 +1172,7 @@ Loader {
                         gifUnfurlingEnabled: root.gifUnfurlingEnabled
                         onSetGifUnfurlingEnabled: localAccountSensitiveSettings.gifUnfurlingEnabled = true
                         canAskToUnfurlGifs: !root.neverAskAboutUnfurlingAgain
-                        onSetNeverAskAboutUnfurlingAgain: root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+                        onSetNeverAskAboutUnfurlingAgain: neverAskAgain => root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
                         onPaymentRequestClicked: (index) => {
                             const request = StatusQUtils.ModelUtils.get(paymentRequestModel, index)
                             root.tokenPaymentRequested(request.receiver, request.tokenKey, request.amount)


### PR DESCRIPTION
### What does the PR do

- hide everything else when `!gifUnfurlingEnabled`
- fix the columns widths and spacing
- make the Favorite button always visible (not just on hover) to make it possible to use it on mobile too
- fix some runtime warnings

Fixes #22126
Fixes #22127

### Affected areas

GIF popup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

GIFs disabled:
<img width="2516" height="1990" alt="Snímek obrazovky z 2026-09-01 10-02-07" src="https://github.com/user-attachments/assets/d76b3624-3970-4848-9210-66947d4d54c6" />

<img width="894" height="1990" alt="Snímek obrazovky z 2026-09-01 10-02-18" src="https://github.com/user-attachments/assets/6394562f-4242-42c5-b993-d18382d96df2" />

GIFs enabled:
<img width="2244" height="1990" alt="image" src="https://github.com/user-attachments/assets/b4778dcc-5715-4023-9b8c-699a0c467d28" />

GIFs enabled, portrait/mobile view:
<img width="934" height="1990" alt="Snímek obrazovky z 2026-09-01 10-03-32" src="https://github.com/user-attachments/assets/139cf10c-a4c6-4a59-92ea-426bd6595855" />


### Impact on end user

Better UX

### How to test

- open the GIF popup while having the unfurling or 2rd party services disabled

### Risk 

low
