### PR TITLE
test(threads): red tests for the threads stack context-menu regressions

### DIFF
--- a/docs/adr/0002-android-push-notifications.md
+++ b/docs/adr/0002-android-push-notifications.md
@@ -103,6 +103,8 @@ Message notifications use `NotificationCompat.MessagingStyle` rather than plain 
 
 No in-process conversation buffer is maintained. Instead, conversation state is stored directly in the OS notification itself: when a new message arrives for an active conversation, `StatusNotificationManager` extracts the existing `MessagingStyle` from the active `StatusBarNotification` via `NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification()`, appends the new message with its sender `Person` (including icon), and re-posts the updated notification. This preserves all historical `Person` icons without any in-process caching and automatically ties the conversation thread lifetime to the notification's lifetime — swiping the notification away discards the thread state.
 
+Conversation identity is the `NotificationBuilder.conversationKey()` value — the chat ID, or `chatId#threadId` when the message belongs to a message thread — not the bare `conversationId` reported by `status-go` (which is always the parent chat). It derives the notification ID, the group key and the shortcut ID, so a thread gets its own notification stack. This is required for correctness, not just presentation: the notification ID doubles as the inline-reply `PendingIntent` request code, and `PendingIntent` matching ignores extras, so a shared ID would let whichever notification was posted last decide where a reply is sent.
+
 ---
 
 ### 6. Outgoing message handling (`isFromMe`)
@@ -132,6 +134,12 @@ When the UI comes to the foreground, all active notifications are cancelled and 
 2. Calls `StatusGoService.callRpc("wakuext_sendChatMessage", ...)` directly (same process — no Binder round-trip needed).
 3. On success the notification is updated with the sent message via a new `local-notifications` signal from `status-go`.
 4. On failure a "Reply failed" notification is shown.
+
+The reply intent carries the chat ID, the thread ID and the conversation key. The thread ID is
+read from `body.message.threadId` on the originating signal and passed straight back as the
+`threadId` field of the send RPC, so a reply to a thread notification lands in that thread
+rather than the parent chat. It is empty for non-threaded messages, which `status-go` treats as
+absent.
 
 The send response is also forwarded to the UI process as an internal `notification.reply.sent`
 signal. It is queued while the UI is backgrounded, then processed through the same messenger

--- a/mobile/android/qt6/src/app/status/mobile/ipc/NotificationReplyReceiver.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/NotificationReplyReceiver.java
@@ -48,15 +48,20 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
         }
     }
 
+    /** Falls back to the chat ID for PendingIntents created before thread-aware keys existed. */
+    private static String conversationKeyOf(Intent intent) {
+        String key = intent.getStringExtra("conversationKey");
+        return (key != null && !key.isEmpty()) ? key : intent.getStringExtra("conversationId");
+    }
+
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent == null) return;
 
         String action = intent.getAction();
         if (NotificationBuilder.ACTION_DISMISS.equals(action)) {
-            String conversationId = intent.getStringExtra("conversationId");
             StatusNotificationManager mgr = StatusNotificationManager.getInstance();
-            if (mgr != null) mgr.clearConversation(conversationId);
+            if (mgr != null) mgr.clearConversation(conversationKeyOf(intent));
             return;
         }
 
@@ -77,6 +82,8 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
         String conversationId = intent.getStringExtra("conversationId");
         if (conversationId == null || conversationId.isEmpty()) return;
 
+        final String threadId = intent.getStringExtra("threadId");
+        final String conversationKey = conversationKeyOf(intent);
         final String replyTextStr = replyText.toString().trim();
         final int androidNotificationId = intent.getIntExtra("androidNotificationId", 0);
 
@@ -89,6 +96,7 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
                 // Build sendChatMessage params (same format as Nim backend)
                 JSONObject msg = new JSONObject();
                 msg.put("chatId", conversationId);
+                msg.put("threadId", threadId == null ? "" : threadId);
                 msg.put("text", replyTextStr);
                 msg.put("contentType", 1); // 1 = TEXT_PLAIN (protobuf ChatMessage_ContentType)
                 msg.put("responseTo", "");
@@ -149,7 +157,7 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
 
                 if (failed) {
                     Log.w(TAG, "sendChatMessage failed: " + errorMsg);
-                    if (mgr != null) mgr.clearConversation(conversationId);
+                    if (mgr != null) mgr.clearConversation(conversationKey);
                     StatusNotificationManager.showReplyFailed(appContext);
                     if (androidNotificationId != 0) {
                         NotificationManagerCompat.from(appContext).cancel(androidNotificationId);
@@ -158,7 +166,7 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
             } catch (Exception e) {
                 Log.w(TAG, "failed to send reply", e);
                 StatusNotificationManager mgr = StatusNotificationManager.getInstance();
-                if (mgr != null) mgr.clearConversation(conversationId);
+                if (mgr != null) mgr.clearConversation(conversationKey);
                 StatusNotificationManager.showReplyFailed(appContext);
                 if (androidNotificationId != 0) {
                     NotificationManagerCompat.from(appContext).cancel(androidNotificationId);

--- a/mobile/android/qt6/src/app/status/mobile/ipc/notifications/NotificationBuilder.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/notifications/NotificationBuilder.java
@@ -53,6 +53,18 @@ public final class NotificationBuilder {
     /** ID for "reply failed" notifications. */
     private static final int REPLY_FAILED_NOTIFICATION_ID = 4243;
 
+    /**
+     * Notification identity for a conversation. Thread messages get their own stack: the
+     * notification ID doubles as the inline-reply PendingIntent request code, and PendingIntent
+     * matching ignores extras, so sharing an ID with the parent chat would let whichever
+     * notification was posted last dictate where a reply is sent.
+     */
+    public static String conversationKey(String chatId, String threadId) {
+        if (chatId == null || chatId.isEmpty()) return "";
+        if (threadId == null || threadId.isEmpty()) return chatId;
+        return chatId + "#" + threadId;
+    }
+
     /** Message item used to build MessagingStyle entries. */
     public static final class MessageEntry {
         public final String text;
@@ -97,16 +109,19 @@ public final class NotificationBuilder {
      *
      * @param context         service context
      * @param title           conversation title
-     * @param conversationId  chat ID for grouping/buffering
+     * @param conversationId  chat ID, used as the target of an inline reply
+     * @param threadId        thread ID when the message belongs to a thread, otherwise empty
      * @param notificationId  Android notification ID (stable per conversation)
      * @param deepLink        deep link URI for tap action
      * @param largeIcon       large icon bitmap (may be null)
      * @param messages        buffered messages for MessagingStyle
      */
     public static void postMessageNotification(Context context, String title,
-            String conversationId, int notificationId, String deepLink,
+            String conversationId, String threadId, int notificationId, String deepLink,
             Bitmap largeIcon, List<MessageEntry> messages,
             boolean isOneToOne) {
+
+        final String conversationKey = conversationKey(conversationId, threadId);
 
         Intent intent = buildTapIntent(context, deepLink);
         if (intent == null) return;
@@ -126,7 +141,7 @@ public final class NotificationBuilder {
         buildMessagingStyle(context, builder, title, messages, isOneToOne);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            String shortcutId = "conv_" + conversationId;
+            String shortcutId = "conv_" + conversationKey;
             // For 1-1 chats: pin the first (contact's) message sender as the shortcut Person so
             // the contact avatar is stable and does not change when the user replies.
             // For group/community: no Person — the largeIcon (group/community icon) is used instead.
@@ -136,12 +151,12 @@ public final class NotificationBuilder {
         }
 
         // Delete intent: clear per-conversation state when user swipes away
-        addDismissIntent(context, builder, conversationId, notificationId);
+        addDismissIntent(context, builder, conversationId, conversationKey, notificationId);
 
         // Reply action
-        addReplyAction(context, builder, conversationId, notificationId);
+        addReplyAction(context, builder, conversationId, threadId, conversationKey, notificationId);
 
-        builder.setGroup("conv_" + conversationId);
+        builder.setGroup("conv_" + conversationKey);
 
         NotificationManagerCompat.from(context).notify(notificationId, builder.build());
     }
@@ -175,7 +190,7 @@ public final class NotificationBuilder {
 
         addContactRequestActions(context, builder, conversationId, contactRequestId, notificationId);
         if (conversationId != null && !conversationId.isEmpty()) {
-            addDismissIntent(context, builder, conversationId, notificationId);
+            addDismissIntent(context, builder, conversationId, conversationId, notificationId);
         }
         if (conversationId != null && !conversationId.isEmpty()) {
             builder.setGroup("conv_" + conversationId);
@@ -335,18 +350,19 @@ public final class NotificationBuilder {
     }
 
     private static void addDismissIntent(Context context, NotificationCompat.Builder builder,
-            String conversationId, int notificationId) {
+            String conversationId, String conversationKey, int notificationId) {
         Intent dismissIntent = new Intent(context, NotificationReplyReceiver.class);
         dismissIntent.setAction(ACTION_DISMISS);
         dismissIntent.setPackage(context.getPackageName());
         dismissIntent.putExtra("conversationId", conversationId);
+        dismissIntent.putExtra("conversationKey", conversationKey);
         builder.setDeleteIntent(PendingIntent.getBroadcast(
                 context, notificationId, dismissIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
     }
 
     private static void addReplyAction(Context context, NotificationCompat.Builder builder,
-            String conversationId, int notificationId) {
+            String conversationId, String threadId, String conversationKey, int notificationId) {
         RemoteInput remoteInput = new RemoteInput.Builder(REPLY_REMOTE_INPUT_KEY)
                 .setLabel(context.getString(R.string.notification_reply))
                 .build();
@@ -354,6 +370,8 @@ public final class NotificationBuilder {
         replyIntent.setAction(ACTION_REPLY);
         replyIntent.setPackage(context.getPackageName());
         replyIntent.putExtra("conversationId", conversationId);
+        replyIntent.putExtra("threadId", threadId);
+        replyIntent.putExtra("conversationKey", conversationKey);
         replyIntent.putExtra("androidNotificationId", notificationId);
         int replyFlags = PendingIntent.FLAG_UPDATE_CURRENT;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/mobile/android/qt6/src/app/status/mobile/ipc/notifications/StatusNotificationManager.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/notifications/StatusNotificationManager.java
@@ -129,6 +129,12 @@ public final class StatusNotificationManager {
         final String chatIcon = eventWrap.optString("chatIcon", "");
         final boolean isFromMe = eventWrap.optBoolean("isFromMe", false);
 
+        // status-go always reports the parent chat as conversationId; the thread, if any, is only
+        // discoverable from the embedded message.
+        final JSONObject body = eventWrap.optJSONObject("body");
+        final JSONObject bodyMessage = body != null ? body.optJSONObject("message") : null;
+        final String threadId = bodyMessage != null ? bodyMessage.optString("threadId", "") : "";
+
         String senderIcon = "";
         String senderName = "";
         final JSONObject author = eventWrap.optJSONObject("notificationAuthor");
@@ -157,6 +163,7 @@ public final class StatusNotificationManager {
                 message,
                 deepLink.isEmpty() ? null : deepLink,
                 conversationId.isEmpty() ? null : conversationId,
+                threadId,
                 notificationId.isEmpty() ? null : notificationId,
                 largeIconUri != null && !largeIconUri.isEmpty() ? largeIconUri : null,
                 category,
@@ -171,7 +178,7 @@ public final class StatusNotificationManager {
     // ── Show notification ─────────────────────────────────────────────────────
 
     private void showNotification(Context context, String title, String message,
-            String deepLink, String conversationId, String notificationId,
+            String deepLink, String conversationId, String threadId, String notificationId,
             String largeIconUri, String category, long timestamp,
             String senderName, String personAvatarUri, boolean isOneToOne,
             boolean isFromMe) {
@@ -201,7 +208,8 @@ public final class StatusNotificationManager {
                         largeIcon, conversationId, contactRequestId);
                 return;
             } else if (isMessage) {
-                notifIdInt = conversationId.hashCode() & 0x7fffffff;
+                notifIdInt = NotificationBuilder.conversationKey(conversationId, threadId)
+                        .hashCode() & 0x7fffffff;
                 // Rebuild message history from the currently active notification.
                 List<NotificationBuilder.MessageEntry> messages =
                         getConversationMessagesFromActiveNotification(context, notifIdInt);
@@ -235,7 +243,7 @@ public final class StatusNotificationManager {
                 Bitmap largeIcon = activeVisual != null && activeVisual.largeIcon != null
                         ? activeVisual.largeIcon : largeIconFromEvent;
                 NotificationBuilder.postMessageNotification(
-                        context, notificationTitle, conversationId, notifIdInt,
+                        context, notificationTitle, conversationId, threadId, notifIdInt,
                         deepLink, largeIcon, messages, isOneToOne);
             } else {
                 String idBase = (notificationId != null ? notificationId
@@ -257,12 +265,15 @@ public final class StatusNotificationManager {
 
     // ── Public API for NotificationReplyReceiver ──────────────────────────────
 
-    /** Clears state for a conversation (called when notification dismissed). */
-    public void clearConversation(String conversationId) {
-        if (conversationId == null || conversationId.isEmpty()) return;
+    /**
+     * Clears state for a conversation (called when notification dismissed).
+     * Takes a {@link NotificationBuilder#conversationKey} value, not a bare chat ID.
+     */
+    public void clearConversation(String conversationKey) {
+        if (conversationKey == null || conversationKey.isEmpty()) return;
         Context context = contextRef.get();
         if (context == null) return;
-        NotificationManagerCompat.from(context).cancel(conversationId.hashCode() & 0x7fffffff);
+        NotificationManagerCompat.from(context).cancel(conversationKey.hashCode() & 0x7fffffff);
     }
 
     /**

--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -2,7 +2,7 @@ import json, chronicles, tables
 
 import base
 
-import app_service/service/message/dto/[message, pinned_message_update, reaction, removed_message]
+import app_service/service/message/dto/[message, pinned_message_update, reaction, removed_message, thread]
 import app_service/service/chat/dto/[chat]
 import app_service/service/bookmarks/dto/[bookmark]
 import app_service/service/community/dto/[community]
@@ -19,6 +19,7 @@ include app_service/common/json_utils
 type MessageSignal* = ref object of Signal
   bookmarks*: seq[BookmarkDto]
   messages*: seq[MessageDto]
+  threads*: seq[ThreadDto]
   pinnedMessages*: seq[PinnedMessageUpdateDto]
   chats*: seq[ChatDto]
   contacts*: seq[ContactsDto]
@@ -81,6 +82,10 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
       var message = jsonMsg.toMessageDto()
       signal.messages.add(message)
       info "received", signal="messages.new", messageID=message.id
+
+  if e.contains("threads"):
+    for jsonThread in e["threads"]:
+      signal.threads.add(jsonThread.toThreadDto())
 
   if e.contains("chats"):
     for jsonChat in e["chats"]:

--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -24,6 +24,7 @@ const DEFAULT_FLAG_LOCAL_BACKUP_ENABLED = true
 const DEFAULT_FLAG_PRIVACY_MODE_FEATURE_ENABLED = true
 const DEFAULT_FLAG_MESSAGE_LINK_SHARING_ENABLED = true
 const DEFAULT_FLAG_STATUS_SUPPORT_BOT_ENABLED = true
+const DEFAULT_FLAG_THREADS_ENABLED = false
 
 # Compile time feature flags
 const DEFAULT_FLAG_DAPPS_ENABLED  = true
@@ -44,6 +45,7 @@ featureFlag("LOCAL_BACKUP_ENABLED",           DEFAULT_FLAG_LOCAL_BACKUP_ENABLED)
 featureFlag("PRIVACY_MODE_FEATURE_ENABLED",   DEFAULT_FLAG_PRIVACY_MODE_FEATURE_ENABLED)
 featureFlag("MESSAGE_LINK_SHARING_ENABLED",   DEFAULT_FLAG_MESSAGE_LINK_SHARING_ENABLED)
 featureFlag("STATUS_SUPPORT_BOT_ENABLED",     DEFAULT_FLAG_STATUS_SUPPORT_BOT_ENABLED)
+featureFlag("THREADS_ENABLED",                DEFAULT_FLAG_THREADS_ENABLED)
 
 featureFlag("DAPPS_ENABLED",                  DEFAULT_FLAG_DAPPS_ENABLED, true)
 featureFlag("BROWSER_ENABLED",                DEFAULT_FLAG_BROWSER_ENABLED, true)
@@ -100,6 +102,7 @@ QtObject:
     messageLinkSharingEnabled: bool
     statusSupportBotEnabled: bool
     buyEnabled: bool
+    threadsEnabled: bool
 
   proc setup(self: FeatureFlags) =
     self.QObject.setup()
@@ -117,6 +120,7 @@ QtObject:
     self.messageLinkSharingEnabled = MESSAGE_LINK_SHARING_ENABLED
     self.statusSupportBotEnabled = STATUS_SUPPORT_BOT_ENABLED
     self.buyEnabled = BUY_ENABLED
+    self.threadsEnabled = THREADS_ENABLED
 
   proc newFeatureFlags*(): FeatureFlags =
     new(result)
@@ -208,3 +212,9 @@ QtObject:
 
   proc getBuyEnabled*(self: FeatureFlags): bool {.slot.} =
     return self.buyEnabled
+
+  QtProperty[bool] threadsEnabled:
+    read = getThreadsEnabled
+
+  proc getThreadsEnabled*(self: FeatureFlags): bool {.slot.} =
+    return self.threadsEnabled

--- a/src/app/modules/main/chat_section/active_item.nim
+++ b/src/app/modules/main/chat_section/active_item.nim
@@ -20,6 +20,7 @@ QtObject:
 
   proc setActiveItemData*(self: ActiveItem, item: ChatItem) =
     self.item = item
+    self.idChanged()
 
   # Used when there is no longer an active item (last channel was deleted)
   proc resetActiveItemData*(self: ActiveItem) =
@@ -82,6 +83,24 @@ QtObject:
 
   QtProperty[int] type:
     read = getType
+
+  proc getIsThread(self: ActiveItem): bool {.slot.} =
+    if(self.item.isNil):
+      return false
+    return self.item.isThread
+
+  QtProperty[bool] isThread:
+    read = getIsThread
+    notify = idChanged
+
+  proc getParentChatId(self: ActiveItem): string {.slot.} =
+    if(self.item.isNil):
+      return ""
+    return self.item.parentChatId
+
+  QtProperty[string] parentChatId:
+    read = getParentChatId
+    notify = idChanged
 
   proc getHasUnreadMessages(self: ActiveItem): bool {.slot.} =
     if(self.item.isNil):

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -198,6 +198,12 @@ proc init*(self: Controller) =
       return
     self.delegate.onMessageEdited(args.message)
 
+  self.events.on(SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
+    let args = ChatThreadsLoadedArgs(e)
+    if self.chatId != args.chatId:
+      return
+    self.delegate.onChatThreadsLoaded(args.threads)
+
 proc getMyChatId*(self: Controller): string =
   return self.chatId
 

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -20,6 +20,7 @@ type
     events: UniqueUUIDEventEmitter
     sectionId: string
     chatId: string
+    threadId: string
     belongsToCommunity: bool
     isUsersListAvailable: bool #users list is not available for 1:1 chat
     nodeConfigurationService: node_configuration_service.Service
@@ -37,12 +38,13 @@ proc newController*(delegate: io_interface.AccessInterface, events: EventEmitter
     belongsToCommunity: bool, isUsersListAvailable: bool, settingsService: settings_service.Service,
     nodeConfigurationService: node_configuration_service.Service, contactService: contact_service.Service,
     chatService: chat_service.Service, communityService: community_service.Service,
-    messageService: message_service.Service): Controller =
+  messageService: message_service.Service, threadId: string = ""): Controller =
   result = Controller()
   result.delegate = delegate
   result.events = initUniqueUUIDEventEmitter(events)
   result.sectionId = sectionId
   result.chatId = chatId
+  result.threadId = threadId
   result.belongsToCommunity = belongsToCommunity
   result.isUsersListAvailable = isUsersListAvailable
   result.settingsService = settingsService
@@ -238,7 +240,7 @@ proc unblockChat*(self: Controller) =
   self.contactService.unblockContact(self.chatId)
 
 proc markAllMessagesRead*(self: Controller) =
-  self.messageService.markAllMessagesRead(self.chatId)
+  self.messageService.markAllMessagesRead(self.chatId, self.threadId)
 
 proc markMessageRead*(self: Controller, msgID: string) =
   self.messageService.markCertainMessagesRead(self.chatId, @[msgID])

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -200,12 +200,6 @@ proc init*(self: Controller) =
       return
     self.delegate.onMessageEdited(args.message)
 
-  self.events.on(SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
-    let args = ChatThreadsLoadedArgs(e)
-    if self.chatId != args.chatId:
-      return
-    self.delegate.onChatThreadsLoaded(args.threads)
-
 proc getMyChatId*(self: Controller): string =
   return self.chatId
 

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -131,7 +131,8 @@ proc sendImages*(self: Controller,
                  replyTo: string,
                  preferredUsername: string = "",
                  linkPreviews: seq[LinkPreview],
-                 paymentRequests: seq[PaymentRequest]) =
+                 paymentRequests: seq[PaymentRequest],
+                 threadId: string = "") =
   self.resetLinkPreviews()
   self.chatService.asyncSendImages(
     self.chatId,
@@ -140,7 +141,8 @@ proc sendImages*(self: Controller,
     replyTo,
     preferredUsername,
     linkPreviews,
-    paymentRequests
+    paymentRequests,
+    threadId
   )
 
 proc sendChatMessage*(self: Controller,
@@ -149,7 +151,8 @@ proc sendChatMessage*(self: Controller,
                       contentType: int,
                       preferredUsername: string = "",
                       linkPreviews: seq[LinkPreview],
-                      paymentRequests: seq[PaymentRequest]) =
+                      paymentRequests: seq[PaymentRequest],
+                      threadId: string) =
   self.resetLinkPreviews()
   self.chatService.asyncSendChatMessage(self.chatId,
     msg,
@@ -157,7 +160,8 @@ proc sendChatMessage*(self: Controller,
     contentType,
     preferredUsername,
     linkPreviews,
-    paymentRequests
+    paymentRequests,
+    threadId = threadId
   )
 
 proc getLinkPreviewEnabled*(self: Controller): bool =

--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -20,10 +20,15 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method sendChatMessage*(self: AccessInterface, msg: string, replyTo: string, contentType: int, linkPreviews: seq[LinkPreview], paymentRequests: seq[PaymentRequest]) {.base.} =
+method sendChatMessage*(self: AccessInterface, msg: string, replyTo: string, contentType: int,
+  linkPreviews: seq[LinkPreview], paymentRequests: seq[PaymentRequest]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method sendImages*(self: AccessInterface, imagePathsJson: string, msg: string, replyTo: string, linkPreviews: seq[LinkPreview], paymentRequests: seq[PaymentRequest]) {.base.} =
+method sendImages*(self: AccessInterface, imagePathsJson: string, msg: string, replyTo: string,
+  linkPreviews: seq[LinkPreview], paymentRequests: seq[PaymentRequest]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getThreadId*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method searchGifs*(self: AccessInterface, query: string) {.base.} =
@@ -56,7 +61,7 @@ method searchGifsStarted*(self: AccessInterface) {.base.} =
 method searchGifsError*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method serachGifsDone*(self: AccessInterface, gifs: seq[GifDto]) {.base.} =
+method searchGifsDone*(self: AccessInterface, gifs: seq[GifDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getFavoritesGifs*(self: AccessInterface): seq[GifDto] {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -21,6 +21,7 @@ type
     viewVariant: QVariant
     controller: Controller
     moduleLoaded: bool
+    threadId: string
 
 proc newModule*(
     delegate: delegate_interface.AccessInterface,
@@ -32,7 +33,8 @@ proc newModule*(
     communityService: community_service.Service,
     contactService: contact_service.Service,
     messageService: message_service.Service,
-    settingsService: settings_service.Service
+    settingsService: settings_service.Service,
+    threadId: string = ""
     ):
   Module =
   result = Module()
@@ -41,6 +43,7 @@ proc newModule*(
   result.viewVariant = newQVariant(result.view)
   result.controller = controller.newController(result, events, sectionId, chatId, belongsToCommunity, chatService, communityService, contactService, messageService, settingsService)
   result.moduleLoaded = false
+  result.threadId = threadId
 
 method delete*(self: Module) =
   self.view.delete
@@ -66,8 +69,17 @@ method getModuleAsVariant*(self: Module): QVariant =
 proc getChatId*(self: Module): string =
   return self.controller.getChatId()
 
-method sendImages*(self: Module, imagePathsJson: string, msg: string, replyTo: string, linkPreviews: seq[LinkPreview], paymentRequests: seq[PaymentRequest]) =
-  self.controller.sendImages(imagePathsJson, msg, replyTo, singletonInstance.userProfile.getPreferredName(), linkPreviews, paymentRequests)
+method sendImages*(self: Module, imagePathsJson: string, msg: string, replyTo: string,
+    linkPreviews: seq[LinkPreview], paymentRequests: seq[PaymentRequest]) =
+  self.controller.sendImages(
+    imagePathsJson = imagePathsJson,
+    msg = msg,
+    replyTo = replyTo,
+    preferredUsername = singletonInstance.userProfile.getPreferredName(),
+    linkPreviews = linkPreviews,
+    paymentRequests = paymentRequests,
+    self.threadId,
+  )
 
 method sendChatMessage*(
     self: Module,
@@ -75,9 +87,20 @@ method sendChatMessage*(
     replyTo: string,
     contentType: int,
     linkPreviews: seq[LinkPreview],
-    paymentRequests: seq[PaymentRequest]) =
-  self.controller.sendChatMessage(msg, replyTo, contentType,
-    singletonInstance.userProfile.getPreferredName(), linkPreviews, paymentRequests)
+    paymentRequests: seq[PaymentRequest],
+  ) =
+  self.controller.sendChatMessage(
+    msg = msg,
+    replyTo = replyTo,
+    contentType = contentType,
+    preferredUsername = singletonInstance.userProfile.getPreferredName(),
+    linkPreviews,
+    paymentRequests,
+    self.threadId,
+  )
+
+method getThreadId*(self: Module): string =
+  return self.threadId
 
 method setText*(self: Module, text: string, unfurlNewUrls: bool) =
   self.controller.setText(text, unfurlNewUrls)

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -20,6 +20,7 @@ QtObject:
       urlsModelVariant: QVariant
       sendingInProgress: bool
       askToEnableLinkPreview: bool
+      threadId: string
 
   proc setSendingInProgress*(self: View, value: bool)
 
@@ -37,6 +38,7 @@ QtObject:
     result.urlsModel = newUrlsModel()
     result.urlsModelVariant = newQVariant(result.urlsModel)
     result.askToEnableLinkPreview = false
+    result.threadId = ""
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -59,6 +61,12 @@ QtObject:
     self.setSendingInProgress(true)
     self.delegate.setText(msg, false)
     self.delegate.sendImages(imagePathsJson, msg, replyTo, self.linkPreviewModel.getUnfuledLinkPreviews(), self.payment_request_model.getPaymentRequests())
+
+  proc getThreadId(self: View): string {.slot.} =
+    return self.delegate.getThreadId()
+
+  QtProperty[string] threadId:
+    read = getThreadId
 
   proc getPreservedProperties(self: View): QVariant {.slot.} =
     return self.preservedPropertiesVariant

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -5,6 +5,7 @@ import app_service/service/message/dto/pinned_message
 import app_service/service/chat/dto/chat
 import app_service/service/message/dto/message
 import app_service/service/message/dto/reaction
+import app_service/service/message/dto/thread
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -25,6 +26,12 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onNotificationsUpdated*(self: AccessInterface, hasUnreadMessages: bool, notificationCount: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method openThreadAsChat*(self: AccessInterface, threadId: string, threadName: string, parentMessageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onChatThreadsLoaded*(self: AccessInterface, threads: seq[ThreadDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method newPinnedMessagesLoaded*(self: AccessInterface, pinnedMessages: seq[PinnedMessageDto], reactions: seq[ReactionDto]) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -32,9 +32,6 @@ method openThreadAsChat*(self: AccessInterface, threadId: string, threadName: st
     setActive: bool = true, hasUnreadMessages: bool = false, notificationsCount: int = 0) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onChatThreadsLoaded*(self: AccessInterface, threads: seq[ThreadDto]) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method newPinnedMessagesLoaded*(self: AccessInterface, pinnedMessages: seq[PinnedMessageDto], reactions: seq[ReactionDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -28,7 +28,8 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
 method onNotificationsUpdated*(self: AccessInterface, hasUnreadMessages: bool, notificationCount: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method openThreadAsChat*(self: AccessInterface, threadId: string, threadName: string, parentMessageId: string) {.base.} =
+method openThreadAsChat*(self: AccessInterface, threadId: string, threadName: string, parentMessageId: string,
+    setActive: bool = true, hasUnreadMessages: bool = false, notificationsCount: int = 0) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onChatThreadsLoaded*(self: AccessInterface, threads: seq[ThreadDto]) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -150,6 +150,8 @@ proc init*(self: Controller) =
     let args = MessagesMarkedAsReadArgs(e)
     if self.chatId != args.chatId:
       return
+    if self.threadId != args.threadId:
+      return
     if args.allMessagesMarked:
       self.delegate.markAllMessagesRead()
     else:

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -22,6 +22,7 @@ type
     events: UniqueUUIDEventEmitter
     sectionId: string
     chatId: string
+    threadId: string
     belongsToCommunity: bool
     searchedMessageId: string
     loadingMessagesPerPageFactor: int
@@ -35,12 +36,14 @@ type
 proc newController*(delegate: io_interface.AccessInterface, events: EventEmitter, sectionId: string, chatId: string,
     belongsToCommunity: bool, contactService: contact_service.Service, communityService: community_service.Service,
     chatService: chat_service.Service, messageService: message_service.Service,
-    mailserversService: mailservers_service.Service, sharedUrlsService: shared_urls_service.Service): Controller =
+    mailserversService: mailservers_service.Service, sharedUrlsService: shared_urls_service.Service,
+    threadId: string = ""): Controller =
   result = Controller()
   result.delegate = delegate
   result.events = initUniqueUUIDEventEmitter(events)
   result.sectionId = sectionId
   result.chatId = chatId
+  result.threadId = threadId
   result.loadingMessagesPerPageFactor = 1
   result.belongsToCommunity = belongsToCommunity
   result.contactService = contactService
@@ -72,7 +75,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):
     let args = MessageSendingSuccess(e)
-    if self.chatId != args.chat.id:
+    if self.chatId != args.chat.id or args.message.threadId != self.threadId:
       return
     self.delegate.onSendingMessageSuccess(args.message)
 
@@ -235,11 +238,51 @@ proc init*(self: Controller) =
     let args = GetMessageResult(e)
     self.delegate.onGetMessageById(args.requestId, args.messageId, args.message, args.error)
 
+  self.events.on(SIGNAL_THREAD_CREATED) do(e: Args):
+    let args = ThreadCreatedArgs(e)
+    if self.chatId != args.chatId:
+      return
+    self.delegate.onThreadCreated(args.parentMessageId, args.threads)
+
+  self.events.on(SIGNAL_THREAD_MESSAGES_LOADED) do(e: Args):
+    let args = ThreadMessagesLoadedArgs(e)
+    if self.chatId != args.chatId:
+      return
+    if self.threadId != args.threadId:
+      return
+    self.delegate.newMessagesLoaded(args.messages, @[])
+
+  self.events.on(SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
+    let args = ChatThreadsLoadedArgs(e)
+    if self.chatId != args.chatId:
+      return
+    self.delegate.onChatThreadsLoaded(args.threads)
+
 proc getMySectionId*(self: Controller): string =
   return self.sectionId
 
 proc getMyChatId*(self: Controller): string =
   return self.chatId
+
+proc getMyThreadId*(self: Controller): string =
+  return self.threadId
+
+proc setThreadId*(self: Controller, threadId: string) =
+  self.threadId = threadId
+
+proc createThread*(self: Controller, parentMessageId: string) =
+  if parentMessageId.len == 0:
+    return
+  self.messageService.asyncCreateThread(self.chatId, parentMessageId)
+
+proc loadChatThreadsIfNeeded*(self: Controller) =
+  self.messageService.loadChatThreadsIfNeeded(self.chatId)
+
+proc hasThreadForParentMessage*(self: Controller, parentMessageId: string): bool =
+  return self.messageService.chatHasThreadForParentMessage(self.chatId, parentMessageId)
+
+proc closeThread*(self: Controller) =
+  self.threadId = ""
 
 proc getChatDetails*(self: Controller): lent ChatDto =
   return self.chatService.getChatById(self.chatId)
@@ -264,6 +307,9 @@ proc belongsToCommunity*(self: Controller): bool =
 
 proc loadMoreMessages*(self: Controller): bool =
   let limit = self.loadingMessagesPerPageFactor * MESSAGES_PER_PAGE
+  # TODO is it possible to just extend the existing messages API?
+  if self.threadId.len > 0:
+    return self.messageService.asyncLoadMoreMessagesForThread(self.chatId, self.threadId, limit)
   return self.messageService.asyncLoadMoreMessagesForChat(self.chatId, limit)
 
 proc addReaction*(self: Controller, messageId: string, emoji: string) =

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -65,11 +65,16 @@ proc init*(self: Controller) =
     let args = MessagesLoadedArgs(e)
     if self.chatId != args.chatId:
       return
+    if self.threadId != args.threadId:
+      return
+
     self.delegate.newMessagesLoaded(args.messages, args.reactions)
 
   self.events.on(SIGNAL_NEW_MESSAGE_RECEIVED) do(e: Args):
     var args = MessagesArgs(e)
     if self.chatId != args.chatId:
+      return
+    if self.threadId != args.threadId:
       return
     self.delegate.messagesAdded(args.messages)
 
@@ -243,14 +248,6 @@ proc init*(self: Controller) =
     if self.chatId != args.chatId:
       return
     self.delegate.onThreadCreated(args.parentMessageId, args.threads)
-
-  self.events.on(SIGNAL_THREAD_MESSAGES_LOADED) do(e: Args):
-    let args = ThreadMessagesLoadedArgs(e)
-    if self.chatId != args.chatId:
-      return
-    if self.threadId != args.threadId:
-      return
-    self.delegate.newMessagesLoaded(args.messages, @[])
 
   self.events.on(SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
     let args = ChatThreadsLoadedArgs(e)

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -1,8 +1,9 @@
 import nimqml, uuids
 
-import ../../../../../../app_service/service/message/dto/[message, reaction, pinned_message]
-import ../../../../../../app_service/service/community/dto/community
-import ../../../../../../app_service/common/types
+import app_service/service/message/dto/[message, reaction, pinned_message]
+import app_service/service/message/dto/thread
+import app_service/service/community/dto/community
+import app_service/common/types
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -105,6 +106,9 @@ method getSectionId*(self: AccessInterface): string {.base.} =
 method getChatId*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getThreadId*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getChatType*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -187,4 +191,19 @@ method onGetMessageById*(self: AccessInterface, requestId: UUID, messageId: stri
   raise newException(ValueError, "No implementation available")
 
 method forceLinkPreviewsLocalData*(self: AccessInterface, messageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method createThread*(self: AccessInterface, parentMessageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method closeThread*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setThreadId*(self: AccessInterface, threadId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onThreadCreated*(self: AccessInterface, parentMessageId: string, threads: seq[ThreadDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onChatThreadsLoaded*(self: AccessInterface, threads: seq[ThreadDto]) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -11,6 +11,7 @@ import ../../../../../../app_service/service/contacts/service as contact_service
 import ../../../../../../app_service/service/community/service as community_service
 import ../../../../../../app_service/service/chat/service as chat_service
 import ../../../../../../app_service/service/message/service as message_service
+import ../../../../../../app_service/service/message/dto/thread
 import ../../../../../../app_service/service/mailservers/service as mailservers_service
 import ../../../../../../app_service/service/shared_urls/service as shared_urls_service
 import ../../../../../../app_service/service/contacts/dto/contact_details
@@ -47,14 +48,15 @@ type
 proc newModule*(delegate: delegate_interface.AccessInterface, events: EventEmitter, sectionId: string, chatId: string,
     belongsToCommunity: bool, contactService: contact_service.Service, communityService: community_service.Service,
     chatService: chat_service.Service, messageService: message_service.Service,
-    mailserversService: mailservers_service.Service, sharedUrlsService: shared_urls_service.Service):
+    mailserversService: mailservers_service.Service, sharedUrlsService: shared_urls_service.Service,
+    threadId: string = ""):
   Module =
   result = Module()
   result.delegate = delegate
   result.view = view.newView(result)
   result.viewVariant = newQVariant(result.view)
   result.controller = controller.newController(result, events, sectionId, chatId, belongsToCommunity, contactService,
-    communityService, chatService, messageService, mailserversService, sharedUrlsService)
+    communityService, chatService, messageService, mailserversService, sharedUrlsService, threadId = threadId)
   result.moduleLoaded = false
   result.initialMessagesLoaded = false
   result.firstUnseenMessageState = (false, false, false)
@@ -82,8 +84,14 @@ method isLoaded*(self: Module): bool =
   return self.moduleLoaded
 
 method viewDidLoad*(self: Module) =
+  self.controller.loadChatThreadsIfNeeded()
+  self.view.setThreadId(self.controller.getMyThreadId())
+
+  if self.controller.getMyThreadId().len > 0:
+    discard self.controller.loadMoreMessages()
+
   let chatDto = self.controller.getChatDetails()
-  if chatDto.hasMoreMessagesToRequest():
+  if self.controller.getMyThreadId().len == 0 and chatDto.hasMoreMessagesToRequest():
     self.view.model().insertItemBasedOnClock(self.createFetchMoreMessagesItem())
 
   self.updateChatIdentifier()
@@ -158,6 +166,8 @@ proc createMessageItemsFromMessageDtos(self: Module, messages: seq[MessageDto], 
       transactionContract,
       transactionValue,
     )
+
+    item.hasThread = self.controller.hasThreadForParentMessage(message.id)
 
     self.updateLinkPreviewsContacts(item, requestFromMailserver = item.seen)
     self.updateLinkPreviewsCommunities(item, requestFromMailserver = item.seen)
@@ -264,17 +274,22 @@ proc currentUserWalletContainsAddress(self: Module, address: string): bool =
   return false
 
 method reevaluateViewLoadingState*(self: Module) =
+  let inThreadMode = self.controller.getMyThreadId().len > 0
   let loading = not self.initialMessagesLoaded or
-                not self.firstUnseenMessageState.initialized or
-                self.firstUnseenMessageState.fetching or
+                (not inThreadMode and (not self.firstUnseenMessageState.initialized or
+                self.firstUnseenMessageState.fetching)) or
                 self.view.getMessageSearchOngoing()
   self.view.setLoading(loading)
 
 method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: seq[ReactionDto]) =
-  if messages.len > 0:
-    var viewItems = self.createMessageItemsFromMessageDtos(messages, reactions)
+  var filtered = messages
+  if self.controller.getMyThreadId().len > 0:
+    filtered = messages.filterIt(it.threadId == self.controller.getMyThreadId())
 
-    if self.controller.getChatDetails().hasMoreMessagesToRequest():
+  if filtered.len > 0:
+    var viewItems = self.createMessageItemsFromMessageDtos(filtered, reactions)
+
+    if self.controller.getMyThreadId().len == 0 and self.controller.getChatDetails().hasMoreMessagesToRequest():
       viewItems.add(self.createFetchMoreMessagesItem())
     viewItems.add(self.createChatIdentifierItem())
     self.view.model().removeItem(FETCH_MORE_MESSAGES_MESSAGE_ID)
@@ -290,7 +305,14 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
   self.reevaluateViewLoadingState()
 
 method messagesAdded*(self: Module, messages: seq[MessageDto]) =
-  let items = self.createMessageItemsFromMessageDtos(messages)
+  var filtered = messages
+  if self.controller.getMyThreadId().len > 0:
+    filtered = messages.filterIt(it.threadId == self.controller.getMyThreadId())
+
+  if filtered.len == 0:
+    return
+
+  let items = self.createMessageItemsFromMessageDtos(filtered)
 
   self.view.model().insertItemsBasedOnClock(items)
   self.checkIfMessageLoadedAndScroll()
@@ -395,6 +417,63 @@ method getSectionId*(self: Module): string =
 
 method getChatId*(self: Module): string =
   return self.controller.getMyChatId()
+
+method getThreadId*(self: Module): string =
+  return self.controller.getMyThreadId()
+
+method setThreadId*(self: Module, threadId: string) =
+  if self.controller.getMyThreadId() == threadId:
+    return
+
+  self.controller.setThreadId(threadId)
+  self.view.setThreadId(threadId)
+  self.initialMessagesLoaded = false
+  self.view.model().clear()
+
+  if threadId.len == 0 and self.controller.getChatDetails().hasMoreMessagesToRequest():
+    self.view.model().insertItemBasedOnClock(self.createFetchMoreMessagesItem())
+
+  self.updateChatIdentifier()
+  discard self.controller.loadMoreMessages()
+  self.reevaluateViewLoadingState()
+
+method createThread*(self: Module, parentMessageId: string) =
+  if self.controller.hasThreadForParentMessage(parentMessageId):
+    # TODO get thread name from service
+    # threadId == parentMessageId; open the existing thread as a sub-channel chat
+    # Note: threadName would ideally come from ThreadDto, but for existing threads
+    # the module should already be loaded, so threadName is not used
+    self.delegate.openThreadAsChat(parentMessageId, "", parentMessageId)
+    return
+
+  self.controller.createThread(parentMessageId)
+
+method closeThread*(self: Module) =
+  self.setThreadId("")
+
+method onThreadCreated*(self: Module, parentMessageId: string, threads: seq[ThreadDto]) =
+  if threads.len == 0:
+    return
+
+  var selectedThread = threads[0]
+  if parentMessageId.len > 0:
+    for thread in threads:
+      if thread.parentMessageId == parentMessageId:
+        selectedThread = thread
+        break
+
+  if selectedThread.parentMessageId.len > 0:
+    self.view.model().setHasThread(selectedThread.parentMessageId, true)
+
+  # Open the freshly created thread as a sub-channel chat
+  self.delegate.openThreadAsChat(selectedThread.threadId, selectedThread.name, selectedThread.parentMessageId)
+
+method onChatThreadsLoaded*(self: Module, threads: seq[ThreadDto]) =
+  for thread in threads:
+    if thread.parentMessageId.len > 0:
+      self.view.model().setHasThread(thread.parentMessageId, true)
+      # Add the thread to the chat list so it appears as a sub-chat
+      self.delegate.openThreadAsChat(thread.threadId, thread.name, thread.parentMessageId)
 
 method getChatType*(self: Module): int =
   let chatDto = self.controller.getChatDetails()

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -466,14 +466,18 @@ method onThreadCreated*(self: Module, parentMessageId: string, threads: seq[Thre
     self.view.model().setHasThread(selectedThread.parentMessageId, true)
 
   # Open the freshly created thread as a sub-channel chat
-  self.delegate.openThreadAsChat(selectedThread.threadId, selectedThread.name, selectedThread.parentMessageId)
+  self.delegate.openThreadAsChat(selectedThread.threadId, selectedThread.name, selectedThread.parentMessageId,
+    setActive = true, hasUnreadMessages = selectedThread.unviewedMessagesCount > 0,
+    notificationsCount = selectedThread.unviewedMentionsCount)
 
 method onChatThreadsLoaded*(self: Module, threads: seq[ThreadDto]) =
   for thread in threads:
     if thread.parentMessageId.len > 0:
       self.view.model().setHasThread(thread.parentMessageId, true)
       # Add the thread to the chat list so it appears as a sub-chat
-      self.delegate.openThreadAsChat(thread.threadId, thread.name, thread.parentMessageId)
+      self.delegate.openThreadAsChat(thread.threadId, thread.name, thread.parentMessageId,
+        setActive = false, hasUnreadMessages = thread.unviewedMessagesCount > 0,
+        notificationsCount = thread.unviewedMentionsCount)
 
 method getChatType*(self: Module): int =
   let chatDto = self.controller.getChatDetails()

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -471,13 +471,11 @@ method onThreadCreated*(self: Module, parentMessageId: string, threads: seq[Thre
     notificationsCount = selectedThread.unviewedMentionsCount)
 
 method onChatThreadsLoaded*(self: Module, threads: seq[ThreadDto]) =
+  # Adding the thread rows is the chat section's job; this only back-fills the flag for
+  # messages that were already rendered when the fetch landed.
   for thread in threads:
     if thread.parentMessageId.len > 0:
       self.view.model().setHasThread(thread.parentMessageId, true)
-      # Add the thread to the chat list so it appears as a sub-chat
-      self.delegate.openThreadAsChat(thread.threadId, thread.name, thread.parentMessageId,
-        setActive = false, hasUnreadMessages = thread.unviewedMessagesCount > 0,
-        notificationsCount = thread.unviewedMentionsCount)
 
 method getChatType*(self: Module): int =
   let chatDto = self.controller.getChatDetails()

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -10,6 +10,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       model: Model
       modelVariant: QVariant
+      threadId: string
       messageSearchOngoing: bool
       amIChatAdmin: bool
       isPinMessageAllowedForMembers: bool
@@ -26,6 +27,7 @@ QtObject:
     result.delegate = delegate
     result.model = newModel()
     result.modelVariant = newQVariant(result.model)
+    result.threadId = ""
     result.messageSearchOngoing = false
     result.amIChatAdmin = false
     result.isPinMessageAllowedForMembers = false
@@ -91,6 +93,32 @@ QtObject:
 
   proc getChatId*(self: View): string {.slot.} =
     return self.delegate.getChatId()
+
+  proc threadIdChanged*(self: View) {.signal.}
+  proc getThreadId*(self: View): string {.slot.} =
+    return self.threadId
+  proc setThreadId*(self: View, value: string) {.slot.} =
+    self.threadId = value
+    self.threadIdChanged()
+
+  QtProperty[string] threadId:
+    read = getThreadId
+    notify = threadIdChanged
+
+  proc createThread*(self: View, parentMessageId: string) {.slot.} =
+    self.delegate.createThread(parentMessageId)
+
+  # QML uses this to enter an existing thread; forward to the module so
+  # controller/view/model state stay in sync.
+  proc setThreadIdFromUI*(self: View, value: string) {.slot.} =
+    self.delegate.setThreadId(value)
+
+  proc closeThread*(self: View) {.slot.} =
+    self.delegate.closeThread()
+
+  proc threadCreated*(self: View, threadId: string, parentMessageId: string) {.signal.}
+  proc emitThreadCreatedSignal*(self: View, threadId: string, parentMessageId: string) =
+    self.threadCreated(threadId, parentMessageId)
 
   proc getNumberOfPinnedMessages*(self: View): int {.slot.} =
     return self.delegate.getNumberOfPinnedMessages()

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -14,15 +14,15 @@ import input_area/module as input_area_module
 import messages/module as messages_module
 import users/module as users_module
 
-import ../../../../../app_service/service/settings/service as settings_service
-import ../../../../../app_service/service/node_configuration/service as node_configuration_service
-import ../../../../../app_service/service/contacts/service as contact_service
-import ../../../../../app_service/service/chat/service as chat_service
-import ../../../../../app_service/service/community/service as community_service
-import ../../../../../app_service/service/message/service as message_service
-import ../../../../../app_service/service/mailservers/service as mailservers_service
-import ../../../../../app_service/service/shared_urls/service as shared_urls_service
-import ../../../../../app_service/common/types
+import app_service/service/settings/service as settings_service
+import app_service/service/node_configuration/service as node_configuration_service
+import app_service/service/contacts/service as contact_service
+import app_service/service/chat/service as chat_service
+import app_service/service/community/service as community_service
+import app_service/service/message/service as message_service
+import app_service/service/mailservers/service as mailservers_service
+import app_service/service/shared_urls/service as shared_urls_service
+import app_service/common/types
 
 export io_interface
 
@@ -45,7 +45,8 @@ proc newModule*(delegate: delegate_interface.AccessInterface, events: EventEmitt
     nodeConfigurationService: node_configuration_service.Service, contactService: contact_service.Service,
     chatService: chat_service.Service, communityService: community_service.Service,
     messageService: message_service.Service,
-    mailserversService: mailservers_service.Service, sharedUrlsService: shared_urls_service.Service):
+    mailserversService: mailservers_service.Service, sharedUrlsService: shared_urls_service.Service,
+    threadId: string = ""):
   Module =
   result = Module()
   result.delegate = delegate
@@ -57,9 +58,9 @@ proc newModule*(delegate: delegate_interface.AccessInterface, events: EventEmitt
   result.moduleLoaded = false
 
   result.inputAreaModule = input_area_module.newModule(result, events, sectionId, chatId, belongsToCommunity,
-    chatService, communityService, contactService, messageService, settingsService)
+    chatService, communityService, contactService, messageService, settingsService, threadId = threadId)
   result.messagesModule = messages_module.newModule(result, events, sectionId, chatId, belongsToCommunity,
-    contactService, communityService, chatService, messageService, mailserversService, sharedUrlsService)
+    contactService, communityService, chatService, messageService, mailserversService, sharedUrlsService, threadId = threadId)
   result.usersModule = users_module.newModule(events, sectionId, chatId, belongsToCommunity,
     isUsersListAvailable, contactService, chat_service, communityService, messageService)
 
@@ -257,6 +258,15 @@ method onMessageEdited*(self: Module, message: MessageDto) =
 
 method getMyChatId*(self: Module): string =
   self.controller.getMyChatId()
+
+method openThreadAsChat*(self: Module, threadId: string, threadName: string, parentMessageId: string) =
+  self.delegate.openThreadAsChat(self.controller.getMyChatId(), threadId, threadName, parentMessageId, setActive = true)
+
+method onChatThreadsLoaded*(self: Module, threads: seq[ThreadDto]) =
+  for thread in threads:
+    if thread.parentMessageId.len > 0:
+      # Add the thread to the chat list so it appears as a sub-chat
+      self.delegate.openThreadAsChat(self.controller.getMyChatId(), thread.threadId, thread.name, thread.parentMessageId, setActive = false)
 
 method muteChat*(self: Module, interval: int) =
   self.controller.muteChat(interval)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -259,14 +259,17 @@ method onMessageEdited*(self: Module, message: MessageDto) =
 method getMyChatId*(self: Module): string =
   self.controller.getMyChatId()
 
-method openThreadAsChat*(self: Module, threadId: string, threadName: string, parentMessageId: string) =
-  self.delegate.openThreadAsChat(self.controller.getMyChatId(), threadId, threadName, parentMessageId, setActive = true)
+method openThreadAsChat*(self: Module, threadId: string, threadName: string, parentMessageId: string,
+    setActive: bool = true, hasUnreadMessages: bool = false, notificationsCount: int = 0) =
+  self.delegate.openThreadAsChat(self.controller.getMyChatId(), threadId, threadName, parentMessageId,
+    setActive = setActive, hasUnreadMessages = hasUnreadMessages, notificationsCount = notificationsCount)
 
 method onChatThreadsLoaded*(self: Module, threads: seq[ThreadDto]) =
   for thread in threads:
     if thread.parentMessageId.len > 0:
       # Add the thread to the chat list so it appears as a sub-chat
-      self.delegate.openThreadAsChat(self.controller.getMyChatId(), thread.threadId, thread.name, thread.parentMessageId, setActive = false)
+      self.delegate.openThreadAsChat(self.controller.getMyChatId(), thread.threadId, thread.name, thread.parentMessageId,
+        setActive = false, hasUnreadMessages = thread.unviewedMessagesCount > 0, notificationsCount = thread.unviewedMentionsCount)
 
 method muteChat*(self: Module, interval: int) =
   self.controller.muteChat(interval)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -264,13 +264,6 @@ method openThreadAsChat*(self: Module, threadId: string, threadName: string, par
   self.delegate.openThreadAsChat(self.controller.getMyChatId(), threadId, threadName, parentMessageId,
     setActive = setActive, hasUnreadMessages = hasUnreadMessages, notificationsCount = notificationsCount)
 
-method onChatThreadsLoaded*(self: Module, threads: seq[ThreadDto]) =
-  for thread in threads:
-    if thread.parentMessageId.len > 0:
-      # Add the thread to the chat list so it appears as a sub-chat
-      self.delegate.openThreadAsChat(self.controller.getMyChatId(), thread.threadId, thread.name, thread.parentMessageId,
-        setActive = false, hasUnreadMessages = thread.unviewedMessagesCount > 0, notificationsCount = thread.unviewedMentionsCount)
-
 method muteChat*(self: Module, interval: int) =
   self.controller.muteChat(interval)
 

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -54,7 +54,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface, events: EventEmitt
   result.viewVariant = newQVariant(result.view)
   result.controller = controller.newController(result, events, sectionId, chatId, belongsToCommunity,
     isUsersListAvailable, settingsService, nodeConfigurationService, contactService, chatService, communityService,
-    messageService)
+    messageService, threadId = threadId)
   result.moduleLoaded = false
 
   result.inputAreaModule = input_area_module.newModule(result, events, sectionId, chatId, belongsToCommunity,

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -519,8 +519,8 @@ proc muteChat*(self: Controller, chatId: string, interval: int) =
 proc unmuteChat*(self: Controller, chatId: string) =
   self.chatService.unmuteChat(chatId)
 
-proc markAllMessagesRead*(self: Controller, chatId: string) =
-  self.messageService.markAllMessagesRead(chatId)
+proc markAllMessagesRead*(self: Controller, chatId: string, threadId: string = "") =
+  self.messageService.markAllMessagesRead(chatId, threadId)
 
 proc clearChatHistory*(self: Controller, chatId: string) =
   self.chatService.clearChatHistory(chatId)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -96,6 +96,9 @@ proc asyncCheckPermissionsToJoin*(self: Controller) =
 proc asyncCheckChannelPermissions*(self: Controller, communityId: string, chatId: string) =
   self.chatService.asyncCheckChannelPermissions(communityId, chatId)
 
+proc loadChatThreadsForChats*(self: Controller, chatIds: seq[string]) =
+  self.messageService.loadChatThreadsForChatsIfNeeded(chatIds)
+
 proc init*(self: Controller) =
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):
     let args = MessageSendingSuccess(e)
@@ -135,6 +138,10 @@ proc init*(self: Controller) =
         (not self.isCommunitySection and chat.communityId != "")):
       return
     self.delegate.onMarkMessageAsUnread(chat)
+
+  self.events.on(message_service.SIGNAL_CHAT_THREADS_LOADED) do(e: Args):
+    let args = message_service.ChatThreadsLoadedArgs(e)
+    self.delegate.onChatThreadsLoaded(args.chatId, args.threads)
 
   self.events.on(chat_service.SIGNAL_CHAT_LEFT) do(e: Args):
     let args = chat_service.ChatArgs(e)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -105,7 +105,8 @@ proc init*(self: Controller) =
     let args = MessagesArgs(e)
     if (self.sectionId != args.sectionId or args.messages.len == 0):
       return
-    self.delegate.onNewMessagesReceived(args.sectionId, args.chatId, args.chatType, args.lastMessageTimestamp,
+    let displayChatId = if args.threadId.len > 0: args.threadId else: args.chatId
+    self.delegate.onNewMessagesReceived(args.sectionId, args.chatId, displayChatId, args.chatType, args.lastMessageTimestamp,
       args.unviewedMessagesCount, args.unviewedMentionsCount, args.messages[0])
 
   self.events.on(chat_service.SIGNAL_CHAT_MUTED) do(e:Args):

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -124,8 +124,9 @@ proc init*(self: Controller) =
     if ((self.isCommunitySection and chat.communityId != self.sectionId) or
         (not self.isCommunitySection and chat.communityId != "")):
       return
-    self.chatService.updateUnreadMessagesAndMentions(args.chatId, args.allMessagesMarked, args.messagesCount, args.messagesWithMentionsCount)
-    self.delegate.onMarkAllMessagesRead(chat)
+    if args.threadId.len == 0:
+      self.chatService.updateUnreadMessagesAndMentions(args.chatId, args.allMessagesMarked, args.messagesCount, args.messagesWithMentionsCount)
+    self.delegate.onMarkAllMessagesRead(chat, args.threadId)
 
   self.events.on(message_service.SIGNAL_MESSAGE_MARKED_AS_UNREAD) do(e:Args):
     let args = message_service.MessageMarkMessageAsUnreadArgs(e)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -169,7 +169,7 @@ proc init*(self: Controller) =
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.mailserversService, self.sharedUrlsService, setChatAsActive = true)
 
-  if (self.isCommunitySection):
+  if self.isCommunitySection:
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CREATED) do(e:Args):
       let args = CommunityChatArgs(e)
       let belongsToCommunity = args.chat.communityId.len > 0
@@ -488,7 +488,8 @@ proc setActiveItem*(self: Controller, itemId: string) =
   self.delegate.activeItemSet(self.activeItemId)
 
   if self.activeItemId != "":
-    self.messageService.asyncLoadInitialMessagesForChat(self.activeItemId)
+    if not self.delegate.isChatThread(self.activeItemId):
+      self.messageService.asyncLoadInitialMessagesForChat(self.activeItemId)
 
 proc removeCommunityChat*(self: Controller, itemId: string) =
   self.communityService.deleteCommunityChat(self.getMySectionId(), itemId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -220,7 +220,7 @@ method onCategoryMuted*(self: AccessInterface, categoryId: string) {.base.} =
 method onCategoryUnmuted*(self: AccessInterface, categoryId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method markAllMessagesRead*(self: AccessInterface, chatId: string) {.base.} =
+method markAllMessagesRead*(self: AccessInterface, chatId: string, threadId: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method clearChatHistory*(self: AccessInterface, chatId: string) {.base.} =

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -105,6 +105,9 @@ method changeMutedOnChat*(self: AccessInterface, chatId: string, muted: bool) {.
 method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto, threadId: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onChatThreadsLoaded*(self: AccessInterface, chatId: string, threads: seq[ThreadDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onMarkMessageAsUnread*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -95,7 +95,7 @@ method addOrUpdateChat*(self: AccessInterface,
   ): ChatItem {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onNewMessagesReceived*(self: AccessInterface, sectionIdMsgBelongsTo: string, chatIdMsgBelongsTo: string,
+method onNewMessagesReceived*(self: AccessInterface, sectionIdMsgBelongsTo: string, chatIdMsgBelongsTo: string, displayChatId: string,
   chatTypeMsgBelongsTo: ChatType, lastMessageTimestamp: int, unviewedMessagesCount: int, unviewedMentionsCount: int, message: MessageDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -171,7 +171,8 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method setActiveItem*(self: AccessInterface, itemId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method openThreadAsChat*(self: AccessInterface, parentChatId: string, threadId: string, threadName: string, parentMessageId: string, setActive: bool = false) {.base.} =
+method openThreadAsChat*(self: AccessInterface, parentChatId: string, threadId: string, threadName: string, parentMessageId: string,
+    setActive: bool = false, hasUnreadMessages: bool = false, notificationsCount: int = 0) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method isChatThread*(self: AccessInterface, chatId: string): bool {.base.} =

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -171,6 +171,12 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method setActiveItem*(self: AccessInterface, itemId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method openThreadAsChat*(self: AccessInterface, parentChatId: string, threadId: string, threadName: string, parentMessageId: string, setActive: bool = false) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method isChatThread*(self: AccessInterface, chatId: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getChatContentModule*(self: AccessInterface, chatId: string): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -102,7 +102,7 @@ method onNewMessagesReceived*(self: AccessInterface, sectionIdMsgBelongsTo: stri
 method changeMutedOnChat*(self: AccessInterface, chatId: string, muted: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto) {.base.} =
+method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto, threadId: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onMarkMessageAsUnread*(self: AccessInterface, chat: ChatDto) {.base.} =

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -42,6 +42,7 @@ type
     missingEncryptionKey: bool
     permissionsCheckOngoing: bool
     hidden: bool # cached: row hidden by its collapsed category (see recomputeHidden)
+    isThread: bool
 
 # Row is hidden by its collapsed category. Active, unmuted-unread and
 # notification-carrying chats stay visible so the list can surface them.
@@ -88,6 +89,7 @@ proc initChatItem*(
     hideIfPermissionsNotMet: bool = false,
     missingEncryptionKey: bool = false,
     permissionsCheckOngoing: bool = false,
+    isThread: bool = false,
     ): ChatItem =
   result = ChatItem()
   result.id = id
@@ -125,6 +127,7 @@ proc initChatItem*(
   result.missingEncryptionKey = missingEncryptionKey
   result.permissionsCheckOngoing = permissionsCheckOngoing
   result.recomputeHidden()
+  result.isThread = isThread
 
 proc `$`*(self: ChatItem): string =
   result = fmt"""chat_section/ChatItem(
@@ -410,3 +413,6 @@ proc permissionsCheckOngoing*(self: ChatItem): bool =
 
 proc `permissionsCheckOngoing=`*(self: var ChatItem, value: bool) =
   self.permissionsCheckOngoing = value
+
+proc isThread*(self: ChatItem): bool =
+  self.isThread

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -43,6 +43,7 @@ type
     permissionsCheckOngoing: bool
     hidden: bool # cached: row hidden by its collapsed category (see recomputeHidden)
     isThread: bool
+    parentChatId: string
 
 # Row is hidden by its collapsed category. Active, unmuted-unread and
 # notification-carrying chats stay visible so the list can surface them.
@@ -90,6 +91,7 @@ proc initChatItem*(
     missingEncryptionKey: bool = false,
     permissionsCheckOngoing: bool = false,
     isThread: bool = false,
+    parentChatId: string = "",
     ): ChatItem =
   result = ChatItem()
   result.id = id
@@ -128,6 +130,7 @@ proc initChatItem*(
   result.permissionsCheckOngoing = permissionsCheckOngoing
   result.recomputeHidden()
   result.isThread = isThread
+  result.parentChatId = parentChatId
 
 proc `$`*(self: ChatItem): string =
   result = fmt"""chat_section/ChatItem(
@@ -200,6 +203,8 @@ proc toJsonNode*(self: ChatItem): JsonNode =
     "viewersCanPostReactions": self.viewersCanPostReactions,
     "hideIfPermissionsNotMet": self.hideIfPermissionsNotMet,
     "permissionsCheckOngoing": self.permissionsCheckOngoing,
+    "isThread": self.isThread,
+    "parentChatId": self.parentChatId,
   }
 
 proc delete*(self: ChatItem) =
@@ -416,3 +421,6 @@ proc `permissionsCheckOngoing=`*(self: var ChatItem, value: bool) =
 
 proc isThread*(self: ChatItem): bool =
   self.isThread
+
+proc parentChatId*(self: ChatItem): string =
+  self.parentChatId

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -45,6 +45,8 @@ type
     PermissionsCheckOngoing
     Hidden # derived: chat hidden by its collapsed category
            # (depends on CategoryOpened, Active, Muted, HasUnreadMessages, NotificationsCount)
+    IsThread
+    ParentChatId
 
 QtObject:
   type
@@ -143,6 +145,8 @@ QtObject:
       ModelRole.MissingEncryptionKey.int:"missingEncryptionKey",
       ModelRole.PermissionsCheckOngoing.int:"permissionsCheckOngoing",
       ModelRole.Hidden.int:"hidden",
+      ModelRole.IsThread.int:"isThread",
+      ModelRole.ParentChatId.int:"parentChatId",
 
     }.toTable
 
@@ -227,6 +231,10 @@ QtObject:
       return newQVariant(item.permissionsCheckOngoing)
     of ModelRole.Hidden:
       return newQVariant(item.hidden)
+    of ModelRole.IsThread:
+      return newQVariant(item.isThread)
+    of ModelRole.ParentChatId:
+      return newQVariant(item.parentChatId)
 
   proc getItemIdxById(items: seq[ChatItem], id: string): int =
     var idx = 0

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -263,11 +263,26 @@ QtObject:
         if categoryIdx == -1:
           return
         indexToInsertTo = categoryIdx + item.position + 1
+
     if indexToInsertTo < 0:
       indexToInsertTo = 0
     elif indexToInsertTo >= self.items.len + 1:
       indexToInsertTo = self.items.len
 
+    self.beginInsertRows(parentModelIndex, indexToInsertTo, indexToInsertTo)
+    self.items.insert(item, indexToInsertTo)
+    self.endInsertRows()
+
+    self.countChanged()
+
+  proc appendItemAfterParent*(self: Model, item: ChatItem, parentIndex: int) =
+    if parentIndex < 0 or parentIndex >= self.items.len:
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    let indexToInsertTo = parentIndex + 1
     self.beginInsertRows(parentModelIndex, indexToInsertTo, indexToInsertTo)
     self.items.insert(item, indexToInsertTo)
     self.endInsertRows()

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -330,6 +330,7 @@ proc buildChatSectionUI(
 
   self.view.chatsModel.setData(items)
   self.setActiveItem(selectedItemId)
+  self.controller.loadChatThreadsForChats(chats.mapIt(it.id))
 
 proc createItemFromPublicKey(self: Module, publicKey: string): UserItem =
   let contactDetails = self.controller.getContactDetails(publicKey)
@@ -538,6 +539,19 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
   self.view.chatsModel().appendItemAfterParent(threadItem, parentIndex)
   if setActive:
     self.setActiveItem(threadId)
+
+method onChatThreadsLoaded*(self: Module, chatId: string, threads: seq[ThreadDto]) =
+  # The signal is global; other sections' chats are none of our business, and letting them
+  # through would just make openThreadAsChat log an unknown-parent error.
+  if not self.doesTopLevelChatExist(chatId):
+    return
+
+  for thread in threads:
+    if thread.parentMessageId.len == 0:
+      continue
+    self.openThreadAsChat(chatId, thread.threadId, thread.name, thread.parentMessageId,
+      setActive = false, hasUnreadMessages = thread.unviewedMessagesCount > 0,
+      notificationsCount = thread.unviewedMentionsCount)
 
 proc updateActiveChatMembership*(self: Module) =
   let activeChatId = self.controller.getActiveChatId()

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -472,13 +472,17 @@ method setActiveItem*(self: Module, itemId: string) =
 method isChatThread*(self: Module, chatId: string): bool =
   return self.threadChatIds.contains(chatId)
 
-method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, threadName: string, parentMessageId: string, setActive: bool = false) =
+method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, threadName: string, parentMessageId: string,
+    setActive: bool = false, hasUnreadMessages: bool = false, notificationsCount: int = 0) =
   if threadId.len == 0:
     return
 
-  # If the thread sub-channel already exists, just activate it.
-  if self.chatContentModules.contains(threadId) and setActive:
-    self.setActiveItem(threadId)
+  # If the thread sub-channel already exists, just activate it if needed.
+  if self.chatContentModules.contains(threadId):
+    self.view.chatsModel().updateNotificationsForItemById(threadId, hasUnreadMessages, notificationsCount)
+    self.chatContentModules[threadId].onNotificationsUpdated(hasUnreadMessages, notificationsCount)
+    if setActive:
+      self.setActiveItem(threadId)
     return
 
   let parentItem = self.view.chatsModel().getItemById(parentChatId)
@@ -516,8 +520,8 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
     parentItem.memberRole,
     lastMessageTimestamp = 0,
     lastMessageText = "",
-    hasUnreadMessages = false,
-    notificationsCount = 0,
+    hasUnreadMessages = hasUnreadMessages,
+    notificationsCount = notificationsCount,
     muted = false,
     blocked = false,
     active = false,
@@ -1322,10 +1326,10 @@ method onContactDetailsUpdated*(self: Module, publicKey: string) =
   )
   self.view.chatsModel().updateUserItemDetailsById(publicKey, chatName, usesUsedDefaultName, chatImage, trustStatus)
 
-method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatIdMsgBelongsTo: string,
+method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatIdMsgBelongsTo: string, displayChatId: string,
     chatTypeMsgBelongsTo: ChatType, lastMessageTimestamp: int, unviewedMessagesCount: int, unviewedMentionsCount: int,
     message: MessageDto) =
-  self.updateLastMessage(chatIdMsgBelongsTo, lastMessageTimestamp, message)
+  self.updateLastMessage(displayChatId, lastMessageTimestamp, message)
 
   # Any type of message coming from ourselves should never be shown as notification
   # and no need in badge notification update
@@ -1341,6 +1345,11 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
 
   if chatDetails.categoryId != "":
     self.view.chatsModel().setCategoryHasUnreadMessages(chatDetails.categoryId, true)
+
+  if displayChatId == chatIdMsgBelongsTo:
+    self.view.chatsModel().updateNotificationsForItemById(displayChatId, unviewedMessagesCount > 0, unviewedMentionsCount)
+    if self.chatContentModules.contains(displayChatId):
+      self.chatContentModules[displayChatId].onNotificationsUpdated(unviewedMessagesCount > 0, unviewedMentionsCount)
 
   # Prepare notification
   var notificationType = notification_details.NotificationType.NewMessage

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1,4 +1,4 @@
-import nimqml, tables, chronicles, json, sequtils, std/strformat, sugar, marshal
+import nimqml, tables, chronicles, json, sequtils, std/strformat, sugar, marshal, std/sets
 from seaqt/qtimer import QTimer, create, setSingleShot, onTimeout, start, stop, isActive
 
 import io_interface
@@ -56,6 +56,17 @@ type
     # defers the first-activation model build off the tap handler (seaqt
     # QTimer, auto-destroyed via =destroy)
     initialBuildTimer: QTimer
+    # services retained so thread sub-channels can be created on demand
+    events: EventEmitter
+    settingsService: settings_service.Service
+    nodeConfigurationService: node_configuration_service.Service
+    contactService: contact_service.Service
+    chatService: chat_service.Service
+    communityService: community_service.Service
+    messageService: message_service.Service
+    mailserversService: mailservers_service.Service
+    sharedUrlsService: shared_urls_service.Service
+    threadChatIds: HashSet[string]
 
 # Forward declaration
 proc buildChatSectionUI(
@@ -123,6 +134,17 @@ proc newModule*(
   result.viewVariant = newQVariant(result.view)
   result.moduleLoaded = false
   result.chatsLoaded = false
+
+  result.events = events
+  result.settingsService = settingsService
+  result.nodeConfigurationService = nodeConfigurationService
+  result.contactService = contactService
+  result.chatService = chatService
+  result.communityService = communityService
+  result.messageService = messageService
+  result.mailserversService = mailserversService
+  result.sharedUrlsService = sharedUrlsService
+  result.threadChatIds = initHashSet[string]()
 
   result.chatContentModules = initOrderedTable[string, chat_content_module.AccessInterface]()
   if isCommunity:
@@ -446,6 +468,71 @@ method chatContentDidLoad*(self: Module) =
 
 method setActiveItem*(self: Module, itemId: string) =
   self.controller.setActiveItem(itemId)
+
+method isChatThread*(self: Module, chatId: string): bool =
+  return self.threadChatIds.contains(chatId)
+
+method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, threadName: string, parentMessageId: string, setActive: bool = false) =
+  if threadId.len == 0:
+    return
+
+  # If the thread sub-channel already exists, just activate it.
+  if self.chatContentModules.contains(threadId) and setActive:
+    self.setActiveItem(threadId)
+    return
+
+  let parentItem = self.view.chatsModel().getItemById(parentChatId)
+  if parentItem.isNil:
+    error "openThreadAsChat: unknown parent chat", parentChatId, methodName="openThreadAsChat"
+    return
+
+  let parentIndex = self.view.chatsModel().getItemIdxById(parentChatId)
+  if parentIndex == -1:
+    error "openThreadAsChat: unknown parent chat index", parentChatId, methodName="openThreadAsChat"
+    return
+
+  let belongsToCommunity = self.controller.isCommunity()
+  let isUsersListAvailable = parentItem.`type` != ChatType.OneToOne.int
+
+  # The thread content module is keyed in the chat list by the threadId, but it
+  # loads/sends messages against the parent chat id together with the threadId.
+  self.chatContentModules[threadId] = chat_content_module.newModule(
+    self, self.events, self.controller.getMySectionId(), parentChatId,
+    belongsToCommunity, isUsersListAvailable, self.settingsService, self.nodeConfigurationService,
+    self.contactService, self.chatService, self.communityService, self.messageService,
+    self.mailserversService, self.sharedUrlsService, threadId = threadId)
+
+  self.threadChatIds.incl(threadId)
+
+  let threadItem = chat_item.initChatItem(
+    id = threadId,
+    name = "🧵 " & threadName,
+    usesDefaultName = false,
+    icon = parentItem.icon,
+    color = parentItem.color,
+    emoji = parentItem.emoji,
+    description = "",
+    `type` = parentItem.`type`,
+    parentItem.memberRole,
+    lastMessageTimestamp = 0,
+    lastMessageText = "",
+    hasUnreadMessages = false,
+    notificationsCount = 0,
+    muted = false,
+    blocked = false,
+    active = false,
+    position = parentItem.position,
+    categoryId = parentItem.categoryId,
+    categoryPosition = parentItem.categoryPosition,
+    canPost = parentItem.canPost,
+    canView = parentItem.canView,
+    canPostReactions = parentItem.canPostReactions,
+    isThread = true,
+  )
+
+  self.view.chatsModel().appendItemAfterParent(threadItem, parentIndex)
+  if setActive:
+    self.setActiveItem(threadId)
 
 proc updateActiveChatMembership*(self: Module) =
   let activeChatId = self.controller.getActiveChatId()

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -532,6 +532,7 @@ method openThreadAsChat*(self: Module, parentChatId: string, threadId: string, t
     canView = parentItem.canView,
     canPostReactions = parentItem.canPostReactions,
     isThread = true,
+    parentChatId = parentChatId,
   )
 
   self.view.chatsModel().appendItemAfterParent(threadItem, parentIndex)
@@ -982,9 +983,24 @@ method onReorderCategory*(self: Module, catId: string, position: int) =
 method onCategoryNameChanged*(self: Module, category: Category) =
   self.view.chatsModel().renameCategory(category.id, category.name)
 
+proc removeThreadsForParent(self: Module, parentChatId: string) =
+  var threadIds: seq[string]
+  for item in self.view.chatsModel().items:
+    if item.isThread and item.parentChatId == parentChatId:
+      threadIds.add(item.id)
+
+  for threadId in threadIds:
+    self.view.chatsModel().removeItemById(threadId)
+    self.removeSubmodule(threadId)
+    self.threadChatIds.excl(threadId)
+
 method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
   if not self.chatContentModules.contains(chatId):
     return
+  if self.isChatThread(chatId):
+    self.threadChatIds.excl(chatId)
+  else:
+    self.removeThreadsForParent(chatId)
   self.view.chatsModel().removeItemById(chatId)
   self.removeSubmodule(chatId)
 
@@ -1265,8 +1281,8 @@ method onMarkMessageAsUnread*(self: Module, chat: ChatDto) =
 method onSectionMutedChanged*(self: Module) =
   self.updateParentBadgeNotifications()
 
-method markAllMessagesRead*(self: Module, chatId: string) =
-  self.controller.markAllMessagesRead(chatId)
+method markAllMessagesRead*(self: Module, chatId: string, threadId: string = "") =
+  self.controller.markAllMessagesRead(chatId, threadId)
 
 method clearChatHistory*(self: Module, chatId: string) =
   self.controller.clearChatHistory(chatId)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1249,7 +1249,14 @@ method onJoinedCommunity*(self: Module) =
   self.view.setWaitingOnNewCommunityOwnerToConfirmRequestToRejoin(false)
   self.view.setRequestToJoinState(RequestToJoinState.None)
 
-method onMarkAllMessagesRead*(self: Module, chat: ChatDto) =
+method onMarkAllMessagesRead*(self: Module, chat: ChatDto, threadId: string = "") =
+  if threadId.len > 0:
+    self.view.chatsModel().updateNotificationsForItemById(threadId, hasUnreadMessages=false, notificationsCount=0)
+    if self.chatContentModules.contains(threadId):
+      self.chatContentModules[threadId].onNotificationsUpdated(hasUnreadMessages=false, notificationCount=0)
+    self.updateParentBadgeNotifications()
+    return
+
   self.updateBadgeNotifications(chat, hasUnreadMessages=false, unviewedMentionsCount=0)
 
 method onMarkMessageAsUnread*(self: Module, chat: ChatDto) =

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -163,8 +163,8 @@ QtObject:
   proc unmuteCategory*(self: View, categoryId: string) {.slot.} =
     self.delegate.unmuteCategory(categoryId)
 
-  proc markAllMessagesRead*(self: View, chatId: string) {.slot.} =
-    self.delegate.markAllMessagesRead(chatId)
+  proc markAllMessagesRead*(self: View, chatId: string, threadId: string = "") {.slot.} =
+    self.delegate.markAllMessagesRead(chatId, threadId)
 
   proc clearChatHistory*(self: View, chatId: string) {.slot.} =
     self.delegate.clearChatHistory(chatId)

--- a/src/app/modules/main/gifs/controller.nim
+++ b/src/app/modules/main/gifs/controller.nim
@@ -48,7 +48,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_SEARCH_GIFS_DONE) do(e:Args):
     let args = GifsArgs(e)
-    self.delegate.serachGifsDone(args.gifs)
+    self.delegate.searchGifsDone(args.gifs)
 
   self.events.on(SIGNAL_SEARCH_GIFS_ERROR) do(e:Args):
     self.delegate.searchGifsError()

--- a/src/app/modules/main/gifs/io_interface.nim
+++ b/src/app/modules/main/gifs/io_interface.nim
@@ -45,7 +45,7 @@ method searchGifsStarted*(self: AccessInterface) {.base.} =
 method searchGifsError*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method serachGifsDone*(self: AccessInterface, gifs: seq[GifDto]) {.base.} =
+method searchGifsDone*(self: AccessInterface, gifs: seq[GifDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getFavoritesGifs*(self: AccessInterface): seq[GifDto] {.base.} =

--- a/src/app/modules/main/gifs/module.nim
+++ b/src/app/modules/main/gifs/module.nim
@@ -84,7 +84,7 @@ method searchGifsError*(self: Module) =
   # Just setting loading to false works because the UI shows an error when there are no gifs
   self.view.setGifLoading(false)
 
-method serachGifsDone*(self: Module, gifs: seq[GifDto]) =
+method searchGifsDone*(self: Module, gifs: seq[GifDto]) =
   self.view.setGifLoading(false)
   self.view.updateGifColumns(gifs)
 

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -120,8 +120,9 @@ proc sendSticker*(
     channelId: string,
     replyTo: string,
     sticker: StickerDto,
-    preferredUsername: string) =
-  self.stickerService.asyncSendSticker(channelId, replyTo, sticker, preferredUsername)
+    preferredUsername: string,
+    threadId: string = "") =
+  self.stickerService.asyncSendSticker(channelId, replyTo, sticker, preferredUsername, threadId)
 
 proc getStickerMarketAddress*(self: Controller): string =
   return self.stickerService.getStickerMarketAddress()

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -68,7 +68,7 @@ method uninstallStickerPack*(self: AccessInterface, packId: string) {.base.} =
 method removeRecentStickers*(self: AccessInterface, packId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method sendSticker*(self: AccessInterface, channelId: string, replyTo: string, sticker: Item) {.base.} =
+method sendSticker*(self: AccessInterface, channelId: string, replyTo: string, sticker: Item, threadId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method populateInstalledStickerPacks*(self: AccessInterface, stickers: Table[string, StickerPackDto]) {.base.} =

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -76,13 +76,14 @@ method uninstallStickerPack*(self: Module, packId: string) =
 method removeRecentStickers*(self: Module, packId: string) =
   self.controller.removeRecentStickers(packId)
 
-method sendSticker*(self: Module, channelId: string, replyTo: string, sticker: Item) =
+method sendSticker*(self: Module, channelId: string, replyTo: string, sticker: Item, threadId: string) =
   let stickerDto = StickerDto(hash: sticker.getHash, packId: sticker.getPackId)
   self.controller.sendSticker(
     channelId,
     replyTo,
     stickerDto,
-    singletonInstance.userProfile.getPreferredName())
+    singletonInstance.userProfile.getPreferredName(),
+    threadId)
 
 method addRecentStickerToList*(self: Module, sticker: StickerDto) =
   self.view.addRecentStickerToList(initItem(sticker.hash, sticker.packId, sticker.url))

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -150,10 +150,11 @@ QtObject:
     if not self.installedStickerPacksLoaded:
       self.delegate.getInstalledStickerPacks()
 
-  proc send*(self: View, channelId: string, hash: string, replyTo: string, pack: string, url: string) {.slot.} =
+  proc send*(self: View, channelId: string, hash: string, replyTo: string, pack: string, url: string,
+      threadId: string) {.slot.} =
     let sticker = initItem(hash, pack, url)
     self.addRecentStickerToList(sticker)
-    self.delegate.sendSticker(channelId, replyTo, sticker)
+    self.delegate.sendSticker(channelId, replyTo, sticker, threadId)
 
   proc getStickersMarketAddress(self: View): string {.slot.} =
     return self.stickersMarketAddress

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -76,6 +76,7 @@ type
     albumImagesCount: int
     bridgeName: string
     paymentRequestModel: payment_request_model.Model
+    hasThread: bool
 
 proc initMessageItem*(
     id,
@@ -132,6 +133,7 @@ proc initMessageItem*(
     bridgeMessage: BridgeMessage,
     quotedBridgeMessage: BridgeMessage,
     paymentRequests: seq[PaymentRequest],
+    hasThread: bool = false,
     ): Item =
   result = Item()
   result.id = id
@@ -193,6 +195,7 @@ proc initMessageItem*(
   result.albumMessageIds = albumMessageIds
   result.albumImagesCount = albumImagesCount
   result.paymentRequestModel = newPaymentRequestModel(paymentRequests)
+  result.hasThread = hasThread
 
   if quotedMessageContentType == ContentType.DiscordMessage:
     result.quotedMessageAuthorDisplayName = quotedMessageDiscordMessage.author.name
@@ -596,8 +599,15 @@ proc toJsonNode*(self: Item): JsonNode =
     "albumMessageImages": self.albumMessageImages,
     "albumMessageIds": self.albumMessageIds,
     "albumImagesCount": self.albumImagesCount,
-    "bridgeName": self.bridgeName
+    "bridgeName": self.bridgeName,
+    "hasThread": self.hasThread
   }
+
+proc hasThread*(self: Item): bool {.inline.} =
+  self.hasThread
+
+proc `hasThread=`*(self: Item, value: bool) {.inline.} =
+  self.hasThread = value
 
 proc editMode*(self: Item): bool {.inline.} =
   self.editMode

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -75,6 +75,7 @@ type
     BridgeName
     PaymentRequestModel
     CompressedKey
+    HasThread
 
 QtObject:
   type
@@ -185,6 +186,7 @@ QtObject:
       ModelRole.BridgeName.int: "bridgeName",
       ModelRole.PaymentRequestModel.int: "paymentRequestModel",
       ModelRole.CompressedKey.int: "compressedKey",
+      ModelRole.HasThread.int: "hasThread",
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -356,6 +358,8 @@ QtObject:
       result = newQVariant(item.paymentRequestModel)
     of ModelRole.CompressedKey:
       result = newQVariant(item.compressedKey)
+    of ModelRole.HasThread:
+      result = newQVariant(item.hasThread)
 
   proc updateAdjacentMessageRolesAtIndex(self: Model, row: int) =
     if row < 0 or row >= self.items.len:
@@ -627,6 +631,20 @@ QtObject:
         return
       updateRole(pinned)
       updateRoleWithValue(pinnedBy, targetPinnedBy)
+
+  proc setHasThread*(self: Model, messageId: string, hasThread: bool) =
+    let ind = self.findIndexForMessageId(messageId)
+    if ind == -1:
+      return
+
+    if self.items[ind].hasThread == hasThread:
+      return
+
+    self.items[ind].hasThread = hasThread
+
+    let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
+    self.dataChanged(index, index, @[ModelRole.HasThread.int])
 
   proc getMessageByIdAsJson*(self: Model, messageId: string): JsonNode =
     for it in self.items:
@@ -1002,4 +1020,5 @@ QtObject:
       message.bridgeMessage,
       message.quotedMessage.bridgeMessage,
       message.paymentRequests,
+      hasThread = false,
     )

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -68,6 +68,7 @@ type
     chatId: string
     processedMsg: string
     replyTo: string
+    threadId: string
     contentType: int
     preferredUsername: string
     communityId: string
@@ -84,6 +85,7 @@ const asyncSendMessageTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} 
       arg.processedMsg,
       arg.replyTo,
       arg.contentType,
+      arg.threadId,
       arg.preferredUsername,
       arg.standardLinkPreviews,
       arg.statusLinkPreviews,
@@ -107,6 +109,7 @@ type
     imagePathsJson: string
     msg: string
     replyTo: string
+    threadId: string
     preferredUsername: string
     standardLinkPreviews: JsonNode
     statusLinkPreviews: JsonNode
@@ -138,6 +141,7 @@ const asyncSendImagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
       arg.msg,
       arg.replyTo,
       arg.preferredUsername,
+      arg.threadId,
       arg.standardLinkPreviews,
       arg.statusLinkPreviews,
       arg.paymentRequests

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -437,7 +437,8 @@ QtObject:
                    replyTo: string,
                    preferredUsername: string = "",
                    linkPreviews: seq[LinkPreview] = @[],
-                   paymentRequests: seq[PaymentRequest] = @[]) =
+                   paymentRequests: seq[PaymentRequest] = @[],
+                   threadId: string = "") =
     try:
       let (standardLinkPreviews, statusLinkPreviews) = extractLinkPreviewsLists(linkPreviews)
 
@@ -449,6 +450,7 @@ QtObject:
         imagePathsJson: imagePathsJson,
         msg: msg,
         replyTo: replyTo,
+        threadId: threadId,
         preferredUsername: preferredUsername,
         standardLinkPreviews: %standardLinkPreviews,
         statusLinkPreviews: %statusLinkPreviews,
@@ -486,7 +488,8 @@ QtObject:
       preferredUsername: string = "",
       linkPreviews: seq[LinkPreview] = @[],
       paymentRequests: seq[PaymentRequest] = @[],
-      communityId: string = "") =
+      communityId: string = "",
+      threadId: string = "") =
     try:
       let allKnownContacts = self.contactService.getContactsByGroup(ContactsGroup.AllKnownContacts)
       let processedMsg = message_common.replaceMentionsWithPubKeys(allKnownContacts, msg)
@@ -500,6 +503,7 @@ QtObject:
         chatId: chatId,
         processedMsg: processedMsg,
         replyTo: replyTo,
+        threadId: threadId,
         contentType: contentType,
         preferredUsername: preferredUsername,
         communityId: communityId, # Only send a community ID for the community invites

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -23,20 +23,29 @@ proc getCountAndCountWithMentionsFromResponse(chatId: string, seenAndUnseenMessa
 type
   AsyncFetchChatMessagesTaskArg = ref object of QObjectTaskArg
     chatId: string
+    threadId: string
     msgCursor: string
     limit: int
+
+  AsyncFetchChatThreadsTaskArg = ref object of QObjectTaskArg
+    chatId: string
+
+  AsyncCreateThreadTaskArg = ref object of QObjectTaskArg
+    chatId: string
+    parentMessageId: string
 
 proc asyncFetchChatMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncFetchChatMessagesTaskArg](argEncoded)
   try:
     var responseJson = %*{
-      "chatId": arg.chatId
+      "chatId": arg.chatId,
+      "threadId": arg.threadId,
     }
 
     # handle messages
     var messagesArr: JsonNode
     var messagesCursor: JsonNode
-    let msgsResponse = status_go.fetchMessages(arg.chatId, arg.msgCursor, arg.limit)
+    let msgsResponse = status_go.fetchMessages(arg.chatId, arg.threadId, arg.msgCursor, arg.limit)
 
     if not msgsResponse.error.isNil:
       raise newException(CatchableError, msgsResponse.error.message)
@@ -46,20 +55,70 @@ proc asyncFetchChatMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
     responseJson["messages"] = messagesArr
     responseJson["messagesCursor"] = messagesCursor
 
-    # handle reactions
-    var reactionsArr: JsonNode
-    let rResponse = status_go.fetchReactions(arg.chatId, arg.msgCursor, arg.limit)
-    if not rResponse.error.isNil:
-      raise newException(CatchableError, rResponse.error.message)
-
-    reactionsArr = rResponse.result
-    responseJson["reactions"] = reactionsArr
+    # handle reactions (only for base chats, not threads)
+    if arg.threadId == "":
+      var reactionsArr: JsonNode
+      let rResponse = status_go.fetchReactions(arg.chatId, arg.msgCursor, arg.limit)
+      if not rResponse.error.isNil:
+        raise newException(CatchableError, rResponse.error.message)
+      responseJson["reactions"] = rResponse.result
 
     arg.finish(responseJson)
 
   except Exception as e:
     arg.finish(%* {
       "chatId": arg.chatId,
+      "threadId": arg.threadId,
+      "error": e.msg,
+    })
+
+proc asyncFetchChatThreadsTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncFetchChatThreadsTaskArg](argEncoded)
+  try:
+    let response = status_go_chat.fetchChatThreads(arg.chatId)
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+
+    var responseJson = %*{
+      "chatId": arg.chatId,
+      "threads": %*[],
+      "error": "",
+    }
+
+    var threadsArr: JsonNode
+    if response.result.getProp("threads", threadsArr):
+      responseJson["threads"] = threadsArr
+
+    arg.finish(responseJson)
+  except Exception as e:
+    arg.finish(%* {
+      "chatId": arg.chatId,
+      "error": e.msg,
+    })
+
+proc asyncCreateThreadTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncCreateThreadTaskArg](argEncoded)
+  try:
+    let response = status_go_chat.createThread(arg.chatId, arg.parentMessageId)
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+
+    var responseJson = %*{
+      "chatId": arg.chatId,
+      "parentMessageId": arg.parentMessageId,
+      "threads": %*[],
+      "error": "",
+    }
+
+    var threadsArr: JsonNode
+    if response.result.getProp("threads", threadsArr):
+      responseJson["threads"] = threadsArr
+
+    arg.finish(responseJson)
+  except Exception as e:
+    arg.finish(%* {
+      "chatId": arg.chatId,
+      "parentMessageId": arg.parentMessageId,
       "error": e.msg,
     })
 

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -30,6 +30,9 @@ type
   AsyncFetchChatThreadsTaskArg = ref object of QObjectTaskArg
     chatId: string
 
+  AsyncFetchChatThreadsForChatsTaskArg = ref object of QObjectTaskArg
+    chatIds: seq[string]
+
   AsyncCreateThreadTaskArg = ref object of QObjectTaskArg
     chatId: string
     parentMessageId: string
@@ -91,6 +94,30 @@ proc asyncFetchChatThreadsTask(argEncoded: string) {.gcsafe, nimcall.} =
   except Exception as e:
     arg.finish(%* {
       "chatId": arg.chatId,
+      "error": e.msg,
+    })
+
+proc asyncFetchChatThreadsForChatsTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncFetchChatThreadsForChatsTaskArg](argEncoded)
+  try:
+    let response = status_go_chat.fetchChatThreadsForChats(arg.chatIds)
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+
+    var responseJson = %*{
+      "chatIds": arg.chatIds,
+      "threads": %*[],
+      "error": "",
+    }
+
+    var threadsArr: JsonNode
+    if response.result.getProp("threads", threadsArr):
+      responseJson["threads"] = threadsArr
+
+    arg.finish(responseJson)
+  except Exception as e:
+    arg.finish(%* {
+      "chatIds": arg.chatIds,
       "error": e.msg,
     })
 

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -357,18 +357,24 @@ proc asyncSearchMessagesInChatsAndCommunitiesTask(argEncoded: string) {.gcsafe, 
 type
   AsyncMarkAllMessagesReadTaskArg = ref object of QObjectTaskArg
     chatId: string
+    threadId: string
 
 proc asyncMarkAllMessagesReadTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncMarkAllMessagesReadTaskArg](argEncoded)
 
   try:
-    let rpcResponse =  status_go.markAllMessagesFromChatWithIdAsRead(arg.chatId)
+    let rpcResponse =
+      if arg.threadId.len > 0:
+        status_go.markAllMessagesFromThreadWithIdAsRead(arg.chatId, arg.threadId)
+      else:
+        status_go.markAllMessagesFromChatWithIdAsRead(arg.chatId)
 
     var activityCenterNotifications: JsonNode = newJObject()
     discard rpcResponse.result.getProp("activityCenterNotifications", activityCenterNotifications)
 
     arg.finish(%*{
       "chatId": arg.chatId,
+      "threadId": arg.threadId,
       "activityCenterNotifications": activityCenterNotifications,
       "error": rpcResponse.error,
     })
@@ -376,6 +382,7 @@ proc asyncMarkAllMessagesReadTask(argEncoded: string) {.gcsafe, nimcall.} =
   except Exception as e:
     arg.finish(%* {
       "chatId": arg.chatId,
+      "threadId": arg.threadId,
       "error": e.msg,
     })
 

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -55,13 +55,11 @@ proc asyncFetchChatMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
     responseJson["messages"] = messagesArr
     responseJson["messagesCursor"] = messagesCursor
 
-    # handle reactions (only for base chats, not threads)
-    if arg.threadId == "":
-      var reactionsArr: JsonNode
-      let rResponse = status_go.fetchReactions(arg.chatId, arg.msgCursor, arg.limit)
-      if not rResponse.error.isNil:
-        raise newException(CatchableError, rResponse.error.message)
-      responseJson["reactions"] = rResponse.result
+    # handle reactions
+    let rResponse = status_go.fetchReactions(arg.chatId, arg.threadId, arg.msgCursor, arg.limit)
+    if not rResponse.error.isNil:
+      raise newException(CatchableError, rResponse.error.message)
+    responseJson["reactions"] = rResponse.result
 
     arg.finish(responseJson)
 

--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -111,6 +111,7 @@ type MessageDto* = object
   text*: string
   chatId*: string
   localChatId*: string
+  threadId*: string
   clock*: int64
   replace*: string
   responseTo*: string
@@ -259,6 +260,7 @@ proc toMessageDto*(jsonObj: JsonNode): MessageDto =
   discard jsonObj.getProp("text", result.text)
   discard jsonObj.getProp("chatId", result.chatId)
   discard jsonObj.getProp("localChatId", result.localChatId)
+  discard jsonObj.getProp("threadId", result.threadId)
   discard jsonObj.getProp("clock", result.clock)
   discard jsonObj.getProp("replace", result.replace)
   discard jsonObj.getProp("responseTo", result.responseTo)

--- a/src/app_service/service/message/dto/thread.nim
+++ b/src/app_service/service/message/dto/thread.nim
@@ -1,0 +1,16 @@
+import json
+
+include ../../../common/json_utils
+
+type ThreadDto* = object
+  threadId*: string
+  chatId*: string
+  parentMessageId*: string
+  name*: string
+
+proc toThreadDto*(jsonObj: JsonNode): ThreadDto =
+  result = ThreadDto()
+  discard jsonObj.getProp("threadId", result.threadId)
+  discard jsonObj.getProp("chatId", result.chatId)
+  discard jsonObj.getProp("parentMessageId", result.parentMessageId)
+  discard jsonObj.getProp("name", result.name)

--- a/src/app_service/service/message/dto/thread.nim
+++ b/src/app_service/service/message/dto/thread.nim
@@ -7,6 +7,8 @@ type ThreadDto* = object
   chatId*: string
   parentMessageId*: string
   name*: string
+  unviewedMessagesCount*: int
+  unviewedMentionsCount*: int
 
 proc toThreadDto*(jsonObj: JsonNode): ThreadDto =
   result = ThreadDto()
@@ -14,3 +16,5 @@ proc toThreadDto*(jsonObj: JsonNode): ThreadDto =
   discard jsonObj.getProp("chatId", result.chatId)
   discard jsonObj.getProp("parentMessageId", result.parentMessageId)
   discard jsonObj.getProp("name", result.name)
+  discard jsonObj.getProp("unviewedMessagesCount", result.unviewedMessagesCount)
+  discard jsonObj.getProp("unviewedMentionsCount", result.unviewedMentionsCount)

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -937,8 +937,17 @@ QtObject:
 
       self.checkPaymentRequestsInMessages(messages)
 
+      var reactionsArr: JsonNode
+      var reactions: seq[ReactionDto]
+      if responseObj.getProp("reactions", reactionsArr):
+        reactions = map(
+          reactionsArr.getElems(),
+          proc(x: JsonNode): ReactionDto =
+            result = x.toReactionDto()
+        )
+
       self.events.emit(SIGNAL_MESSAGES_LOADED,
-        MessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: messages, reactions: @[]))
+        MessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: messages, reactions: reactions))
     except Exception as e:
       error "error loading thread messages", msg = e.msg
       if chatId.len > 0 and threadId.len > 0:

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -45,8 +45,6 @@ const MESSAGES_PER_PAGE_MAX* = 40
 const SIGNAL_MESSAGES_LOADED* = "messagesLoaded"
 const SIGNAL_CHAT_THREADS_LOADED* = "chatThreadsLoaded"
 const SIGNAL_CHAT_THREADS_LOADING_FAILED* = "chatThreadsLoadingFailed"
-const SIGNAL_THREAD_MESSAGES_LOADED* = "threadMessagesLoaded"
-const SIGNAL_THREAD_MESSAGES_LOADING_FAILED* = "threadMessagesLoadingFailed"
 const SIGNAL_THREAD_CREATED* = "threadCreated"
 const SIGNAL_THREAD_CREATION_FAILED* = "threadCreationFailed"
 const SIGNAL_PINNED_MESSAGES_LOADED* = "pinnedMessagesLoaded"
@@ -80,6 +78,7 @@ type
   MessagesArgs* = ref object of Args
     sectionId*: string
     chatId*: string
+    threadId*: string
     chatType*: ChatType
     lastMessageTimestamp*: int
     unviewedMessagesCount*: int
@@ -88,6 +87,7 @@ type
 
   MessagesLoadedArgs* = ref object of Args
     chatId*: string
+    threadId*: string
     messages*: seq[MessageDto]
     reactions*: seq[ReactionDto]
 
@@ -99,11 +99,6 @@ type
     chatId*: string
     parentMessageId*: string
     threads*: seq[ThreadDto]
-
-  ThreadMessagesLoadedArgs* = ref object of Args
-    chatId*: string
-    threadId*: string
-    messages*: seq[MessageDto]
 
   PinnedMessagesLoadedArgs* = ref object of Args
     chatId*: string
@@ -282,6 +277,20 @@ QtObject:
       return false
 
     return self.chatThreadsParentIdsByChat[chatId].contains(parentMessageId)
+
+  proc handleThreadsUpdate(self: Service, threads: seq[ThreadDto]) =
+    var threadsByChat = initTable[string, seq[ThreadDto]]()
+    for thread in threads:
+      if thread.chatId.len == 0:
+        continue
+
+      if not threadsByChat.hasKey(thread.chatId):
+        threadsByChat[thread.chatId] = @[]
+      threadsByChat[thread.chatId].add(thread)
+
+    for chatId, chatThreads in threadsByChat:
+      self.cacheCreatedThreads(chatId, chatThreads)
+      self.events.emit(SIGNAL_CHAT_THREADS_LOADED, ChatThreadsLoadedArgs(chatId: chatId, threads: chatThreads))
 
   proc isChatCursorInitialized(self: Service, chatId: string): bool =
     return self.msgCursor.hasKey(chatId)
@@ -504,6 +513,7 @@ QtObject:
   proc asyncLoadInitialMessagesForChat*(self: Service, chatId: string) =
     if self.isChatCursorInitialized(chatId):
       let data = MessagesLoadedArgs(chatId: chatId,
+        threadId: "",
         messages: @[],
         reactions: @[])
 
@@ -549,6 +559,7 @@ QtObject:
         self.events.emit(SIGNAL_CHAT_UPDATE, ChatUpdateArgs(chats: chats))
 
       var chatMessages: seq[MessageDto]
+      var threadMessagesByThread = initTable[string, seq[MessageDto]]()
       for msg in messages:
         if(msg.localChatId != chatId):
           continue
@@ -564,12 +575,17 @@ QtObject:
         if msg.editedAt > 0:
           let data = MessageEditedArgs(chatId: msg.localChatId, message: msg)
           self.events.emit(SIGNAL_MESSAGE_EDITED, data)
+        elif msg.threadId.len > 0:
+          if not threadMessagesByThread.hasKey(msg.threadId):
+            threadMessagesByThread[msg.threadId] = @[]
+          threadMessagesByThread[msg.threadId].add(msg)
         else:
           chatMessages.add(msg)
 
       let data = MessagesArgs(
         sectionId: if chats[i].communityId.len != 0: chats[i].communityId else: singletonInstance.userProfile.getPubKey(),
         chatId: chatId,
+        threadId: "",
         chatType: chats[i].chatType,
         lastMessageTimestamp: chats[i].timestamp.int,
         unviewedMessagesCount: chats[i].unviewedMessagesCount,
@@ -577,6 +593,19 @@ QtObject:
         messages: chatMessages
       )
       self.events.emit(SIGNAL_NEW_MESSAGE_RECEIVED, data)
+
+      for threadId, threadMessages in threadMessagesByThread:
+        let threadData = MessagesArgs(
+          sectionId: if chats[i].communityId.len != 0: chats[i].communityId else: singletonInstance.userProfile.getPubKey(),
+          chatId: chatId,
+          threadId: threadId,
+          chatType: chats[i].chatType,
+          lastMessageTimestamp: chats[i].timestamp.int,
+          unviewedMessagesCount: chats[i].unviewedMessagesCount,
+          unviewedMentionsCount: chats[i].unviewedMentionsCount,
+          messages: threadMessages
+        )
+        self.events.emit(SIGNAL_NEW_MESSAGE_RECEIVED, threadData)
 
   proc getNumOfPinnedMessages*(self: Service, chatId: string): int =
     if(self.numOfPinnedMessagesPerChat.hasKey(chatId)):
@@ -675,6 +704,7 @@ QtObject:
 
         self.events.emit(SIGNAL_MESSAGES_LOADED, MessagesLoadedArgs(
           chatId: args.chatId,
+          threadId: "",
           messages: messages,
           reactions: @[],
         ))
@@ -682,6 +712,9 @@ QtObject:
     self.events.on(SignalType.Message.event) do(e: Args):
       var receivedData = MessageSignal(e)
 
+      # Handling thread updates
+      if (receivedData.threads.len > 0):
+        self.handleThreadsUpdate(receivedData.threads)
       # Handling messages updates
       if (receivedData.messages.len > 0 and receivedData.chats.len > 0):
         self.handleMessagesUpdate(receivedData.chats, receivedData.messages)
@@ -792,6 +825,7 @@ QtObject:
       self.events.emit(SIGNAL_PINNED_MESSAGES_LOADED, PinnedMessagesLoadedArgs())
 
   proc onAsyncLoadMoreMessagesForChat*(self: Service, response: string) {.slot.} =
+    var chatId: string = ""
     try:
       let responseObj = response.parseJson
       if responseObj.kind != JObject:
@@ -801,7 +835,6 @@ QtObject:
       if errorString != "":
         raise newException(CatchableError, errorString)
 
-      var chatId: string
       discard responseObj.getProp("chatId", chatId)
 
       let msgCursor = self.initOrGetMessageCursor(chatId)
@@ -834,6 +867,7 @@ QtObject:
 
       let data = MessagesLoadedArgs(
         chatId: chatId,
+        threadId: "",
         messages: messages,
         reactions: reactions,
       )
@@ -842,7 +876,8 @@ QtObject:
     except Exception as e:
       error "Erorr load more messages for chat async", msg = e.msg
       # notify view, this is important
-      self.events.emit(SIGNAL_MESSAGES_LOADED, MessagesLoadedArgs())
+      self.events.emit(SIGNAL_MESSAGES_LOADED,
+        MessagesLoadedArgs(chatId: chatId, threadId: "", messages: @[], reactions: @[]))
 
   proc onAsyncLoadChatThreads*(self: Service, response: string) {.slot.} =
     var chatId = ""
@@ -901,8 +936,8 @@ QtObject:
 
       self.checkPaymentRequestsInMessages(messages)
 
-      self.events.emit(SIGNAL_THREAD_MESSAGES_LOADED,
-        ThreadMessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: messages))
+      self.events.emit(SIGNAL_MESSAGES_LOADED,
+        MessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: messages, reactions: @[]))
     except Exception as e:
       error "error loading thread messages", msg = e.msg
       if chatId.len > 0 and threadId.len > 0:
@@ -910,8 +945,8 @@ QtObject:
         if self.threadMsgCursor.hasKey(key):
           # Clear the cursor for this thread so that we can try to load it again later
           self.threadMsgCursor.del(key)
-        self.events.emit(SIGNAL_THREAD_MESSAGES_LOADING_FAILED,
-          ThreadMessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: @[]))
+        self.events.emit(SIGNAL_MESSAGES_LOADED,
+          MessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: @[], reactions: @[]))
 
   proc onAsyncCreateThread*(self: Service, response: string) {.slot.} =
     var chatId: string = ""

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -5,6 +5,7 @@ import ../../../app/core/tasks/[qt, threadpool]
 import ../../../app/core/signals/types
 import ../../../app/core/eventemitter
 import ../../../app/global/global_singleton
+import ../../../app/global/feature_flags
 import ../../../backend/accounts as status_accounts
 import ../../../backend/messages as status_go
 import ../contacts/service as contact_service
@@ -210,6 +211,7 @@ QtObject:
     chatThreadsLoadingChats: HashSet[string]
 
   proc asyncLoadChatThreads*(self: Service, chatId: string)
+  proc asyncLoadChatThreadsForChats*(self: Service, chatIds: seq[string])
 
   proc delete*(self: Service)
   proc newService*(
@@ -258,6 +260,9 @@ QtObject:
     self.chatThreadsLoadingChats.excl(chatId)
 
   proc loadChatThreadsIfNeeded*(self: Service, chatId: string) =
+    if not THREADS_ENABLED:
+      return
+
     if chatId.len == 0:
       return
 
@@ -269,6 +274,26 @@ QtObject:
 
     self.chatThreadsLoadingChats.incl(chatId)
     self.asyncLoadChatThreads(chatId)
+
+  proc loadChatThreadsForChatsIfNeeded*(self: Service, chatIds: seq[string]) =
+    if not THREADS_ENABLED:
+      return
+
+    var pending: seq[string] = @[]
+    for chatId in chatIds:
+      if chatId.len == 0 or
+         self.chatThreadsLoadedChats.contains(chatId) or
+         self.chatThreadsLoadingChats.contains(chatId):
+        continue
+      pending.add(chatId)
+
+    if pending.len == 0:
+      return
+
+    for chatId in pending:
+      self.chatThreadsLoadingChats.incl(chatId)
+
+    self.asyncLoadChatThreadsForChats(pending)
 
   proc chatHasThreadForParentMessage*(self: Service, chatId: string, parentMessageId: string): bool =
     if chatId.len == 0 or parentMessageId.len == 0:
@@ -393,6 +418,19 @@ QtObject:
       vptr: cast[uint](self.vptr),
       slot: "onAsyncLoadChatThreads",
       chatId: chatId,
+    )
+
+    self.threadpool.start(arg)
+
+  proc asyncLoadChatThreadsForChats*(self: Service, chatIds: seq[string]) =
+    if chatIds.len == 0:
+      return
+
+    let arg = AsyncFetchChatThreadsForChatsTaskArg(
+      tptr: asyncFetchChatThreadsForChatsTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncLoadChatThreadsForChats",
+      chatIds: chatIds,
     )
 
     self.threadpool.start(arg)
@@ -908,6 +946,48 @@ QtObject:
         self.chatThreadsLoadingChats.excl(chatId)
         self.events.emit(SIGNAL_CHAT_THREADS_LOADING_FAILED, ChatThreadsLoadedArgs(chatId: chatId, threads: @[]))
       error "error loading chat threads", msg = e.msg
+
+  proc onAsyncLoadChatThreadsForChats*(self: Service, response: string) {.slot.} =
+    var chatIds: seq[string] = @[]
+    try:
+      let responseObj = response.parseJson
+      if responseObj.kind != JObject:
+        raise newException(CatchableError, "load chat threads response is not a json object")
+
+      var chatIdsArr: JsonNode
+      if responseObj.getProp("chatIds", chatIdsArr):
+        chatIds = map(chatIdsArr.getElems(), proc(x: JsonNode): string = x.getStr())
+
+      let errorString = responseObj{"error"}.getStr()
+      if errorString != "":
+        raise newException(CatchableError, errorString)
+
+      var threads: seq[ThreadDto]
+      var threadsArr: JsonNode
+      if responseObj.getProp("threads", threadsArr):
+        threads = map(threadsArr.getElems(), proc(x: JsonNode): ThreadDto = x.toThreadDto())
+
+      var threadsByChat = initTable[string, seq[ThreadDto]]()
+      for thread in threads:
+        if thread.chatId.len == 0:
+          continue
+        threadsByChat.mgetOrPut(thread.chatId, @[]).add(thread)
+
+      # Settle every requested chat, including those with no threads, so they leave the
+      # loading set and listeners are not left waiting on a signal that never comes.
+      for chatId in chatIds:
+        let chatThreads = threadsByChat.getOrDefault(chatId, @[])
+        self.replaceChatThreadsCache(chatId, chatThreads)
+        self.chatThreadsLoadedChats.incl(chatId)
+        self.chatThreadsLoadingChats.excl(chatId)
+        self.events.emit(SIGNAL_CHAT_THREADS_LOADED,
+          ChatThreadsLoadedArgs(chatId: chatId, threads: chatThreads))
+    except Exception as e:
+      for chatId in chatIds:
+        self.chatThreadsLoadingChats.excl(chatId)
+        self.events.emit(SIGNAL_CHAT_THREADS_LOADING_FAILED,
+          ChatThreadsLoadedArgs(chatId: chatId, threads: @[]))
+      error "error loading chat threads for chats", msg = e.msg
 
   proc onAsyncLoadMoreMessagesForThread*(self: Service, response: string) {.slot.} =
     var threadId: string = ""

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -123,6 +123,7 @@ type
 
   MessagesMarkedAsReadArgs* = ref object of Args
     chatId*: string
+    threadId*: string
     allMessagesMarked*: bool
     messagesIds*: seq[string]
     messagesCount*: int
@@ -1310,13 +1311,16 @@ QtObject:
       var chatId: string
       discard responseObj.getProp("chatId", chatId)
 
-      let data = MessagesMarkedAsReadArgs(chatId: chatId, allMessagesMarked: true)
+      var threadId: string
+      discard responseObj.getProp("threadId", threadId)
+
+      let data = MessagesMarkedAsReadArgs(chatId: chatId, threadId: threadId, allMessagesMarked: true)
       self.events.emit(SIGNAL_MESSAGES_MARKED_AS_READ, data)
       checkAndEmitACNotificationsFromResponse(self.events, responseObj{"activityCenterNotifications"})
     except Exception as e:
       error "error: ", procName="onMarkAllMessagesRead", errDesription = e.msg
 
-  proc markAllMessagesRead*(self: Service, chatId: string) =
+  proc markAllMessagesRead*(self: Service, chatId: string, threadId: string = "") =
     if (chatId.len == 0):
       error "empty chat id", procName="markAllMessagesRead"
       return
@@ -1325,7 +1329,8 @@ QtObject:
       tptr: asyncMarkAllMessagesReadTask,
       vptr: cast[uint](self.vptr),
       slot: "onMarkAllMessagesRead",
-      chatId: chatId
+      chatId: chatId,
+      threadId: threadId
     )
 
     self.threadpool.start(arg)

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1,4 +1,4 @@
-import nimqml, tables, json, regex, sequtils, std/strformat, strutils, chronicles, times, oids, uuids
+import nimqml, tables, json, regex, sequtils, std/strformat, strutils, chronicles, times, oids, uuids, sets
 import ../../common/utils as common_utils
 
 import ../../../app/core/tasks/[qt, threadpool]
@@ -15,6 +15,7 @@ import ../wallet_account/service as wallet_account_service
 import ./dto/message as message_dto
 import ./dto/pinned_message as pinned_msg_dto
 import ./dto/reaction as reaction_dto
+import ./dto/thread as thread_dto
 import ../chat/dto/chat as chat_dto
 import ./dto/pinned_message_update as pinned_msg_update_dto
 import ./dto/removed_message as removed_msg_dto
@@ -32,6 +33,7 @@ import web3/conversions
 export message_dto
 export pinned_msg_dto
 export reaction_dto
+export thread_dto
 
 logScope:
   topics = "messages-service"
@@ -41,6 +43,12 @@ const MESSAGES_PER_PAGE_MAX* = 40
 
 # Signals which may be emitted by this service:
 const SIGNAL_MESSAGES_LOADED* = "messagesLoaded"
+const SIGNAL_CHAT_THREADS_LOADED* = "chatThreadsLoaded"
+const SIGNAL_CHAT_THREADS_LOADING_FAILED* = "chatThreadsLoadingFailed"
+const SIGNAL_THREAD_MESSAGES_LOADED* = "threadMessagesLoaded"
+const SIGNAL_THREAD_MESSAGES_LOADING_FAILED* = "threadMessagesLoadingFailed"
+const SIGNAL_THREAD_CREATED* = "threadCreated"
+const SIGNAL_THREAD_CREATION_FAILED* = "threadCreationFailed"
 const SIGNAL_PINNED_MESSAGES_LOADED* = "pinnedMessagesLoaded"
 const SIGNAL_REACTIONS_FOR_MESSAGE_LOADED* = "signalReactionsForMessageLoaded"
 const SIGNAL_FIRST_UNSEEN_MESSAGE_LOADED* = "firstUnseenMessageLoaded"
@@ -82,6 +90,20 @@ type
     chatId*: string
     messages*: seq[MessageDto]
     reactions*: seq[ReactionDto]
+
+  ChatThreadsLoadedArgs* = ref object of Args
+    chatId*: string
+    threads*: seq[ThreadDto]
+
+  ThreadCreatedArgs* = ref object of Args
+    chatId*: string
+    parentMessageId*: string
+    threads*: seq[ThreadDto]
+
+  ThreadMessagesLoadedArgs* = ref object of Args
+    chatId*: string
+    threadId*: string
+    messages*: seq[MessageDto]
 
   PinnedMessagesLoadedArgs* = ref object of Args
     chatId*: string
@@ -184,8 +206,14 @@ QtObject:
     walletAccountService: wallet_account_service.Service
     networkService: network_service.Service
     msgCursor: Table[string, MessageCursor]
+    threadMsgCursor: Table[string, MessageCursor]
     pinnedMsgCursor: Table[string, MessageCursor]
     numOfPinnedMessagesPerChat: Table[string, int] # [chat_id, num_of_pinned_messages]
+    chatThreadsParentIdsByChat: Table[string, HashSet[string]]
+    chatThreadsLoadedChats: HashSet[string]
+    chatThreadsLoadingChats: HashSet[string]
+
+  proc asyncLoadChatThreads*(self: Service, chatId: string)
 
   proc delete*(self: Service)
   proc newService*(
@@ -207,7 +235,53 @@ QtObject:
     result.walletAccountService = walletAccountService
     result.networkService = networkService
     result.msgCursor = initTable[string, MessageCursor]()
+    result.threadMsgCursor = initTable[string, MessageCursor]()
     result.pinnedMsgCursor = initTable[string, MessageCursor]()
+    result.chatThreadsParentIdsByChat = initTable[string, HashSet[string]]()
+    result.chatThreadsLoadedChats = initHashSet[string]()
+    result.chatThreadsLoadingChats = initHashSet[string]()
+
+  proc replaceChatThreadsCache(self: Service, chatId: string, threads: seq[ThreadDto]) =
+    var parentIds = initHashSet[string]()
+    for thread in threads:
+      if thread.parentMessageId.len > 0:
+        parentIds.incl(thread.parentMessageId)
+    self.chatThreadsParentIdsByChat[chatId] = parentIds
+
+  proc cacheCreatedThreads(self: Service, chatId: string, threads: seq[ThreadDto]) =
+    if not self.chatThreadsParentIdsByChat.hasKey(chatId):
+      self.chatThreadsParentIdsByChat[chatId] = initHashSet[string]()
+
+    for thread in threads:
+      if thread.parentMessageId.len > 0:
+        self.chatThreadsParentIdsByChat[chatId].incl(thread.parentMessageId)
+
+  proc clearChatThreadsCacheForChat(self: Service, chatId: string) =
+    self.chatThreadsParentIdsByChat.del(chatId)
+    self.chatThreadsLoadedChats.excl(chatId)
+    self.chatThreadsLoadingChats.excl(chatId)
+
+  proc loadChatThreadsIfNeeded*(self: Service, chatId: string) =
+    if chatId.len == 0:
+      return
+
+    if self.chatThreadsLoadedChats.contains(chatId):
+      return
+
+    if self.chatThreadsLoadingChats.contains(chatId):
+      return
+
+    self.chatThreadsLoadingChats.incl(chatId)
+    self.asyncLoadChatThreads(chatId)
+
+  proc chatHasThreadForParentMessage*(self: Service, chatId: string, parentMessageId: string): bool =
+    if chatId.len == 0 or parentMessageId.len == 0:
+      return false
+
+    if not self.chatThreadsParentIdsByChat.hasKey(chatId):
+      return false
+
+    return self.chatThreadsParentIdsByChat[chatId].contains(parentMessageId)
 
   proc isChatCursorInitialized(self: Service, chatId: string): bool =
     return self.msgCursor.hasKey(chatId)
@@ -219,7 +293,25 @@ QtObject:
 
   proc resetAllMessageCursors*(self: Service) =
     self.msgCursor = initTable[string, MessageCursor]()
+    self.threadMsgCursor = initTable[string, MessageCursor]()
     self.pinnedMsgCursor = initTable[string, MessageCursor]()
+
+  proc getThreadMessageCursorKey(self: Service, chatId: string, threadId: string): string =
+    return chatId & ":" & threadId
+
+  proc initOrGetThreadMessageCursor(self: Service, chatId: string, threadId: string): MessageCursor =
+    let key = self.getThreadMessageCursorKey(chatId, threadId)
+    if not self.threadMsgCursor.hasKey(key):
+      self.threadMsgCursor[key] = initMessageCursor(value="", pending=false, mostRecent=false)
+    return self.threadMsgCursor[key]
+
+  proc resetThreadMessageCursorsForChat*(self: Service, chatId: string) =
+    var keys = newSeq[string]()
+    for key in self.threadMsgCursor.keys:
+      if key.startsWith(chatId & ":"):
+        keys.add(key)
+    for key in keys:
+      self.threadMsgCursor.del(key)
 
   proc initOrGetMessageCursor(self: Service, chatId: string): MessageCursor =
     if(not self.msgCursor.hasKey(chatId)):
@@ -280,6 +372,64 @@ QtObject:
 
     self.threadpool.start(arg)
     return true
+
+  proc asyncLoadChatThreads*(self: Service, chatId: string) =
+    if chatId.len == 0:
+      error "empty chat id", procName="asyncLoadChatThreads"
+      return
+
+    let arg = AsyncFetchChatThreadsTaskArg(
+      tptr: asyncFetchChatThreadsTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncLoadChatThreads",
+      chatId: chatId,
+    )
+
+    self.threadpool.start(arg)
+
+  proc asyncLoadMoreMessagesForThread*(self: Service, chatId: string, threadId: string,
+      limit = MESSAGES_PER_PAGE): bool =
+    if chatId.len == 0 or threadId.len == 0:
+      error "empty chat id or thread id", procName="asyncLoadMoreMessagesForThread"
+      return false
+
+    let msgCursor = self.initOrGetThreadMessageCursor(chatId, threadId)
+    if msgCursor.isPending():
+      return true
+
+    if msgCursor.isMostRecent():
+      return false
+
+    let msgCursorValue = msgCursor.getValue()
+    msgCursor.setPending()
+
+    let arg = AsyncFetchChatMessagesTaskArg(
+      tptr: asyncFetchChatMessagesTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncLoadMoreMessagesForThread",
+      chatId: chatId,
+      threadId: threadId,
+      msgCursor: msgCursorValue,
+      limit: if(limit <= MESSAGES_PER_PAGE_MAX): limit else: MESSAGES_PER_PAGE_MAX,
+    )
+
+    self.threadpool.start(arg)
+    return true
+
+  proc asyncCreateThread*(self: Service, chatId: string, parentMessageId: string) =
+    if chatId.len == 0 or parentMessageId.len == 0:
+      error "empty chat id or parent message id", procName="asyncCreateThread"
+      return
+
+    let arg = AsyncCreateThreadTaskArg(
+      tptr: asyncCreateThreadTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncCreateThread",
+      chatId: chatId,
+      parentMessageId: parentMessageId,
+    )
+
+    self.threadpool.start(arg)
 
   proc onAsyncLoadReactionsForMessage*(self: Service, response: string) {.slot.} =
     try:
@@ -476,11 +626,25 @@ QtObject:
       self.msgCursor.del(k)
 
     keys = @[]
+    for k in self.threadMsgCursor.keys:
+      if k.startsWith(communityId):
+        keys.add(k)
+    for k in keys:
+      self.threadMsgCursor.del(k)
+
+    keys = @[]
     for k in self.pinnedMsgCursor.keys:
       if k.startsWith(communityId):
         keys.add(k)
     for k in keys:
       self.pinnedMsgCursor.del(k)
+
+    keys = @[]
+    for k in self.chatThreadsParentIdsByChat.keys:
+      if k.startsWith(communityId):
+        keys.add(k)
+    for k in keys:
+      self.clearChatThreadsCacheForChat(k)
 
     self.events.emit(SIGNAL_RELOAD_MESSAGES, ReloadMessagesArgs(communityId: communityId))
 
@@ -550,6 +714,8 @@ QtObject:
     self.events.on(SIGNAL_CHAT_LEFT) do(e: Args):
       var chatArg = ChatArgs(e)
       self.resetMessageCursor(chatArg.chatId)
+      self.resetThreadMessageCursorsForChat(chatArg.chatId)
+      self.clearChatThreadsCacheForChat(chatArg.chatId)
 
     self.events.on(SignalType.LocalMessageBackupDone.event) do(e: Args):
       self.resetAllMessageCursors()
@@ -677,6 +843,106 @@ QtObject:
       error "Erorr load more messages for chat async", msg = e.msg
       # notify view, this is important
       self.events.emit(SIGNAL_MESSAGES_LOADED, MessagesLoadedArgs())
+
+  proc onAsyncLoadChatThreads*(self: Service, response: string) {.slot.} =
+    var chatId = ""
+    try:
+      let responseObj = response.parseJson
+      if responseObj.kind != JObject:
+        raise newException(CatchableError, "load chat threads response is not a json object")
+
+      discard responseObj.getProp("chatId", chatId)
+
+      let errorString = responseObj{"error"}.getStr()
+      if errorString != "":
+        raise newException(CatchableError, errorString)
+
+      var threads: seq[ThreadDto]
+      var threadsArr: JsonNode
+      if responseObj.getProp("threads", threadsArr):
+        threads = map(threadsArr.getElems(), proc(x: JsonNode): ThreadDto = x.toThreadDto())
+
+      self.replaceChatThreadsCache(chatId, threads)
+      self.chatThreadsLoadedChats.incl(chatId)
+      self.chatThreadsLoadingChats.excl(chatId)
+
+      self.events.emit(SIGNAL_CHAT_THREADS_LOADED, ChatThreadsLoadedArgs(chatId: chatId, threads: threads))
+    except Exception as e:
+      if chatId.len > 0:
+        self.chatThreadsLoadingChats.excl(chatId)
+        self.events.emit(SIGNAL_CHAT_THREADS_LOADING_FAILED, ChatThreadsLoadedArgs(chatId: chatId, threads: @[]))
+      error "error loading chat threads", msg = e.msg
+
+  proc onAsyncLoadMoreMessagesForThread*(self: Service, response: string) {.slot.} =
+    var threadId: string = ""
+    var chatId: string = ""
+    try:
+      let responseObj = response.parseJson
+      if responseObj.kind != JObject:
+        raise newException(CatchableError, "load thread messages response is not a json object")
+
+      discard responseObj.getProp("chatId", chatId)
+      discard responseObj.getProp("threadId", threadId)
+
+      let errorString = responseObj{"error"}.getStr()
+      if errorString != "":
+        raise newException(CatchableError, errorString)
+
+      let msgCursor = self.initOrGetThreadMessageCursor(chatId, threadId)
+
+      var msgCursorValue: string
+      if responseObj.getProp("messagesCursor", msgCursorValue):
+        msgCursor.setValue(msgCursorValue)
+
+      var messagesArr: JsonNode
+      var messages: seq[MessageDto]
+      if responseObj.getProp("messages", messagesArr):
+        messages = map(messagesArr.getElems(), proc(x: JsonNode): MessageDto = x.toMessageDto())
+
+      self.checkPaymentRequestsInMessages(messages)
+
+      self.events.emit(SIGNAL_THREAD_MESSAGES_LOADED,
+        ThreadMessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: messages))
+    except Exception as e:
+      error "error loading thread messages", msg = e.msg
+      if chatId.len > 0 and threadId.len > 0:
+        let key = self.getThreadMessageCursorKey(chatId, threadId)
+        if self.threadMsgCursor.hasKey(key):
+          # Clear the cursor for this thread so that we can try to load it again later
+          self.threadMsgCursor.del(key)
+        self.events.emit(SIGNAL_THREAD_MESSAGES_LOADING_FAILED,
+          ThreadMessagesLoadedArgs(chatId: chatId, threadId: threadId, messages: @[]))
+
+  proc onAsyncCreateThread*(self: Service, response: string) {.slot.} =
+    var chatId: string = ""
+    var parentMessageId: string = ""
+    try:
+      let responseObj = response.parseJson
+      if responseObj.kind != JObject:
+        raise newException(CatchableError, "create thread response is not a json object")
+
+      discard responseObj.getProp("chatId", chatId)
+      discard responseObj.getProp("parentMessageId", parentMessageId)
+
+      let errorString = responseObj{"error"}.getStr()
+      if errorString != "":
+        raise newException(CatchableError, errorString)
+
+
+      var threads: seq[ThreadDto]
+      var threadsArr: JsonNode
+      if responseObj.getProp("threads", threadsArr):
+        threads = map(threadsArr.getElems(), proc(x: JsonNode): ThreadDto = x.toThreadDto())
+
+      self.cacheCreatedThreads(chatId, threads)
+
+      self.events.emit(SIGNAL_THREAD_CREATED,
+        ThreadCreatedArgs(chatId: chatId, parentMessageId: parentMessageId, threads: threads))
+    except Exception as e:
+      error "error creating thread", msg = e.msg
+      if chatId.len > 0:
+        self.events.emit(SIGNAL_THREAD_CREATION_FAILED,
+          ThreadCreatedArgs(chatId: chatId, parentMessageId: parentMessageId, threads: @[]))
 
   proc onAsyncLoadCommunityMemberAllMessages*(self: Service, response: string) {.slot.} =
     try:

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -74,6 +74,7 @@ type
   AsyncSendStickerTaskArg = ref object of QObjectTaskArg
     chatId: string
     replyTo: string
+    threadId: string
     stickerHash: string
     stickerPackId: string
     preferredUsername: string
@@ -86,7 +87,7 @@ const asyncSendStickerTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} 
       "You can see a nice sticker here!",
       arg.replyTo,
       ContentType.Sticker.int,
-      "",
+      arg.threadId,
       arg.preferredUsername,
       standardLinkPreviews = JsonNode(),
       statusLinkPreviews = JsonNode(),

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -86,6 +86,7 @@ const asyncSendStickerTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} 
       "You can see a nice sticker here!",
       arg.replyTo,
       ContentType.Sticker.int,
+      "",
       arg.preferredUsername,
       standardLinkPreviews = JsonNode(),
       statusLinkPreviews = JsonNode(),

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -328,13 +328,15 @@ QtObject:
       chatId: string,
       replyTo: string,
       sticker: StickerDto,
-      preferredUsername: string) =
+      preferredUsername: string,
+      threadId: string = "") =
     let arg = AsyncSendStickerTaskArg(
       tptr: asyncSendStickerTask,
       vptr: cast[uint](self.vptr),
       slot: "onAsyncSendStickerDone",
       chatId: chatId,
       replyTo: replyTo,
+      threadId: threadId,
       stickerHash: sticker.hash,
       stickerPackId: sticker.packId,
       preferredUsername: preferredUsername,
@@ -354,7 +356,8 @@ QtObject:
       discard self.chatService.processMessengerResponse(rpcResponse)
     except Exception as e:
       error "Error sending sticker", msg = e.msg
-      self.events.emit(SIGNAL_SENDING_FAILED, ChatArgs(chatId: rpcResponseObj["chatId"].getStr))
+      self.events.emit(SIGNAL_SENDING_FAILED,
+        MessageSendingFailure(chatId: rpcResponseObj["chatId"].getStr, error: e.msg))
 
   proc removeRecentStickers*(self: Service, packId: string) =
     self.recentStickers.keepItIf(it.packId != packId)

--- a/src/backend/chat.nim
+++ b/src/backend/chat.nim
@@ -55,6 +55,7 @@ proc sendChatMessage*(
     msg: string,
     replyTo: string,
     contentType: int,
+  threadId: string = "",
     preferredUsername: string = "",
     standardLinkPreviews: JsonNode,
     statusLinkPreviews: JsonNode,
@@ -68,6 +69,7 @@ proc sendChatMessage*(
       "chatId": chatId,
       "text": msg,
       "responseTo": replyTo,
+      "threadId": threadId,
       "ensName": preferredUsername,
       "sticker": {
         "hash": stickerHash,
@@ -86,6 +88,7 @@ proc sendImages*(chatId: string,
                  msg: string,
                  replyTo: string,
                  preferredUsername: string,
+                 threadId: string = "",
                  standardLinkPreviews: JsonNode,
                  statusLinkPreviews: JsonNode,
                  paymentRequests: JsonNode,
@@ -98,12 +101,21 @@ proc sendImages*(chatId: string,
         "ensName": preferredUsername,
         "text": msg,
         "responseTo": replyTo,
+        "threadId": threadId,
         "linkPreviews": standardLinkPreviews,
         "statusLinkPreviews": statusLinkPreviews,
         "paymentRequests": paymentRequests,
       }
     )
   callPrivateRPC("sendChatMessages".prefix, %* [imagesJson])
+
+proc createThread*(chatId: string, parentMessageId: string): RpcResponse[JsonNode] =
+  let payload = %* [chatId, parentMessageId]
+  result = callPrivateRPC("createThread".prefix, payload)
+
+proc fetchChatThreads*(chatId: string): RpcResponse[JsonNode] =
+  let payload = %* [chatId]
+  result = callPrivateRPC("chatThreads".prefix, payload)
 
 proc muteChat*(chatId: string, interval: int): RpcResponse[JsonNode] =
   result = callPrivateRPC("muteChatV2".prefix, %* [

--- a/src/backend/chat.nim
+++ b/src/backend/chat.nim
@@ -117,6 +117,10 @@ proc fetchChatThreads*(chatId: string): RpcResponse[JsonNode] =
   let payload = %* [chatId]
   result = callPrivateRPC("chatThreads".prefix, payload)
 
+proc fetchChatThreadsForChats*(chatIds: seq[string]): RpcResponse[JsonNode] =
+  let payload = %* [chatIds]
+  result = callPrivateRPC("chatThreadsByChatIDs".prefix, payload)
+
 proc muteChat*(chatId: string, interval: int): RpcResponse[JsonNode] =
   result = callPrivateRPC("muteChatV2".prefix, %* [
     {

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -12,9 +12,9 @@ proc fetchPinnedMessages*(chatId: string, cursorVal: string, limit: int): RpcRes
   let payload = %* [chatId, cursorVal, limit]
   result = callPrivateRPC("chatPinnedMessages".prefix, payload)
 
-proc fetchReactions*(chatId: string, cursorVal: string, limit: int): RpcResponse[JsonNode] =
-  let payload = %* [chatId, cursorVal, limit]
-  result = callPrivateRPC("emojiReactionsByChatID".prefix, payload)
+proc fetchReactions*(chatId: string, threadId: string = "", cursorVal: string, limit: int): RpcResponse[JsonNode] =
+  let payload = %* [chatId, threadId, cursorVal, limit]
+  result = callPrivateRPC("emojiReactionsByChatIDV2".prefix, payload)
 
 proc addReaction*(chatId: string, messageId: string, emoji: string): RpcResponse[JsonNode] =
   let payload = %* [chatId, messageId, emoji]

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -4,9 +4,9 @@ import response_type
 
 export response_type
 
-proc fetchMessages*(chatId: string, cursorVal: string, limit: int): RpcResponse[JsonNode] =
-  let payload = %* [chatId, cursorVal, limit]
-  result = callPrivateRPC("chatMessages".prefix, payload)
+proc fetchMessages*(chatId: string, threadId: string = "", cursorVal: string, limit: int): RpcResponse[JsonNode] =
+  let payload = %* [chatId, threadId, cursorVal, limit]
+  result = callPrivateRPC("chatMessagesV2".prefix, payload)
 
 proc fetchPinnedMessages*(chatId: string, cursorVal: string, limit: int): RpcResponse[JsonNode] =
   let payload = %* [chatId, cursorVal, limit]

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -58,6 +58,10 @@ proc markAllMessagesFromChatWithIdAsRead*(chatId: string): RpcResponse[JsonNode]
   let payload = %* [chatId]
   result = callPrivateRPC("markAllRead".prefix, payload)
 
+proc markAllMessagesFromThreadWithIdAsRead*(chatId: string, threadId: string): RpcResponse[JsonNode] =
+  let payload = %* [chatId, threadId]
+  result = callPrivateRPC("markThreadRead".prefix, payload)
+
 proc markCertainMessagesFromChatWithIdAsRead*(chatId: string, messageIds: seq[string]):
   RpcResponse[JsonNode] =
   let payload = %* [chatId, messageIds]

--- a/storybook/qmlTests/tests/tst_ThreadsChatContextMenu.qml
+++ b/storybook/qmlTests/tests/tst_ThreadsChatContextMenu.qml
@@ -1,0 +1,135 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Popups
+
+import shared.views.chat
+import utils
+
+// RED tests for the threads PR stack (status-im/status-app#21351 .. #22245).
+//
+// ChatContextMenuView is reused verbatim for the new "thread" rows that the
+// stack inserts into the chat list (CommunityColumnView / ContactsColumnView
+// set `isThread` and `threadId` from the model row). Every channel-scoped
+// action in that menu was given a `!root.isThread` guard except
+// `editChannelMenuItem`, and the thread row's `chatId` is the *thread* id
+// (== the parent message id), not a channel id.
+//
+// StatusMenu sets `hideDisabledItems: true`, so `enabled` is also the row's
+// visibility here.
+Item {
+    id: root
+    width: 600
+    height: 400
+
+    property var editChannelCalls: []
+    property var markAsReadCalls: []
+
+    Component {
+        id: menuComponent
+
+        ChatContextMenuView {
+            onDisplayEditChannelPopup: (chatId) => root.editChannelCalls.push(chatId)
+            onMarkAllMessagesRead: (chatId, threadId) => root.markAsReadCalls.push({
+                chatId: chatId, threadId: threadId })
+        }
+    }
+
+    TestCase {
+        name: "ThreadsChatContextMenu"
+        when: windowShown
+
+        function init() {
+            root.editChannelCalls = []
+            root.markAsReadCalls = []
+        }
+
+        function createMenu(props) {
+            return createTemporaryObject(menuComponent, root, props || {})
+        }
+
+        function actionByObjectName(menu, objectName) {
+            for (let i = 0; i < menu.count; ++i) {
+                const action = menu.actionAt(i)
+                if (action && action.objectName === objectName)
+                    return action
+            }
+            return null
+        }
+
+        // A community thread row, seen by a channel admin.
+        function threadRowProps() {
+            return {
+                isThread: true,
+                isCommunityChat: true,
+                amIChatAdmin: true,
+                // the chat list assigns the row's own id, which for a thread row
+                // is the thread id (== parent message id)
+                chatId: "0xparentmessageid",
+                threadId: "0xparentmessageid",
+                chatName: "🧵 a thread",
+                chatType: Constants.chatType.communityChat
+            }
+        }
+
+        // RED: "Edit Channel" is the one channel-scoped action that was not
+        // given the `!isThread` guard its siblings got. Right-clicking a thread
+        // row as a channel admin therefore offers "Edit Channel", and triggering
+        // it opens the channel-edit popup keyed on a *message* id.
+        function test_editChannelIsNotOfferedOnAThreadRow() {
+            const menu = createMenu(threadRowProps())
+
+            const editAction = actionByObjectName(menu, "editChannelMenuItem")
+            verify(!!editAction, "expected the edit-channel action to exist")
+            verify(!editAction.enabled,
+                   "Edit Channel must be hidden on a thread row, like every other "
+                   + "channel-scoped action in this menu")
+        }
+
+        // RED: the same action, triggered, proves what it would do - it hands the
+        // thread id (a message id) to the channel-edit popup.
+        function test_editChannelOnAThreadRowDoesNotLeakTheThreadId() {
+            const menu = createMenu(threadRowProps())
+
+            const editAction = actionByObjectName(menu, "editChannelMenuItem")
+            verify(!!editAction)
+            if (editAction.enabled)
+                editAction.trigger()
+
+            compare(root.editChannelCalls.length, 0,
+                    "the channel-edit popup was opened with "
+                    + JSON.stringify(root.editChannelCalls)
+                    + ", which is a message id, not a channel id")
+        }
+
+        // Guard: the actions that DID get the guard stay hidden.
+        function test_guardedActionsAreHiddenOnAThreadRow() {
+            const menu = createMenu(threadRowProps())
+
+            const guarded = ["copyChannelLinkStatusAction",
+                             "editNameAndImageMenuItem",
+                             "chatMarkAsReadMenuItem",
+                             "clearHistoryGroupMenuItem"]
+            for (const name of guarded) {
+                const action = actionByObjectName(menu, name)
+                verify(!!action, "missing action " + name)
+                verify(!action.enabled, name + " must be hidden on a thread row")
+            }
+        }
+
+        // Guard: on a normal community channel the admin can still edit it.
+        function test_editChannelStillOfferedOnARealChannel() {
+            const menu = createMenu({
+                isThread: false,
+                isCommunityChat: true,
+                amIChatAdmin: true,
+                chatId: "0xchannelid",
+                chatType: Constants.chatType.communityChat
+            })
+
+            const editAction = actionByObjectName(menu, "editChannelMenuItem")
+            verify(!!editAction)
+            verify(editAction.enabled)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ThreadsMessageContextMenu.qml
+++ b/storybook/qmlTests/tests/tst_ThreadsMessageContextMenu.qml
@@ -1,0 +1,142 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Popups
+
+import shared.views.chat
+import utils
+
+// RED tests for the threads PR stack (status-im/status-app#21351 .. #22245).
+//
+// MessageContextMenuView gained an "Open/Create Thread" action. Every other
+// action row in that menu is gated on `root.expanded`, because StatusMenu sets
+// `hideDisabledItems: true` - i.e. in that menu `enabled` doubles as `visible`.
+// The thread action omits the `root.expanded` term, so it leaks into the
+// collapsed (reaction-bar) form of the menu.
+Item {
+    id: root
+    width: 600
+    height: 400
+
+    ListModel {
+        id: emojiModel
+    }
+    property var testEmojiModel: emojiModel
+
+    Component {
+        id: menuComponent
+
+        MessageContextMenuView {
+            emojiModel: root.testEmojiModel
+            myPublicKey: "me"
+            messageSenderId: "me"
+            unparsedText: "full message"
+            messageContentType: Constants.messageContentType.messageType
+            chatType: Constants.chatType.communityChat
+            canPin: true
+        }
+    }
+
+    TestCase {
+        name: "ThreadsMessageContextMenu"
+        when: windowShown
+
+        function createMenu(props) {
+            return createTemporaryObject(menuComponent, root, props || {})
+        }
+
+        // StatusMenu { hideDisabledItems: true } => a disabled action is not
+        // rendered, so "enabled" is the visibility of the row.
+        function visibleActionTexts(menu) {
+            const texts = []
+            for (let i = 0; i < menu.count; ++i) {
+                const item = menu.itemAt(i)
+                if (!item || item instanceof StatusMenuSeparator)
+                    continue
+                if (item.enabled && item.text)
+                    texts.push(item.text)
+            }
+            return texts
+        }
+
+        function threadAction(menu) {
+            for (let i = 0; i < menu.count; ++i) {
+                const action = menu.actionAt(i)
+                if (action && action.objectName === "messageContextMenu_openThread")
+                    return action
+            }
+            return null
+        }
+
+        // RED: the collapsed menu is meant to show only the reaction row plus
+        // the compact single-row actions. Because openThreadAction is not gated
+        // on `root.expanded`, "Create Thread" is the one full-width action row
+        // that survives collapsing, so right-clicking a message renders a menu
+        // with a stray "Create Thread" entry under the reactions.
+        function test_collapsedMenuDoesNotExposeThreadAction() {
+            const menu = createMenu({
+                openExpanded: false,
+                threadsFeatureEnabled: true
+            })
+            menu.open()
+
+            compare(menu.expanded, false)
+
+            const action = threadAction(menu)
+            verify(!!action, "expected the thread action to exist")
+            verify(!action.enabled,
+                   "the thread action must be hidden while the menu is collapsed, "
+                   + "like every other action row in this menu")
+            verify(visibleActionTexts(menu).indexOf(qsTr("Create Thread")) < 0,
+                   "collapsed menu leaked the thread action: "
+                   + JSON.stringify(visibleActionTexts(menu)))
+
+            menu.close()
+        }
+
+        // Guard: expanding the menu must still surface the action.
+        function test_expandedMenuExposesThreadAction() {
+            const menu = createMenu({
+                openExpanded: true,
+                threadsFeatureEnabled: true
+            })
+            menu.open()
+
+            verify(visibleActionTexts(menu).indexOf(qsTr("Create Thread")) >= 0)
+
+            menu.close()
+        }
+
+        // Guard: with the feature flag off nothing thread-related is offered.
+        function test_threadActionHiddenWhenFeatureFlagOff() {
+            const menu = createMenu({
+                openExpanded: true,
+                threadsFeatureEnabled: false
+            })
+            menu.open()
+
+            const action = threadAction(menu)
+            verify(!!action)
+            verify(!action.enabled)
+
+            menu.close()
+        }
+
+        // Guard: unsupported chat types (public chat) must not offer threads,
+        // matching status-go's Chat.SupportsThreads().
+        function test_threadActionHiddenForUnsupportedChatType() {
+            const menu = createMenu({
+                openExpanded: true,
+                threadsFeatureEnabled: true,
+                chatType: Constants.chatType.publicChat
+            })
+            menu.open()
+
+            const action = threadAction(menu)
+            verify(!!action)
+            verify(!action.enabled)
+
+            menu.close()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -99,6 +99,7 @@ StackLayout {
 
     property bool sendViaPersonalChatEnabled
     property bool messageLinkSharingEnabled
+    property bool threadsFeatureEnabled
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
@@ -317,6 +318,7 @@ StackLayout {
                                     root.communityPermissionsStore.viewOnlyPermissionsModel.count > 0
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
             messageLinkSharingEnabled: root.messageLinkSharingEnabled
+            threadsFeatureEnabled: root.threadsFeatureEnabled
             disabledTooltipText: root.disabledTooltipText
             paymentRequestFeatureEnabled: root.paymentRequestFeatureEnabled
             extraLeftPadding: root.extraLeftPadding

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -23,6 +23,7 @@ QtObject {
     readonly property string chatColor: messageModule ? messageModule.chatColor : Theme.palette.primaryColor1
     readonly property string chatIcon: messageModule ? messageModule.chatIcon : ""
     readonly property bool keepUnread: messageModule ? messageModule.keepUnread : false
+    readonly property string threadId: messageModule ? messageModule.threadId : ""
 
     onMessageModuleChanged: {
         if(!messageModule)
@@ -231,5 +232,11 @@ QtObject {
         }
 
         return sharedUrlsModule.createMessageUrl(chatId, messageId)
+    }
+
+    function createThread(parentMessageId) {
+        if (!messageModule)
+            return
+        messageModule.createThread(parentMessageId)
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -347,8 +347,8 @@ QtObject {
         stickersModule: stickersModuleInst
     }
 
-    function sendSticker(channelId, hash, replyTo, pack, url) {
-        stickersModuleInst.send(channelId, hash, replyTo, pack, url)
+    function sendSticker(channelId, hash, replyTo, pack, url, threadId = "") {
+        stickersModuleInst.send(channelId, hash, replyTo, pack, url, threadId || "")
     }
 
     function isCurrentUser(pubkey) {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -294,7 +294,10 @@ QtObject {
                     return UrlUtils.convertUrlToLocalPath(file)
                 }
             })
-            chatContentModule.inputAreaModule.sendImages(JSON.stringify(convertedImagePaths), textMsg.trim(), replyMessageId)
+            chatContentModule.inputAreaModule.sendImages(
+                        JSON.stringify(convertedImagePaths),
+                        textMsg.trim(),
+                        replyMessageId)
             result = true
         } else {
             result = chatContentModule.inputAreaModule.sendMessage(

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -601,19 +601,22 @@ QtObject {
         }
 
         property var oneToOneContactModelEntryLoader: Loader {
-            active: d.activeChatId && d.activeChatType === Constants.chatType.oneToOne
+            active: d.activeContactId && d.activeChatType === Constants.chatType.oneToOne
 
             sourceComponent: ContactModelEntry {
-                publicKey: d.activeChatId
+                publicKey: d.activeContactId
                 contactsModel: root.contactsModel
                 onPopulateContactDetailsRequested: {
-                    root.populateContactDetailsRequested(d.activeChatId)
+                    root.populateContactDetailsRequested(d.activeContactId)
                 }
             }
         }
 
         readonly property string activeChatId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ? chatCommunitySectionModule.activeItem.id : ""
         readonly property int activeChatType: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ? chatCommunitySectionModule.activeItem.type : -1
+        readonly property bool activeIsThread: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ? chatCommunitySectionModule.activeItem.isThread : false
+        readonly property string activeContactId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ?
+                                                     (d.activeIsThread ? chatCommunitySectionModule.activeItem.parentChatId : d.activeChatId) : ""
         readonly property bool amIMember: chatCommunitySectionModule ? chatCommunitySectionModule.amIMember : false
 
         property var oneToOneChatContact: oneToOneContactModelEntryLoader.active ? d.oneToOneContactModelEntryLoader.item.contactDetails : undefined

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -516,7 +516,7 @@ Item {
                         }
                         onOpenThread: (messageId) => {
                             if (root.threadsFeatureEnabled
-                                    && root.activeChatType === Constants.chatType.communityChat
+                                    && Utils.isThreadSupportedChatType(root.activeChatType)
                                     && !d.activeMessagesStore.threadId) {
                                 d.activeMessagesStore.createThread(messageId)
                             }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -653,7 +653,8 @@ Item {
                                                    hashId,
                                                    chatInput.isReply ? chatInput.replyMessageId : "",
                                                    packId,
-                                                   url)
+                                                   url,
+                                                   d.activeMessagesStore.threadId)
                     }
 
                     onIsReplyChanged: {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -68,6 +68,7 @@ Item {
     property bool amIBanned: false
     property bool sendViaPersonalChatEnabled
     property bool messageLinkSharingEnabled
+    property bool threadsFeatureEnabled
     property string disabledTooltipText
     property bool paymentRequestFeatureEnabled
     property bool joined
@@ -490,6 +491,7 @@ Item {
                         isBlocked: model.blocked
                         sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
                         messageLinkSharingEnabled: root.messageLinkSharingEnabled
+                        threadsFeatureEnabled: root.threadsFeatureEnabled
                         disabledTooltipText: root.disabledTooltipText
                         areTestNetworksEnabled: root.areTestNetworksEnabled
                         extraLeftPadding: root.extraLeftPadding
@@ -511,6 +513,13 @@ Item {
                                         }
                         onEditMessageRequested: (messageId) => {
                             d.startEditMessage(messageId)
+                        }
+                        onOpenThread: (messageId) => {
+                            if (root.threadsFeatureEnabled
+                                    && root.activeChatType === Constants.chatType.communityChat
+                                    && !d.activeMessagesStore.threadId) {
+                                d.activeMessagesStore.createThread(messageId)
+                            }
                         }
                         onForceInputFocus: {
                             chatInput.forceInputActiveFocus()
@@ -668,7 +677,7 @@ Item {
                             return
                         }
 
-                        if (root.rootStore.sendMessage(d.activeChatContentModule.getMyChatId(),
+                        if (root.rootStore.sendMessage(root.activeChatId,
                                                     chatInput.getTextWithPublicKeys(),
                                                     chatInput.isReply? chatInput.replyMessageId : "",
                                                     chatInput.fileUrlsAndSources

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -60,6 +60,7 @@ ColumnLayout {
 
     property bool sendViaPersonalChatEnabled
     property bool messageLinkSharingEnabled
+    property bool threadsFeatureEnabled
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
@@ -68,6 +69,7 @@ ColumnLayout {
     property string myPublicKey
 
     signal showReplyArea(messageId: string)
+    signal openThread(messageId: string)
     signal forceInputFocus()
     signal editMessageRequested(messageId: string)
 
@@ -140,6 +142,7 @@ ColumnLayout {
             channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
             messageLinkSharingEnabled: root.messageLinkSharingEnabled
+            threadsFeatureEnabled: root.threadsFeatureEnabled
             disabledTooltipText: root.disabledTooltipText
             areTestNetworksEnabled: root.areTestNetworksEnabled
             extraLeftPadding: root.extraLeftPadding
@@ -155,6 +158,9 @@ ColumnLayout {
 
             onShowReplyArea: (messageId, senderId) => {
                 root.showReplyArea(messageId)
+            }
+            onOpenThread: (messageId) => {
+                root.openThread(messageId)
             }
             onOpenStickerPackPopup: stickerPackId => root.openStickerPackPopup(stickerPackId)
             onTokenPaymentRequested: root.tokenPaymentRequested(recipientAddress, tokenKey, rawAmount)

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -66,6 +66,7 @@ Item {
 
     property bool sendViaPersonalChatEnabled
     property bool messageLinkSharingEnabled
+    property bool threadsFeatureEnabled
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
@@ -78,6 +79,7 @@ Item {
     signal tokenPaymentRequested(string recipientAddress, string tokenKey, string rawAmount)
     signal showReplyArea(string messageId, string author)
     signal editModeChanged(bool editModeOn, string messageId)
+    signal openThread(string messageId)
 
     // Unfurling related requests:
     signal setNeverAskAboutUnfurlingAgain(bool neverAskAgain)
@@ -360,6 +362,7 @@ Item {
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
             messageLinkSharingEnabled: root.messageLinkSharingEnabled
             createMessageLink: (chatId, messageId) => root.messageStore.createMessageLink(chatId, messageId)
+            threadsFeatureEnabled: root.threadsFeatureEnabled
             disabledTooltipText: root.disabledTooltipText
             areTestNetworksEnabled: root.areTestNetworksEnabled
             extraLeftPadding: root.extraLeftPadding
@@ -418,6 +421,7 @@ Item {
             quotedMessageAlbumMessageImages: model.quotedMessageAlbumMessageImages.split(" ")
             quotedMessageAlbumImagesCount: model.quotedMessageAlbumImagesCount
             bridgeName: model.bridgeName
+            hasThread: model.hasThread
 
             gapFrom: model.gapFrom
             gapTo: model.gapTo
@@ -446,6 +450,7 @@ Item {
             onTokenPaymentRequested: root.tokenPaymentRequested(recipientAddress, tokenKey, rawAmount)
 
             onShowReplyArea: (messageId, author) => root.showReplyArea(messageId, author)
+            onOpenThread: (messageId) => root.openThread(messageId)
 
             stickersLoaded: root.stickersLoaded
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -110,6 +110,7 @@ Item {
 
     property bool sendViaPersonalChatEnabled
     property bool messageLinkSharingEnabled
+    property bool threadsFeatureEnabled
     property string disabledTooltipText
     property bool paymentRequestFeatureEnabled
 
@@ -496,6 +497,7 @@ Item {
             amIBanned: root.sectionItemModel ? root.sectionItemModel.amIBanned : false
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
             messageLinkSharingEnabled: root.messageLinkSharingEnabled
+            threadsFeatureEnabled: root.threadsFeatureEnabled
             disabledTooltipText: root.disabledTooltipText
             paymentRequestFeatureEnabled: root.paymentRequestFeatureEnabled
             extraLeftPadding: root.extraLeftPadding

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import StatusQ
 import StatusQ.Core
 import StatusQ.Core.Utils as SQUtils
 import StatusQ.Core.Theme
@@ -113,9 +114,27 @@ Item {
                         enabled: searchInput.visible && !!searchPhrase
                     }
                 ]
-                sorters: RoleSorter {
-                    roleName: "lastMessageTimestamp"
-                    sortOrder: Qt.DescendingOrder
+                sorters: FastExpressionSorter {
+                    expectedRoles: ["itemId", "parentChatId", "isThread", "lastMessageTimestamp", "position"]
+                    expression: {
+                        function timestampFor(item) {
+                            if (!item.isThread)
+                                return item.lastMessageTimestamp
+
+                            const parent = JSON.parse(root.chatSectionModule.getItemAsJson(item.parentChatId))
+                            return parent.lastMessageTimestamp
+                        }
+
+                        const leftTimestamp = timestampFor(modelLeft)
+                        const rightTimestamp = timestampFor(modelRight)
+                        if (leftTimestamp !== rightTimestamp)
+                            return rightTimestamp - leftTimestamp
+
+                        if (modelLeft.isThread !== modelRight.isThread)
+                            return modelLeft.isThread ? 1 : -1
+
+                        return modelLeft.position - modelRight.position
+                    }
                 }
             }
 
@@ -152,6 +171,8 @@ Item {
                     chatIcon = obj.icon
                     chatType = obj.type
                     chatMuted = obj.muted
+                    isThread = obj.isThread
+                    threadId = obj.isThread ? obj.itemId : ""
                 }
 
                 onMuteChat: (chatId, interval) => {
@@ -162,8 +183,8 @@ Item {
                     root.chatSectionModule.unmuteChat(chatId)
                 }
 
-                onMarkAllMessagesRead: (chatId) => {
-                    root.chatSectionModule.markAllMessagesRead(chatId)
+                onMarkAllMessagesRead: (chatId, threadId) => {
+                    root.chatSectionModule.markAllMessagesRead(chatId, threadId)
                 }
 
                 onClearChatHistory: (chatId) => {

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -328,6 +328,8 @@ Item {
                             chatColor = obj.color
                             chatType = obj.type
                             chatMuted = obj.muted
+                            isThread = obj.isThread
+                            threadId = obj.isThread ? obj.itemId : ""
                             channelPosition = obj.position
                             chatCategoryId = obj.categoryId
                             viewersCanPostReactions = obj.viewersCanPostReactions
@@ -347,8 +349,8 @@ Item {
                         root.communitySectionModule.unmuteChat(chatId)
                     }
 
-                    onMarkAllMessagesRead: (chatId) => {
-                        root.communitySectionModule.markAllMessagesRead(chatId)
+                    onMarkAllMessagesRead: (chatId, threadId) => {
+                        root.communitySectionModule.markAllMessagesRead(chatId, threadId)
                     }
 
                     onClearChatHistory: (chatId) => {

--- a/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
+++ b/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
@@ -15,4 +15,5 @@ QtObject {
     property bool messageLinkSharingEnabled
     property bool statusSupportBotEnabled
     property bool buyEnabled
+    property bool threadsEnabled
 }

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -248,6 +248,7 @@ Loader {
                                                    ? root.networkConnectionStore.walletReadyForTransactionsToolTipText : ""),
             messageLinkSharingEnabled:      Qt.binding(() => root.featureFlagsStore.messageLinkSharingEnabled
                                                    && root.advancedStore.copyMessageLinksEnabled),
+            threadsFeatureEnabled:          Qt.binding(() => root.featureFlagsStore.threadsEnabled),
             paymentRequestFeatureEnabled:   Qt.binding(() => root.featureFlagsStore.paymentRequestEnabled),
             extraLeftPadding:               Qt.binding(() => root.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0),
             isPortraitMode:                 Qt.binding(() => root.isPortraitMode),

--- a/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
@@ -318,6 +318,7 @@ Loader {
             advancedStore:                  Qt.binding(() => root.advancedStore),
             messageLinkSharingEnabled:      Qt.binding(() => root.featureFlagsStore.messageLinkSharingEnabled
                                                      && root.advancedStore.copyMessageLinksEnabled),
+            threadsFeatureEnabled:          Qt.binding(() => root.featureFlagsStore.threadsEnabled),
             paymentRequestFeatureEnabled:   Qt.binding(() => root.featureFlagsStore.paymentRequestEnabled),
             extraLeftPadding:               Qt.binding(() => root.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0),
             mutualContactsModel:            Qt.binding(() => root.contactsAdaptor.mutualContacts),

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -11209,6 +11209,14 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Open Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -11279,6 +11279,14 @@ selhalo</translation>
         <translation type="unfinished">Odpovědět</translation>
     </message>
     <message>
+        <source>Open Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -11222,6 +11222,14 @@ al cargar</translation>
         <translation type="unfinished">Responder</translation>
     </message>
     <message>
+        <source>Open Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -11223,6 +11223,14 @@ chargement</translation>
         <translation type="unfinished">Répondre</translation>
     </message>
     <message>
+        <source>Open Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Edit</source>
         <translation type="unfinished">Modifier</translation>
     </message>
@@ -16851,11 +16859,11 @@ avec un retour à la ligne</translation>
     </message>
     <message>
         <source>Fastest</source>
-        <translation type="unfinished"></translation>
+        <translation>Le plus rapide</translation>
     </message>
     <message>
         <source>Lowest fee</source>
-        <translation type="unfinished"></translation>
+        <translation>Frais le plus bas</translation>
     </message>
     <message>
         <source>Swap + Bridge</source>
@@ -16872,11 +16880,11 @@ avec un retour à la ligne</translation>
     <message>
         <source>%1s</source>
         <comment>short for seconds</comment>
-        <translation type="unfinished">%1&#xa0;s</translation>
+        <translation>%1&#xa0;s</translation>
     </message>
     <message>
         <source>Choose route</source>
-        <translation type="unfinished"></translation>
+        <translation>Choisir la route</translation>
     </message>
     <message>
         <source>by %1</source>
@@ -16989,7 +16997,7 @@ avec un retour à la ligne</translation>
     </message>
     <message>
         <source>Fastest</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Le plus rapide</translation>
     </message>
     <message>
         <source>Shortest execution time</source>
@@ -16997,7 +17005,7 @@ avec un retour à la ligne</translation>
     </message>
     <message>
         <source>Lowest fee</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Frais le plus bas</translation>
     </message>
     <message>
         <source>Lowest network cost</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -11166,6 +11166,14 @@ to load</source>
         <translation type="unfinished">답장</translation>
     </message>
     <message>
+        <source>Open Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Edit</source>
         <translation type="unfinished">편집</translation>
     </message>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -11286,6 +11286,14 @@ to load</source>
         <translation type="unfinished">Відповісти</translation>
     </message>
     <message>
+        <source>Open Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -17,6 +17,7 @@ StatusMenu {
     property bool isCommunityChat: false
     property bool amIChatAdmin: false
     property string chatId: ""
+    property string threadId: ""
     property string chatName: ""
     property string chatDescription: ""
     property string chatEmoji: ""
@@ -30,12 +31,13 @@ StatusMenu {
     property bool showDebugOptions: false
     property alias deleteChatConfirmationDialog: deleteChatConfirmationDialogComponent
     property bool hideIfPermissionsNotMet: false
+    property bool isThread: false
 
     signal displayProfilePopup(string publicKey)
     signal displayEditChannelPopup(string chatId)
     signal unmuteChat(string chatId)
     signal muteChat(string chatId, int interval)
-    signal markAllMessagesRead(string chatId)
+    signal markAllMessagesRead(string chatId, string threadId)
     signal clearChatHistory(string chatId)
     signal deleteCommunityChat(string chatId)
     signal leaveChat(string chatId)
@@ -46,7 +48,7 @@ StatusMenu {
     width: root.amIChatAdmin && (root.chatType === Constants.chatType.privateGroupChat) ? 207 : implicitWidth
 
     ViewProfileMenuItem {
-        enabled: root.chatType === Constants.chatType.oneToOne
+        enabled: !root.isThread && root.chatType === Constants.chatType.oneToOne
         onTriggered: root.displayProfilePopup(root.chatId)
     }
 
@@ -54,7 +56,7 @@ StatusMenu {
         objectName: "addRemoveFromGroupStatusAction"
         text: root.amIChatAdmin ? qsTr("Add / remove from group") : qsTr("Add to group")
         icon.name: "add-to-dm"
-        enabled: (root.chatType === Constants.chatType.privateGroupChat)
+        enabled: !root.isThread && root.chatType === Constants.chatType.privateGroupChat
         onTriggered: { root.addRemoveGroupMember() }
     }
 
@@ -62,7 +64,7 @@ StatusMenu {
         objectName: "copyChannelLinkStatusAction"
         text: qsTr("Copy channel link")
         icon.name: "copy"
-        enabled: root.isCommunityChat
+        enabled: !root.isThread && root.isCommunityChat
         onTriggered: {
             const link = Utils.getCommunityChannelShareLinkWithChatId(root.chatId)
             ClipboardUtils.setText(link)
@@ -70,14 +72,14 @@ StatusMenu {
     }
 
     StatusMenuSeparator {
-        visible: root.chatType === Constants.chatType.oneToOne || root.chatType === Constants.chatType.privateGroupChat || root.isCommunityChat
+        visible: !root.isThread && (root.chatType === Constants.chatType.oneToOne || root.chatType === Constants.chatType.privateGroupChat || root.isCommunityChat)
     }
 
     StatusAction {
         objectName: "editNameAndImageMenuItem"
         text: qsTr("Edit name and image")
         icon.name: "edit_pencil"
-        enabled: root.chatType === Constants.chatType.privateGroupChat
+        enabled: !root.isThread && root.chatType === Constants.chatType.privateGroupChat
         onTriggered: {
             Global.openPopup(renameGroupPopupComponent, {
                 activeGroupName: root.chatName,
@@ -99,7 +101,7 @@ StatusMenu {
     }
 
     MuteChatMenuItem {
-        enabled: !root.chatMuted
+        enabled: !root.isThread && !root.chatMuted
         isCommunityChat: root.isCommunityChat
 
         onMuteTriggered: {
@@ -109,7 +111,7 @@ StatusMenu {
 
     StatusAction {
         objectName: "muteChatStatusAction"
-        enabled: root.chatMuted
+        enabled: !root.isThread && root.chatMuted
         text: root.isCommunityChat ? qsTr("Unmute Channel") : qsTr("Unmute Chat")
         icon.name: "notification"
         onTriggered: {
@@ -121,8 +123,9 @@ StatusMenu {
         objectName: "chatMarkAsReadMenuItem"
         text: qsTr("Mark as Read")
         icon.name: "checkmark-circle"
+        enabled: !root.isThread
         onTriggered: {
-            root.markAllMessagesRead(root.chatId)
+            root.markAllMessagesRead(root.chatId, root.threadId)
         }
     }
 
@@ -138,7 +141,7 @@ StatusMenu {
 
     StatusMenu {
         title: qsTr("Debug actions")
-        enabled: root.showDebugOptions
+        enabled: root.showDebugOptions && !root.isThread
 
         StatusAction {
             text: root.isCommunityChat ? qsTr("Copy channel ID") : qsTr("Copy chat ID")
@@ -154,7 +157,7 @@ StatusMenu {
     StatusAction {
         id: clearHistoryGroupMenuItem
         objectName: "clearHistoryGroupMenuItem"
-        enabled: (root.chatType !== Constants.chatType.oneToOne)
+        enabled: !root.isThread && (root.chatType !== Constants.chatType.oneToOne)
         text: qsTr("Clear History")
         icon.name: "delete"
         type: StatusAction.Type.Danger
@@ -189,13 +192,13 @@ StatusMenu {
             }
         }
 
-        enabled: !root.isCommunityChat || root.amIChatAdmin
+        enabled: !root.isThread && (!root.isCommunityChat || root.amIChatAdmin)
     }
 
     StatusAction {
         id: clearHistoryMenuItem
         objectName: "clearHistoryMenuItem"
-        enabled: (root.chatType === Constants.chatType.oneToOne)
+        enabled: !root.isThread && (root.chatType === Constants.chatType.oneToOne)
         text: qsTr("Clear History")
         icon.name: "delete"
         type: StatusAction.Type.Danger

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -342,7 +342,7 @@ StatusMenu {
         onTriggered: root.openThread()
         enabled: !root.disabledForChat &&
                 root.threadsFeatureEnabled &&
-                root.chatType === Constants.chatType.communityChat
+                Utils.isThreadSupportedChatType(root.chatType)
     }
 
     MsgCtxAction {

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -30,6 +30,8 @@ StatusMenu {
     property string selectedText
 
     property bool pinMessageAllowedForMembers: false
+    property bool threadsFeatureEnabled: false
+    property bool hasThread: false
     property bool editRestricted: false
     property bool pinnedMessage: false
     property bool canPin: false
@@ -47,6 +49,7 @@ StatusMenu {
     signal unpinMessage()
     signal pinnedMessagesLimitReached()
     signal showReplyArea(string messageSenderId)
+    signal openThread()
     signal toggleReaction(string hexcode)
     signal deleteMessage()
     signal editClicked()
@@ -329,6 +332,17 @@ StatusMenu {
         icon.name: "reply"
         onTriggered: root.showReplyArea(root.messageSenderId)
         enabled: root.expanded && !root.disabledForChat
+    }
+
+    MsgCtxAction {
+        id: openThreadAction
+        objectName: "messageContextMenu_openThread"
+        text: root.hasThread ? qsTr("Open Thread") : qsTr("Create Thread")
+        icon.name: "chat"
+        onTriggered: root.openThread()
+        enabled: !root.disabledForChat &&
+                root.threadsFeatureEnabled &&
+                root.chatType === Constants.chatType.communityChat
     }
 
     MsgCtxAction {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -149,6 +149,8 @@ Loader {
 
     property bool sendViaPersonalChatEnabled
     property bool messageLinkSharingEnabled
+    property bool threadsFeatureEnabled
+    property bool hasThread: false
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
@@ -281,6 +283,8 @@ Loader {
             myPublicKey: userProfile.pubKey,
             amIChatAdmin: root.amIChatAdmin,
             pinMessageAllowedForMembers: messageStore.isPinMessageAllowedForMembers,
+            threadsFeatureEnabled: root.threadsFeatureEnabled,
+            hasThread: root.hasThread,
             chatType: messageStore.chatType,
 
             messageId: root.messageId,
@@ -358,6 +362,7 @@ Loader {
     }
 
     signal showReplyArea(string messageId, string author)
+    signal openThread(string messageId)
 
 
     function startMessageFoundAnimation() {
@@ -1280,6 +1285,9 @@ Loader {
             onEditClicked: root.messageStore.setEditModeOn(messageContextMenuView.messageId)
             onShowReplyArea: (senderId) => {
                 root.showReplyArea(messageContextMenuView.messageId, senderId)
+            }
+            onOpenThread: {
+                root.openThread(messageContextMenuView.messageId)
             }
             onCopyToClipboard: (text) => {
                 ClipboardUtils.setText(text)

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -1337,6 +1337,12 @@ QtObject {
         return getCommunityChannelShareLink(communityId, channelId)
     }
 
+    function isThreadSupportedChatType(chatType) {
+        return chatType === Constants.chatType.communityChat ||
+                chatType === Constants.chatType.oneToOne ||
+                chatType === Constants.chatType.privateGroupChat
+    }
+
     function getCommunityDataFromSharedLink(link: string) {
         const communityDataString = sharedUrlsModuleInst.parseCommunitySharedUrl(link)
         try {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -55,6 +55,7 @@ Window {
         messageLinkSharingEnabled: featureFlags ? featureFlags.messageLinkSharingEnabled : false
         statusSupportBotEnabled: featureFlags ? featureFlags.statusSupportBotEnabled : false
         buyEnabled: featureFlags ? featureFlags.buyEnabled : false
+        threadsEnabled: featureFlags ? featureFlags.threadsEnabled : false
     }
 
     readonly property UtilsStore utilsStore: UtilsStore {}


### PR DESCRIPTION
Failing tests pinning three context-menu defects found while reviewing the threads stack (#21351 → #22245). **Not for merge as-is** — these are red by design; they go green when the defects are fixed.

Based on the stack tip (`feat/threads-load-threads-on-section-load`), so the diff here is only the two new test files.

## What fails today

```
ThreadsMessageContextMenu:  5 passed, 1 failed
  FAIL  test_collapsedMenuDoesNotExposeThreadAction

ThreadsChatContextMenu:     4 passed, 2 failed
  FAIL  test_editChannelIsNotOfferedOnAThreadRow
  FAIL  test_editChannelOnAThreadRowDoesNotLeakTheThreadId
```

| test | defect | PR |
|---|---|---|
| `test_collapsedMenuDoesNotExposeThreadAction` | `openThreadAction` (`MessageContextMenuView.qml:343`) omits the `root.expanded` term every sibling action carries. `StatusMenu.hideDisabledItems` makes `enabled` the row's visibility, so "Create Thread" is the one full-width row that survives the collapsed (reaction-bar) menu — laid out inside a menu whose width was computed for icons only. | #21351, live at #22244 |
| `test_editChannelIsNotOfferedOnAThreadRow` | `editChannelMenuItem` (`ChatContextMenuView.qml:136`) is the only channel-scoped action that did not get the `!root.isThread` guard its 10 siblings got. Because disabled items are hidden, it is the *only* visible entry when a channel admin right-clicks a thread row. | #22095 |
| `test_editChannelOnAThreadRowDoesNotLeakTheThreadId` | Triggering it hands `displayEditChannelPopup` the thread id — which is the parent **message** id, not a channel id. | #22095 |

The other nine cases are green guards for the intended behaviour (feature flag off, unsupported chat type, the correctly-guarded siblings, a real channel), so a fix can be validated without regressing them.

## Run

```
cmake -DCMAKE_BUILD_TYPE=Debug -DSTATUSQ_SHADOW_BUILD=OFF \
      -DCMAKE_PREFIX_PATH=<Qt6.11.0>/macos \
      -B storybook/build/Qt6.11.0 -S storybook -Wno-dev
cmake --build storybook/build/Qt6.11.0 --target QmlTests -j8
storybook/build/Qt6.11.0/bin/QmlTests -platform offscreen \
  -input storybook/qmlTests/tests/tst_ThreadsMessageContextMenu.qml
storybook/build/Qt6.11.0/bin/QmlTests -platform offscreen \
  -input storybook/qmlTests/tests/tst_ThreadsChatContextMenu.qml
```

## Not covered here

Several findings in the review could not be red-tested from storybook and are described in the per-PR review comments instead:

- The chat **header** ⋯ menu acting on the parent channel inside a thread (the highest-consequence defect in the stack) — `ChatHeaderContentView` needs a live `chatContentModule` context property and no storybook stub exists.
- The `ContactsColumnView` sorter throwing on a missing parent row — the sorter is inline in a view needing `RootStore` + `Global` + a `chatSectionModule` context property.
- Everything Nim-side (thread unread badges, mark-as-read routing, thread-message routing, the wedged loading sets) — `test/nim/` is Linux-only in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fn7ehMWUZJ3YKSajsab5M
