### PR TITLE
Profile: Ens settings basic refactor to provide responsive layout

### DIFF
--- a/src/app_service/service/ens/utils.nim
+++ b/src/app_service/service/ens/utils.nim
@@ -110,8 +110,11 @@ proc label*(username:string): string =
   result = "0x" & node.toHex()
 
 proc getExpirationTime*(chainId: int, username: string): int =
-  let res = status_ens.expireAt(chainId, username)
-  return fromHex[int](res.result.getStr)
+  try:
+    let res = status_ens.expireAt(chainId, username)
+    return fromHex[int](res.result.getStr)
+  except:
+    return 0
 
 proc hex2Token*(input: string, decimals: int): string =
   var value = fromHex(Stuint[256], input)

--- a/storybook/pages/ENSPopupPage.qml
+++ b/storybook/pages/ENSPopupPage.qml
@@ -1,0 +1,80 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Storybook
+
+import AppLayouts.Profile.popups
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    QtObject {
+        id: d
+
+        property string preferredUsername: ""
+    }
+
+    ListModel {
+        id: ensUsernamesModel
+
+        ListElement { ensUsername: "alice.stateofus.eth" }
+        ListElement { ensUsername: "alice.eth" }
+        ListElement { ensUsername: "bob.stateofus.eth" }
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+
+            onClicked: popup.open()
+        }
+
+        ENSPopup {
+            id: popup
+
+            anchors.centerIn: parent
+            visible: true
+            modal: false
+            destroyOnClose: false
+            closePolicy: Popup.NoAutoClose
+
+            preferredUsername: d.preferredUsername
+            model: ensUsernamesModel
+
+            onPreferredUsernameSelected: (ensUsername) => {
+                d.preferredUsername = ensUsername
+                logs.logEvent("ENSPopup::preferredUsernameSelected: " + ensUsername)
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 160
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            Button {
+                text: "Clear preferred username"
+
+                onClicked: d.preferredUsername = ""
+            }
+        }
+    }
+}
+
+// category: Popups

--- a/storybook/pages/EnsDetailsViewPage.qml
+++ b/storybook/pages/EnsDetailsViewPage.qml
@@ -1,0 +1,126 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Profile.views
+
+import Storybook
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    readonly property string mockPubkey:
+        "0x04c1a3b5d7e9f0112233445566778899aabbccddeeff00112233445566778899" +
+        "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aa"
+
+    function applyDetails() {
+        let expirationTime = 0
+        const nowSec = Math.floor(Date.now() / 1000)
+        if (ctrlExpired.checked)
+            expirationTime = nowSec - 24 * 60 * 60          // yesterday -> releasable
+        else if (ctrlLocked.checked)
+            expirationTime = nowSec + 30 * 24 * 60 * 60     // +30 days -> locked
+
+        detailsView.setDetails(1 /*chainId*/, ctrlUsername.text, ctrlAddress.text,
+                               root.mockPubkey, ctrlIsStatus.checked, expirationTime,
+                               ctrlIsPreferred.checked)
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        EnsDetailsView {
+            id: detailsView
+
+            width: Math.min(parent.width - 48, 560)
+            height: parent.height
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            username: ctrlUsername.text
+            isLoading: ctrlLoading.checked
+
+            onBackBtnClicked: logs.logEvent("EnsDetailsView::backBtnClicked")
+            onReleaseUsernameRequested: (senderAddress) =>
+                logs.logEvent("EnsDetailsView::releaseUsernameRequested: " + senderAddress)
+            onRemoveEnsUsernameRequested: (chainId, username) =>
+                logs.logEvent("EnsDetailsView::removeEnsUsernameRequested: chainId=" + chainId + ", username=" + username)
+
+            Component.onCompleted: root.applyDetails()
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 320
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            RowLayout {
+                Label { text: "Username:" }
+                TextField {
+                    id: ctrlUsername
+                    text: "michal.stateofus.eth"
+                }
+            }
+
+            RowLayout {
+                Label { text: "Address:" }
+                TextField {
+                    id: ctrlAddress
+                    Layout.preferredWidth: 360
+                    text: "0x1234567890abcdef1234567890abcdef12345678"
+                }
+            }
+
+            Switch {
+                id: ctrlLoading
+                text: "Loading"
+            }
+
+            Switch {
+                id: ctrlIsStatus
+                text: "Is Status name (shows Release button)"
+                checked: true
+            }
+
+            Switch {
+                id: ctrlIsPreferred
+                text: "Is preferred username (blocks release)"
+            }
+
+            RowLayout {
+                Label { text: "Expiration:" }
+
+                RadioButton {
+                    id: ctrlExpired
+                    text: "Expired (releasable)"
+                    checked: true
+                }
+                RadioButton {
+                    id: ctrlLocked
+                    text: "Locked (future)"
+                }
+                RadioButton {
+                    id: ctrlNoExpiration
+                    text: "None (0)"
+                }
+            }
+
+            Button {
+                text: "Apply details"
+
+                onClicked: root.applyDetails()
+            }
+        }
+    }
+}
+
+// category: Views

--- a/storybook/pages/EnsListViewPage.qml
+++ b/storybook/pages/EnsListViewPage.qml
@@ -1,0 +1,92 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Profile.views
+
+import Storybook
+
+import utils
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    QtObject {
+        id: d
+
+        property string preferredUsername: "alice.stateofus.eth"
+    }
+
+    ListModel {
+        id: ensUsernamesModel
+
+        ListElement { ensUsername: "alice.stateofus.eth"; isPending: false; chainId: 1 }
+        ListElement { ensUsername: "bob.eth"; isPending: true; chainId: 1 }
+        ListElement { ensUsername: "carol.stateofus.eth"; isPending: false; chainId: 1 }
+    }
+
+    Item {
+        id: viewContainer
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        EnsListView {
+            anchors.fill: parent
+            profileContentWidth: Math.min(parent.width, 800)
+
+            model: ensUsernamesModel
+            preferredUsername: d.preferredUsername
+            pubkey: "0xdeadbeef"
+            icon: ""
+            hasConfirmedEnsUsernames: ctrlHasConfirmed.checked
+
+            onAddBtnClicked: logs.logEvent("EnsListView::addBtnClicked")
+            onSelectEns: (username, chainId) => logs.logEvent("EnsListView::selectEns: " + username + " (chainId: " + chainId + ")")
+            onPreferredUsernameSelected: (ensUsername) => {
+                d.preferredUsername = ensUsername
+                logs.logEvent("EnsListView::preferredUsernameSelected: " + ensUsername)
+            }
+        }
+
+        // EnsListView opens its "Primary username" popup via Global.openPopup();
+        // instantiate the requested component so the popup is visible in Storybook.
+        Connections {
+            target: Global
+
+            function onOpenPopupRequested(popupComponent, params) {
+                const popup = popupComponent.createObject(viewContainer, params)
+                popup.open()
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 180
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            Switch {
+                id: ctrlHasConfirmed
+                text: "Has confirmed/pending ENS usernames"
+                checked: true
+            }
+
+            Button {
+                text: "Clear preferred username"
+
+                onClicked: d.preferredUsername = ""
+            }
+        }
+    }
+}
+
+// category: Views

--- a/storybook/pages/EnsTermsAndConditionsViewPage.qml
+++ b/storybook/pages/EnsTermsAndConditionsViewPage.qml
@@ -1,0 +1,112 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import AppLayouts.Profile.views
+
+import Storybook
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        EnsTermsAndConditionsView {
+            width: Math.min(parent.width - 48, 560)
+            height: parent.height
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            username: ctrlUsername.text
+
+            registrarAddress: ctrlRegistrarAddress.text
+            ensRegistryAddress: ctrlEnsRegistryAddress.text
+            etherscanAddressLink: ctrlEtherscanLink.text
+
+            walletAddress: ctrlWalletAddress.text
+            pubkey: ctrlPubkey.text
+
+            sntBalance: ctrlHasEnoughSnt.checked ? 100 : 5
+
+            onBackBtnClicked: logs.logEvent("EnsTermsAndConditionsView::backBtnClicked")
+            onRegisterUsername: logs.logEvent("EnsTermsAndConditionsView::registerUsername")
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 320
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            RowLayout {
+                Label { text: "Username:" }
+                TextField {
+                    id: ctrlUsername
+                    text: "michal"
+                }
+            }
+
+            RowLayout {
+                Label { text: "Wallet address:" }
+                TextField {
+                    id: ctrlWalletAddress
+                    Layout.preferredWidth: 360
+                    text: "0x1234567890abcdef1234567890abcdef12345678"
+                }
+            }
+
+            RowLayout {
+                Label { text: "Pubkey:" }
+                TextField {
+                    id: ctrlPubkey
+                    Layout.preferredWidth: 360
+                    text: "0x0400112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+                }
+            }
+
+            RowLayout {
+                Label { text: "Registrar address:" }
+                TextField {
+                    id: ctrlRegistrarAddress
+                    Layout.preferredWidth: 360
+                    text: "0xDB5ac1a559b02E12F29fC0eC0e37Be8E046DEF49"
+                }
+            }
+
+            RowLayout {
+                Label { text: "ENS registry address:" }
+                TextField {
+                    id: ctrlEnsRegistryAddress
+                    Layout.preferredWidth: 360
+                    text: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
+                }
+            }
+
+            RowLayout {
+                Label { text: "Etherscan address link:" }
+                TextField {
+                    id: ctrlEtherscanLink
+                    Layout.preferredWidth: 360
+                    text: "https://etherscan.io/address"
+                }
+            }
+
+            Switch {
+                id: ctrlHasEnoughSnt
+                text: "Has enough SNT (≥ 10)"
+                checked: true
+            }
+        }
+    }
+}
+
+// category: Views

--- a/ui/app/AppLayouts/Profile/popups/ENSPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/ENSPopup.qml
@@ -13,26 +13,31 @@ import shared
 import shared.panels
 import shared.popups
 
-import AppLayouts.Profile.stores
-
 StatusDialog {
     id: root
 
-    property EnsUsernamesStore ensUsernamesStore
+    // The currently preferred ENS username (empty when none is selected yet).
+    property string preferredUsername
+
+    // Model of the selectable ENS usernames; expected role: ensUsername.
+    property var model
+
+    // Emitted when the user confirms a different username as their preferred one.
+    signal preferredUsernameSelected(string ensUsername)
 
     title: qsTr("Primary username")
     standardButtons: Dialog.ApplyRole
     implicitWidth: 400
 
     onApplied: {
-        ensUsernamesStore.setPrefferedEnsUsername(d.newUsername);
+        root.preferredUsernameSelected(d.newUsername);
         close();
     }
 
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
             StatusButton {
-                enabled: d.newUsername !== root.ensUsernamesStore.preferredUsername
+                enabled: d.newUsername !== root.preferredUsername
                 text: qsTr("Apply")
                 onClicked: {
                     root.applied()
@@ -44,7 +49,7 @@ StatusDialog {
     QtObject {
         id: d
 
-        property string newUsername: root.ensUsernamesStore.preferredUsername
+        property string newUsername: root.preferredUsername
     }
 
     ColumnLayout {
@@ -53,7 +58,7 @@ StatusDialog {
 
         StyledText {
             Layout.fillWidth: true
-            text: root.ensUsernamesStore.preferredUsername ?
+            text: root.preferredUsername ?
                   qsTr("Your messages are displayed to others with this username:")
                   :
                   qsTr("Once you select a username, you won’t be able to disable it afterwards. You will only be able choose a different username to display.")
@@ -62,8 +67,8 @@ StatusDialog {
         }
 
         StyledText {
-            visible: root.ensUsernamesStore.preferredUsername
-            text: root.ensUsernamesStore.preferredUsername
+            visible: root.preferredUsername
+            text: root.preferredUsername
             font.pixelSize: Theme.secondaryAdditionalTextSize
             font.weight: Font.Bold
         }
@@ -74,14 +79,14 @@ StatusDialog {
             Layout.fillWidth: true
             Layout.fillHeight: true
             implicitHeight: contentHeight
-            model: root.ensUsernamesStore.currentChainEnsUsernamesModel
+            model: root.model
 
             delegate: RadioDelegate {
                 id: radioDelegate
 
                 width: ListView.view.width
                 text: ensUsername
-                checked: root.ensUsernamesStore.preferredUsername === ensUsername
+                checked: root.preferredUsername === ensUsername
 
                 contentItem: StyledText {
                     color: Theme.palette.textColor
@@ -100,6 +105,5 @@ StatusDialog {
             }
         }
     }
-
 }
 

--- a/ui/app/AppLayouts/Profile/popups/EnsTermsAndConditionsPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/EnsTermsAndConditionsPopup.qml
@@ -1,0 +1,149 @@
+import QtQuick
+import QtQuick.Controls
+
+import utils
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Popups.Dialog
+
+StatusDialog {
+    id: root
+
+    // Status UsernameRegistrar contract address.
+    property string registrarAddress
+    // ENS Registry contract address.
+    property string ensRegistryAddress
+    // Base Etherscan address URL used to build the "look up" links.
+    property string etherscanAddressLink
+
+    title: qsTr("Terms of name registration")
+    width: 480
+    standardButtons: Dialog.Ok
+
+    StatusScrollView {
+        id: scroll
+        anchors.fill: parent
+        contentWidth: availableWidth
+
+        Column {
+            spacing: Theme.halfPadding
+            width: scroll.availableWidth
+
+
+            StatusBaseText {
+                text: qsTr("Funds are deposited for 1 year. Your SNT will be locked, but not spent.")
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("After 1 year, you can release the name and get your deposit back, or take no action to keep the name.")
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.")
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.")
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("Your address(es) will be publicly associated with your ENS name.")
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.")
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.")
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("These terms are guaranteed by the smart contract logic at addresses:")
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                font.weight: Font.Bold
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("%1 (Status UsernameRegistrar).").arg(root.registrarAddress)
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                font.family: Fonts.monoFont.family
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("<a href='%1/%2'>Look up on Etherscan</a>")
+                .arg(root.etherscanAddressLink)
+                .arg(root.registrarAddress)
+                anchors.left: parent.left
+                anchors.right: parent.right
+                onLinkActivated: (link) => Global.requestOpenLink(link)
+                color: Theme.palette.directColor1
+                StatusMouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
+                    cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                }
+            }
+
+            StatusBaseText {
+                text: qsTr("%1 (ENS Registry).").arg(root.ensRegistryAddress)
+                wrapMode: Text.WordWrap
+                anchors.left: parent.left
+                anchors.right: parent.right
+                font.family: Fonts.monoFont.family
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                text: qsTr("<a href='%1/%2'>Look up on Etherscan</a>")
+                .arg(root.etherscanAddressLink)
+                .arg(root.ensRegistryAddress)
+                anchors.left: parent.left
+                anchors.right: parent.right
+                onLinkActivated: (link) => Global.requestOpenLink(link)
+                color: Theme.palette.directColor1
+                StatusMouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
+                    cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                }
+            }
+
+        }
+    }
+}

--- a/ui/app/AppLayouts/Profile/popups/qmldir
+++ b/ui/app/AppLayouts/Profile/popups/qmldir
@@ -12,5 +12,6 @@ WalletKeypairAccountMenu 1.0 WalletKeypairAccountMenu.qml
 WalletAddressMenu 1.0 WalletAddressMenu.qml
 ConfirmChangePasswordModal 1.0 ConfirmChangePasswordModal.qml
 ENSPopup 1.0 ENSPopup.qml
+EnsTermsAndConditionsPopup 1.0 EnsTermsAndConditionsPopup.qml
 SearchEngineModal 1.0 SearchEngineModal.qml
 ExemptionNotificationsModal 1.0 ExemptionNotificationsModal.qml

--- a/ui/app/AppLayouts/Profile/popups/qmldir
+++ b/ui/app/AppLayouts/Profile/popups/qmldir
@@ -11,5 +11,6 @@ TokenListPopup 1.0 TokenListPopup.qml
 WalletKeypairAccountMenu 1.0 WalletKeypairAccountMenu.qml
 WalletAddressMenu 1.0 WalletAddressMenu.qml
 ConfirmChangePasswordModal 1.0 ConfirmChangePasswordModal.qml
+ENSPopup 1.0 ENSPopup.qml
 SearchEngineModal 1.0 SearchEngineModal.qml
 ExemptionNotificationsModal 1.0 ExemptionNotificationsModal.qml

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -1,29 +1,38 @@
 import QtQuick
 import QtQuick.Layouts
-import QtQuick.Controls
 
 import StatusQ
+import StatusQ.Components
+import StatusQ.Controls
 import StatusQ.Core
 import StatusQ.Core.Theme
-import StatusQ.Controls as StatusQControls
-import StatusQ.Components
-
-import utils
-import shared.status
-import shared.popups
-import shared.popups.send
-import shared.stores.send
-
-import AppLayouts.Profile.stores
 
 Item {
     id: root
-    property EnsUsernamesStore ensUsernamesStore
+
     property string username: ""
-    property int chainId: -1
+    property bool isLoading
 
     signal backBtnClicked()
     signal releaseUsernameRequested(string senderAddress)
+    signal removeEnsUsernameRequested(int chainId, string username)
+
+    function setDetails(chainId: int, ensName: string, address: string, pubkey: string,
+                        isStatus: bool, expirationTime: int, isPreferred: bool) {
+        d.chainId = chainId
+        d.walletAddress = address
+        walletAddressLbl.subTitle = address
+
+        d.key = pubkey
+        keyLbl.subTitle = pubkey.substring(0, 20) + "..."
+                + pubkey.substring(pubkey.length - 20)
+
+        d.isStatus = isStatus
+        releaseBtn.enabled = expirationTime > 0
+                             && (Date.now() / 1000) > expirationTime
+                             && !isPreferred
+        d.expirationTimestamp = expirationTime * 1000
+    }
 
     QtObject {
         id: d
@@ -31,140 +40,114 @@ Item {
         property double expirationTimestamp: 0
         property string walletAddress: "-"
         property string key: "-"
-    }
-
-    StatusBaseText {
-        id: sectionTitle
-        text: username
-        anchors.left: parent.left
-        anchors.leftMargin: 24
-        anchors.top: parent.top
-        anchors.topMargin: 24
-        font.weight: Font.Bold
-        font.pixelSize: Theme.fontSize(20)
-        color: Theme.palette.directColor1
-    }
-
-    Component {
-        id: loadingImageComponent
-        StatusLoadingIndicator {}
-    }
-
-    Loader {
-        id: loadingImg
-        active: false
-        sourceComponent: loadingImageComponent
-        anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
-        anchors.top: parent.top
-        anchors.topMargin: Theme.padding
-    }
-
-    Connections {
-        target: root.ensUsernamesStore.ensUsernamesModule
-        function onDetailsObtained(chainId: int, ensName: string, address: string, pubkey: string, isStatus: bool, expirationTime: int) {
-            if(username != (isStatus ? ensName + ".stateofus.eth" : ensName))
-                return;
-            d.walletAddress = address
-            walletAddressLbl.subTitle = address;
-            walletAddressLbl.visible = !!address;
-
-            d.key = pubkey
-            keyLbl.subTitle = pubkey.substring(0, 20) + "..." + pubkey.substring(pubkey.length - 20);
-            keyLbl.visible = !!pubkey;
-
-            releaseBtn.visible = isStatus
-            removeButton.visible = true
-            releaseBtn.enabled = expirationTime > 0
-                                 && (Date.now() / 1000) > expirationTime
-                                 && root.ensUsernamesStore.preferredUsername !== username
-            d.expirationTimestamp = expirationTime * 1000
-        }
-        function onLoading(isLoading: bool) {
-            loadingImg.active = isLoading
-            if (!isLoading)
-                return;
-            walletAddressLbl.visible = false;
-            keyLbl.visible = false;
-            releaseBtn.visible = false;
-            removeButton.visible = false;
-            d.expirationTimestamp = 0;
-        }
-    }
-
-    StatusDescriptionListItem {
-        id: walletAddressLbl
-        title: qsTr("Wallet address")
-        visible: false
-        anchors.top: sectionTitle.bottom
-        anchors.topMargin: 24
-        asset.name: "copy"
-        tooltip.text: qsTr("Copied to clipboard!")
-        iconButton.onClicked: {
-            ClipboardUtils.setText(subTitle)
-            tooltip.visible = !tooltip.visible
-        }
-    }
-    StatusDescriptionListItem {
-        id: keyLbl
-        title: qsTr("Key")
-        visible: false
-        anchors.top: walletAddressLbl.bottom
-        anchors.topMargin: 24
-        asset.name: "copy"
-        tooltip.text: qsTr("Copied to clipboard!")
-        iconButton.onClicked: {
-            ClipboardUtils.setText(subTitle)
-            tooltip.visible = !tooltip.visible
-        }
+        property int chainId: -1
+        property bool isStatus
     }
 
     RowLayout {
-        id: actionsLayout
+        id: headerRow
 
-        anchors.top: keyLbl.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: 24
+        anchors.top: parent.top
         anchors.topMargin: 24
-        anchors.left: parent.left
-        anchors.leftMargin: 24
 
-        StatusQControls.StatusButton {
-            id: removeButton
-            visible: false
-            type: StatusQControls.StatusBaseButton.Type.Danger
-            text: qsTr("Remove username")
-            onClicked: {
-                root.ensUsernamesStore.removeEnsUsername(root.chainId, root.username)
-                root.backBtnClicked()
-            }
+        StatusBaseText {
+            id: sectionTitle
+
+            Layout.fillWidth: true
+
+            text: username
+            font.weight: Font.Bold
+            font.pixelSize: Theme.fontSize(20)
+            color: Theme.palette.directColor1
+            elide: Text.ElideRight
         }
 
-        StatusQControls.StatusButton {
-            id: releaseBtn
-            visible: false
-            enabled: false
-            text: qsTr("Release username")
-            onClicked: {
-                root.releaseUsernameRequested(d.walletAddress)
-            }
+        Loader {
+            id: loadingImg
+            active: root.isLoading
+            sourceComponent: StatusLoadingIndicator {}
         }
     }
 
-    Text {
-        visible: releaseBtn.visible && !releaseBtn.enabled
-        anchors.top: actionsLayout.bottom
-        anchors.topMargin: 2
+    ColumnLayout {
+        anchors.top: headerRow.bottom
         anchors.left: parent.left
-        anchors.leftMargin: 24
-        text: {
-            if (d.expirationTimestamp === 0)
-                return ""
-            const formattedDate = LocaleUtils.formatDate(d.expirationTimestamp, Locale.ShortFormat)
-            return qsTr("Username locked. You won't be able to release it until %1").arg(formattedDate)
+        anchors.right: parent.right
+        anchors.topMargin: 24
+        spacing: 24
+
+        StatusDescriptionListItem {
+            id: walletAddressLbl
+
+            Layout.fillWidth: true
+
+            title: qsTr("Wallet address")
+            visible: !!d.walletAddress && !root.isLoading
+            asset.name: "copy"
+            tooltip.text: qsTr("Copied to clipboard!")
+            iconButton.onClicked: {
+                ClipboardUtils.setText(subTitle)
+                tooltip.visible = !tooltip.visible
+            }
         }
-        color: Theme.palette.darkGrey
+        StatusDescriptionListItem {
+            id: keyLbl
+
+            Layout.fillWidth: true
+
+            title: qsTr("Key")
+            visible: !!d.key && !root.isLoading
+            asset.name: "copy"
+            tooltip.text: qsTr("Copied to clipboard!")
+            iconButton.onClicked: {
+                ClipboardUtils.setText(subTitle)
+                tooltip.visible = !tooltip.visible
+            }
+        }
+
+        Flow {
+            id: actionsLayout
+
+            Layout.fillWidth: true
+
+            spacing: root.Theme.padding
+
+            StatusButton {
+                id: removeButton
+                visible: !root.isLoading
+                type: StatusBaseButton.Type.Danger
+                text: qsTr("Remove username")
+                onClicked: root.removeEnsUsernameRequested(d.chainId, root.username)
+            }
+
+            StatusButton {
+                id: releaseBtn
+                visible: d.isStatus && !root.isLoading
+                enabled: false
+                text: qsTr("Release username")
+                onClicked: root.releaseUsernameRequested(d.walletAddress)
+            }
+        }
+
+        StatusBaseText {
+            visible: releaseBtn.visible && !releaseBtn.enabled
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+
+            text: {
+                if (d.expirationTimestamp === 0)
+                    return ""
+                const formattedDate = LocaleUtils.formatDate(d.expirationTimestamp, Locale.ShortFormat)
+                return qsTr("Username locked. You won't be able to release it until %1").arg(formattedDate)
+            }
+            color: Theme.palette.darkGrey
+        }
     }
 
-    StatusQControls.StatusButton {
+    StatusButton {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Theme.padding
         anchors.horizontalCenter: parent.horizontalCenter

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -13,35 +13,29 @@ import shared.views.chat
 import shared.controls.chat
 import utils
 
-import AppLayouts.Profile.stores
-
 import "../popups"
 
 Item {
     id: root
 
-    property EnsUsernamesStore ensUsernamesStore
-
     property int profileContentWidth
+
+    // ENS usernames for the current chain; expected roles: ensUsername, isPending, chainId.
+    property var model
+
+    // Profile fields used to preview how the preferred username appears in chats.
+    property string preferredUsername
+    property string pubkey
+    property string icon
+
+    // Whether the user has any confirmed or pending ENS usernames (gates the chat settings section).
+    property bool hasConfirmedEnsUsernames
 
     signal addBtnClicked()
     signal selectEns(string username, int chainId)
 
-    Component.onCompleted: {
-        d.updateNumberOfPendingEnsUsernames()
-    }
-
-    QtObject {
-        id: d
-
-        property int numOfPendingEnsUsernames: 0
-        readonly property bool hasConfirmedEnsUsernames: root.ensUsernamesStore.ensUsernamesModel.count > 0
-                                                         || numOfPendingEnsUsernames > 0
-
-        function updateNumberOfPendingEnsUsernames() {
-            numOfPendingEnsUsernames = root.ensUsernamesStore.numOfPendingEnsUsernames()
-        }
-    }
+    // Emitted when the user confirms a different preferred username in the popup.
+    signal preferredUsernameSelected(string ensUsername)
 
     Item {
         anchors.top: parent.top
@@ -115,7 +109,7 @@ Item {
             StatusListView {
                 id: lvEns
                 anchors.fill: parent
-                model: root.ensUsernamesStore.currentChainEnsUsernamesModel
+                model: root.model
 
                 spacing: 10
                 delegate: StatusListItem {
@@ -158,7 +152,7 @@ Item {
 
         StatusBaseText {
             id: chatSettingsLabel
-            visible: d.hasConfirmedEnsUsernames
+            visible: root.hasConfirmedEnsUsernames
             text: qsTr("Chat settings")
             anchors.left: parent.left
             anchors.top: ensList.bottom
@@ -188,7 +182,7 @@ Item {
             StatusBaseText {
                 id: usernameLabel2
                 visible: chatSettingsLabel.visible
-                text: root.ensUsernamesStore.preferredUsername || qsTr("None selected")
+                text: root.preferredUsername || qsTr("None selected")
                 anchors.left: usernameLabel.right
                 anchors.leftMargin: Theme.padding
                 font.pixelSize: Theme.secondaryTextFontSize
@@ -210,8 +204,8 @@ Item {
             anchors.top: !visible ? separator.bottom : primaryUsernameItem.bottom
             anchors.topMargin: Theme.padding * 2
 
-            visible: d.hasConfirmedEnsUsernames
-                     && root.ensUsernamesStore.preferredUsername !== ""
+            visible: root.hasConfirmedEnsUsernames
+                     && root.preferredUsername !== ""
 
             timestamp: new Date().getTime()
             disableHover: true
@@ -221,10 +215,10 @@ Item {
                 contentType: StatusMessage.ContentType.Text
                 messageText: qsTr("Hey!")
                 amISender: false
-                sender.displayName: root.ensUsernamesStore.preferredUsername
+                sender.displayName: root.preferredUsername
                 sender.profileImage.assetSettings.isImage: true
-                sender.profileImage.assetSettings.color: Utils.colorForPubkey(root.Theme.palette, root.ensUsernamesStore.pubkey)
-                sender.profileImage.name: root.ensUsernamesStore.icon
+                sender.profileImage.assetSettings.color: Utils.colorForPubkey(root.Theme.palette, root.pubkey)
+                sender.profileImage.name: root.icon
             }
         }
 
@@ -242,11 +236,11 @@ Item {
         id: ensPopupComponent
 
         ENSPopup {
-            preferredUsername: root.ensUsernamesStore.preferredUsername
-            model: root.ensUsernamesStore.currentChainEnsUsernamesModel
+            preferredUsername: root.preferredUsername
+            model: root.model
             destroyOnClose: true
 
-            onPreferredUsernameSelected: (ensUsername) => root.ensUsernamesStore.setPrefferedEnsUsername(ensUsername)
+            onPreferredUsernameSelected: (ensUsername) => root.preferredUsernameSelected(ensUsername)
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -13,7 +13,7 @@ import shared.views.chat
 import shared.controls.chat
 import utils
 
-import "../popups"
+import AppLayouts.Profile.popups
 
 Item {
     id: root

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -162,11 +162,11 @@ Item {
         }
 
         Item {
-            width: childrenRect.width
             height: childrenRect.height
 
             id: primaryUsernameItem
             anchors.left: parent.left
+            anchors.right: parent.right
             anchors.top: chatSettingsLabel.bottom
             anchors.topMargin: 24
 
@@ -203,6 +203,8 @@ Item {
 
             anchors.top: !visible ? separator.bottom : primaryUsernameItem.bottom
             anchors.topMargin: Theme.padding * 2
+            anchors.left: parent.left
+            anchors.right: parent.right
 
             visible: root.hasConfirmedEnsUsernames
                      && root.preferredUsername !== ""
@@ -214,10 +216,12 @@ Item {
             messageDetails: StatusMessageDetails {
                 contentType: StatusMessage.ContentType.Text
                 messageText: qsTr("Hey!")
+                unparsedText: messageText
                 amISender: false
                 sender.displayName: root.preferredUsername
                 sender.profileImage.assetSettings.isImage: true
-                sender.profileImage.assetSettings.color: Utils.colorForPubkey(root.Theme.palette, root.pubkey)
+                sender.profileImage.assetSettings.color:
+                    Utils.colorForPubkey(root.Theme.palette, root.pubkey)
                 sender.profileImage.name: root.icon
             }
         }
@@ -225,10 +229,12 @@ Item {
         StatusBaseText {
             anchors.top: messagesShownAs.bottom
             anchors.left: messagesShownAs.left
+            anchors.right: messagesShownAs.right
             anchors.topMargin: Theme.padding
             text: qsTr("You’re displaying your ENS username in chats")
             font.pixelSize: Theme.fontSize(14)
             color: Theme.palette.baseColor1
+            wrapMode: Text.Wrap
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -242,8 +242,11 @@ Item {
         id: ensPopupComponent
 
         ENSPopup {
-            ensUsernamesStore: root.ensUsernamesStore
+            preferredUsername: root.ensUsernamesStore.preferredUsername
+            model: root.ensUsernamesStore.currentChainEnsUsernamesModel
             destroyOnClose: true
+
+            onPreferredUsernameSelected: (ensUsername) => root.ensUsernamesStore.setPrefferedEnsUsername(ensUsername)
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -61,7 +61,7 @@ Item {
     Item {
         id: ensContainer
         anchors.top: parent.top
-        width: profileContentWidth
+        width: Math.min(profileContentWidth, parent.width)
         anchors.horizontalCenter: parent.horizontalCenter
 
         Rectangle {
@@ -176,52 +176,71 @@ Item {
 
         Rectangle {
             id: ensTypeRect
-            anchors.top: ensUsername.bottom
-            anchors.topMargin: Theme.bigPadding
+
+            anchors.top: ensTypeRow.top
+            anchors.bottom: ensTypeRow.bottom
+            anchors.margins: -Theme.smallPadding / 2
+
+            width: ensTypeLbl.contentWidth + ensTypeDesc.contentWidth + Theme.smallPadding*3
+
             border.width: 1
             border.color: Theme.palette.border
             color: Theme.palette.background
             radius: 50
             height: 30
-            width: ensTypeRow.width + Theme.halfPadding*2
+        }
 
-            Row {
-                id: ensTypeRow
-                anchors.top: parent.top
-                anchors.topMargin: Theme.halfPadding
-                leftPadding: Theme.padding
-                spacing: Theme.smallPadding
-                height: 20
+        RowLayout {
+            id: ensTypeRow
 
-                StatusBaseText {
-                    text: !isStatus ?
-                        qsTr("Custom domain")
-                        :
-                        ".stateofus.eth"
-                    font.weight: Font.Bold
-                    font.pixelSize: Theme.tertiaryTextFontSize
-                    color: Theme.palette.directColor1
-                }
+            anchors.top: ensUsername.bottom
+            anchors.margins: Theme.smallPadding
+            anchors.topMargin: Theme.bigPadding
+            anchors.left: parent.left
+            anchors.right: parent.right
 
-                StatusBaseText {
-                    text: !isStatus ?
-                        qsTr("I want a stateofus.eth domain")
-                        :
-                        qsTr("I own a name on another domain")
-                    font.pixelSize: Theme.tertiaryTextFontSize
-                    color: Theme.palette.primaryColor1
+            spacing: Theme.smallPadding
 
-                    StatusMouseArea {
-                        cursorShape: Qt.PointingHandCursor
-                        anchors.fill: parent
-                        onClicked : {
-                            isStatus = !isStatus;
-                            let ensUser = ensUsername.text;
-                            if(validate(ensUser))
-                                validateENS(ensUser, isStatus)
-                        }
+            StatusBaseText {
+                id: ensTypeLbl
+                Layout.alignment: Qt.AlignVCenter
+
+                text: !isStatus ?
+                    qsTr("Custom domain")
+                    :
+                    ".stateofus.eth"
+                font.weight: Font.Bold
+                font.pixelSize: Theme.tertiaryTextFontSize
+                color: Theme.palette.directColor1
+            }
+
+            StatusBaseText {
+                id: ensTypeDesc
+
+                Layout.fillWidth: true
+
+                text: !isStatus ?
+                    qsTr("I want a stateofus.eth domain")
+                    :
+                    qsTr("I own a name on another domain")
+                font.pixelSize: Theme.tertiaryTextFontSize
+                color: Theme.palette.primaryColor1
+                wrapMode: Text.Wrap
+
+                StatusMouseArea {
+                    cursorShape: Qt.PointingHandCursor
+                    anchors.fill: parent
+                    onClicked : {
+                        isStatus = !isStatus;
+                        let ensUser = ensUsername.text;
+                        if(validate(ensUser))
+                            validateENS(ensUser, isStatus)
                     }
                 }
+            }
+
+            Item {
+                Layout.fillWidth: true
             }
         }
 

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -234,6 +234,10 @@ Item {
 
             StatusDescriptionListItem {
                 id: walletAddressLbl
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+
                 title: qsTr("Wallet address")
                 subTitle: root.ensUsernamesStore.getWalletDefaultAddress()
                 tooltip.text: qsTr("Copied to clipboard!")
@@ -248,6 +252,10 @@ Item {
 
             StatusDescriptionListItem {
                 id: keyLbl
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+
                 title: qsTr("Key")
                 subTitle: {
                     let pubKey = root.ensUsernamesStore.pubkey;
@@ -263,32 +271,43 @@ Item {
                 anchors.topMargin: 24
             }
 
-            StatusCheckBox {
-                id: termsAndConditionsCheckbox
-                objectName: "ensAgreeTerms"
+            RowLayout {
+
                 anchors.top: keyLbl.bottom
                 anchors.topMargin: Theme.padding
                 anchors.left: parent.left
-                anchors.leftMargin: 24
-            }
-
-            StatusBaseText {
-                text: qsTr("Agree to <a href=\"#\">Terms of name registration.</a> I understand that my wallet address will be publicly connected to my username.")
-                anchors.left: termsAndConditionsCheckbox.right
-                anchors.leftMargin: Theme.halfPadding
                 anchors.right: parent.right
-                wrapMode: Text.WordWrap
-                anchors.verticalCenter: termsAndConditionsCheckbox.verticalCenter
-                onLinkActivated: popup.open()
-                color: Theme.palette.directColor1
-                TapHandler {
-                    enabled: !parent.hoveredLink
-                    onSingleTapped: termsAndConditionsCheckbox.toggle()
+                anchors.leftMargin: 24
+                anchors.rightMargin: 24
+
+                spacing: Theme.halfPadding
+
+                StatusCheckBox {
+                    id: termsAndConditionsCheckbox
+                    objectName: "ensAgreeTerms"
+
+                    Layout.alignment: Qt.AlignVCenter
                 }
-                StatusMouseArea {
-                    anchors.fill: parent
-                    acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
-                    cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+
+                StatusBaseText {
+                    text: qsTr("Agree to <a href=\"#\">Terms of name registration.</a> I understand that my wallet address will be publicly connected to my username.")
+
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.fillWidth: true
+
+                    wrapMode: Text.WordWrap
+                    onLinkActivated: popup.open()
+                    color: Theme.palette.directColor1
+
+                    TapHandler {
+                        enabled: !parent.hoveredLink
+                        onSingleTapped: termsAndConditionsCheckbox.toggle()
+                    }
+                    StatusMouseArea {
+                        anchors.fill: parent
+                        acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
+                        cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -1,42 +1,35 @@
 import QtQuick
 import QtQuick.Layouts
-import QtQuick.Controls
 
 import utils
 
 import StatusQ
 import StatusQ.Core
 import StatusQ.Core.Theme
-import StatusQ.Core.Utils
 import StatusQ.Controls
 import StatusQ.Components
 
-import AppLayouts.Profile.stores
 import AppLayouts.Profile.popups
-
-import QtModelsToolkit
 
 Item {
     id: root
 
-    property EnsUsernamesStore ensUsernamesStore
     property string username: ""
 
-    required property var assetsModel
+    // Contract info shown in the terms-of-registration dialog.
+    property string registrarAddress
+    property string ensRegistryAddress
+    property string etherscanAddressLink
+
+    // Registrant details.
+    property string walletAddress
+    property string pubkey
+
+    // Available SNT balance; registration requires >= 10 SNT.
+    property real sntBalance
 
     signal backBtnClicked()
     signal registerUsername()
-
-    QtObject {
-        id: d
-
-        readonly property var sntToken: statusTokenEntry.item
-        readonly property SumAggregator aggregator: SumAggregator {
-            model: !!d.sntToken && !!d.sntToken.balances ? d.sntToken.balances: null
-            roleName: "balance"
-        }
-        readonly property real sntBalance: !!sntToken && !!sntToken.decimals ? aggregator.value/(10 ** sntToken.decimals): 0
-    }
 
     StatusBaseText {
         id: sectionTitle
@@ -53,9 +46,9 @@ Item {
     EnsTermsAndConditionsPopup {
         id: popup
 
-        registrarAddress: root.ensUsernamesStore.ensRegisteredAddress
-        ensRegistryAddress: root.ensUsernamesStore.getEnsRegistry()
-        etherscanAddressLink: root.ensUsernamesStore.getEtherscanAddressLink()
+        registrarAddress: root.registrarAddress
+        ensRegistryAddress: root.ensRegistryAddress
+        etherscanAddressLink: root.etherscanAddressLink
     }
 
     StatusScrollView {
@@ -115,7 +108,7 @@ Item {
                 anchors.right: parent.right
 
                 title: qsTr("Wallet address")
-                subTitle: root.ensUsernamesStore.getWalletDefaultAddress()
+                subTitle: root.walletAddress
                 tooltip.text: qsTr("Copied to clipboard!")
                 asset.name: "copy"
                 iconButton.onClicked: {
@@ -134,7 +127,7 @@ Item {
 
                 title: qsTr("Key")
                 subTitle: {
-                    let pubKey = root.ensUsernamesStore.pubkey;
+                    let pubKey = root.pubkey;
                     return pubKey.substring(0, 20) + "..." + pubKey.substring(pubKey.length - 20);
                 }
                 tooltip.text: qsTr("Copied to clipboard!")
@@ -239,10 +232,10 @@ Item {
 
                 Layout.alignment: Qt.AlignVCenter
 
-                text: d.sntBalance < 10 ?
+                text: root.sntBalance < 10 ?
                   qsTr("Not enough SNT") :
                   qsTr("Register")
-                enabled: d.sntBalance >= 10 && termsAndConditionsCheckbox.checked
+                enabled: root.sntBalance >= 10 && termsAndConditionsCheckbox.checked
                 onClicked: root.registerUsername()
             }
         }
@@ -253,14 +246,5 @@ Item {
             text: qsTr("Back")
             onClicked: backBtnClicked()
         }
-    }
-
-
-
-    ModelEntry {
-        id: statusTokenEntry
-        sourceModel: root.assetsModel
-        key: "key"
-        value: root.ensUsernamesStore.getStatusTokenGroupKey()
     }
 }

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -62,12 +62,13 @@ Item {
         id: sview
         anchors.top: sectionTitle.bottom
         anchors.topMargin: Theme.padding
-        anchors.bottom: startBtn.top
+        anchors.bottom: bottomLayout.top
         anchors.bottomMargin: Theme.padding
         anchors.left: parent.left
         anchors.right: parent.right
 
         contentWidth: availableWidth
+        contentHeight: contentItem.childrenRect.y + contentItem.childrenRect.height
 
         Item {
             id: contentItem
@@ -147,7 +148,6 @@ Item {
             }
 
             RowLayout {
-
                 anchors.top: keyLbl.bottom
                 anchors.topMargin: Theme.padding
                 anchors.left: parent.left
@@ -188,64 +188,74 @@ Item {
         }
     }
 
-    StatusButton {
+    ColumnLayout {
+        id: bottomLayout
+        spacing: Theme.padding
+
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Theme.padding
         anchors.left: parent.left
         anchors.leftMargin: Theme.padding
-        text: qsTr("Back")
-        onClicked: backBtnClicked()
-    }
-
-    Item {
-        anchors.top: startBtn.top
-        anchors.right: startBtn.left
-        anchors.rightMargin: Theme.padding
-        width: childrenRect.width
-
-        Image {
-            id: image1
-            height: 50
-            width: height
-            source: Assets.png("tokens/SNT")
-            sourceSize: Qt.size(width, height)
-            cache: false
-        }
-
-        StatusBaseText {
-            id: ensPriceLbl
-            text: qsTr("10 SNT")
-            anchors.left: image1.right
-            anchors.leftMargin: 5
-            anchors.top: image1.top
-            color: Theme.palette.directColor1
-            font.pixelSize: Theme.secondaryTextFontSize
-        }
-
-        StatusBaseText {
-            text: qsTr("Deposit")
-            anchors.left: image1.right
-            anchors.leftMargin: 5
-            anchors.topMargin: 5
-            anchors.top: ensPriceLbl.bottom
-            color: Theme.palette.baseColor1
-            font.pixelSize: Theme.secondaryTextFontSize
-        }
-    }
-
-    StatusButton {
-        id: startBtn
-        objectName: "ensStartTransaction"
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: Theme.padding
         anchors.right: parent.right
         anchors.rightMargin: Theme.padding
-        text: d.sntBalance < 10 ?
-          qsTr("Not enough SNT") :
-          qsTr("Register")
-        enabled: d.sntBalance >= 10 && termsAndConditionsCheckbox.checked
-        onClicked: root.registerUsername()
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            spacing: Theme.padding
+
+            Image {
+                id: image1
+
+                Layout.preferredWidth: 50
+                Layout.preferredHeight: 50
+                Layout.alignment: Qt.AlignVCenter
+
+                source: Assets.png("tokens/SNT")
+                sourceSize: Qt.size(width, height)
+                cache: false
+            }
+
+            ColumnLayout {
+                spacing: 5
+
+                Layout.fillHeight: false
+                Layout.alignment: Qt.AlignVCenter
+
+                StatusBaseText {
+                    text: qsTr("10 SNT")
+                    color: Theme.palette.directColor1
+                    font.pixelSize: Theme.secondaryTextFontSize
+                }
+
+                StatusBaseText {
+                    text: qsTr("Deposit")
+                    color: Theme.palette.baseColor1
+                    font.pixelSize: Theme.secondaryTextFontSize
+                }
+            }
+
+            StatusButton {
+                objectName: "ensStartTransaction"
+
+                Layout.alignment: Qt.AlignVCenter
+
+                text: d.sntBalance < 10 ?
+                  qsTr("Not enough SNT") :
+                  qsTr("Register")
+                enabled: d.sntBalance >= 10 && termsAndConditionsCheckbox.checked
+                onClicked: root.registerUsername()
+            }
+        }
+
+        StatusButton {
+            Layout.alignment: Qt.AlignHCenter
+
+            text: qsTr("Back")
+            onClicked: backBtnClicked()
+        }
     }
+
+
 
     ModelEntry {
         id: statusTokenEntry

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -10,9 +10,9 @@ import StatusQ.Core.Theme
 import StatusQ.Core.Utils
 import StatusQ.Controls
 import StatusQ.Components
-import StatusQ.Popups.Dialog
 
 import AppLayouts.Profile.stores
+import AppLayouts.Profile.popups
 
 import QtModelsToolkit
 
@@ -50,137 +50,12 @@ Item {
         color: Theme.palette.directColor1
     }
 
-    StatusDialog {
+    EnsTermsAndConditionsPopup {
         id: popup
-        title: qsTr("Terms of name registration")
-        width: 480
-        standardButtons: Dialog.Ok
 
-        StatusScrollView {
-            id: scroll
-            anchors.fill: parent
-            contentWidth: availableWidth
-
-            Column {
-                spacing: Theme.halfPadding
-                width: scroll.availableWidth
-
-
-                StatusBaseText {
-                    text: qsTr("Funds are deposited for 1 year. Your SNT will be locked, but not spent.")
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("After 1 year, you can release the name and get your deposit back, or take no action to keep the name.")
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.")
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.")
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("Your address(es) will be publicly associated with your ENS name.")
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.")
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.")
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("These terms are guaranteed by the smart contract logic at addresses:")
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    font.weight: Font.Bold
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("%1 (Status UsernameRegistrar).").arg(root.ensUsernamesStore.ensRegisteredAddress)
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    font.family: Fonts.monoFont.family
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("<a href='%1/%2'>Look up on Etherscan</a>")
-                    .arg(root.ensUsernamesStore.getEtherscanAddressLink())
-                    .arg(root.ensUsernamesStore.ensRegisteredAddress)
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    onLinkActivated: (link) => Global.requestOpenLink(link)
-                    color: Theme.palette.directColor1
-                    StatusMouseArea {
-                        anchors.fill: parent
-                        acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
-                        cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    }
-                }
-
-                StatusBaseText {
-                    text: qsTr("%1 (ENS Registry).").arg(root.ensUsernamesStore.getEnsRegistry())
-                    wrapMode: Text.WordWrap
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    font.family: Fonts.monoFont.family
-                    color: Theme.palette.directColor1
-                }
-
-                StatusBaseText {
-                    text: qsTr("<a href='%1/%2'>Look up on Etherscan</a>")
-                    .arg(root.ensUsernamesStore.getEtherscanAddressLink())
-                    .arg(root.ensUsernamesStore.getEnsRegistry())
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    onLinkActivated: (link) => Global.requestOpenLink(link)
-                    color: Theme.palette.directColor1
-                    StatusMouseArea {
-                        anchors.fill: parent
-                        acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
-                        cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    }
-                }
-
-            }
-        }
+        registrarAddress: root.ensUsernamesStore.ensRegisteredAddress
+        ensRegistryAddress: root.ensUsernamesStore.getEnsRegistry()
+        etherscanAddressLink: root.ensUsernamesStore.getEtherscanAddressLink()
     }
 
     StatusScrollView {

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -389,6 +389,7 @@ Item {
             StatusBaseText {
                 anchors.fill: parent
                 text: qsTr("The account this username was bought with is no longer among active accounts.\nPlease add it and try again.")
+                wrapMode: Text.Wrap
             }
 
             standardButtons: Dialog.Ok

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -277,7 +277,7 @@ Item {
             username: selectedUsername
             assetsModel: ensView.walletAssetsStore.groupedAccountAssetsModel
 
-            onBackBtnClicked: back();
+            onBackBtnClicked: back()
 
             onRegisterUsername: {
                 const chainId = root.ensUsernamesStore.getChainForBuyingEnsName()
@@ -331,9 +331,15 @@ Item {
     Component {
         id: list
         EnsListView {
-            ensUsernamesStore: ensView.ensUsernamesStore
-
             profileContentWidth: ensView.profileContentWidth
+
+            model: ensView.ensUsernamesStore.currentChainEnsUsernamesModel
+            preferredUsername: ensView.ensUsernamesStore.preferredUsername
+            pubkey: ensView.ensUsernamesStore.pubkey
+            icon: ensView.ensUsernamesStore.icon
+            hasConfirmedEnsUsernames: ensView.ensUsernamesStore.ensUsernamesModel.count > 0
+                                      || ensView.ensUsernamesStore.numOfPendingEnsUsernames() > 0
+
             onAddBtnClicked: next("search")
             onSelectEns: (username, chainId) => {
                 ensView.ensUsernamesStore.ensDetails(chainId, username)
@@ -341,6 +347,7 @@ Item {
                 selectedChainId = chainId
                 next("details")
             }
+            onPreferredUsernameSelected: (ensUsername) => ensView.ensUsernamesStore.setPrefferedEnsUsername(ensUsername)
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -9,6 +9,8 @@ import StatusQ.Core.Utils
 import StatusQ.Popups.Dialog
 import StatusQ.Core.Theme
 
+import QtModelsToolkit
+
 import utils
 import shared
 import shared.stores as SharedStores
@@ -273,14 +275,26 @@ Item {
     Component {
         id: termsAndConditions
         EnsTermsAndConditionsView {
-            ensUsernamesStore: ensView.ensUsernamesStore
             username: selectedUsername
-            assetsModel: ensView.walletAssetsStore.groupedAccountAssetsModel
+
+            registrarAddress: ensView.ensUsernamesStore.ensRegisteredAddress
+            ensRegistryAddress: ensView.ensUsernamesStore.getEnsRegistry()
+            etherscanAddressLink: ensView.ensUsernamesStore.getEtherscanAddressLink()
+
+            walletAddress: ensView.ensUsernamesStore.getWalletDefaultAddress()
+            pubkey: ensView.ensUsernamesStore.pubkey
+
+            sntBalance: {
+                const token = statusTokenEntry.item
+                if (!token || !token.decimals)
+                    return 0
+                return sntAggregator.value / (10 ** token.decimals)
+            }
 
             onBackBtnClicked: back()
 
             onRegisterUsername: {
-                const chainId = root.ensUsernamesStore.getChainForBuyingEnsName()
+                const chainId = ensView.ensUsernamesStore.getChainForBuyingEnsName()
 
                 ensView.registerUsernameRequested(ensView.selectedUsername, chainId)
             }
@@ -293,6 +307,22 @@ Item {
                     }
                     done(ensView.selectedUsername)
                 }
+            }
+
+            ModelEntry {
+                id: statusTokenEntry
+                sourceModel: ensView.walletAssetsStore.groupedAccountAssetsModel
+                key: "key"
+                value: ensView.ensUsernamesStore.getStatusTokenGroupKey()
+            }
+
+            SumAggregator {
+                id: sntAggregator
+                model: {
+                    const token = statusTokenEntry.item
+                    return !!token && !!token.balances ? token.balances : null
+                }
+                roleName: "balance"
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -342,10 +342,13 @@ Item {
 
             onAddBtnClicked: next("search")
             onSelectEns: (username, chainId) => {
-                ensView.ensUsernamesStore.ensDetails(chainId, username)
+
+
                 selectedUsername = username
                 selectedChainId = chainId
                 next("details")
+
+                ensView.ensUsernamesStore.ensDetails(chainId, username)
             }
             onPreferredUsernameSelected: (ensUsername) => ensView.ensUsernamesStore.setPrefferedEnsUsername(ensUsername)
         }
@@ -354,10 +357,9 @@ Item {
     Component {
         id: details
         EnsDetailsView {
-            ensUsernamesStore: ensView.ensUsernamesStore
-            username: selectedUsername
-            chainId: selectedChainId
+            id: ensDetailsView
 
+            username: selectedUsername
             onBackBtnClicked: back()
 
             onReleaseUsernameRequested: (senderAddress) => {
@@ -366,16 +368,35 @@ Item {
                     Global.openPopup(noAccountPopupComponent)
                     return
                 }
-                ensView.releaseUsernameRequested(ensView.selectedUsername, senderAddress, ensView.selectedChainId)
+                ensView.releaseUsernameRequested(ensView.selectedUsername, senderAddress,
+                                                 ensView.selectedChainId)
+            }
+
+            onRemoveEnsUsernameRequested: (chainId, username) => {
+                ensView.ensUsernamesStore.removeEnsUsername(chainId, username)
+                back()
             }
 
             Connections {
                 target: ensView.ensUsernamesStore.ensUsernamesModule
+
                 function onTransactionWasSent(trxType: string, chainId: int, txHash: string, username: string, error: string) {
                     if (!!error || trxType !== d.releaseENS) {
                         return
                     }
                     done(ensView.selectedUsername)
+                }
+
+                function onDetailsObtained(chainId: int, ensName: string, address: string, pubkey: string, isStatus: bool, expirationTime: int) {
+                    if(username !== (isStatus ? ensName + ".stateofus.eth" : ensName))
+                        return
+
+                    ensDetailsView.setDetails(chainId, ensName, address, pubkey, isStatus, expirationTime,
+                                             ensView.ensUsernamesStore.preferredUsername === username)
+                }
+
+                function onLoading(isLoading: bool) {
+                    ensDetailsView.isLoading = isLoading
                 }
             }
         }

--- a/ui/app/AppLayouts/Profile/views/qmldir
+++ b/ui/app/AppLayouts/Profile/views/qmldir
@@ -6,6 +6,7 @@ BrowserView 1.0 BrowserView.qml
 ChangePasswordView 1.0 ChangePasswordView.qml
 CommunitiesView 1.0 CommunitiesView.qml
 ContactsView 1.0 ContactsView.qml
+EnsListView 1.0 EnsListView.qml
 LanguageView 1.0 LanguageView.qml
 LogosNetworkView 1.0 LogosNetworkView.qml
 NotificationsView 1.0 NotificationsView.qml

--- a/ui/app/AppLayouts/Profile/views/qmldir
+++ b/ui/app/AppLayouts/Profile/views/qmldir
@@ -8,6 +8,7 @@ CommunitiesView 1.0 CommunitiesView.qml
 ContactsView 1.0 ContactsView.qml
 EnsDetailsView 1.0 EnsDetailsView.qml
 EnsListView 1.0 EnsListView.qml
+EnsTermsAndConditionsView 1.0 EnsTermsAndConditionsView.qml
 LanguageView 1.0 LanguageView.qml
 LogosNetworkView 1.0 LogosNetworkView.qml
 NotificationsView 1.0 NotificationsView.qml

--- a/ui/app/AppLayouts/Profile/views/qmldir
+++ b/ui/app/AppLayouts/Profile/views/qmldir
@@ -6,6 +6,7 @@ BrowserView 1.0 BrowserView.qml
 ChangePasswordView 1.0 ChangePasswordView.qml
 CommunitiesView 1.0 CommunitiesView.qml
 ContactsView 1.0 ContactsView.qml
+EnsDetailsView 1.0 EnsDetailsView.qml
 EnsListView 1.0 EnsListView.qml
 LanguageView 1.0 LanguageView.qml
 LogosNetworkView 1.0 LogosNetworkView.qml

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -7299,11 +7299,7 @@ key pair. Keycard will be required for signing</source>
     </message>
 </context>
 <context>
-    <name>EnsTermsAndConditionsView</name>
-    <message>
-        <source>ENS usernames</source>
-        <translation type="unfinished"></translation>
-    </message>
+    <name>EnsTermsAndConditionsPopup</name>
     <message>
         <source>Terms of name registration</source>
         <translation type="unfinished"></translation>
@@ -7350,6 +7346,13 @@ key pair. Keycard will be required for signing</source>
     </message>
     <message>
         <source>%1 (ENS Registry).</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnsTermsAndConditionsView</name>
+    <message>
+        <source>ENS usernames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -7340,58 +7340,61 @@ Keycard bude vyžadována pro podepisování</translation>
     </message>
 </context>
 <context>
+    <name>EnsTermsAndConditionsPopup</name>
+    <message>
+        <source>Terms of name registration</source>
+        <translation type="unfinished">Podmínky registrace jména</translation>
+    </message>
+    <message>
+        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
+        <translation type="unfinished">Prostředky jsou uloženy na 1 rok. Vaše SNT budou uzamčeny, ale nebudou utraceny.</translation>
+    </message>
+    <message>
+        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
+        <translation type="unfinished">Po 1 roce můžete jméno uvolnit a získat svůj vklad zpět, nebo neprovádět žádnou akci a jméno si ponechat.</translation>
+    </message>
+    <message>
+        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
+        <translation type="unfinished">Pokud se změní podmínky smlouvy — např. Status provede upgrade smlouvy — uživatel má právo uvolnit uživatelské jméno bez ohledu na dobu držení.</translation>
+    </message>
+    <message>
+        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
+        <translation type="unfinished">Správce smlouvy nemá přístup k vašim uloženým prostředkům. Mohou být přesunuty pouze zpět na adresu, která je odeslala.</translation>
+    </message>
+    <message>
+        <source>Your address(es) will be publicly associated with your ENS name.</source>
+        <translation type="unfinished">Vaše adresa(y) budou veřejně spojeny s vaším ENS jménem.</translation>
+    </message>
+    <message>
+        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
+        <translation type="unfinished">Uživatelská jména jsou vytvářena jako uzly subdomén stateofus.eth a podléhají podmínkám chytré smlouvy ENS.</translation>
+    </message>
+    <message>
+        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
+        <translation type="unfinished">Autorizujete smlouvu k převodu SNT vaším jménem. K tomu může dojít pouze tehdy, když schválíte transakci k autorizaci převodu.</translation>
+    </message>
+    <message>
+        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
+        <translation type="unfinished">Tyto podmínky jsou zaručeny logikou chytré smlouvy na adresách:</translation>
+    </message>
+    <message>
+        <source>%1 (Status UsernameRegistrar).</source>
+        <translation type="unfinished">%1 (Status UsernameRegistrar).</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
+        <translation type="unfinished">&lt;a href=&apos;%1/%2&apos;&gt;Vyhledat na Etherscanu&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>%1 (ENS Registry).</source>
+        <translation type="unfinished">%1 (ENS Registry).</translation>
+    </message>
+</context>
+<context>
     <name>EnsTermsAndConditionsView</name>
     <message>
         <source>ENS usernames</source>
         <translation>ENS uživatelská jména</translation>
-    </message>
-    <message>
-        <source>Terms of name registration</source>
-        <translation>Podmínky registrace jména</translation>
-    </message>
-    <message>
-        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
-        <translation>Prostředky jsou uloženy na 1 rok. Vaše SNT budou uzamčeny, ale nebudou utraceny.</translation>
-    </message>
-    <message>
-        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
-        <translation>Po 1 roce můžete jméno uvolnit a získat svůj vklad zpět, nebo neprovádět žádnou akci a jméno si ponechat.</translation>
-    </message>
-    <message>
-        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
-        <translation>Pokud se změní podmínky smlouvy — např. Status provede upgrade smlouvy — uživatel má právo uvolnit uživatelské jméno bez ohledu na dobu držení.</translation>
-    </message>
-    <message>
-        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
-        <translation>Správce smlouvy nemá přístup k vašim uloženým prostředkům. Mohou být přesunuty pouze zpět na adresu, která je odeslala.</translation>
-    </message>
-    <message>
-        <source>Your address(es) will be publicly associated with your ENS name.</source>
-        <translation>Vaše adresa(y) budou veřejně spojeny s vaším ENS jménem.</translation>
-    </message>
-    <message>
-        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
-        <translation>Uživatelská jména jsou vytvářena jako uzly subdomén stateofus.eth a podléhají podmínkám chytré smlouvy ENS.</translation>
-    </message>
-    <message>
-        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
-        <translation>Autorizujete smlouvu k převodu SNT vaším jménem. K tomu může dojít pouze tehdy, když schválíte transakci k autorizaci převodu.</translation>
-    </message>
-    <message>
-        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
-        <translation>Tyto podmínky jsou zaručeny logikou chytré smlouvy na adresách:</translation>
-    </message>
-    <message>
-        <source>%1 (Status UsernameRegistrar).</source>
-        <translation>%1 (Status UsernameRegistrar).</translation>
-    </message>
-    <message>
-        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
-        <translation>&lt;a href=&apos;%1/%2&apos;&gt;Vyhledat na Etherscanu&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>%1 (ENS Registry).</source>
-        <translation>%1 (ENS Registry).</translation>
     </message>
     <message>
         <source>Wallet address</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -7310,58 +7310,61 @@ key pair. Keycard will be required for signing</source>
     </message>
 </context>
 <context>
+    <name>EnsTermsAndConditionsPopup</name>
+    <message>
+        <source>Terms of name registration</source>
+        <translation type="unfinished">Términos de registro de nombre</translation>
+    </message>
+    <message>
+        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
+        <translation type="unfinished">Los fondos se depositan por 1 año. Tu SNT se bloqueará, pero no se gastará.</translation>
+    </message>
+    <message>
+        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
+        <translation type="unfinished">Después de 1 año, puedes liberar el nombre y recuperar tu depósito, o no tomar ninguna acción para mantener el nombre.</translation>
+    </message>
+    <message>
+        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
+        <translation type="unfinished">Si los términos del contrato cambian —por ejemplo, Status actualiza el contrato— el usuario tiene derecho a liberar el nombre de usuario independientemente del tiempo retenido.</translation>
+    </message>
+    <message>
+        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
+        <translation type="unfinished">El controlador del contrato no puede acceder a tus fondos depositados. Sólo pueden ser devueltos a la dirección que los envió.</translation>
+    </message>
+    <message>
+        <source>Your address(es) will be publicly associated with your ENS name.</source>
+        <translation type="unfinished">Tu(s) dirección(es) se asociará(n) públicamente con tu nombre ENS.</translation>
+    </message>
+    <message>
+        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
+        <translation type="unfinished">Los nombres de usuario se crean como nodos de subdominio de stateofus.eth y están sujetos a los términos del contrato inteligente de ENS.</translation>
+    </message>
+    <message>
+        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
+        <translation type="unfinished">Autorizas el contrato para transferir SNT en tu nombre. Esto solo puede ocurrir cuando apruebas una transacción para autorizar la transferencia.</translation>
+    </message>
+    <message>
+        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
+        <translation type="unfinished">Estos términos están garantizados por la lógica del contrato inteligente en las direcciones:</translation>
+    </message>
+    <message>
+        <source>%1 (Status UsernameRegistrar).</source>
+        <translation type="unfinished">%1 (Status UsernameRegistrar).</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
+        <translation type="unfinished">&lt;a href=&apos;%1/%2&apos;&gt;Buscar en Etherscan&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>%1 (ENS Registry).</source>
+        <translation type="unfinished">%1 (ENS Registry).</translation>
+    </message>
+</context>
+<context>
     <name>EnsTermsAndConditionsView</name>
     <message>
         <source>ENS usernames</source>
         <translation>Nombres de usuario ENS</translation>
-    </message>
-    <message>
-        <source>Terms of name registration</source>
-        <translation>Términos de registro de nombre</translation>
-    </message>
-    <message>
-        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
-        <translation>Los fondos se depositan por 1 año. Tu SNT se bloqueará, pero no se gastará.</translation>
-    </message>
-    <message>
-        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
-        <translation>Después de 1 año, puedes liberar el nombre y recuperar tu depósito, o no tomar ninguna acción para mantener el nombre.</translation>
-    </message>
-    <message>
-        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
-        <translation>Si los términos del contrato cambian —por ejemplo, Status actualiza el contrato— el usuario tiene derecho a liberar el nombre de usuario independientemente del tiempo retenido.</translation>
-    </message>
-    <message>
-        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
-        <translation>El controlador del contrato no puede acceder a tus fondos depositados. Sólo pueden ser devueltos a la dirección que los envió.</translation>
-    </message>
-    <message>
-        <source>Your address(es) will be publicly associated with your ENS name.</source>
-        <translation>Tu(s) dirección(es) se asociará(n) públicamente con tu nombre ENS.</translation>
-    </message>
-    <message>
-        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
-        <translation>Los nombres de usuario se crean como nodos de subdominio de stateofus.eth y están sujetos a los términos del contrato inteligente de ENS.</translation>
-    </message>
-    <message>
-        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
-        <translation>Autorizas el contrato para transferir SNT en tu nombre. Esto solo puede ocurrir cuando apruebas una transacción para autorizar la transferencia.</translation>
-    </message>
-    <message>
-        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
-        <translation>Estos términos están garantizados por la lógica del contrato inteligente en las direcciones:</translation>
-    </message>
-    <message>
-        <source>%1 (Status UsernameRegistrar).</source>
-        <translation>%1 (Status UsernameRegistrar).</translation>
-    </message>
-    <message>
-        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
-        <translation>&lt;a href=&apos;%1/%2&apos;&gt;Buscar en Etherscan&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>%1 (ENS Registry).</source>
-        <translation>%1 (ENS Registry).</translation>
     </message>
     <message>
         <source>Wallet address</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -7309,58 +7309,61 @@ key pair. Keycard will be required for signing</source>
     </message>
 </context>
 <context>
+    <name>EnsTermsAndConditionsPopup</name>
+    <message>
+        <source>Terms of name registration</source>
+        <translation type="unfinished">Conditions d’enregistrement des noms</translation>
+    </message>
+    <message>
+        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
+        <translation type="unfinished">Les fonds sont déposés pour une durée de 1 an. Vos SNT seront bloqués, mais non dépensés.</translation>
+    </message>
+    <message>
+        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
+        <translation type="unfinished">Après 1 an, vous pouvez libérer le nom et récupérer votre dépôt, ou ne rien faire pour conserver le nom.</translation>
+    </message>
+    <message>
+        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
+        <translation type="unfinished">Si les conditions du contrat changent (par exemple, si Status effectue des mises à niveau du contrat), l’utilisateur a le droit de libérer le nom d’utilisateur, quel que soit le temps pendant lequel il l’a conservé.</translation>
+    </message>
+    <message>
+        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
+        <translation type="unfinished">Le contrôleur du contrat n’a pas accès à vos fonds déposés. Ils ne peuvent être renvoyés qu’à l’adresse qui les a envoyés.</translation>
+    </message>
+    <message>
+        <source>Your address(es) will be publicly associated with your ENS name.</source>
+        <translation type="unfinished">Votre ou vos adresses seront publiquement associées à votre nom ENS.</translation>
+    </message>
+    <message>
+        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
+        <translation type="unfinished">Les noms d’utilisateur sont créés en tant que nœuds de sous-domaine de stateofus.eth et sont soumis aux conditions du contrat intelligent ENS.</translation>
+    </message>
+    <message>
+        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
+        <translation type="unfinished">Vous autorisez le contrat à transférer des SNT en votre nom. Cela ne peut se produire que lorsque vous approuvez une transaction pour autoriser le transfert.</translation>
+    </message>
+    <message>
+        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
+        <translation type="unfinished">Ces conditions sont garanties par la logique du contrat intelligent aux adresses suivantes&#xa0;:</translation>
+    </message>
+    <message>
+        <source>%1 (Status UsernameRegistrar).</source>
+        <translation type="unfinished">%1 (Enregistreur de noms d’utilisateur Status).</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
+        <translation type="unfinished">&lt;a href=&apos;%1/%2&apos;&gt;Rechercher sur Etherscan&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>%1 (ENS Registry).</source>
+        <translation type="unfinished">%1 (Registre ENS).</translation>
+    </message>
+</context>
+<context>
     <name>EnsTermsAndConditionsView</name>
     <message>
         <source>ENS usernames</source>
         <translation>Noms d’utilisateur ENS</translation>
-    </message>
-    <message>
-        <source>Terms of name registration</source>
-        <translation>Conditions d’enregistrement des noms</translation>
-    </message>
-    <message>
-        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
-        <translation>Les fonds sont déposés pour une durée de 1 an. Vos SNT seront bloqués, mais non dépensés.</translation>
-    </message>
-    <message>
-        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
-        <translation>Après 1 an, vous pouvez libérer le nom et récupérer votre dépôt, ou ne rien faire pour conserver le nom.</translation>
-    </message>
-    <message>
-        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
-        <translation>Si les conditions du contrat changent (par exemple, si Status effectue des mises à niveau du contrat), l’utilisateur a le droit de libérer le nom d’utilisateur, quel que soit le temps pendant lequel il l’a conservé.</translation>
-    </message>
-    <message>
-        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
-        <translation>Le contrôleur du contrat n’a pas accès à vos fonds déposés. Ils ne peuvent être renvoyés qu’à l’adresse qui les a envoyés.</translation>
-    </message>
-    <message>
-        <source>Your address(es) will be publicly associated with your ENS name.</source>
-        <translation>Votre ou vos adresses seront publiquement associées à votre nom ENS.</translation>
-    </message>
-    <message>
-        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
-        <translation>Les noms d’utilisateur sont créés en tant que nœuds de sous-domaine de stateofus.eth et sont soumis aux conditions du contrat intelligent ENS.</translation>
-    </message>
-    <message>
-        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
-        <translation>Vous autorisez le contrat à transférer des SNT en votre nom. Cela ne peut se produire que lorsque vous approuvez une transaction pour autoriser le transfert.</translation>
-    </message>
-    <message>
-        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
-        <translation>Ces conditions sont garanties par la logique du contrat intelligent aux adresses suivantes&#xa0;:</translation>
-    </message>
-    <message>
-        <source>%1 (Status UsernameRegistrar).</source>
-        <translation>%1 (Enregistreur de noms d’utilisateur Status).</translation>
-    </message>
-    <message>
-        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
-        <translation>&lt;a href=&apos;%1/%2&apos;&gt;Rechercher sur Etherscan&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>%1 (ENS Registry).</source>
-        <translation>%1 (Registre ENS).</translation>
     </message>
     <message>
         <source>Wallet address</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -7281,58 +7281,61 @@ key pair. Keycard will be required for signing</source>
     </message>
 </context>
 <context>
+    <name>EnsTermsAndConditionsPopup</name>
+    <message>
+        <source>Terms of name registration</source>
+        <translation type="unfinished">이름 등록 약관</translation>
+    </message>
+    <message>
+        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
+        <translation type="unfinished">자산은 1년 동안 예치됩니다. 여러분의 SNT는 잠기게 되며, 별도로 지출되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
+        <translation type="unfinished">1년 후, 등록한 이름의 계약을 해지하고 예치금을 돌려받을 수 있습니다. 이름을 유지하고 싶을 경우에는 별도의 조치를 할 필요가 없습니다.</translation>
+    </message>
+    <message>
+        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
+        <translation type="unfinished">스테이터스가 컨트랙트를 업그레이드 하는 등으로 이용 약관을 변경하는 경우, 사용자는 남은 기간에 상관 없이 사용자 이름을 해지할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
+        <translation type="unfinished">컨트랙트 관리자는 사용자의 예치금에 접근할 수 없습니다. 이는 등록된 주소로만 반환됩니다.</translation>
+    </message>
+    <message>
+        <source>Your address(es) will be publicly associated with your ENS name.</source>
+        <translation type="unfinished">사용자의 주소는 ENS 이름과 공개적으로 연동됩니다.</translation>
+    </message>
+    <message>
+        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
+        <translation type="unfinished">사용자 이름은 stateofus.eth 의 서브 도메인 노드로 생성되며, ENS 스마트 컨트랙트 이용 약관을 따릅니다.</translation>
+    </message>
+    <message>
+        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
+        <translation type="unfinished">사용자를 대신하여 SNT를 양도하는 계약을 승인합니다. 이는 트랜잭션에 전송 권한을 부여할 때부터 유효합니다.</translation>
+    </message>
+    <message>
+        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
+        <translation type="unfinished">이러한 조항은 다음 주소의 스마트 컨트랙트 로직으로 보장됩니다:</translation>
+    </message>
+    <message>
+        <source>%1 (Status UsernameRegistrar).</source>
+        <translation type="unfinished">%1 (Status UsernameRegistrar).</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
+        <translation type="unfinished">&lt;a href=&apos;%1/%2&apos;&gt;Etherscan에서 조회&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>%1 (ENS Registry).</source>
+        <translation type="unfinished">%1 (ENS Registry).</translation>
+    </message>
+</context>
+<context>
     <name>EnsTermsAndConditionsView</name>
     <message>
         <source>ENS usernames</source>
         <translation>ENS 이름</translation>
-    </message>
-    <message>
-        <source>Terms of name registration</source>
-        <translation>이름 등록 약관</translation>
-    </message>
-    <message>
-        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
-        <translation>자산은 1년 동안 예치됩니다. 여러분의 SNT는 잠기게 되며, 별도로 지출되지 않습니다.</translation>
-    </message>
-    <message>
-        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
-        <translation>1년 후, 등록한 이름의 계약을 해지하고 예치금을 돌려받을 수 있습니다. 이름을 유지하고 싶을 경우에는 별도의 조치를 할 필요가 없습니다.</translation>
-    </message>
-    <message>
-        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
-        <translation>스테이터스가 컨트랙트를 업그레이드 하는 등으로 이용 약관을 변경하는 경우, 사용자는 남은 기간에 상관 없이 사용자 이름을 해지할 수 있습니다.</translation>
-    </message>
-    <message>
-        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
-        <translation>컨트랙트 관리자는 사용자의 예치금에 접근할 수 없습니다. 이는 등록된 주소로만 반환됩니다.</translation>
-    </message>
-    <message>
-        <source>Your address(es) will be publicly associated with your ENS name.</source>
-        <translation>사용자의 주소는 ENS 이름과 공개적으로 연동됩니다.</translation>
-    </message>
-    <message>
-        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
-        <translation>사용자 이름은 stateofus.eth 의 서브 도메인 노드로 생성되며, ENS 스마트 컨트랙트 이용 약관을 따릅니다.</translation>
-    </message>
-    <message>
-        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
-        <translation>사용자를 대신하여 SNT를 양도하는 계약을 승인합니다. 이는 트랜잭션에 전송 권한을 부여할 때부터 유효합니다.</translation>
-    </message>
-    <message>
-        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
-        <translation>이러한 조항은 다음 주소의 스마트 컨트랙트 로직으로 보장됩니다:</translation>
-    </message>
-    <message>
-        <source>%1 (Status UsernameRegistrar).</source>
-        <translation>%1 (Status UsernameRegistrar).</translation>
-    </message>
-    <message>
-        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
-        <translation>&lt;a href=&apos;%1/%2&apos;&gt;Etherscan에서 조회&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>%1 (ENS Registry).</source>
-        <translation>%1 (ENS Registry).</translation>
     </message>
     <message>
         <source>Wallet address</source>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -7339,58 +7339,61 @@ key pair. Keycard will be required for signing</source>
     </message>
 </context>
 <context>
+    <name>EnsTermsAndConditionsPopup</name>
+    <message>
+        <source>Terms of name registration</source>
+        <translation type="unfinished">Умови реєстрації імені</translation>
+    </message>
+    <message>
+        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
+        <translation type="unfinished">Кошти вносяться на депозит на 1 рік. Ваші SNT буде заблоковано, але не витрачено.</translation>
+    </message>
+    <message>
+        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
+        <translation type="unfinished">Через 1 рік ви можете звільнити ім’я та повернути депозит або нічого не робити й зберегти ім’я.</translation>
+    </message>
+    <message>
+        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
+        <translation type="unfinished">Якщо умови контракту зміняться, наприклад Status оновить контракт, користувач має право звільнити ім’я незалежно від терміну володіння.</translation>
+    </message>
+    <message>
+        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
+        <translation type="unfinished">Контролер контракту не має доступу до внесених вами коштів. Їх можна повернути лише на адресу, з якої їх надіслано.</translation>
+    </message>
+    <message>
+        <source>Your address(es) will be publicly associated with your ENS name.</source>
+        <translation type="unfinished">Ваші адреси буде публічно пов’язано з вашим іменем ENS.</translation>
+    </message>
+    <message>
+        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
+        <translation type="unfinished">Імена користувачів створюються як вузли субдомену stateofus.eth і підпорядковуються умовам смартконтракту ENS.</translation>
+    </message>
+    <message>
+        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
+        <translation type="unfinished">Ви дозволяєте контракту переказувати SNT від вашого імені. Це можливо лише після схвалення транзакції, яка дозволяє переказ.</translation>
+    </message>
+    <message>
+        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
+        <translation type="unfinished">Ці умови гарантовано логікою смартконтрактів за адресами:</translation>
+    </message>
+    <message>
+        <source>%1 (Status UsernameRegistrar).</source>
+        <translation type="unfinished">%1 (Status UsernameRegistrar).</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
+        <translation type="unfinished">&lt;a href=&apos;%1/%2&apos;&gt;Переглянути на Etherscan&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>%1 (ENS Registry).</source>
+        <translation type="unfinished">%1 (реєстр ENS).</translation>
+    </message>
+</context>
+<context>
     <name>EnsTermsAndConditionsView</name>
     <message>
         <source>ENS usernames</source>
         <translation>ENS-імена</translation>
-    </message>
-    <message>
-        <source>Terms of name registration</source>
-        <translation>Умови реєстрації імені</translation>
-    </message>
-    <message>
-        <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
-        <translation>Кошти вносяться на депозит на 1 рік. Ваші SNT буде заблоковано, але не витрачено.</translation>
-    </message>
-    <message>
-        <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
-        <translation>Через 1 рік ви можете звільнити ім’я та повернути депозит або нічого не робити й зберегти ім’я.</translation>
-    </message>
-    <message>
-        <source>If terms of the contract change — e.g. Status makes contract upgrades — user has the right to release the username regardless of time held.</source>
-        <translation>Якщо умови контракту зміняться, наприклад Status оновить контракт, користувач має право звільнити ім’я незалежно від терміну володіння.</translation>
-    </message>
-    <message>
-        <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
-        <translation>Контролер контракту не має доступу до внесених вами коштів. Їх можна повернути лише на адресу, з якої їх надіслано.</translation>
-    </message>
-    <message>
-        <source>Your address(es) will be publicly associated with your ENS name.</source>
-        <translation>Ваші адреси буде публічно пов’язано з вашим іменем ENS.</translation>
-    </message>
-    <message>
-        <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
-        <translation>Імена користувачів створюються як вузли субдомену stateofus.eth і підпорядковуються умовам смартконтракту ENS.</translation>
-    </message>
-    <message>
-        <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
-        <translation>Ви дозволяєте контракту переказувати SNT від вашого імені. Це можливо лише після схвалення транзакції, яка дозволяє переказ.</translation>
-    </message>
-    <message>
-        <source>These terms are guaranteed by the smart contract logic at addresses:</source>
-        <translation>Ці умови гарантовано логікою смартконтрактів за адресами:</translation>
-    </message>
-    <message>
-        <source>%1 (Status UsernameRegistrar).</source>
-        <translation>%1 (Status UsernameRegistrar).</translation>
-    </message>
-    <message>
-        <source>&lt;a href=&apos;%1/%2&apos;&gt;Look up on Etherscan&lt;/a&gt;</source>
-        <translation>&lt;a href=&apos;%1/%2&apos;&gt;Переглянути на Etherscan&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>%1 (ENS Registry).</source>
-        <translation>%1 (реєстр ENS).</translation>
     </message>
     <message>
         <source>Wallet address</source>


### PR DESCRIPTION
### What does the PR do

Refactors components related to ENS-settings in order to:
- make the layout responsive and well-formed on small screens
- remove/limit dependencies on stores, simplify APIs
- add Storybook pages for easier development / testing

Those components are currently quite outdated, this PR brings first refactor fixing basic issues. Further work is needed to improve design and reliability of this area.

Closes: https://github.com/status-im/status-app/issues/20796

### Affected areas
Views related to ENS settings

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="370" height="760" alt="Screenshot from 2026-09-02 12-23-42" src="https://github.com/user-attachments/assets/5b09a3a1-d9f4-4be1-9ff2-d7076c032c7b" />

<img width="370" height="760" alt="Screenshot from 2026-09-02 12-22-32" src="https://github.com/user-attachments/assets/25aab5fd-2e9b-4186-bba0-d8f54b868757" />

<img width="370" height="760" alt="Screenshot from 2026-09-02 12-22-36" src="https://github.com/user-attachments/assets/1e0353cc-bd3f-43b4-ba11-358c123fed2f" />

### Impact on end user

Medium

### How to test

Explore flows under `ENS usernames` section in Profile settings.

### Risk 

Low
