### PR TITLE
fix(AppMain): fix overflowing toast notifications

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
@@ -232,7 +232,6 @@ Control {
 
     background: Rectangle {
         id: background
-        anchors.fill: parent
         color: Theme.palette.statusToastMessage.backgroundColor
         radius: 8
         border.color: Theme.palette.baseColor2

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2896,7 +2896,7 @@ Item {
         anchors.rightMargin: 8
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 60
-        width: 374
+        width: Math.min(parent.width - anchors.rightMargin*2, 374)
         height: Math.min(parent.height - 120, toastArea.contentHeight)
         spacing: 8
         verticalLayoutDirection: ListView.BottomToTop


### PR DESCRIPTION
### What does the PR do

- restrict the toast width by the window width

Fixes #20647

### Affected areas

AppMain/Toasts

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="764" height="1480" alt="Snímek obrazovky z 2026-09-01 16-20-43" src="https://github.com/user-attachments/assets/f89d0afd-8cef-4ab4-90da-a755c94941b1" />


### Impact on end user

Mobile UX

### How to test

- get a real or fire a Test Notification (Settings/Notifications) on mobile (or narrow desktop view)

### Risk 

low
