### PR TITLE
fix(@e2e): wait for wallet balance before Send; fix SignSendAdaptor NaN warnings

### DIFF
--- a/storybook/qmlTests/tests/tst_SignSendAdaptor.qml
+++ b/storybook/qmlTests/tests/tst_SignSendAdaptor.qml
@@ -1,0 +1,57 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Core.Theme
+
+import AppLayouts.Wallet.adaptors
+
+import Models
+import utils
+
+Item {
+    id: root
+    width: 400
+    height: 400
+
+    Component {
+        id: adaptorComp
+
+        SignSendAdaptor {
+            palette: Theme.palette
+            accountKey: ""
+            chainId: 1
+            groupKey: Constants.ethGroupKey
+            selectedAmountInBaseUnit: ""
+            selectedRecipientAddress: ""
+            accountsModel: ListModel {}
+            networksModel: ListModel {}
+            tokenGroupsModel: TokenGroupsModel {}
+            recipientModel: ListModel {}
+        }
+    }
+
+    TestCase {
+        name: "SignSendAdaptor"
+        when: windowShown
+
+        function test_emptyRawAmount_returnsZero() {
+            const adaptor = createTemporaryObject(adaptorComp, root)
+            compare(adaptor.selectedAmount, "0")
+            compare(adaptor.selectedAsset.symbol, Constants.ethToken)
+        }
+
+        function test_missingDecimalsAndInvalidRaw_returnsZero() {
+            const adaptor = createTemporaryObject(adaptorComp, root, {
+                groupKey: "no-decimals",
+                selectedAmountInBaseUnit: "not-a-number",
+                tokenGroupsModel: dummyTokens
+            })
+            compare(adaptor.selectedAmount, "0")
+        }
+    }
+
+    ListModel {
+        id: dummyTokens
+        Component.onCompleted: append([{ key: "no-decimals", symbol: "XYZ", logoUri: "", tokens: [] }])
+    }
+}

--- a/test/e2e/gui/components/wallet/send_popup.py
+++ b/test/e2e/gui/components/wallet/send_popup.py
@@ -112,6 +112,49 @@ class SendPopup(QObject):
         self.send_modal_review_send_button.click()
         return SignSendModalPopup().wait_until_appears()
 
+    def _parse_amount(self, raw: str) -> float:
+        if not raw:
+            return 0.0
+
+        for prefix in ('Max.', 'Max:'):
+            if prefix in raw:
+                raw = raw.split(prefix, 1)[-1]
+
+        number = raw.strip().split()[0].replace(',', '').replace('\xa0', '')
+        try:
+            return float(number)
+        except (ValueError, IndexError):
+            return 0.0
+
+    def _max_send_balance(self) -> float:
+        try:
+            button = driver.waitForObjectExists(names.sendModalMaxButton, 200)
+        except (LookupError, RuntimeError):
+            return 0.0
+
+        formatted_value = getattr(button, 'formattedValue', None)
+        if formatted_value not in (None, ''):
+            return self._parse_amount(str(formatted_value))
+
+        return self._parse_amount(str(getattr(button, 'text', '')))
+
+    @allure.step('Wait until send modal token balance is ready')
+    def wait_until_send_balance_ready(
+            self,
+            timeout_msec: int = configs.timeouts.ROUTES_TIMEOUT_MSEC,
+    ):
+        assert driver.waitFor(lambda: self._max_send_balance() > 0, timeout_msec), (
+            f'Send modal still shows zero max balance, got: {self._max_send_balance()!r}'
+        )
+        return self
+
+    def _review_send_enabled(self) -> bool:
+        try:
+            button = driver.waitForObjectExists(names.sendModalReviewSendButton, 200)
+        except (LookupError, RuntimeError):
+            return False
+        return button.enabled
+
     @allure.step('Wait until route estimation completes and Review Send is enabled')
     def wait_for_review_send_ready(
             self,
@@ -132,7 +175,7 @@ class SendPopup(QObject):
                     return False
             except Exception:
                 pass
-            return self.send_modal_review_send_button.object.enabled
+            return self._review_send_enabled()
 
         assert driver.waitFor(review_send_ready, timeout_msec), (
             'Review Send is not enabled (insufficient funds, fees loading, or router error)'
@@ -145,6 +188,7 @@ class SendPopup(QObject):
 
         if asset:
             token_selector.select_asset_from_list(asset_name=asset)
+            self.wait_until_send_balance_ready()
             self.send_modal_amount_field.text = amount
             self.ens_address_text_input.click()
             pyperclip.copy(address)

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -1020,7 +1020,9 @@ sendModalRecipientField = {"container": statusDesktop_mainWindow_overlay, "type"
 sendModalSendTransactionFees = {"container": statusDesktop_mainWindow_overlay, "objectName": "signTransactionFees",
                                 "type": "SimpleTransactionsFees", "visible": True}
 sendModalReviewSendButton = {"container": statusDesktop_mainWindow_overlay,
-                             "objectName": "transactionModalFooterButton", "type": "StatusButton", "visible": True}
+                             "objectName": "transactionModalFooterButton", "type": "StatusButton"}
+sendModalMaxButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "maxSendButton",
+                      "type": "StatusButton"}
 
 # Network selector
 sendModalNetworkSelectorItem = {"container": statusDesktop_mainWindow_overlay,

--- a/test/e2e/helpers/wallet_helper.py
+++ b/test/e2e/helpers/wallet_helper.py
@@ -7,7 +7,11 @@ from gui.objects_map import wallet_names
 from constants import ReturningUser
 from constants.wallet import WalletNetworkSettings
 from gui.components.authenticate_popup import AuthenticatePopup
-from helpers.onboarding_helper import open_create_profile_view, import_seed_and_log_in
+from helpers.onboarding_helper import (
+    import_seed_and_log_in,
+    open_create_profile_view,
+    skip_post_login_popups_if_visible,
+)
 from helpers.settings_helper import enable_testnet_mode
 
 
@@ -33,7 +37,8 @@ def is_assets_tab_content_loaded(asset_item) -> bool:
     except (RuntimeError, AttributeError):
         return False
 
-    return bool(driver.findAllObjects(asset_item.real_name))
+    items = driver.findAllObjects(asset_item.real_name)
+    return bool(items) and all(not getattr(item, 'balanceLoading', False) for item in items)
 
 
 def is_activity_tab_content_loaded() -> bool:
@@ -49,7 +54,7 @@ def wait_for_account_assets_loaded(
         wallet_account_view,
         timeout_msec: int = configs.timeouts.WALLET_SYNC_TIMEOUT_MSEC,
 ):
-        wallet_account_view.open_assets_tab(wait_until_loaded=True, loading_timeout_msec=timeout_msec)
+    wallet_account_view.open_assets_tab(wait_until_loaded=True, loading_timeout_msec=timeout_msec)
 
 
 def authenticate_with_password(user_account):
@@ -66,9 +71,8 @@ def assert_authenticate_popup_not_appears(timeout_msec: int = 2000):
 @step('Open wallet account after balances are loaded')
 def open_wallet_account(main_window, account_name=None):
     account_name = account_name or WalletNetworkSettings.STATUS_ACCOUNT_DEFAULT_NAME.value
-    timeout_msec = configs.timeouts.WALLET_TRANSACTION_SYNC_TIMEOUT_MSEC
     wallet = main_window.left_panel.open_wallet()
-    wait_for_wallet_balances_loaded(wallet.left_panel, timeout_msec=timeout_msec)
+    wait_for_wallet_balances_loaded(wallet.left_panel)
     return wallet.left_panel.select_account(account_name)
 
 
@@ -80,10 +84,13 @@ def wallet_send_returning_user():
 
 def wallet_send_import_user(main_window, user_account):
     with step('Import seed and log in'):
-        with step('Open Create your profile view'):
-            create_your_profile_view = open_create_profile_view()
-        with step('Import seed and log in'):
-            import_seed_and_log_in(create_your_profile_view, user_account.seed_phrase, user_account)
+        import_seed_and_log_in(
+            open_create_profile_view(),
+            user_account.seed_phrase,
+            user_account,
+        )
+        skip_post_login_popups_if_visible()
 
-    with step('Set testnet mode'):
+    with step('Enable testnet mode'):
         enable_testnet_mode(main_window)
+        skip_post_login_popups_if_visible()

--- a/test/e2e/tests/transactions_tests/test_buy_ens_name_in_settings.py
+++ b/test/e2e/tests/transactions_tests/test_buy_ens_name_in_settings.py
@@ -13,7 +13,6 @@ from helpers.wallet_helper import (
 )
 from scripts.utils.generators import random_ens_string
 from constants.wallet import WalletHistoryTitles, WalletNetworkNaming
-from gui.components.wallet.send_popup import SendPopup
 from gui.screens.settings_ens_usernames import ENSRegisteredView
 
 
@@ -38,8 +37,8 @@ def test_ens_name_purchase(main_window, user_account, ens_name):
         register_ens = ens_settings.click_next_button().register_ens_name()
 
     with step('Confirm sending amount for purchasing ens username in send popup'):
-        register_ens.send_button.click()
-        send_popup = SendPopup().wait_until_appears()
+        send_popup = register_ens
+        send_popup.wait_for_review_send_ready()
 
     with step('Sign and send transaction to blockchain'):
         sent_at = time.time()

--- a/ui/app/AppLayouts/Wallet/adaptors/SignSendAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/SignSendAdaptor.qml
@@ -44,9 +44,9 @@ QObject {
     /**
       Expected model structure:
 
-        key                   [int]    - group key
-        symbol                [int]    - symbol of token
-        decimals              [string] - decimals of token
+        key                   [string] - group key
+        symbol                [string] - symbol of token
+        decimals              [int]    - decimals of token
     **/
     required property var tokenGroupsModel
 
@@ -68,14 +68,14 @@ QObject {
     readonly property var selectedNetwork: selectedNetworkEntry.item
     /** output property of the asset (ERC20) selected **/
     readonly property var selectedAsset: selectedAssetEntry.item
-    readonly property var selectedAssetEntry: selectedAssetContractEntry.item
     /** output property of the localised amount to send **/
     readonly property string selectedAmount: {
-        const decimals = !!root.selectedAsset ? root.selectedAsset.decimals: 0
-        const divisor = AmountsArithmetic.fromExponent(decimals)
-        let amount =  AmountsArithmetic.div(
-                AmountsArithmetic.fromString(root.selectedAmountInBaseUnit),
-                divisor).toFixed(decimals)
+        const amountBig = AmountsArithmetic.fromString(root.selectedAmountInBaseUnit || "0")
+        if (typeof amountBig === "number")
+            return "0"
+
+        const decimals = (root.selectedAsset?.decimals | 0) || 0
+        let amount = AmountsArithmetic.div(amountBig, AmountsArithmetic.fromExponent(decimals)).toFixed(decimals)
         // removeDecimalTrailingZeros
         amount = Utils.stripTrailingZeros(amount)
         // localize

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -780,6 +780,7 @@ StatusDialog {
 
                     bottomRightComponent: MaxSendButton {
                         id: maxButton
+                        objectName: "maxSendButton"
 
                         formattedValue: {
                             let maxSafeValue = amountToSend.fiatMode ? d.maxSafeCryptoValue * amountToSend.cryptoPrice : d.maxSafeCryptoValue


### PR DESCRIPTION
### What does the PR do

Fix https://github.com/status-im/status-app/issues/22223

- guard empty/invalid amount, fix `selectedAssetEntry` shadowing, QML tests
- wait for assets to load (`balanceLoading`) in e2e and wait for non-zero Max before send