### PR TITLE
fix(e2e_appium): expand the message context menu before asserting on it

### DIFF
--- a/test/e2e_appium/locators/messaging/message_context_menu_locators.py
+++ b/test/e2e_appium/locators/messaging/message_context_menu_locators.py
@@ -19,10 +19,21 @@ class MessageContextMenuLocators(BaseLocators):
     # so we use resource_id_contains() instead of id()
     REPLY_TO = BaseLocators.resource_id_contains("messageContextMenu_replyTo")
     EDIT_MESSAGE = BaseLocators.resource_id_contains("messageContextMenu_edit")
-    COPY_MESSAGE = BaseLocators.resource_id_contains("messageContextMenu_copy")
+    # Substring match would also hit messageContextMenu_copySelection/_copyLink,
+    # which sit before plain copy in the expanded menu's tree order.
+    COPY_MESSAGE = BaseLocators.xpath(
+        "//*[contains(@resource-id,'messageContextMenu_copy')"
+        " and not(contains(@resource-id,'messageContextMenu_copySelection'))"
+        " and not(contains(@resource-id,'messageContextMenu_copyLink'))]"
+    )
     PIN_MESSAGE = BaseLocators.resource_id_contains("messageContextMenu_pin")
     MARK_AS_UNREAD = BaseLocators.resource_id_contains("messageContextMenu_markUnread")
     DELETE_MESSAGE = BaseLocators.resource_id_contains("messageContextMenu_delete")
+
+    # Expand ("more") button. Every collapsed-row action sets visible:
+    # !root.expanded in the QML, so this button hides exactly when the menu
+    # is expanded — the single signal is_expanded() reads.
+    EXPAND_BUTTON = BaseLocators.resource_id_contains("messageContextMenu_expand")
 
     # Quick reaction emojis - direct children of MessageContextMenuView ScrollView
     # Accessible.name is set to emojiId (Unicode hex code) in EmojiReaction.qml

--- a/test/e2e_appium/pages/messaging/message_context_menu_page.py
+++ b/test/e2e_appium/pages/messaging/message_context_menu_page.py
@@ -144,11 +144,51 @@ class MessageContextMenuPage(BasePage):
             self.logger.error(f"Long-press on element failed: {e}")
             return False
 
+    def is_expanded(self, timeout: int = 2) -> bool:
+        """Check if the menu is open in its expanded state."""
+        if not self.is_displayed(timeout=timeout):
+            return False
+        return not self.is_element_visible(self.locators.EXPAND_BUTTON, timeout=1)
+
+    def tap_expand(self, timeout: int = 5) -> bool:
+        """Expand the menu from its collapsed single-row state.
+
+        Idempotent — an already-expanded menu returns True.
+
+        Returns:
+            bool: True if the menu is open and expanded.
+        """
+        if not self.is_displayed(timeout=2):
+            self.logger.error("Context menu not visible when trying to expand")
+            return False
+
+        if self.is_element_visible(self.locators.EXPAND_BUTTON, timeout=3):
+            if not self.try_click(self.locators.EXPAND_BUTTON, timeout=timeout):
+                self.logger.error("Failed to tap the expand button")
+                return False
+
+        # Success is positive: the menu must still be open with the expand
+        # button gone. A tap that dismissed the menu must not read as expanded.
+        if not self.wait_for_condition(
+            lambda: self.is_expanded(timeout=1), timeout=timeout
+        ):
+            self.logger.error("Menu is not open in the expanded state")
+            return False
+
+        self.logger.info("Context menu expanded")
+        return True
+
     def _tap_menu_action(self, locator: tuple, action_name: str, timeout: int = 5) -> bool:
-        """Tap a menu action and wait for menu to close."""
+        """Tap a menu action, expanding the menu first when the action needs it."""
         if not self.is_displayed(timeout=2):
             self.logger.error(f"Context menu not visible when trying to tap {action_name}")
             return False
+
+        # Some actions exist only in the expanded menu: delete always, pin on
+        # own messages (edit takes the compact slot).
+        if not self.is_element_visible(locator, timeout=1) and not self.is_expanded(timeout=1):
+            if not self.tap_expand(timeout=timeout):
+                return False
 
         if not self.try_click(locator, timeout=timeout):
             self.logger.error(f"Failed to tap {action_name}")
@@ -352,6 +392,10 @@ class MessageContextMenuPage(BasePage):
     def is_pin_visible(self, timeout: int = 2) -> bool:
         """Check if Pin/Unpin action is visible."""
         return self.is_element_visible(self.locators.PIN_MESSAGE, timeout=timeout)
+
+    def is_mark_unread_visible(self, timeout: int = 2) -> bool:
+        """Check if Mark as unread action is visible."""
+        return self.is_element_visible(self.locators.MARK_AS_UNREAD, timeout=timeout)
 
     # ===== Compound Actions =====
 

--- a/test/e2e_appium/tests/messaging/test_message_context_menu.py
+++ b/test/e2e_appium/tests/messaging/test_message_context_menu.py
@@ -175,7 +175,9 @@ class TestMessageContextMenuLocal(_MessageContextMenuBase):
     async def test_context_menu_own_message_actions(self) -> None:
         """Verify context menu shows correct actions for own message.
 
-        Own messages should show: Reply, Edit, Copy, Pin, Mark as unread, Delete
+        The menu opens collapsed: quick reactions plus Reply, Edit, Copy and
+        the expand button. The full action set (including Pin and Delete)
+        exists only after expanding.
         """
         test_message = _unique_message("ctx_menu_test")
         context_menu = MessageContextMenuPage(self.driver)
@@ -189,10 +191,25 @@ class TestMessageContextMenuLocal(_MessageContextMenuBase):
             )
             assert context_menu.is_displayed(), "Context menu not visible"
 
-        async with self.step("Verify own message actions are visible"):
+        async with self.step("Verify collapsed quick actions"):
+            assert not context_menu.is_expanded(), (
+                "Menu should open collapsed on long-press"
+            )
             assert context_menu.is_reply_visible(), "Reply action not visible"
             assert context_menu.is_edit_visible(), "Edit action not visible (own message)"
             assert context_menu.is_copy_visible(), "Copy action not visible"
+
+        async with self.step("Expand the menu"):
+            assert context_menu.tap_expand(), "Failed to expand context menu"
+
+        async with self.step("Verify full own-message action set"):
+            # The compact buttons hide on expansion, so these can only match
+            # the expanded menu's items. Pin appears only here on own messages
+            # (edit takes the compact slot).
+            assert context_menu.is_reply_visible(), "Reply not in expanded menu"
+            assert context_menu.is_edit_visible(), "Edit not in expanded menu"
+            assert context_menu.is_copy_visible(), "Copy not in expanded menu"
+            assert context_menu.is_mark_unread_visible(), "Mark as unread not in expanded menu"
             assert context_menu.is_pin_visible(), "Pin action not visible"
             assert context_menu.is_delete_visible(), "Delete action not visible (own message)"
 
@@ -441,7 +458,18 @@ class TestMessageContextMenuCrossDevice(_MessageContextMenuBase):
             )
             assert context_menu.is_displayed(), "Context menu not visible"
 
+        async with self.step("Expand the menu"):
+            # Expand before asserting: delete is never in the collapsed row,
+            # so without this the assertion passes for any message.
+            assert context_menu.tap_expand(), "Failed to expand context menu"
+
         async with self.step("Verify Delete action is NOT visible"):
+            # The positive sibling keeps the negative honest: if the menu were
+            # dismissed or still collapsed, the pin assert fails instead of the
+            # delete assert passing vacuously.
+            assert context_menu.is_pin_visible(), (
+                "Expanded menu should show Pin for another user's message"
+            )
             assert not context_menu.is_delete_visible(), (
                 "Delete action should NOT be visible for another user's message"
             )

--- a/test/e2e_appium/tests/test_context_menu_expand.py
+++ b/test/e2e_appium/tests/test_context_menu_expand.py
@@ -1,0 +1,117 @@
+"""Device-free contract for the context-menu expand step.
+
+The message context menu opens collapsed, and some actions exist only in
+the expanded state, so a test asserting the full action set against the
+collapsed menu fails on a correct product. These tests pin the expand
+step's contract: it probes and taps the expand button specifically, treats
+an already-expanded menu as success, expands on demand when a tapped
+action is missing, and refuses to call a dismissed or still-collapsed
+menu expanded.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from locators.messaging.message_context_menu_locators import (
+    MessageContextMenuLocators,
+)
+from pages.messaging.message_context_menu_page import MessageContextMenuPage
+
+pytestmark = [pytest.mark.gate, pytest.mark.component]
+
+EXPAND = MessageContextMenuLocators.EXPAND_BUTTON
+DELETE = MessageContextMenuLocators.DELETE_MESSAGE
+
+
+def _menu(monkeypatch, displayed=True, visible=(), click_ok=True,
+          expands=True, dismisses=False):
+    """Build a page whose probes read scripted state.
+
+    ``visible`` lists the locators currently in the tree; a click on the
+    expand button mutates that state per ``expands``/``dismisses``.
+    """
+    page = MessageContextMenuPage(MagicMock())
+    state = {"displayed": displayed, "visible": set(visible)}
+    probes, clicks = [], []
+
+    monkeypatch.setattr(
+        page, "is_displayed", lambda timeout=2: state["displayed"]
+    )
+
+    def fake_visible(locator, timeout=None):
+        probes.append(locator)
+        return locator in state["visible"]
+
+    def fake_click(locator, *, timeout=None, **kwargs):
+        clicks.append(locator)
+        if locator == EXPAND and click_ok:
+            if dismisses:
+                state["displayed"] = False
+            if expands:
+                state["visible"].discard(EXPAND)
+        return click_ok
+
+    monkeypatch.setattr(page, "is_element_visible", fake_visible)
+    monkeypatch.setattr(page, "try_click", fake_click)
+    return page, probes, clicks
+
+
+def test_expand_taps_the_expand_button(monkeypatch):
+    page, probes, clicks = _menu(monkeypatch, visible=[EXPAND])
+    assert page.tap_expand() is True
+    assert clicks == [EXPAND]
+    assert EXPAND in probes
+
+
+def test_expand_skips_the_tap_when_already_expanded(monkeypatch):
+    page, probes, clicks = _menu(monkeypatch, visible=[])
+    assert page.tap_expand() is True
+    assert clicks == []
+    assert EXPAND in probes
+
+
+def test_expand_fails_when_menu_is_closed(monkeypatch):
+    page, _, clicks = _menu(monkeypatch, displayed=False)
+    assert page.tap_expand() is False
+    assert clicks == []
+
+
+def test_expand_fails_when_the_tap_dismisses_the_menu(monkeypatch):
+    """A mis-landed tap that closes the menu must not read as expanded."""
+    page, _, clicks = _menu(monkeypatch, visible=[EXPAND], dismisses=True)
+    assert page.tap_expand(timeout=1) is False
+    assert clicks == [EXPAND]
+
+
+def test_expand_fails_when_menu_stays_collapsed(monkeypatch):
+    page, _, _ = _menu(monkeypatch, visible=[EXPAND], expands=False)
+    assert page.tap_expand(timeout=1) is False
+
+
+def test_expand_fails_when_tap_fails(monkeypatch):
+    page, _, clicks = _menu(monkeypatch, visible=[EXPAND], click_ok=False)
+    assert page.tap_expand(timeout=1) is False
+    assert clicks == [EXPAND]
+
+
+def test_tap_delete_expands_first_when_collapsed(monkeypatch):
+    page, _, clicks = _menu(monkeypatch, visible=[EXPAND])
+    assert page.tap_delete() is True
+    assert clicks == [EXPAND, DELETE]
+
+
+def test_tap_delete_skips_expand_when_action_is_visible(monkeypatch):
+    page, _, clicks = _menu(monkeypatch, visible=[DELETE])
+    assert page.tap_delete() is True
+    assert clicks == [DELETE]
+
+
+def test_is_expanded_requires_an_open_menu(monkeypatch):
+    expanded, probes, _ = _menu(monkeypatch, visible=[])
+    collapsed, _, _ = _menu(monkeypatch, visible=[EXPAND])
+    closed, _, _ = _menu(monkeypatch, displayed=False)
+    assert expanded.is_expanded() is True
+    assert EXPAND in probes
+    assert collapsed.is_expanded() is False
+    assert closed.is_expanded() is False


### PR DESCRIPTION
The context menu opens collapsed; pin shows compactly only on other users' messages and delete exists only in the expanded list, so the own-message actions test failed on a correct product (gate runs 254 and 6050) and the ownership test passed for any message.

Adds `tap_expand()` with positive success evidence (menu still open, expand button gone), expand-on-demand in `_tap_menu_action`, and hardened assertions on both tests. Device-free contract tests included; verified on a Moto G55 and a Samsung A34 (15 passed, 2 xpassed). Test code only.