### PR TITLE
fix(AppMain): close AC when navigating to Settings

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1079,6 +1079,7 @@ Item {
         }
 
         function openSettingsRoot() {
+            mainLayoutItem.openACCenterPanel = false
             profileLoader.settingsSubSubsection = -1
             profileLoader.settingsSubsection = appMain.isPortraitMode ? -1 : Constants.settingsSubsection.profile
             appMain.rootStore.setActiveSectionBySectionType(Constants.appSection.profile)
@@ -1379,8 +1380,7 @@ Item {
         }
 
         function onCloseActivityCenterRequested() {
-            if (mainLayoutItem.isPortraitMode)
-                mainLayoutItem.openACCenterPanel = false
+            mainLayoutItem.openACCenterPanel = false
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Fixes #22249

### Affected areas

AppMain

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/b60d30e5-dabb-4575-99bb-13242d03077d

### Impact on end user

UX

### How to test

- have AC open
- Sidebar -> Profile button -> Settings
- AC should close

### Risk 

low
