### PR TITLE
fix(threads): load emoji reactions for messages in threads

### DIFF
--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -55,13 +55,11 @@ proc asyncFetchChatMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
     responseJson["messages"] = messagesArr
     responseJson["messagesCursor"] = messagesCursor
 
-    # handle reactions (only for base chats, not threads)
-    if arg.threadId == "":
-      var reactionsArr: JsonNode
-      let rResponse = status_go.fetchReactions(arg.chatId, arg.msgCursor, arg.limit)
-      if not rResponse.error.isNil:
-        raise newException(CatchableError, rResponse.error.message)
-      responseJson["reactions"] = rResponse.result
+    # handle reactions
+    let rResponse = status_go.fetchReactions(arg.chatId, arg.threadId, arg.msgCursor, arg.limit)
+    if not rResponse.error.isNil:
+      raise newException(CatchableError, rResponse.error.message)
+    responseJson["reactions"] = rResponse.result
 
     arg.finish(responseJson)
 

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -937,8 +937,17 @@ QtObject:
 
       self.checkPaymentRequestsInMessages(messages)
 
+      var reactionsArr: JsonNode
+      var reactions: seq[ReactionDto]
+      if responseObj.getProp("reactions", reactionsArr):
+        reactions = map(
+          reactionsArr.getElems(),
+          proc(x: JsonNode): ReactionDto =
+            result = x.toReactionDto()
+        )
+
       self.events.emit(SIGNAL_MESSAGES_LOADED,
-        MessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: messages, reactions: @[]))
+        MessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: messages, reactions: reactions))
     except Exception as e:
       error "error loading thread messages", msg = e.msg
       if chatId.len > 0 and threadId.len > 0:

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -12,9 +12,9 @@ proc fetchPinnedMessages*(chatId: string, cursorVal: string, limit: int): RpcRes
   let payload = %* [chatId, cursorVal, limit]
   result = callPrivateRPC("chatPinnedMessages".prefix, payload)
 
-proc fetchReactions*(chatId: string, cursorVal: string, limit: int): RpcResponse[JsonNode] =
-  let payload = %* [chatId, cursorVal, limit]
-  result = callPrivateRPC("emojiReactionsByChatID".prefix, payload)
+proc fetchReactions*(chatId: string, threadId: string = "", cursorVal: string, limit: int): RpcResponse[JsonNode] =
+  let payload = %* [chatId, threadId, cursorVal, limit]
+  result = callPrivateRPC("emojiReactionsByChatIDV2".prefix, payload)
 
 proc addReaction*(chatId: string, messageId: string, emoji: string): RpcResponse[JsonNode] =
   let payload = %* [chatId, messageId, emoji]


### PR DESCRIPTION
### What does the PR do

Fixes #21900
status-go PR: https://github.com/status-im/status-go/pull/7795

The reaction fetch was skipped entirely for threads — asyncFetchChatMessagesTask guarded it behind `if arg.threadId == ""` and onAsyncLoadMoreMessagesForThread hardcoded an empty reaction seq — because the status-go query was not thread-aware. A reaction added in a thread rendered optimistically and then disappeared on reload.

Now that emojiReactionsByChatIDV2 accepts a thread ID, drop the guard, pass the thread ID through, and deliver the reactions on the thread load path the same way the base chat path already does. The thread cursor plumbing already carried the right value, so nothing else changes: sending and retracting from a thread and live incoming reactions were already working.

### Affected areas

- message service and async task
- status-go

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

Also ask Copilot to align feedback with repository architecture boundaries:

- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[reactions-in-threads.webm](https://github.com/user-attachments/assets/ed79dbaf-f305-4c9b-8963-931ce2269e20)

### Impact on end user

None until the feature flags are enabled. Once enabled, makes emoji reaction fetching on app start work and sending emoji reactions work

### How to test

0. See initial PR for feature flag enabling
1. Send a message on a thread
2. react to it
3. restart the app
4. reaction should still be there

### Risk 

None until feature flag is enabled. Low once enabled
