### PR TITLE
fix(l10n): retranslate stale welcome messages

### DIFF
--- a/ui/imports/shared/panels/DidYouKnowSplashScreen.qml
+++ b/ui/imports/shared/panels/DidYouKnowSplashScreen.qml
@@ -45,7 +45,6 @@ Pane {
                 font.weight: Font.DemiBold
                 font.pixelSize: Theme.asideTextFontSize
                 text: qsTr("DID YOU KNOW?")
-
             }
             StatusBaseText {
                 id: didYouKnowText
@@ -72,8 +71,15 @@ Pane {
                     interval: 7000
                     repeat: true
                     running: didYouKnowText.visible
+                    triggeredOnStart: true
                     onTriggered: didYouKnowText.text = didYouKnowMessages.iterator.next()
                 }
+            }
+        }
+        Connections {
+            target: Qt
+            function onUiLanguageChanged() {
+                didYouKnowTimer.restart()
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

- restart the timer; the text is not a binding so it doesn't reevaluate

Fixes #22142

### Affected areas

Splash screen

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/a09e6da1-130b-4901-9309-8b88b956d081

### Impact on end user

i18n

### How to test

- go to Settings/Language, change it
- restart app
- observe the splash screen messages at the bottom

### Risk 

low
