### PR TITLE
fix(CreateCategoryPopup): mobile/narrow view fixes 

### DIFF
--- a/storybook/pages/CreateCategoryPopupPage.qml
+++ b/storybook/pages/CreateCategoryPopupPage.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Models
+import Storybook
+
+import AppLayouts.Communities.popups
+import AppLayouts.Chat.stores
+
+Item {
+    id: root
+
+    Component.onCompleted: openPopup()
+
+    function openPopup() {
+        popupComponent.createObject(root).open()
+    }
+
+    Button {
+        anchors.centerIn: parent
+        text: "Reopen"
+        onClicked: openPopup()
+    }
+
+    ChannelsModel {
+        id: channelsModel
+    }
+
+    Component {
+        id: popupComponent
+        CreateCategoryPopup {
+            visible: true
+            modal: false
+            closePolicy: Popup.NoAutoClose
+            store: RootStore {
+                readonly property var chatCommunitySectionModule: QtObject {
+                    readonly property var editCategoryChannelsModel: channelsModel
+                    readonly property var model: channelsModel
+                }
+                function prepareEditCategoryModel() {}
+                function createCommunityCategory(name, channels) {
+                    console.info("RootStore.createCommunityCategory(name, channels):", name, channels)
+                }
+                function editCommunityCategory(id, name, channels) {
+                    console.info("RootStore.editCommunityCategory(id, name, channels):", id, name, channels)
+                }
+                function deleteCommunityCategory(id) {
+                    console.info("RootStore.deleteCommunityCategory(id):", id)
+                }
+            }
+            communityId: "foo"
+            categoryId: isEdit ? "_support" : ""
+            categoryName: isEdit ? "Sample category name" : ""
+            isEdit: ctrlIsEdit.checked
+        }
+    }
+
+    CheckBox {
+        id: ctrlIsEdit
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
+        anchors.margins: 16
+        text: "is edit?"
+    }
+}
+
+// category: Popups
+// status: good

--- a/storybook/src/Models/ChannelsModel.qml
+++ b/storybook/src/Models/ChannelsModel.qml
@@ -4,26 +4,29 @@ ListModel {
     ListElement {
         itemId: "_welcome"
         isCategory: false
+        type: 0
         categoryId: ""
         name: "welcome"
         emoji: ""
-        color: ""
+        color: "blue"
         icon: ""
         colorId: 1
     }
     ListElement {
         itemId: "_announcements"
         isCategory: false
+        type: 0
         categoryId: ""
         name: "announcements"
         emoji: ""
-        color: ""
+        color: "pink"
         icon: ""
         colorId: 1
     }
     ListElement {
         itemId: ""
         isCategory: true
+        type: -1
         categoryId: "_discussion"
         name: "discussion"
         emoji: ""
@@ -34,6 +37,7 @@ ListModel {
     ListElement {
         itemId: "_general"
         isCategory: false
+        type: 0
         categoryId: "_discussion"
         name: "general"
         emoji: "👋"
@@ -44,6 +48,7 @@ ListModel {
     ListElement {
         itemId: "_help"
         isCategory: false
+        type: 0
         categoryId: "_discussion"
         name: "help"
         emoji: "⚽"
@@ -54,6 +59,7 @@ ListModel {
     ListElement {
         itemId: ""
         isCategory: true
+        type: -1
         categoryId: "_support"
         name: "support"
         emoji: ""
@@ -64,6 +70,7 @@ ListModel {
     ListElement {
         itemId: "_faq"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "faq"
         emoji: ""
@@ -74,6 +81,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam"
         emoji: ""
@@ -84,6 +92,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam2"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam2"
         emoji: ""
@@ -94,6 +103,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam3"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam3"
         emoji: ""
@@ -104,6 +114,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam4"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam4"
         emoji: ""
@@ -114,6 +125,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam5"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam5"
         emoji: ""
@@ -124,6 +136,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam6"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam6"
         emoji: ""
@@ -134,6 +147,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam7"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam7"
         emoji: ""
@@ -144,6 +158,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam8"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam8"
         emoji: ""
@@ -154,6 +169,7 @@ ListModel {
     ListElement {
         itemId: "_report-scam9"
         isCategory: false
+        type: 0
         categoryId: "_support"
         name: "report-scam9"
         emoji: ""
@@ -164,6 +180,7 @@ ListModel {
     ListElement {
         itemId: ""
         isCategory: true
+        type: -1
         categoryId: "_faq"
         name: "faq"
         emoji: ""

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -72,6 +72,9 @@ Dialog {
     // Whether to show the divider between the content and footer.
     property bool showFooterDivider: true
 
+    // allows outside access of properties defined in contentComponent
+    readonly property alias hostedItem: contentHost.hostedItem
+
     function openInternalPopup() {
         internalPopupLayer.open()
     }
@@ -489,8 +492,10 @@ Dialog {
             MouseArea {
                 anchors.fill: parent
                 anchors.bottomMargin: internalPopupLayer.popupObject ? internalPopupLayer.popupObject.height : 0
-                onClicked: if (internalPopupLayer.closeOnOverlayClick)
-                    root.closeInternalPopup()
+                onClicked: {
+                    if (internalPopupLayer.closeOnOverlayClick)
+                        root.closeInternalPopup()
+                }
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
@@ -17,6 +17,9 @@ Control {
     // Natural height requested by the loaded content before the dialog applies its max-height cap.
     readonly property real naturalHeight: d.loadedContentNaturalHeight
 
+    // allows outside access of properties defined in contentComponent/contentLoader
+    readonly property alias hostedItem: contentLoader.item
+
     objectName: "statusAdaptiveDialogContentHost"
     padding: 0
 

--- a/ui/app/AppLayouts/Communities/popups/CreateCategoryPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCategoryPopup.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import StatusQ.Core
 import StatusQ.Core.Theme
@@ -7,7 +8,6 @@ import StatusQ.Core.Utils as StatusQUtils
 import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Controls.Validators
-import StatusQ.Popups
 import StatusQ.Popups.Dialog
 
 import utils
@@ -17,52 +17,50 @@ import SortFilterProxyModel
 
 import AppLayouts.Chat.stores
 
-StatusModal {
+StatusAdaptiveDialog {
     id: root
 
     property RootStore store
     property string communityId
     property string categoryId
     property string categoryName: ""
-    property var channels: []
 
     property bool isEdit: false
 
     readonly property int maxCategoryNameLength: 24
 
+    title: isEdit ? qsTr("Edit category") : qsTr("New category")
+    destroyOnClose: true
+
     onOpened: {
-        if(isEdit){
-            root.contentItem.categoryName.input.text = categoryName
-            root.channels = []
+        if(isEdit) {
             root.store.prepareEditCategoryModel(categoryId);
         }
-        root.contentItem.categoryName.input.edit.forceActiveFocus()
-    }
-    onClosed: destroy()
-
-    function isFormValid() {
-        return contentItem.categoryName.valid
+        root.hostedItem?.categoryName.input.edit.forceActiveFocus()
     }
 
-    headerSettings.title: isEdit ? qsTr("Edit category") : qsTr("New category")
+    QtObject {
+        id: d
+        readonly property bool isFormValid: root.hostedItem?.categoryName.valid
+        property var channels: []
+        property bool channelsDirty
+    }
 
-    contentItem: Column {
-        property alias categoryName: nameInput
-
-        width: root.width
-        topPadding: 16
+    contentComponent: ColumnLayout {
+        readonly property alias categoryName: nameInput
+        spacing: Theme.halfPadding
 
         StatusInput {
             id: nameInput
 
-            anchors.left: parent.left
-            anchors.leftMargin: 16
+            Layout.fillWidth: true
 
             input.edit.objectName: "createOrEditCommunityCategoryNameInput"
             input.clearable: true
             label: qsTr("Category title")
-            charLimit: maxCategoryNameLength
+            charLimit: root.maxCategoryNameLength
             placeholderText: qsTr("Name the category")
+            text: root.isEdit ? root.categoryName : ""
             validators: [
                 StatusMinLengthValidator {
                     minLength: 1
@@ -75,153 +73,133 @@ StatusModal {
             ]
         }
 
-        StatusModalDivider {
-            topPadding: 8
-            bottomPadding: 8
+        StatusDialogDivider {
+            Layout.fillWidth: true
+            Layout.topMargin: parent.spacing
         }
 
-        Item {
-            width: root.width
-            height: Math.min(communityChannelList.contentHeight, 300)
+        StatusListView {
+            id: communityChannelList
+            objectName: "createOrEditCommunityCategoryChannelList"
 
-            Item {
-                anchors.fill: parent
-                anchors.margins: -8
-                clip: true
+            Layout.fillWidth: true
+            Layout.preferredHeight: contentHeight
 
-                StatusListView {
-                    id: communityChannelList
-                    objectName: "createOrEditCommunityCategoryChannelList"
-
-                    anchors.fill: parent
-                    anchors.margins: -parent.anchors.margins
-                    displayMarginBeginning: anchors.margins
-                    displayMarginEnd: anchors.margins
-                    clip: false
-
-                    model: SortFilterProxyModel {
-                        sourceModel: root.isEdit ? root.store.chatCommunitySectionModule.editCategoryChannelsModel
-                                                 : root.store.chatCommunitySectionModule.model
-                        // filter out channels with categories
-                        filters: ValueFilter {
-                            enabled: !root.isEdit
-                            roleName: "categoryId"
-                            value: ""
-                        }
-                    }
-
-                    header: Item {
-                        id: channelsLabel
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        width: parent.width - 32
-                        height: 34
-                        StatusBaseText {
-                            text: qsTr("Channels")
-                            anchors.bottom: parent.bottom
-                            anchors.bottomMargin: 4
-                            font.pixelSize: Theme.primaryTextFontSize
-                            color: Theme.palette.baseColor1
-                        }
-                    }
-
-                    delegate: Loader {
-                        active: model.type !== Constants.chatType.category
-                        
-                        sourceComponent: StatusListItem {
-                            readonly property bool checked: channelItemCheckbox.checked
-                            objectName: "category_item_name_" + model.name
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            anchors.horizontalCenterOffset: 16
-                            height: visible ? implicitHeight : 0
-                            title: "#" + model.name
-                            asset.width: 40
-                            asset.height: 40
-                            asset.emoji: model.emoji
-                            asset.color: model.color
-                            asset.imgIsIdenticon: false
-                            asset.name: model.icon
-                            asset.isImage: !!model.icon
-                            asset.isLetterIdenticon: true
-                            asset.bgColor: model.color
-                            onClicked: channelItemCheckbox.checked = !channelItemCheckbox.checked
-
-                            components: [
-                                StatusCheckBox {
-                                    id: channelItemCheckbox
-                                    checked: root.isEdit ? model.categoryId === root.categoryId : false
-                                    onCheckedChanged: {
-                                        if(checked){
-                                            var idx = root.channels.indexOf(model.itemId)
-                                            if(idx === -1){
-                                                root.channels.push(model.itemId)
-                                            }
-                                        } else {
-                                            root.channels = root.channels.filter(el => el !== model.itemId);
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
+            model: SortFilterProxyModel {
+                sourceModel: root.isEdit ? root.store.chatCommunitySectionModule.editCategoryChannelsModel
+                                         : root.store.chatCommunitySectionModule.model
+                // filter out channels with categories
+                filters: ValueFilter {
+                    enabled: !root.isEdit
+                    roleName: "categoryId"
+                    value: ""
                 }
             }
-        }
 
-        Item {
-            height: 8
-            width: parent.width
-        }
+            header: Item {
+                width: parent.width
+                height: 34
+                StatusBaseText {
+                    text: qsTr("Channels")
+                    anchors.bottom: parent.bottom
+                    anchors.bottomMargin: 4
+                    font.pixelSize: Theme.primaryTextFontSize
+                    color: Theme.palette.baseColor1
+                }
+            }
 
-        Component {
-            id: deleteCategoryConfirmationDialogComponent
-            ConfirmationDialog {
-                btnType: "warn"
-                showCancelButton: true
-                onClosed: {
-                    destroy()
-                }
-                onCancelButtonClicked: {
-                    close();
-                }
-                onConfirmButtonClicked: function(){
-                    const error = root.store.deleteCommunityCategory(root.categoryId);
-                    if (error) {
-                        categoryError.text = error
-                        return categoryError.open()
-                    }
-                    close();
-                    root.close()
+            delegate: Loader {
+                active: model.type !== Constants.chatType.category
+                width: ListView.view.width
+
+                sourceComponent: StatusListItem {
+                    readonly property bool checked: channelItemCheckbox.checked
+                    objectName: "category_item_name_" + model.name
+                    title: "#" + model.name
+                    asset.width: 40
+                    asset.height: 40
+                    asset.emoji: model.emoji
+                    asset.color: model.color
+                    asset.imgIsIdenticon: false
+                    asset.name: model.icon
+                    asset.isImage: !!model.icon
+                    asset.isLetterIdenticon: true
+                    asset.bgColor: model.color
+                    onClicked: channelItemCheckbox.click()
+
+                    components: [
+                        StatusCheckBox {
+                            id: channelItemCheckbox
+                            checked: root.isEdit ? model.categoryId === root.categoryId : false
+                            onCheckedChanged: {
+                                if(checked){
+                                    var idx = d.channels.indexOf(model.itemId)
+                                    if(idx === -1){
+                                        const tmpArray = Array.from(d.channels)
+                                        tmpArray.push(model.itemId)
+                                        d.channels = tmpArray
+                                    }
+                                } else {
+                                    d.channels = d.channels.filter(el => el !== model.itemId);
+                                }
+                            }
+                            onToggled: d.channelsDirty = true // user change
+                        }
+                    ]
                 }
             }
         }
     }
 
-    rightButtons: [
+    Component {
+        id: deleteCategoryConfirmationDialogComponent
+        ConfirmationDialog {
+            btnType: "warn"
+            showCancelButton: true
+            onClosed: {
+                destroy()
+            }
+            onCancelButtonClicked: {
+                close();
+            }
+            onConfirmButtonClicked: function(){
+                const error = root.store.deleteCommunityCategory(root.categoryId);
+                if (error) {
+                    categoryError.text = error
+                    return categoryError.open()
+                }
+                close();
+                root.close()
+            }
+        }
+    }
+
+    footerRightButtons: ObjectModel {
         StatusButton {
-            visible: isEdit
+            visible: root.isEdit
             type: StatusBaseButton.Type.Danger
             text: qsTr("Delete Category")
             onClicked: {
-                Global.openPopup(deleteCategoryConfirmationDialogComponent)
+                deleteCategoryConfirmationDialogComponent.createObject(root).open()
             }
-        },
+        }
         StatusButton {
             objectName: "createOrEditCommunityCategoryBtn"
-            enabled: isFormValid()
-            text: isEdit ?
-                qsTr("Save") :
-                qsTr("Create")
-            onClicked: {
-                if (!isFormValid()) {
-                    scrollView.scrollBackUp()
-                    return
+            enabled: {
+                if (root.isEdit) {
+                    if (d.channelsDirty)
+                        return d.isFormValid || root.hostedItem?.categoryName.text === root.categoryName
                 }
+                return d.isFormValid
+            }
 
+            text: root.isEdit ? qsTr("Save") : qsTr("Create")
+            onClicked: {
                 let error = ""
-                if (isEdit) {
-                    error = root.store.editCommunityCategory(root.categoryId, StatusQUtils.Utils.filterXSS(root.contentItem.categoryName.input.text), JSON.stringify(channels));
+                if (root.isEdit) {
+                    error = root.store.editCommunityCategory(root.categoryId, StatusQUtils.Utils.filterXSS(root.hostedItem.categoryName.input.text), JSON.stringify(d.channels));
                 } else {
-                    error = root.store.createCommunityCategory(StatusQUtils.Utils.filterXSS(root.contentItem.categoryName.input.text), JSON.stringify(channels));
+                    error = root.store.createCommunityCategory(StatusQUtils.Utils.filterXSS(root.hostedItem.categoryName.input.text), JSON.stringify(d.channels));
                 }
 
                 if (error) {
@@ -232,7 +210,7 @@ StatusModal {
                 root.close()
             }
         }
-    ]
+    }
 
     StatusMessageDialog {
         id: categoryError

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -275,7 +275,6 @@ Item {
                         onTriggered: {
                             Global.openPopup(createCategoryPopup, {
                                                  isEdit: true,
-                                                 channels: [],
                                                  categoryId: categoryItem.itemId,
                                                  categoryName: categoryItem.name
                                              })
@@ -571,9 +570,6 @@ Item {
         id: createCategoryPopup
         CreateCategoryPopup {
             store: root.store
-            onClosed: {
-                destroy()
-            }
         }
     }
 


### PR DESCRIPTION
### What does the PR do

- port to StatusAdaptiveDialog
- avoid overflowing the title input and the channels listview (checkboxes were unreachable too)
- fix clicking on the listitem would not actually add the channel to the result
- add to StoryBook

Separate commit/fix for StatusAdaptiveDialog (exposing the `hostedItem` from the `contentComponent`)

Fixes https://github.com/status-im/status-app/issues/22186

### Affected areas

CreateCategoryPopup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/92aaa31b-8f59-4991-b420-1f7f1b9f5035

### Impact on end user

better mobile UX

### How to test

- invoke the Create/Edit category popup in a community chat

### Risk 

low
