### PR TITLE
feat(threads): load threads when the section is opened

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -200,12 +200,6 @@ proc init*(self: Controller) =
       return
     self.delegate.onMessageEdited(args.message)
 
-  self.events.on(SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
-    let args = ChatThreadsLoadedArgs(e)
-    if self.chatId != args.chatId:
-      return
-    self.delegate.onChatThreadsLoaded(args.threads)
-
 proc getMyChatId*(self: Controller): string =
   return self.chatId
 

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -32,9 +32,6 @@ method openThreadAsChat*(self: AccessInterface, threadId: string, threadName: st
     setActive: bool = true, hasUnreadMessages: bool = false, notificationsCount: int = 0) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onChatThreadsLoaded*(self: AccessInterface, threads: seq[ThreadDto]) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method newPinnedMessagesLoaded*(self: AccessInterface, pinnedMessages: seq[PinnedMessageDto], reactions: seq[ReactionDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -257,14 +257,17 @@ proc init*(self: Controller) =
       return
     self.delegate.onThreadCreationFailed()
 
-  self.events.on(SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
-    let args = ChatThreadsLoadedArgs(e)
-    if self.chatId != args.chatId:
-      return
-    self.delegate.onChatThreadsLoaded(args.threads)
+  self.events.on(SIGNAL_CHAT_THREADS_FOR_CHATS_LOADED) do(e: Args):
+    let args = ChatThreadsForChatsLoadedArgs(e)
+    var chatThreads: seq[ThreadDto] = @[]
+    for thread in args.threads:
+      if thread.chatId == self.chatId:
+        chatThreads.add(thread)
+    if chatThreads.len > 0:
+      self.delegate.onChatThreadsLoaded(chatThreads)
 
   self.events.on(SIGNAL_CHAT_THREADS_LOADING_FAILED) do(e: Args):
-    let args = ChatThreadsLoadedArgs(e)
+    let args = ChatThreadsLoadingFailedArgs(e)
     if self.chatId != args.chatId:
       return
     self.delegate.onChatThreadsLoadingFailed()

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -474,6 +474,8 @@ method onThreadCreationFailed*(self: Module) =
   self.view.emitThreadCreationFailedSignal()
 
 method onChatThreadsLoaded*(self: Module, threads: seq[ThreadDto]) =
+  # Adding the thread rows is the chat section's job; this only back-fills the flag for
+  # messages that were already rendered when the fetch landed.
   for thread in threads:
     if thread.parentMessageId.len > 0:
       self.view.model().setHasThread(thread.parentMessageId, true)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -264,13 +264,6 @@ method openThreadAsChat*(self: Module, threadId: string, threadName: string, par
   self.delegate.openThreadAsChat(self.controller.getMyChatId(), threadId, threadName, parentMessageId,
     setActive = setActive, hasUnreadMessages = hasUnreadMessages, notificationsCount = notificationsCount)
 
-method onChatThreadsLoaded*(self: Module, threads: seq[ThreadDto]) =
-  for thread in threads:
-    if thread.parentMessageId.len > 0:
-      # Add the thread to the chat list so it appears as a sub-chat
-      self.delegate.openThreadAsChat(self.controller.getMyChatId(), thread.threadId, thread.name, thread.parentMessageId,
-        setActive = false, hasUnreadMessages = thread.unviewedMessagesCount > 0, notificationsCount = thread.unviewedMentionsCount)
-
 method muteChat*(self: Module, interval: int) =
   self.controller.muteChat(interval)
 

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -96,6 +96,9 @@ proc asyncCheckPermissionsToJoin*(self: Controller) =
 proc asyncCheckChannelPermissions*(self: Controller, communityId: string, chatId: string) =
   self.chatService.asyncCheckChannelPermissions(communityId, chatId)
 
+proc loadChatThreadsForChats*(self: Controller, chatIds: seq[string]) =
+  self.messageService.loadChatThreadsForChatsIfNeeded(chatIds)
+
 proc init*(self: Controller) =
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):
     let args = MessageSendingSuccess(e)
@@ -135,6 +138,10 @@ proc init*(self: Controller) =
         (not self.isCommunitySection and chat.communityId != "")):
       return
     self.delegate.onMarkMessageAsUnread(chat)
+
+  self.events.on(message_service.SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
+    let args = message_service.ChatThreadsLoadedArgs(e)
+    self.delegate.onChatThreadsLoaded(args.chatId, args.threads)
 
   self.events.on(chat_service.SIGNAL_CHAT_LEFT) do(e: Args):
     let args = chat_service.ChatArgs(e)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -139,9 +139,9 @@ proc init*(self: Controller) =
       return
     self.delegate.onMarkMessageAsUnread(chat)
 
-  self.events.on(message_service.SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
-    let args = message_service.ChatThreadsLoadedArgs(e)
-    self.delegate.onChatThreadsLoaded(args.chatId, args.threads)
+  self.events.on(message_service.SIGNAL_CHAT_THREADS_FOR_CHATS_LOADED) do(e: Args):
+    let args = message_service.ChatThreadsForChatsLoadedArgs(e)
+    self.delegate.onChatThreadsForChatsLoaded(args.threads)
 
   self.events.on(chat_service.SIGNAL_CHAT_LEFT) do(e: Args):
     let args = chat_service.ChatArgs(e)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -105,6 +105,9 @@ method changeMutedOnChat*(self: AccessInterface, chatId: string, muted: bool) {.
 method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto, threadId: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onChatThreadsLoaded*(self: AccessInterface, chatId: string, threads: seq[ThreadDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onMarkMessageAsUnread*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -105,7 +105,7 @@ method changeMutedOnChat*(self: AccessInterface, chatId: string, muted: bool) {.
 method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto, threadId: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onChatThreadsLoaded*(self: AccessInterface, chatId: string, threads: seq[ThreadDto]) {.base.} =
+method onChatThreadsForChatsLoaded*(self: AccessInterface, threads: seq[ThreadDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onMarkMessageAsUnread*(self: AccessInterface, chat: ChatDto) {.base.} =

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -301,6 +301,29 @@ QtObject:
 
     self.countChanged()
 
+  proc appendItemsAfterParent*(self: Model, items: seq[ChatItem], parentId: string) =
+    if items.len == 0:
+      return
+
+    let parentIndex = self.getItemIdxById(parentId)
+    if parentIndex == -1:
+      return
+
+    var indexToInsertTo = parentIndex + 1
+    while indexToInsertTo < self.items.len and self.items[indexToInsertTo].isThread and
+        self.items[indexToInsertTo].parentChatId == parentId:
+      inc indexToInsertTo
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    self.beginInsertRows(parentModelIndex, indexToInsertTo, indexToInsertTo + items.len - 1)
+    for offset, item in items:
+      self.items.insert(item, indexToInsertTo + offset)
+    self.endInsertRows()
+
+    self.countChanged()
+
   proc changeCategoryOpened*(self: Model, categoryId: string, opened: bool) {.slot.} =
     for ind in 0 ..< self.items.len:
       if self.items[ind].categoryId == categoryId:

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -243,6 +243,48 @@ proc removeSubmodule(self: Module, chatId: string) =
     return
   self.chatContentModules.del(chatId)
 
+proc createThreadItem(self: Module, parentItem: ChatItem, parentChatId: string, threadId: string,
+    threadName: string, hasUnreadMessages: bool, notificationsCount: int): ChatItem =
+  return chat_item.initChatItem(
+    id = threadId,
+    name = "🧵 " & threadName,
+    usesDefaultName = false,
+    icon = parentItem.icon,
+    color = parentItem.color,
+    emoji = parentItem.emoji,
+    description = "",
+    `type` = parentItem.`type`,
+    parentItem.memberRole,
+    lastMessageTimestamp = 0,
+    lastMessageText = "",
+    hasUnreadMessages = hasUnreadMessages,
+    notificationsCount = notificationsCount,
+    muted = false,
+    blocked = false,
+    active = false,
+    position = parentItem.position,
+    categoryId = parentItem.categoryId,
+    categoryPosition = parentItem.categoryPosition,
+    categoryOpened = parentItem.categoryOpened,
+    canPost = parentItem.canPost,
+    canView = parentItem.canView,
+    canPostReactions = parentItem.canPostReactions,
+    isThread = true,
+    parentChatId = parentChatId,
+    sortTimestamp = parentItem.lastMessageTimestamp,
+  )
+
+proc ensureThreadContentModule(self: Module, threadItem: ChatItem) =
+  if not threadItem.isThread or self.chatContentModules.contains(threadItem.id):
+    return
+
+  let isUsersListAvailable = threadItem.`type` != ChatType.OneToOne.int
+  self.chatContentModules[threadItem.id] = chat_content_module.newModule(
+    self, self.events, self.controller.getMySectionId(), threadItem.parentChatId,
+    self.controller.isCommunity(), isUsersListAvailable, self.settingsService, self.nodeConfigurationService,
+    self.contactService, self.chatService, self.communityService, self.messageService,
+    self.mailserversService, self.sharedUrlsService, threadId = threadItem.id)
+
 
 proc addCategoryItem(self: Module, category: Category, memberRole: MemberRole, communityId: string, insertIntoModel: bool = true): ChatItem =
   let hasUnreadMessages = self.controller.categoryHasUnreadMessages(communityId, category.id)
@@ -478,10 +520,11 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
   if threadId.len == 0:
     return
 
-  # If the thread sub-channel already exists, just activate it if needed.
-  if self.chatContentModules.contains(threadId):
+  # If the thread row already exists, just update it and activate it if needed.
+  if not self.view.chatsModel().getItemById(threadId).isNil:
     self.view.chatsModel().updateNotificationsForItemById(threadId, hasUnreadMessages, notificationsCount)
-    self.chatContentModules[threadId].onNotificationsUpdated(hasUnreadMessages, notificationsCount)
+    if self.chatContentModules.contains(threadId):
+      self.chatContentModules[threadId].onNotificationsUpdated(hasUnreadMessages, notificationsCount)
     if setActive:
       self.setActiveItem(threadId)
     return
@@ -496,63 +539,47 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
     error "openThreadAsChat: unknown parent chat index", parentChatId, methodName="openThreadAsChat"
     return
 
-  let belongsToCommunity = self.controller.isCommunity()
-  let isUsersListAvailable = parentItem.`type` != ChatType.OneToOne.int
-
-  # The thread content module is keyed in the chat list by the threadId, but it
-  # loads/sends messages against the parent chat id together with the threadId.
-  self.chatContentModules[threadId] = chat_content_module.newModule(
-    self, self.events, self.controller.getMySectionId(), parentChatId,
-    belongsToCommunity, isUsersListAvailable, self.settingsService, self.nodeConfigurationService,
-    self.contactService, self.chatService, self.communityService, self.messageService,
-    self.mailserversService, self.sharedUrlsService, threadId = threadId)
-
-  self.threadChatIds.incl(threadId)
-
-  let threadItem = chat_item.initChatItem(
-    id = threadId,
-    name = "🧵 " & threadName,
-    usesDefaultName = false,
-    icon = parentItem.icon,
-    color = parentItem.color,
-    emoji = parentItem.emoji,
-    description = "",
-    `type` = parentItem.`type`,
-    parentItem.memberRole,
-    lastMessageTimestamp = 0,
-    lastMessageText = "",
-    hasUnreadMessages = hasUnreadMessages,
-    notificationsCount = notificationsCount,
-    muted = false,
-    blocked = false,
-    active = false,
-    position = parentItem.position,
-    categoryId = parentItem.categoryId,
-    categoryPosition = parentItem.categoryPosition,
-    canPost = parentItem.canPost,
-    canView = parentItem.canView,
-    canPostReactions = parentItem.canPostReactions,
-    isThread = true,
-    parentChatId = parentChatId,
-    sortTimestamp = parentItem.lastMessageTimestamp,
-  )
-
+  let threadItem = self.createThreadItem(parentItem, parentChatId, threadId, threadName,
+    hasUnreadMessages, notificationsCount)
   self.view.chatsModel().appendItemAfterParent(threadItem, parentIndex)
+  self.threadChatIds.incl(threadId)
   if setActive:
     self.setActiveItem(threadId)
 
-method onChatThreadsLoaded*(self: Module, chatId: string, threads: seq[ThreadDto]) =
-  # The signal is global; other sections' chats are none of our business, and letting them
-  # through would just make openThreadAsChat log an unknown-parent error.
-  if not self.doesTopLevelChatExist(chatId):
-    return
-
+method onChatThreadsForChatsLoaded*(self: Module, threads: seq[ThreadDto]) =
+  var threadsByChat = initOrderedTable[string, seq[ThreadDto]]()
   for thread in threads:
-    if thread.parentMessageId.len == 0:
+    if thread.threadId.len == 0 or thread.parentMessageId.len == 0:
       continue
-    self.openThreadAsChat(chatId, thread.threadId, thread.name, thread.parentMessageId,
-      setActive = false, hasUnreadMessages = thread.unviewedMessagesCount > 0,
-      notificationsCount = thread.unviewedMentionsCount)
+    # The signal is global; other sections' chats are none of our business.
+    if not self.doesTopLevelChatExist(thread.chatId):
+      continue
+    threadsByChat.mgetOrPut(thread.chatId, @[]).add(thread)
+
+  for parentChatId, parentThreads in threadsByChat:
+    let parentItem = self.view.chatsModel().getItemById(parentChatId)
+    if parentItem.isNil:
+      continue
+
+    var items: seq[ChatItem] = @[]
+    var pendingThreadIds = initHashSet[string]()
+    for thread in parentThreads:
+      if not self.view.chatsModel().getItemById(thread.threadId).isNil:
+        self.view.chatsModel().updateNotificationsForItemById(thread.threadId,
+          thread.unviewedMessagesCount > 0, thread.unviewedMentionsCount)
+        if self.chatContentModules.contains(thread.threadId):
+          self.chatContentModules[thread.threadId].onNotificationsUpdated(
+            thread.unviewedMessagesCount > 0, thread.unviewedMentionsCount)
+        continue
+      if pendingThreadIds.contains(thread.threadId):
+        continue
+      pendingThreadIds.incl(thread.threadId)
+      items.add(self.createThreadItem(parentItem, parentChatId, thread.threadId, thread.name,
+        thread.unviewedMessagesCount > 0, thread.unviewedMentionsCount))
+
+    self.view.chatsModel().appendItemsAfterParent(items, parentChatId)
+    for item in items:
+      self.threadChatIds.incl(item.id)
 
 proc updateActiveChatMembership*(self: Module) =
   let activeChatId = self.controller.getActiveChatId()
@@ -583,6 +610,11 @@ method activeItemSet*(self: Module, itemId: string) =
   if chat_item.isNil:
     # Should never be here
     error "chat-view unexisting item id: ", itemId, methodName="activeItemSet"
+    return
+
+  self.ensureThreadContentModule(chat_item)
+  if not self.chatContentModules.contains(itemId):
+    error "chat-view missing chat content module", itemId, methodName="activeItemSet"
     return
 
   if not self.chatContentModules[itemId].isLoaded:
@@ -631,6 +663,12 @@ method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
 method getChatContentModule*(self: Module, chatId: string): QVariant =
+  let chatItem = self.view.chatsModel().getItemById(chatId)
+  if chatItem.isNil:
+    error "getChatContentModule: unexisting chat key", chatId, methodName="getChatContentModule"
+    return
+
+  self.ensureThreadContentModule(chatItem)
   if(not self.chatContentModules.contains(chatId)):
     error "getChatContentModule: unexisting chat key", chatId, methodName="getChatContentModule"
     return
@@ -1015,7 +1053,7 @@ proc removeThreadsForParent(self: Module, parentChatId: string) =
     self.threadChatIds.excl(threadId)
 
 method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
-  if not self.chatContentModules.contains(chatId):
+  if self.view.chatsModel().getItemById(chatId).isNil:
     return
   if self.isChatThread(chatId):
     self.threadChatIds.excl(chatId)
@@ -1803,13 +1841,15 @@ method onCommunityMemberMessagesDeleted*(self: Module, deletedMessages: seq[stri
       self.view.getMemberMessagesModel().removeItem(deletedMessageId)
 
 method communityContainsChat*(self: Module, chatId: string): bool =
-  return self.chatContentModules.hasKey(chatId)
+  return self.view.chatsModel().isItemWithIdAdded(chatId)
 
 method openCommunityChatAndScrollToMessage*(self: Module, chatId: string, messageId: string): bool =
-  if chatId notin self.chatContentModules:
+  if self.view.chatsModel().getItemById(chatId).isNil:
     return false
 
   self.setActiveItem(chatId)
+  if chatId notin self.chatContentModules:
+    return false
   self.chatContentModules[chatId].scrollToMessage(messageId)
   return true
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -330,6 +330,7 @@ proc buildChatSectionUI(
 
   self.view.chatsModel.setData(items)
   self.setActiveItem(selectedItemId)
+  self.controller.loadChatThreadsForChats(chats.mapIt(it.id))
 
 proc createItemFromPublicKey(self: Module, publicKey: string): UserItem =
   let contactDetails = self.controller.getContactDetails(publicKey)
@@ -539,6 +540,19 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
   self.view.chatsModel().appendItemAfterParent(threadItem, parentIndex)
   if setActive:
     self.setActiveItem(threadId)
+
+method onChatThreadsLoaded*(self: Module, chatId: string, threads: seq[ThreadDto]) =
+  # The signal is global; other sections' chats are none of our business, and letting them
+  # through would just make openThreadAsChat log an unknown-parent error.
+  if not self.doesTopLevelChatExist(chatId):
+    return
+
+  for thread in threads:
+    if thread.parentMessageId.len == 0:
+      continue
+    self.openThreadAsChat(chatId, thread.threadId, thread.name, thread.parentMessageId,
+      setActive = false, hasUnreadMessages = thread.unviewedMessagesCount > 0,
+      notificationsCount = thread.unviewedMentionsCount)
 
 proc updateActiveChatMembership*(self: Module) =
   let activeChatId = self.controller.getActiveChatId()

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -30,6 +30,9 @@ type
   AsyncFetchChatThreadsTaskArg = ref object of QObjectTaskArg
     chatId: string
 
+  AsyncFetchChatThreadsForChatsTaskArg = ref object of QObjectTaskArg
+    chatIds: seq[string]
+
   AsyncCreateThreadTaskArg = ref object of QObjectTaskArg
     chatId: string
     parentMessageId: string
@@ -91,6 +94,30 @@ proc asyncFetchChatThreadsTask(argEncoded: string) {.gcsafe, nimcall.} =
   except Exception as e:
     arg.finish(%* {
       "chatId": arg.chatId,
+      "error": e.msg,
+    })
+
+proc asyncFetchChatThreadsForChatsTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncFetchChatThreadsForChatsTaskArg](argEncoded)
+  try:
+    let response = status_go_chat.fetchChatThreadsForChats(arg.chatIds)
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+
+    var responseJson = %*{
+      "chatIds": arg.chatIds,
+      "threads": %*[],
+      "error": "",
+    }
+
+    var threadsArr: JsonNode
+    if response.result.getProp("threads", threadsArr):
+      responseJson["threads"] = threadsArr
+
+    arg.finish(responseJson)
+  except Exception as e:
+    arg.finish(%* {
+      "chatIds": arg.chatIds,
       "error": e.msg,
     })
 

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -5,6 +5,7 @@ import ../../../app/core/tasks/[qt, threadpool]
 import ../../../app/core/signals/types
 import ../../../app/core/eventemitter
 import ../../../app/global/global_singleton
+import ../../../app/global/feature_flags
 import ../../../backend/accounts as status_accounts
 import ../../../backend/messages as status_go
 import ../contacts/service as contact_service
@@ -210,6 +211,7 @@ QtObject:
     chatThreadsLoadingChats: HashSet[string]
 
   proc asyncLoadChatThreads*(self: Service, chatId: string)
+  proc asyncLoadChatThreadsForChats*(self: Service, chatIds: seq[string])
 
   proc delete*(self: Service)
   proc newService*(
@@ -258,6 +260,9 @@ QtObject:
     self.chatThreadsLoadingChats.excl(chatId)
 
   proc loadChatThreadsIfNeeded*(self: Service, chatId: string) =
+    if not THREADS_ENABLED:
+      return
+
     if chatId.len == 0:
       return
 
@@ -269,6 +274,26 @@ QtObject:
 
     self.chatThreadsLoadingChats.incl(chatId)
     self.asyncLoadChatThreads(chatId)
+
+  proc loadChatThreadsForChatsIfNeeded*(self: Service, chatIds: seq[string]) =
+    if not THREADS_ENABLED:
+      return
+
+    var pending: seq[string] = @[]
+    for chatId in chatIds:
+      if chatId.len == 0 or
+         self.chatThreadsLoadedChats.contains(chatId) or
+         self.chatThreadsLoadingChats.contains(chatId):
+        continue
+      pending.add(chatId)
+
+    if pending.len == 0:
+      return
+
+    for chatId in pending:
+      self.chatThreadsLoadingChats.incl(chatId)
+
+    self.asyncLoadChatThreadsForChats(pending)
 
   proc chatHasThreadForParentMessage*(self: Service, chatId: string, parentMessageId: string): bool =
     if chatId.len == 0 or parentMessageId.len == 0:
@@ -393,6 +418,19 @@ QtObject:
       vptr: cast[uint](self.vptr),
       slot: "onAsyncLoadChatThreads",
       chatId: chatId,
+    )
+
+    self.threadpool.start(arg)
+
+  proc asyncLoadChatThreadsForChats*(self: Service, chatIds: seq[string]) =
+    if chatIds.len == 0:
+      return
+
+    let arg = AsyncFetchChatThreadsForChatsTaskArg(
+      tptr: asyncFetchChatThreadsForChatsTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncLoadChatThreadsForChats",
+      chatIds: chatIds,
     )
 
     self.threadpool.start(arg)
@@ -908,6 +946,48 @@ QtObject:
         self.chatThreadsLoadingChats.excl(chatId)
         self.events.emit(SIGNAL_CHAT_THREADS_LOADING_FAILED, ChatThreadsLoadedArgs(chatId: chatId, threads: @[]))
       error "error loading chat threads", msg = e.msg
+
+  proc onAsyncLoadChatThreadsForChats*(self: Service, response: string) {.slot.} =
+    var chatIds: seq[string] = @[]
+    try:
+      let responseObj = response.parseJson
+      if responseObj.kind != JObject:
+        raise newException(CatchableError, "load chat threads response is not a json object")
+
+      var chatIdsArr: JsonNode
+      if responseObj.getProp("chatIds", chatIdsArr):
+        chatIds = map(chatIdsArr.getElems(), proc(x: JsonNode): string = x.getStr())
+
+      let errorString = responseObj{"error"}.getStr()
+      if errorString != "":
+        raise newException(CatchableError, errorString)
+
+      var threads: seq[ThreadDto]
+      var threadsArr: JsonNode
+      if responseObj.getProp("threads", threadsArr):
+        threads = map(threadsArr.getElems(), proc(x: JsonNode): ThreadDto = x.toThreadDto())
+
+      var threadsByChat = initTable[string, seq[ThreadDto]]()
+      for thread in threads:
+        if thread.chatId.len == 0:
+          continue
+        threadsByChat.mgetOrPut(thread.chatId, @[]).add(thread)
+
+      # Settle every requested chat, including those with no threads, so they leave the
+      # loading set and listeners are not left waiting on a signal that never comes.
+      for chatId in chatIds:
+        let chatThreads = threadsByChat.getOrDefault(chatId, @[])
+        self.replaceChatThreadsCache(chatId, chatThreads)
+        self.chatThreadsLoadedChats.incl(chatId)
+        self.chatThreadsLoadingChats.excl(chatId)
+        self.events.emit(SIGNAL_CHAT_THREADS_LOADED,
+          ChatThreadsLoadedArgs(chatId: chatId, threads: chatThreads))
+    except Exception as e:
+      for chatId in chatIds:
+        self.chatThreadsLoadingChats.excl(chatId)
+        self.events.emit(SIGNAL_CHAT_THREADS_LOADING_FAILED,
+          ChatThreadsLoadedArgs(chatId: chatId, threads: @[]))
+      error "error loading chat threads for chats", msg = e.msg
 
   proc onAsyncLoadMoreMessagesForThread*(self: Service, response: string) {.slot.} =
     var threadId: string = ""

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -44,7 +44,7 @@ const MESSAGES_PER_PAGE_MAX* = 40
 
 # Signals which may be emitted by this service:
 const SIGNAL_MESSAGES_LOADED* = "messagesLoaded"
-const SIGNAL_CHAT_THREADS_LOADED* = "chatThreadsLoaded"
+const SIGNAL_CHAT_THREADS_FOR_CHATS_LOADED* = "chatThreadsForChatsLoaded"
 const SIGNAL_CHAT_THREADS_LOADING_FAILED* = "chatThreadsLoadingFailed"
 const SIGNAL_THREAD_CREATED* = "threadCreated"
 const SIGNAL_THREAD_CREATION_FAILED* = "threadCreationFailed"
@@ -92,8 +92,10 @@ type
     messages*: seq[MessageDto]
     reactions*: seq[ReactionDto]
 
-  ChatThreadsLoadedArgs* = ref object of Args
+  ChatThreadsLoadingFailedArgs* = ref object of Args
     chatId*: string
+
+  ChatThreadsForChatsLoadedArgs* = ref object of Args
     threads*: seq[ThreadDto]
 
   ThreadCreatedArgs* = ref object of Args
@@ -305,18 +307,12 @@ QtObject:
     return self.chatThreadsParentIdsByChat[chatId].contains(parentMessageId)
 
   proc handleThreadsUpdate(self: Service, threads: seq[ThreadDto]) =
-    var threadsByChat = initTable[string, seq[ThreadDto]]()
     for thread in threads:
-      if thread.chatId.len == 0:
-        continue
+      if thread.chatId.len > 0:
+        self.cacheCreatedThreads(thread.chatId, @[thread])
 
-      if not threadsByChat.hasKey(thread.chatId):
-        threadsByChat[thread.chatId] = @[]
-      threadsByChat[thread.chatId].add(thread)
-
-    for chatId, chatThreads in threadsByChat:
-      self.cacheCreatedThreads(chatId, chatThreads)
-      self.events.emit(SIGNAL_CHAT_THREADS_LOADED, ChatThreadsLoadedArgs(chatId: chatId, threads: chatThreads))
+    self.events.emit(SIGNAL_CHAT_THREADS_FOR_CHATS_LOADED,
+      ChatThreadsForChatsLoadedArgs(threads: threads))
 
   proc isChatCursorInitialized(self: Service, chatId: string): bool =
     return self.msgCursor.hasKey(chatId)
@@ -940,11 +936,12 @@ QtObject:
       self.chatThreadsLoadedChats.incl(chatId)
       self.chatThreadsLoadingChats.excl(chatId)
 
-      self.events.emit(SIGNAL_CHAT_THREADS_LOADED, ChatThreadsLoadedArgs(chatId: chatId, threads: threads))
+      self.events.emit(SIGNAL_CHAT_THREADS_FOR_CHATS_LOADED,
+        ChatThreadsForChatsLoadedArgs(threads: threads))
     except Exception as e:
       if chatId.len > 0:
         self.chatThreadsLoadingChats.excl(chatId)
-        self.events.emit(SIGNAL_CHAT_THREADS_LOADING_FAILED, ChatThreadsLoadedArgs(chatId: chatId, threads: @[]))
+        self.events.emit(SIGNAL_CHAT_THREADS_LOADING_FAILED, ChatThreadsLoadingFailedArgs(chatId: chatId))
       error "error loading chat threads", msg = e.msg
 
   proc onAsyncLoadChatThreadsForChats*(self: Service, response: string) {.slot.} =
@@ -969,24 +966,23 @@ QtObject:
 
       var threadsByChat = initTable[string, seq[ThreadDto]]()
       for thread in threads:
-        if thread.chatId.len == 0:
-          continue
-        threadsByChat.mgetOrPut(thread.chatId, @[]).add(thread)
+        if thread.chatId.len > 0:
+          threadsByChat.mgetOrPut(thread.chatId, @[]).add(thread)
 
       # Settle every requested chat, including those with no threads, so they leave the
-      # loading set and listeners are not left waiting on a signal that never comes.
+      # loading set without waiting for a per-chat success event.
       for chatId in chatIds:
         let chatThreads = threadsByChat.getOrDefault(chatId, @[])
         self.replaceChatThreadsCache(chatId, chatThreads)
         self.chatThreadsLoadedChats.incl(chatId)
         self.chatThreadsLoadingChats.excl(chatId)
-        self.events.emit(SIGNAL_CHAT_THREADS_LOADED,
-          ChatThreadsLoadedArgs(chatId: chatId, threads: chatThreads))
+      self.events.emit(SIGNAL_CHAT_THREADS_FOR_CHATS_LOADED,
+        ChatThreadsForChatsLoadedArgs(threads: threads))
     except Exception as e:
       for chatId in chatIds:
         self.chatThreadsLoadingChats.excl(chatId)
         self.events.emit(SIGNAL_CHAT_THREADS_LOADING_FAILED,
-          ChatThreadsLoadedArgs(chatId: chatId, threads: @[]))
+          ChatThreadsLoadingFailedArgs(chatId: chatId))
       error "error loading chat threads for chats", msg = e.msg
 
   proc onAsyncLoadMoreMessagesForThread*(self: Service, response: string) {.slot.} =

--- a/src/backend/chat.nim
+++ b/src/backend/chat.nim
@@ -117,6 +117,10 @@ proc fetchChatThreads*(chatId: string): RpcResponse[JsonNode] =
   let payload = %* [chatId]
   result = callPrivateRPC("chatThreads".prefix, payload)
 
+proc fetchChatThreadsForChats*(chatIds: seq[string]): RpcResponse[JsonNode] =
+  let payload = %* [chatIds]
+  result = callPrivateRPC("chatThreadsByChatIDs".prefix, payload)
+
 proc muteChat*(chatId: string, interval: int): RpcResponse[JsonNode] =
   result = callPrivateRPC("muteChatV2".prefix, %* [
     {

--- a/test/nim/chat_section_model_test.nim
+++ b/test/nim/chat_section_model_test.nim
@@ -4,7 +4,8 @@ import app/modules/main/chat_section/[model, Item]
 
 import app_service/common/types
 
-proc createTestChatItem(id: string, catId: string = "", isCategory: bool = false): ChatItem =
+proc createTestChatItem(id: string, catId: string = "", isCategory: bool = false,
+  categoryOpened: bool = true, isThread: bool = false, parentChatId: string = ""): ChatItem =
   discard
   return initChatItem(
       id = id,
@@ -25,6 +26,9 @@ proc createTestChatItem(id: string, catId: string = "", isCategory: bool = false
       active = false,
       position = 0,
       categoryId = catId,
+      categoryOpened = categoryOpened,
+      isThread = isThread,
+      parentChatId = parentChatId,
     )
 
 let chatA = createTestChatItem("0xa")
@@ -145,6 +149,39 @@ suite "updating chat items":
     check(parent.sortTimestamp == 123)
     check(thread.sortTimestamp == 123)
 
+  test "thread batches follow their parent in source order":
+    let parent = createTestChatItem("0xparent")
+    let otherChat = createTestChatItem("0xother")
+    let firstThread = createTestChatItem("0xthread1", isThread = true, parentChatId = parent.id)
+    let secondThread = createTestChatItem("0xthread2", isThread = true, parentChatId = parent.id)
+    let laterThread = createTestChatItem("0xthread3", isThread = true, parentChatId = parent.id)
+    model.setData(@[parent, otherChat])
+
+    model.appendItemsAfterParent(@[firstThread, secondThread], parent.id)
+    check(model.getItemIdxById(parent.id) == 0)
+    check(model.getItemIdxById(firstThread.id) == 1)
+    check(model.getItemIdxById(secondThread.id) == 2)
+    check(model.getItemIdxById(otherChat.id) == 3)
+
+    model.appendItemsAfterParent(@[laterThread], parent.id)
+    check(model.getItemIdxById(laterThread.id) == 3)
+    check(model.getItemIdxById(otherChat.id) == 4)
+
+  test "thread batches remain with their own parent":
+    let firstParent = createTestChatItem("0xparent1")
+    let secondParent = createTestChatItem("0xparent2")
+    let firstThread = createTestChatItem("0xthread1", isThread = true, parentChatId = firstParent.id)
+    let secondThread = createTestChatItem("0xthread2", isThread = true, parentChatId = secondParent.id)
+    model.setData(@[firstParent, secondParent])
+
+    model.appendItemsAfterParent(@[firstThread], firstParent.id)
+    model.appendItemsAfterParent(@[secondThread], secondParent.id)
+
+    check(model.getItemIdxById(firstParent.id) == 0)
+    check(model.getItemIdxById(firstThread.id) == 1)
+    check(model.getItemIdxById(secondParent.id) == 2)
+    check(model.getItemIdxById(secondThread.id) == 3)
+
 suite "hidden role (chat list virtualization)":
   setup:
     # fresh items per test — ChatItem is a ref, shared globals leak state
@@ -164,6 +201,16 @@ suite "hidden role (chat list virtualization)":
 
     model.changeCategoryOpened("0xcatA", true)
     check(model.getItemById("0xc").hidden == false)
+
+  test "thread inherits collapsed category visibility":
+    let thread = createTestChatItem("0xthread", catId = "0xcatA", categoryOpened = false,
+      isThread = true, parentChatId = "0xc")
+    model.appendItem(thread)
+
+    check(thread.hidden == true)
+
+    model.changeCategoryOpened("0xcatA", true)
+    check(thread.hidden == false)
 
   test "active chat stays visible in a closed category":
     model.setActiveItem("0xc")

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -3135,6 +3135,10 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Copy thread ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy channel ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3245,10 +3249,6 @@ Do you wish to override the security check and continue?</source>
     </message>
     <message>
         <source>Couldn&apos;t load threads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t load thread messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -3150,6 +3150,10 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <translation>Ladicí akce</translation>
     </message>
     <message>
+        <source>Copy thread ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy channel ID</source>
         <translation>Kopírovat ID kanálu</translation>
     </message>
@@ -3261,10 +3265,6 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
     </message>
     <message>
         <source>Couldn&apos;t load threads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t load thread messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -3137,6 +3137,10 @@ Do you wish to override the security check and continue?</source>
         <translation>Acciones de depuración</translation>
     </message>
     <message>
+        <source>Copy thread ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy channel ID</source>
         <translation>Copiar ID del canal</translation>
     </message>
@@ -3247,10 +3251,6 @@ Do you wish to override the security check and continue?</source>
     </message>
     <message>
         <source>Couldn&apos;t load threads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t load thread messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -3136,6 +3136,10 @@ Do you wish to override the security check and continue?</source>
         <translation>Actions de débogage</translation>
     </message>
     <message>
+        <source>Copy thread ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy channel ID</source>
         <translation>Copier l’ID du canal</translation>
     </message>
@@ -3246,10 +3250,6 @@ Do you wish to override the security check and continue?</source>
     </message>
     <message>
         <source>Couldn&apos;t load threads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t load thread messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -3123,6 +3123,10 @@ Do you wish to override the security check and continue?</source>
         <translation>디버그 작업</translation>
     </message>
     <message>
+        <source>Copy thread ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy channel ID</source>
         <translation>채널 ID 복사</translation>
     </message>
@@ -3232,10 +3236,6 @@ Do you wish to override the security check and continue?</source>
     </message>
     <message>
         <source>Couldn&apos;t load threads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t load thread messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -3150,6 +3150,10 @@ Do you wish to override the security check and continue?</source>
         <translation>Дії налагодження</translation>
     </message>
     <message>
+        <source>Copy thread ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy channel ID</source>
         <translation>Копіювати ID каналу</translation>
     </message>
@@ -3261,10 +3265,6 @@ Do you wish to override the security check and continue?</source>
     </message>
     <message>
         <source>Couldn&apos;t load threads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Couldn&apos;t load thread messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
### What does the PR do

Fixes #21899
status-go PR: https://github.com/status-im/status-go/pull/7796

Threads were only fetched on chat open, so a thread row appeared in the chat list only after visiting its parent. Moving the trigger alone was not enough: the SIGNAL_CHAT_THREADS_LOADED listeners lived in per-chat controllers, which are constructed at section build but not init'd until the chat is opened.

Fetch the whole section at the end of buildChatSectionUI — which already runs on section activation, behind the switch animation — with a single wakuext_chatThreadsByChatIDs call on the threadpool, and handle the signal in the always-alive chat section module. The completion slot settles every requested chat, including those with no threads, which would otherwise stay in the loading set forever. The two per-chat handlers that both redundantly called openThreadAsChat now only back-fill hasThread. Thread loading is also gated on THREADS_ENABLED, which it never was.

### Affected areas

- chat_content module
- chat_section module
- message service and async task
- status-go 

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

Also ask Copilot to align feedback with repository architecture boundaries:

- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[threads-loaded.webm](https://github.com/user-attachments/assets/a56abf3a-5f80-4875-be91-cbded176df42)

### Impact on end user

None without the feature flags. Once enabled, shows all threads when opening a section, for a better UX

### How to test

0. See first PR to get how to enable the feature flags
1. Create some threads on different chats
2. Restart the app
3. Threads should all show in the section

### Risk 

None with the feature flag. Low/Medium when enabled, but only for performance, since we're loading more modules now
