### PR TITLE
Fix/swap fiat cryoto

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -462,10 +462,11 @@ Control {
             multiplierIndex: d.isSelectedHoldingValidAsset && !!d.selectedHolding.item.decimals ? d.selectedHolding.item.decimals : 18
             cryptoPrice: d.isSelectedHoldingValidAsset && !!d.selectedHolding.item.cryptoPrice ? d.selectedHolding.item.cryptoPrice : 0
             formatFiat: amount => qsTr("≈ %1").arg(root.currencyStore.formatCurrencyAmount(amount, root.currencyStore.currentCurrency))
-            formatBalance: amount => qsTr("≈ %1").arg(root.currencyStore.formatCurrencyAmount(amount, d.inputSymbol))
+            formatBalance: amount => qsTr("≈ %1").arg(root.currencyStore.formatCurrencyAmount(amount, d.inputSymbol, { noSymbol: true, roundingMode: LocaleUtils.RoundingMode.Down }))
 
             mainInputLoading: root.mainInputLoading
             bottomTextLoading: root.bottomTextLoading
+            selectedSymbol: amountToSendInput.fiatMode ? d.inputSymbol : ""
 
             amountInputRightPadding: holdingSelector.width + Theme.padding
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -507,7 +507,7 @@ StatusDialog {
                     and from tokens inputed is supported by backend under
                     https://github.com/status-im/status-app/issues/15095 */
                     interactive: false
-                    fiatInputInteractive: true // read-only for typing, still togglable display
+                    fiatInputInteractive: false // read-only
                 }
 
                 SwapExchangeButton {

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -358,34 +358,10 @@ Control {
 
         RowLayout {
             Layout.fillWidth: true
-            StatusTextWithLoadingState {
-                id: bottomItem
-
-                objectName: "bottomItemText"
-
-                Layout.preferredWidth: contentWidth
-
-                text: {
-                    if (!d.fiatMode && root.cryptoPrice === 0) {
-                        return ""
-                    }
-                    const divisor = SQUtils.AmountsArithmetic.fromExponent(
-                                      d.fiatMode ? root.multiplierIndex
-                                                 : root.fiatDecimalPlaces)
-                    const divided = SQUtils.AmountsArithmetic.div(
-                                      SQUtils.AmountsArithmetic.fromString(
-                                          d.secondaryValue), divisor)
-                    const asNumber = SQUtils.AmountsArithmetic.toNumber(divided)
-
-                    return d.fiatMode ? root.formatBalance(asNumber)
-                                      : root.formatFiat(asNumber)
-                }
-
-                elide: Text.ElideMiddle
-                font.pixelSize: Theme.additionalTextSize
-                customColor: Theme.palette.directColor5
-                loading: root.bottomTextLoading
-
+            Item {
+                Layout.fillWidth: true
+                implicitWidth: bottomItem.contentWidth + (swapIcon.visible ? swapIcon.width + Theme.halfPadding : 0)
+                implicitHeight: Math.max(bottomItem.contentHeight, swapIcon.height)
                 StatusMouseArea {
                     objectName: "amountToSend_mouseArea"
 
@@ -402,35 +378,65 @@ Control {
                             return
 
                         const decimalPlaces = d.fiatMode ? root.fiatDecimalPlaces
-                                                         : root.multiplierIndex
+                                                        : root.multiplierIndex
                         const divisor = SQUtils.AmountsArithmetic.fromExponent(
-                                          decimalPlaces)
+                                        decimalPlaces)
 
                         const stringNumber = SQUtils.AmountsArithmetic.div(
-                                               SQUtils.AmountsArithmetic.fromString(secondaryValue),
-                                               divisor).toFixed(decimalPlaces)
+                                            SQUtils.AmountsArithmetic.fromString(secondaryValue),
+                                            divisor).toFixed(decimalPlaces)
 
                         const trimmed = d.fiatMode
-                                      ? stringNumber
-                                      : d.removeDecimalTrailingZeros(stringNumber)
+                                    ? stringNumber
+                                    : d.removeDecimalTrailingZeros(stringNumber)
 
                         textField.text = d.localize(trimmed)
                         textField.cursorPosition = 0
                     }
                 }
+                StatusTextWithLoadingState {
+                    id: bottomItem
 
-                HoverHandler { id: hoverHandler }
-            }
-            StatusIcon {
-                Layout.preferredWidth: 16
-                Layout.preferredHeight: 16
-                Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+                    objectName: "bottomItemText"
 
-                icon: "swap"
-                rotation: 90
-                color: Theme.palette.directColor5
-                // no hover on touch, so a hover-gated affordance would never show there
-                visible: d.fiatToggleEnabled && (hoverHandler.hovered || SQUtils.Utils.isMobile)
+                    text: {
+                        if (!d.fiatMode && root.cryptoPrice === 0) {
+                            return ""
+                        }
+                        const divisor = SQUtils.AmountsArithmetic.fromExponent(
+                                        d.fiatMode ? root.multiplierIndex
+                                                    : root.fiatDecimalPlaces)
+                        const divided = SQUtils.AmountsArithmetic.div(
+                                        SQUtils.AmountsArithmetic.fromString(
+                                            d.secondaryValue), divisor)
+                        const asNumber = SQUtils.AmountsArithmetic.toNumber(divided)
+
+                        return d.fiatMode ? root.formatBalance(asNumber)
+                                        : root.formatFiat(asNumber)
+                    }
+
+                    width: parent.width - swapIcon.width - Theme.halfPadding
+                    elide: Text.ElideMiddle
+                    font.pixelSize: Theme.additionalTextSize
+                    customColor: Theme.palette.directColor5
+                    loading: root.bottomTextLoading
+
+                    HoverHandler { id: hoverHandler }
+                }
+                StatusIcon {
+                    id: swapIcon
+                    width: 16
+                    height: 16
+
+                    anchors.verticalCenter: bottomItem.verticalCenter
+                    anchors.left: bottomItem.right
+                    anchors.leftMargin: Theme.halfPadding
+
+                    icon: "swap"
+                    rotation: 90
+                    color: Theme.palette.directColor5
+                    visible: d.fiatToggleEnabled && (hoverHandler.hovered || SQUtils.Utils.isMobile)
+                }
             }
             Item { Layout.fillWidth: true }
             Loader {


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-app/issues/22209

- extend mouse area to react on top of switch button
- hide fiat/crypto value switch on receive panel
- fix currency symbol for fiat

### Affected areas

swap

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/dcced2c0-0fc7-4989-9d25-c8ebece39865


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

better UX in swap

### How to test

tap fiat/crypto switch button

### Risk 

low