### PR TITLE
fix(wallet): use asset/collectible key for identification

### DIFF
--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -128,7 +128,7 @@ SplitView {
         customOrderAvailable: controller.hasSettings
         onCollectibleClicked: logs.logEvent("onCollectibleClicked", ["chainId", "contractAddress", "tokenId", "uid", "tokenType", "communityId"], arguments)
         onSendRequested: logs.logEvent("onSendRequested", ["symbol", "tokenType", "fromAddress"], arguments)
-        onReceiveRequested: logs.logEvent("onReceiveRequested", ["symbol"], arguments)
+        onReceiveRequested: logs.logEvent("onReceiveRequested", ["key"], arguments)
         onSwitchToCommunityRequested: logs.logEvent("onSwitchToCommunityRequested", ["communityId"], arguments)
         onManageTokensRequested: logs.logEvent("onManageTokensRequested")
         isError: ctrlErrorCheckbox.checked

--- a/storybook/qmlTests/tests/tst_CollectiblesView.qml
+++ b/storybook/qmlTests/tests/tst_CollectiblesView.qml
@@ -39,7 +39,6 @@ Item {
             append([
                 {
                     uid: "comm_alpha",
-                    symbol: "comm_alpha",
                     chainId: 1,
                     name: "Comm Alpha",
                     collectionUid: "",
@@ -59,7 +58,6 @@ Item {
                 },
                 {
                     uid: "comm_beta",
-                    symbol: "comm_beta",
                     chainId: 1,
                     name: "Comm Beta",
                     collectionUid: "",
@@ -79,7 +77,6 @@ Item {
                 },
                 {
                     uid: "reg_charlie",
-                    symbol: "reg_charlie",
                     chainId: 1,
                     name: "Reg Charlie",
                     collectionUid: "charlie_col",
@@ -99,7 +96,6 @@ Item {
                 },
                 {
                     uid: "reg_delta",
-                    symbol: "reg_delta",
                     chainId: 1,
                     name: "Reg Delta",
                     collectionUid: "delta_col",
@@ -517,8 +513,11 @@ Item {
             verify(!managePanel.dirty)
             verify(customOrderController.hasSettings)
 
-            flowState.screen = "wallet"
-            waitForRendering(harness)
+            // Assert the saved order while it still DIFFERS from the default one.
+            // The final assertion below restores the default order, so on its own it
+            // passes even when the view never consults the controller at all.
+            verifyCustomOrderApplied(applyCustomOrderToWallet(), "regularCollectiblesView",
+                                    ["Reg Delta", "Reg Charlie"])
 
             clickSortMenuItem(getSortComboBox(getView("wallet")), "Edit custom order →")
             tryVerify(() => flowState.screen === "manageTokens")

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -51,7 +51,7 @@ ColumnLayout {
 
     signal collectibleClicked(int chainId, string contractAddress, string tokenId, string uid, int tokenType, string communityId)
     signal sendRequested(string collectionUid, int tokenType, string fromAddress)
-    signal receiveRequested(string symbol)
+    signal receiveRequested(string key)
     signal switchToCommunityRequested(string communityId)
     signal manageTokensRequested()
 
@@ -196,9 +196,9 @@ ColumnLayout {
             FastExpressionFilter {
                 expression: {
                     root.controller.revision
-                    return (customFilter.isCommunity ? !!model.communityId : !model.communityId) && root.controller.filterAcceptsKey(model.symbol) // TODO: use token/group key
+                    return (customFilter.isCommunity ? !!model.communityId : !model.communityId) && root.controller.filterAcceptsKey(model.key)
                 }
-                expectedRoles: ["symbol", "communityId"]
+                expectedRoles: ["key", "communityId"]
             },
             FastExpressionFilter {
                 enabled: customFilter.isCommunity && cmbFilter.hasEnabledFilters
@@ -217,10 +217,10 @@ ColumnLayout {
             FastExpressionSorter {
                 expression: {
                     root.controller.revision
-                    return root.controller.compareTokens(modelLeft.symbol, modelRight.symbol)
+                    return root.controller.compareTokens(modelLeft.key, modelRight.key)
                 }
                 enabled: d.isCustomView
-                expectedRoles: ["symbol"]
+                expectedRoles: ["key"]
             },
             RoleSorter {
                 roleName: cmbTokenOrder.currentSortRoleName
@@ -495,10 +495,10 @@ ColumnLayout {
             communityImage: model.communityImage ?? ""
             balance: model.balance ?? 1
 
-            onClicked: root.collectibleClicked(model.chainId, model.contractAddress, model.tokenId, model.symbol, model.tokenType, model.communityId ?? "")
+            onClicked: root.collectibleClicked(model.chainId, model.contractAddress, model.tokenId, model.key, model.tokenType, model.communityId ?? "")
             onContextMenuRequested: function(x, y) {
                 const userOwnedAddress = d.getFirstUserOwnedAddress(model.ownership)
-                tokenContextMenu.createObject(this, {collectionUid: model.collectionUid, key: model.key, symbol: model.symbol, chainId: model.chainId, tokenName: model.name, tokenImage: model.imageUrl,
+                tokenContextMenu.createObject(this, {collectionUid: model.collectionUid, key: model.key, chainId: model.chainId, tokenName: model.name, tokenImage: model.imageUrl,
                                                   communityId: model.communityId, communityName: model.communityName,
                                                   communityImage: model.communityImage, tokenType: model.tokenType,
                                                   soulbound: model.soulbound,
@@ -517,7 +517,6 @@ ColumnLayout {
 
             property string collectionUid
             property string key
-            property string symbol
             property int chainId
             property string tokenName
             property string tokenImage
@@ -549,7 +548,7 @@ ColumnLayout {
             StatusAction {
                 icon.name: "receive"
                 text: qsTr("Receive")
-                onTriggered: root.receiveRequested(symbol)
+                onTriggered: root.receiveRequested(key)
             }
             StatusMenuSeparator {}
             StatusAction {
@@ -558,11 +557,11 @@ ColumnLayout {
                 onTriggered: root.manageTokensRequested()
             }
             StatusAction {
-                enabled: symbol !== Utils.getNativeTokenSymbol(chainId)
+                enabled: tokenMenu.key !== Utils.getNativeTokenKey(chainId)
                 type: StatusAction.Type.Danger
                 icon.name: "hide"
                 text: qsTr("Hide collectible")
-                onTriggered: Global.openConfirmHideCollectiblePopup(symbol, tokenName, tokenImage, !!communityId)
+                onTriggered: Global.openConfirmHideCollectiblePopup(key, tokenName, tokenImage, !!communityId)
             }
             StatusAction {
                 enabled: !!communityId

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -551,7 +551,7 @@ RightTabBaseView {
 
                         onHideRequested: (key) => {
                                              const token = SQUtils.ModelUtils.getByKey(RootStore.walletAssetsStore.groupedAccountAssetsModel, "key", key)
-                                             Global.openConfirmHideAssetPopup(token.symbol, token.name, token.logoUri || Constants.tokenIcon(token.symbol, false), !!token.communityId)
+                                             Global.openConfirmHideAssetPopup(key, token.symbol, token.name, token.logoUri || Constants.tokenIcon(token.symbol, false), !!token.communityId)
                                          }
                         onHideCommunityAssetsRequested:
                             (communityKey) => {
@@ -662,7 +662,7 @@ RightTabBaseView {
 
                             root.sendTokenRequested(fromAddress, collectionUid, tokenType)
                         }
-                        onReceiveRequested: (symbol) => root.launchShareAddressModal()
+                        onReceiveRequested: (key) => root.launchShareAddressModal()
                         onSwitchToCommunityRequested: (communityId) => Global.switchToCommunity(communityId)
                         onManageTokensRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.wallet,
                                                                                       Constants.walletSettingsSubsection.manageCollectibles)

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -538,8 +538,8 @@ QtObject {
                   })
     }
 
-    function openConfirmHideAssetPopup(assetSymbol, assetName, assetImage, isCommunityToken) {
-        openPopup(confirmHideAssetPopup, { symbol: assetSymbol, name: assetName, icon: assetImage, isCommunityToken })
+    function openConfirmHideAssetPopup(assetKey, assetSymbol, assetName, assetImage, isCommunityToken) {
+        openPopup(confirmHideAssetPopup, { key: assetKey, symbol: assetSymbol, name: assetName, icon: assetImage, isCommunityToken })
     }
 
     function openConfirmHideCollectiblePopup(collectibleSymbol, collectibleName, collectibleImage, isCommunityToken) {
@@ -1518,8 +1518,19 @@ QtObject {
                 destroyOnClose: true
                 communitiesStore: root.communitiesStore
 
-                onHideClicked: (tokenSymbol, tokenName, tokenImage, isAsset) => isAsset ? root.openConfirmHideAssetPopup(tokenSymbol, tokenName, tokenImage, true)
-                                                                                        : root.openConfirmHideCollectiblePopup(tokenSymbol, tokenName, tokenImage, true)
+                // The toast payload carries only a symbol, but the hide popups are keyed
+                // by token group key, so resolve it here.
+                onHideClicked: (tokenSymbol, tokenName, tokenImage, isAsset) => {
+                    if (!isAsset) {
+                        root.openConfirmHideCollectiblePopup(tokenSymbol, tokenName, tokenImage, true)
+                        return
+                    }
+                    const token = SQUtils.ModelUtils.getByKey(
+                                    root.walletAssetsStore.groupedAccountAssetsModel, "symbol", tokenSymbol)
+                    if (!token)
+                        return
+                    root.openConfirmHideAssetPopup(token.key, tokenSymbol, tokenName, tokenImage, true)
+                }
             }
         },
         Component {
@@ -1527,13 +1538,14 @@ QtObject {
             ConfirmHideAssetPopup {
                 destroyOnClose: true
 
+                required property string key
                 required property bool isCommunityToken
 
                 onConfirmButtonClicked: {
                     if (isCommunityToken)
-                        root.walletAssetsStore.assetsController.showHideCommunityToken(symbol, false)
+                        root.walletAssetsStore.assetsController.showHideCommunityToken(key, false)
                     else
-                        root.walletAssetsStore.assetsController.showHideRegularToken(symbol, false)
+                        root.walletAssetsStore.assetsController.showHideRegularToken(key, false)
                     close()
                     Global.displayToastMessage(qsTr("%1 (%2) successfully hidden. You can toggle asset visibility via %3.").arg(name).arg(symbol)
                                                .arg(`<a style="text-decoration:none" href="#${Constants.appSection.profile}/${Constants.settingsSubsection.wallet}/${Constants.walletSettingsSubsection.manageHidden}">` + qsTr("Settings", "Go to Settings") + "</a>"),

--- a/ui/app/mainui/sectionLoaders/PopupsLoader.qml
+++ b/ui/app/mainui/sectionLoaders/PopupsLoader.qml
@@ -288,8 +288,8 @@ Loader {
         function onOpenFirstTokenReceivedPopup(communityId, communityName, communityLogo, tokenSymbol, tokenName, tokenAmount, tokenType, tokenImage) {
             root.invoke(() => root.item.openFirstTokenReceivedPopup(communityId, communityName, communityLogo, tokenSymbol, tokenName, tokenAmount, tokenType, tokenImage))
         }
-        function onOpenConfirmHideAssetPopup(assetSymbol, assetName, assetImage, isCommunityToken) {
-            root.invoke(() => root.item.openConfirmHideAssetPopup(assetSymbol, assetName, assetImage, isCommunityToken))
+        function onOpenConfirmHideAssetPopup(assetKey, assetSymbol, assetName, assetImage, isCommunityToken) {
+            root.invoke(() => root.item.openConfirmHideAssetPopup(assetKey, assetSymbol, assetName, assetImage, isCommunityToken))
         }
         function onOpenConfirmHideCollectiblePopup(collectibleSymbol, collectibleName, collectibleImage, isCommunityToken) {
             root.invoke(() => root.item.openConfirmHideCollectiblePopup(collectibleSymbol, collectibleName, collectibleImage, isCommunityToken))

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -58,7 +58,7 @@ QtObject {
                                        string tokenAmount,
                                        int tokenType,
                                        string tokenImage)
-    signal openConfirmHideAssetPopup(string assetSymbol, string assetName, string assetImage, bool isCommunityToken)
+    signal openConfirmHideAssetPopup(string assetKey, string assetSymbol, string assetName, string assetImage, bool isCommunityToken)
     signal openConfirmHideCollectiblePopup(string collectibleSymbol, string collectibleName, string collectibleImage, bool isCommunityToken)
 
     signal requestOpenLink(string link)


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-app/issues/22131

Use the asset/collectible key instead of symbol for identification.

### Affected areas

tokens management

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/443de0f1-818a-45a5-a53b-b9eb516c39ce


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Restoring the tokens management features

### How to test

Hide, unhide, change custom order for assets and collectibles

### Risk 

low