### PR TITLE
[Threads] Hook sticker send in threads and Android reply in threads 

### DIFF
--- a/docs/adr/0002-android-push-notifications.md
+++ b/docs/adr/0002-android-push-notifications.md
@@ -103,6 +103,8 @@ Message notifications use `NotificationCompat.MessagingStyle` rather than plain 
 
 No in-process conversation buffer is maintained. Instead, conversation state is stored directly in the OS notification itself: when a new message arrives for an active conversation, `StatusNotificationManager` extracts the existing `MessagingStyle` from the active `StatusBarNotification` via `NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification()`, appends the new message with its sender `Person` (including icon), and re-posts the updated notification. This preserves all historical `Person` icons without any in-process caching and automatically ties the conversation thread lifetime to the notification's lifetime — swiping the notification away discards the thread state.
 
+Conversation identity is the `NotificationBuilder.conversationKey()` value — the chat ID, or `chatId#threadId` when the message belongs to a message thread — not the bare `conversationId` reported by `status-go` (which is always the parent chat). It derives the notification ID, the group key and the shortcut ID, so a thread gets its own notification stack. This is required for correctness, not just presentation: the notification ID doubles as the inline-reply `PendingIntent` request code, and `PendingIntent` matching ignores extras, so a shared ID would let whichever notification was posted last decide where a reply is sent.
+
 ---
 
 ### 6. Outgoing message handling (`isFromMe`)
@@ -132,6 +134,12 @@ When the UI comes to the foreground, all active notifications are cancelled and 
 2. Calls `StatusGoService.callRpc("wakuext_sendChatMessage", ...)` directly (same process — no Binder round-trip needed).
 3. On success the notification is updated with the sent message via a new `local-notifications` signal from `status-go`.
 4. On failure a "Reply failed" notification is shown.
+
+The reply intent carries the chat ID, the thread ID and the conversation key. The thread ID is
+read from `body.message.threadId` on the originating signal and passed straight back as the
+`threadId` field of the send RPC, so a reply to a thread notification lands in that thread
+rather than the parent chat. It is empty for non-threaded messages, which `status-go` treats as
+absent.
 
 The send response is also forwarded to the UI process as an internal `notification.reply.sent`
 signal. It is queued while the UI is backgrounded, then processed through the same messenger

--- a/mobile/android/qt6/src/app/status/mobile/ipc/NotificationReplyReceiver.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/NotificationReplyReceiver.java
@@ -48,15 +48,20 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
         }
     }
 
+    /** Falls back to the chat ID for PendingIntents created before thread-aware keys existed. */
+    private static String conversationKeyOf(Intent intent) {
+        String key = intent.getStringExtra("conversationKey");
+        return (key != null && !key.isEmpty()) ? key : intent.getStringExtra("conversationId");
+    }
+
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent == null) return;
 
         String action = intent.getAction();
         if (NotificationBuilder.ACTION_DISMISS.equals(action)) {
-            String conversationId = intent.getStringExtra("conversationId");
             StatusNotificationManager mgr = StatusNotificationManager.getInstance();
-            if (mgr != null) mgr.clearConversation(conversationId);
+            if (mgr != null) mgr.clearConversation(conversationKeyOf(intent));
             return;
         }
 
@@ -77,6 +82,8 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
         String conversationId = intent.getStringExtra("conversationId");
         if (conversationId == null || conversationId.isEmpty()) return;
 
+        final String threadId = intent.getStringExtra("threadId");
+        final String conversationKey = conversationKeyOf(intent);
         final String replyTextStr = replyText.toString().trim();
         final int androidNotificationId = intent.getIntExtra("androidNotificationId", 0);
 
@@ -89,6 +96,7 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
                 // Build sendChatMessage params (same format as Nim backend)
                 JSONObject msg = new JSONObject();
                 msg.put("chatId", conversationId);
+                msg.put("threadId", threadId == null ? "" : threadId);
                 msg.put("text", replyTextStr);
                 msg.put("contentType", 1); // 1 = TEXT_PLAIN (protobuf ChatMessage_ContentType)
                 msg.put("responseTo", "");
@@ -149,7 +157,7 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
 
                 if (failed) {
                     Log.w(TAG, "sendChatMessage failed: " + errorMsg);
-                    if (mgr != null) mgr.clearConversation(conversationId);
+                    if (mgr != null) mgr.clearConversation(conversationKey);
                     StatusNotificationManager.showReplyFailed(appContext);
                     if (androidNotificationId != 0) {
                         NotificationManagerCompat.from(appContext).cancel(androidNotificationId);
@@ -158,7 +166,7 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
             } catch (Exception e) {
                 Log.w(TAG, "failed to send reply", e);
                 StatusNotificationManager mgr = StatusNotificationManager.getInstance();
-                if (mgr != null) mgr.clearConversation(conversationId);
+                if (mgr != null) mgr.clearConversation(conversationKey);
                 StatusNotificationManager.showReplyFailed(appContext);
                 if (androidNotificationId != 0) {
                     NotificationManagerCompat.from(appContext).cancel(androidNotificationId);

--- a/mobile/android/qt6/src/app/status/mobile/ipc/notifications/NotificationBuilder.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/notifications/NotificationBuilder.java
@@ -53,6 +53,18 @@ public final class NotificationBuilder {
     /** ID for "reply failed" notifications. */
     private static final int REPLY_FAILED_NOTIFICATION_ID = 4243;
 
+    /**
+     * Notification identity for a conversation. Thread messages get their own stack: the
+     * notification ID doubles as the inline-reply PendingIntent request code, and PendingIntent
+     * matching ignores extras, so sharing an ID with the parent chat would let whichever
+     * notification was posted last dictate where a reply is sent.
+     */
+    public static String conversationKey(String chatId, String threadId) {
+        if (chatId == null || chatId.isEmpty()) return "";
+        if (threadId == null || threadId.isEmpty()) return chatId;
+        return chatId + "#" + threadId;
+    }
+
     /** Message item used to build MessagingStyle entries. */
     public static final class MessageEntry {
         public final String text;
@@ -97,16 +109,19 @@ public final class NotificationBuilder {
      *
      * @param context         service context
      * @param title           conversation title
-     * @param conversationId  chat ID for grouping/buffering
+     * @param conversationId  chat ID, used as the target of an inline reply
+     * @param threadId        thread ID when the message belongs to a thread, otherwise empty
      * @param notificationId  Android notification ID (stable per conversation)
      * @param deepLink        deep link URI for tap action
      * @param largeIcon       large icon bitmap (may be null)
      * @param messages        buffered messages for MessagingStyle
      */
     public static void postMessageNotification(Context context, String title,
-            String conversationId, int notificationId, String deepLink,
+            String conversationId, String threadId, int notificationId, String deepLink,
             Bitmap largeIcon, List<MessageEntry> messages,
             boolean isOneToOne) {
+
+        final String conversationKey = conversationKey(conversationId, threadId);
 
         Intent intent = buildTapIntent(context, deepLink);
         if (intent == null) return;
@@ -126,7 +141,7 @@ public final class NotificationBuilder {
         buildMessagingStyle(context, builder, title, messages, isOneToOne);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            String shortcutId = "conv_" + conversationId;
+            String shortcutId = "conv_" + conversationKey;
             // For 1-1 chats: pin the first (contact's) message sender as the shortcut Person so
             // the contact avatar is stable and does not change when the user replies.
             // For group/community: no Person — the largeIcon (group/community icon) is used instead.
@@ -136,12 +151,12 @@ public final class NotificationBuilder {
         }
 
         // Delete intent: clear per-conversation state when user swipes away
-        addDismissIntent(context, builder, conversationId, notificationId);
+        addDismissIntent(context, builder, conversationId, conversationKey, notificationId);
 
         // Reply action
-        addReplyAction(context, builder, conversationId, notificationId);
+        addReplyAction(context, builder, conversationId, threadId, conversationKey, notificationId);
 
-        builder.setGroup("conv_" + conversationId);
+        builder.setGroup("conv_" + conversationKey);
 
         NotificationManagerCompat.from(context).notify(notificationId, builder.build());
     }
@@ -175,7 +190,7 @@ public final class NotificationBuilder {
 
         addContactRequestActions(context, builder, conversationId, contactRequestId, notificationId);
         if (conversationId != null && !conversationId.isEmpty()) {
-            addDismissIntent(context, builder, conversationId, notificationId);
+            addDismissIntent(context, builder, conversationId, conversationId, notificationId);
         }
         if (conversationId != null && !conversationId.isEmpty()) {
             builder.setGroup("conv_" + conversationId);
@@ -335,18 +350,19 @@ public final class NotificationBuilder {
     }
 
     private static void addDismissIntent(Context context, NotificationCompat.Builder builder,
-            String conversationId, int notificationId) {
+            String conversationId, String conversationKey, int notificationId) {
         Intent dismissIntent = new Intent(context, NotificationReplyReceiver.class);
         dismissIntent.setAction(ACTION_DISMISS);
         dismissIntent.setPackage(context.getPackageName());
         dismissIntent.putExtra("conversationId", conversationId);
+        dismissIntent.putExtra("conversationKey", conversationKey);
         builder.setDeleteIntent(PendingIntent.getBroadcast(
                 context, notificationId, dismissIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
     }
 
     private static void addReplyAction(Context context, NotificationCompat.Builder builder,
-            String conversationId, int notificationId) {
+            String conversationId, String threadId, String conversationKey, int notificationId) {
         RemoteInput remoteInput = new RemoteInput.Builder(REPLY_REMOTE_INPUT_KEY)
                 .setLabel(context.getString(R.string.notification_reply))
                 .build();
@@ -354,6 +370,8 @@ public final class NotificationBuilder {
         replyIntent.setAction(ACTION_REPLY);
         replyIntent.setPackage(context.getPackageName());
         replyIntent.putExtra("conversationId", conversationId);
+        replyIntent.putExtra("threadId", threadId);
+        replyIntent.putExtra("conversationKey", conversationKey);
         replyIntent.putExtra("androidNotificationId", notificationId);
         int replyFlags = PendingIntent.FLAG_UPDATE_CURRENT;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/mobile/android/qt6/src/app/status/mobile/ipc/notifications/StatusNotificationManager.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/notifications/StatusNotificationManager.java
@@ -129,6 +129,12 @@ public final class StatusNotificationManager {
         final String chatIcon = eventWrap.optString("chatIcon", "");
         final boolean isFromMe = eventWrap.optBoolean("isFromMe", false);
 
+        // status-go always reports the parent chat as conversationId; the thread, if any, is only
+        // discoverable from the embedded message.
+        final JSONObject body = eventWrap.optJSONObject("body");
+        final JSONObject bodyMessage = body != null ? body.optJSONObject("message") : null;
+        final String threadId = bodyMessage != null ? bodyMessage.optString("threadId", "") : "";
+
         String senderIcon = "";
         String senderName = "";
         final JSONObject author = eventWrap.optJSONObject("notificationAuthor");
@@ -157,6 +163,7 @@ public final class StatusNotificationManager {
                 message,
                 deepLink.isEmpty() ? null : deepLink,
                 conversationId.isEmpty() ? null : conversationId,
+                threadId,
                 notificationId.isEmpty() ? null : notificationId,
                 largeIconUri != null && !largeIconUri.isEmpty() ? largeIconUri : null,
                 category,
@@ -171,7 +178,7 @@ public final class StatusNotificationManager {
     // ── Show notification ─────────────────────────────────────────────────────
 
     private void showNotification(Context context, String title, String message,
-            String deepLink, String conversationId, String notificationId,
+            String deepLink, String conversationId, String threadId, String notificationId,
             String largeIconUri, String category, long timestamp,
             String senderName, String personAvatarUri, boolean isOneToOne,
             boolean isFromMe) {
@@ -201,7 +208,8 @@ public final class StatusNotificationManager {
                         largeIcon, conversationId, contactRequestId);
                 return;
             } else if (isMessage) {
-                notifIdInt = conversationId.hashCode() & 0x7fffffff;
+                notifIdInt = NotificationBuilder.conversationKey(conversationId, threadId)
+                        .hashCode() & 0x7fffffff;
                 // Rebuild message history from the currently active notification.
                 List<NotificationBuilder.MessageEntry> messages =
                         getConversationMessagesFromActiveNotification(context, notifIdInt);
@@ -235,7 +243,7 @@ public final class StatusNotificationManager {
                 Bitmap largeIcon = activeVisual != null && activeVisual.largeIcon != null
                         ? activeVisual.largeIcon : largeIconFromEvent;
                 NotificationBuilder.postMessageNotification(
-                        context, notificationTitle, conversationId, notifIdInt,
+                        context, notificationTitle, conversationId, threadId, notifIdInt,
                         deepLink, largeIcon, messages, isOneToOne);
             } else {
                 String idBase = (notificationId != null ? notificationId
@@ -257,12 +265,15 @@ public final class StatusNotificationManager {
 
     // ── Public API for NotificationReplyReceiver ──────────────────────────────
 
-    /** Clears state for a conversation (called when notification dismissed). */
-    public void clearConversation(String conversationId) {
-        if (conversationId == null || conversationId.isEmpty()) return;
+    /**
+     * Clears state for a conversation (called when notification dismissed).
+     * Takes a {@link NotificationBuilder#conversationKey} value, not a bare chat ID.
+     */
+    public void clearConversation(String conversationKey) {
+        if (conversationKey == null || conversationKey.isEmpty()) return;
         Context context = contextRef.get();
         if (context == null) return;
-        NotificationManagerCompat.from(context).cancel(conversationId.hashCode() & 0x7fffffff);
+        NotificationManagerCompat.from(context).cancel(conversationKey.hashCode() & 0x7fffffff);
     }
 
     /**

--- a/mobile/android/qt6/src/app/status/mobile/ipc/notifications/StatusNotificationManager.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/notifications/StatusNotificationManager.java
@@ -129,11 +129,11 @@ public final class StatusNotificationManager {
         final String chatIcon = eventWrap.optString("chatIcon", "");
         final boolean isFromMe = eventWrap.optBoolean("isFromMe", false);
 
-        // status-go always reports the parent chat as conversationId; the thread, if any, is only
-        // discoverable from the embedded message.
+        // Older status-go payloads expose the thread only through the embedded message.
         final JSONObject body = eventWrap.optJSONObject("body");
         final JSONObject bodyMessage = body != null ? body.optJSONObject("message") : null;
-        final String threadId = bodyMessage != null ? bodyMessage.optString("threadId", "") : "";
+        final String fallbackThreadId = bodyMessage != null ? bodyMessage.optString("threadId", "") : "";
+        final String threadId = eventWrap.optString("threadId", fallbackThreadId);
 
         String senderIcon = "";
         String senderName = "";

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -120,8 +120,9 @@ proc sendSticker*(
     channelId: string,
     replyTo: string,
     sticker: StickerDto,
-    preferredUsername: string) =
-  self.stickerService.asyncSendSticker(channelId, replyTo, sticker, preferredUsername)
+    preferredUsername: string,
+    threadId: string = "") =
+  self.stickerService.asyncSendSticker(channelId, replyTo, sticker, preferredUsername, threadId)
 
 proc getStickerMarketAddress*(self: Controller): string =
   return self.stickerService.getStickerMarketAddress()

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -68,7 +68,7 @@ method uninstallStickerPack*(self: AccessInterface, packId: string) {.base.} =
 method removeRecentStickers*(self: AccessInterface, packId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method sendSticker*(self: AccessInterface, channelId: string, replyTo: string, sticker: Item) {.base.} =
+method sendSticker*(self: AccessInterface, channelId: string, replyTo: string, sticker: Item, threadId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method populateInstalledStickerPacks*(self: AccessInterface, stickers: Table[string, StickerPackDto]) {.base.} =

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -76,13 +76,14 @@ method uninstallStickerPack*(self: Module, packId: string) =
 method removeRecentStickers*(self: Module, packId: string) =
   self.controller.removeRecentStickers(packId)
 
-method sendSticker*(self: Module, channelId: string, replyTo: string, sticker: Item) =
+method sendSticker*(self: Module, channelId: string, replyTo: string, sticker: Item, threadId: string) =
   let stickerDto = StickerDto(hash: sticker.getHash, packId: sticker.getPackId)
   self.controller.sendSticker(
     channelId,
     replyTo,
     stickerDto,
-    singletonInstance.userProfile.getPreferredName())
+    singletonInstance.userProfile.getPreferredName(),
+    threadId)
 
 method addRecentStickerToList*(self: Module, sticker: StickerDto) =
   self.view.addRecentStickerToList(initItem(sticker.hash, sticker.packId, sticker.url))

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -150,10 +150,11 @@ QtObject:
     if not self.installedStickerPacksLoaded:
       self.delegate.getInstalledStickerPacks()
 
-  proc send*(self: View, channelId: string, hash: string, replyTo: string, pack: string, url: string) {.slot.} =
+  proc send*(self: View, channelId: string, hash: string, replyTo: string, pack: string, url: string,
+      threadId: string) {.slot.} =
     let sticker = initItem(hash, pack, url)
     self.addRecentStickerToList(sticker)
-    self.delegate.sendSticker(channelId, replyTo, sticker)
+    self.delegate.sendSticker(channelId, replyTo, sticker, threadId)
 
   proc getStickersMarketAddress(self: View): string {.slot.} =
     return self.stickersMarketAddress

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -74,6 +74,7 @@ type
   AsyncSendStickerTaskArg = ref object of QObjectTaskArg
     chatId: string
     replyTo: string
+    threadId: string
     stickerHash: string
     stickerPackId: string
     preferredUsername: string
@@ -86,7 +87,7 @@ const asyncSendStickerTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} 
       "You can see a nice sticker here!",
       arg.replyTo,
       ContentType.Sticker.int,
-      "",
+      arg.threadId,
       arg.preferredUsername,
       standardLinkPreviews = JsonNode(),
       statusLinkPreviews = JsonNode(),

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -328,13 +328,15 @@ QtObject:
       chatId: string,
       replyTo: string,
       sticker: StickerDto,
-      preferredUsername: string) =
+      preferredUsername: string,
+      threadId: string = "") =
     let arg = AsyncSendStickerTaskArg(
       tptr: asyncSendStickerTask,
       vptr: cast[uint](self.vptr),
       slot: "onAsyncSendStickerDone",
       chatId: chatId,
       replyTo: replyTo,
+      threadId: threadId,
       stickerHash: sticker.hash,
       stickerPackId: sticker.packId,
       preferredUsername: preferredUsername,
@@ -354,7 +356,8 @@ QtObject:
       discard self.chatService.processMessengerResponse(rpcResponse)
     except Exception as e:
       error "Error sending sticker", msg = e.msg
-      self.events.emit(SIGNAL_SENDING_FAILED, ChatArgs(chatId: rpcResponseObj["chatId"].getStr))
+      self.events.emit(SIGNAL_SENDING_FAILED,
+        MessageSendingFailure(chatId: rpcResponseObj["chatId"].getStr, error: e.msg))
 
   proc removeRecentStickers*(self: Service, packId: string) =
     self.recentStickers.keepItIf(it.packId != packId)

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -347,8 +347,8 @@ QtObject {
         stickersModule: stickersModuleInst
     }
 
-    function sendSticker(channelId, hash, replyTo, pack, url) {
-        stickersModuleInst.send(channelId, hash, replyTo, pack, url)
+    function sendSticker(channelId, hash, replyTo, pack, url, threadId = "") {
+        stickersModuleInst.send(channelId, hash, replyTo, pack, url, threadId || "")
     }
 
     function isCurrentUser(pubkey) {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -653,7 +653,8 @@ Item {
                                                    hashId,
                                                    chatInput.isReply ? chatInput.replyMessageId : "",
                                                    packId,
-                                                   url)
+                                                   url,
+                                                   d.activeMessagesStore.threadId)
                     }
 
                     onIsReplyChanged: {


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-app/issues/21896

You can review per commit to get the full context.

First commit is about hooking up stickers in threads
The second commit is to hook Android relies in Push notifications to work in threads.

### Affected areas

- message service
- android java files

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[sticker-inthreads.webm](https://github.com/user-attachments/assets/4099c273-3052-47f0-b453-62674cdb60d2)

### Impact on end user

None until feature flags are ON. When enabled, enables sending stickers in threads and replying to push notifications on Android

### How to test

0. See first PR for feature flag enabling
1. Send stickers in a thread
2. Receive a push notif on android in a thread
3. reply to it

### Risk 

None with feature flag. Medium when enabled because of the Android change
