### PR TITLE
Keycard: entering pin/puk layout improved on mobile

### DIFF
--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -9539,10 +9539,6 @@ Are you sure you want to do this?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>I don&apos;t have or don&apos;t know PIN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Factory reset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9556,6 +9552,10 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>Import a key pair from recovery phrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No PIN? Skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -9594,10 +9594,6 @@ Opravdu to chcete udělat?</translation>
         <translation type="unfinished">Hotovo</translation>
     </message>
     <message>
-        <source>I don&apos;t have or don&apos;t know PIN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Factory reset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9611,6 +9607,10 @@ Opravdu to chcete udělat?</translation>
     </message>
     <message>
         <source>Import a key pair from recovery phrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No PIN? Skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -9551,10 +9551,6 @@ Are you sure you want to do this?</source>
         <translation type="unfinished">Listo</translation>
     </message>
     <message>
-        <source>I don&apos;t have or don&apos;t know PIN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Factory reset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9568,6 +9564,10 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>Import a key pair from recovery phrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No PIN? Skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -9548,10 +9548,6 @@ Are you sure you want to do this?</source>
         <translation>Terminé</translation>
     </message>
     <message>
-        <source>I don&apos;t have or don&apos;t know PIN</source>
-        <translation>Je n&apos;ai pas ou je ne connais pas le code PIN</translation>
-    </message>
-    <message>
         <source>Factory reset</source>
         <translation>Réinitialisation d&apos;usine</translation>
     </message>
@@ -9566,6 +9562,10 @@ Are you sure you want to do this?</source>
     <message>
         <source>Import a key pair from recovery phrase</source>
         <translation>Importer une paire de clés à partir d&apos;une phrase de récupération</translation>
+    </message>
+    <message>
+        <source>No PIN? Skip</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Factory reset this Keycard</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -9509,10 +9509,6 @@ Are you sure you want to do this?</source>
         <translation type="unfinished">완료</translation>
     </message>
     <message>
-        <source>I don&apos;t have or don&apos;t know PIN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Factory reset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9526,6 +9522,10 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>Import a key pair from recovery phrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No PIN? Skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -9596,10 +9596,6 @@ Are you sure you want to do this?</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <source>I don&apos;t have or don&apos;t know PIN</source>
-        <translation>У мене немає PIN або я його не знаю</translation>
-    </message>
-    <message>
         <source>Factory reset</source>
         <translation>Заводське скидання</translation>
     </message>
@@ -9614,6 +9610,10 @@ Are you sure you want to do this?</source>
     <message>
         <source>Import a key pair from recovery phrase</source>
         <translation>Імпортувати пару ключів із фрази відновлення</translation>
+    </message>
+    <message>
+        <source>No PIN? Skip</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Factory reset this Keycard</source>

--- a/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
+++ b/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
@@ -1180,7 +1180,7 @@ StatusDialog {
                          && contentLoader.status === Loader.Ready
                          && contentLoader.sourceComponent === enterPinComponent
                 enabled: !d.processing
-                text: qsTr("I don't have or don't know PIN")
+                text: qsTr("No PIN? Skip")
                 onClicked: d.startKeycardReading("")
             }
 

--- a/ui/imports/shared/popups/keycard_new/states/EnterPinState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/EnterPinState.qml
@@ -62,7 +62,11 @@ Control {
 
         Image {
             Layout.alignment: Qt.AlignHCenter
+            // Shrink the image when vertical space is tight
+            Layout.fillHeight: true
+            Layout.minimumHeight: 0
             Layout.preferredHeight: Constants.keycard.shared.imageHeight
+            Layout.maximumHeight: Constants.keycard.shared.imageHeight
             Layout.preferredWidth: Constants.keycard.shared.imageWidth
             source: (root.mode === EnterPinState.Mode.EnterPin && root.wrongPin)
                     || (root.mode === EnterPinState.Mode.RepeatPin && root.pinMismatch)

--- a/ui/imports/shared/popups/keycard_new/states/EnterPukState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/EnterPukState.qml
@@ -61,7 +61,11 @@ Control {
 
         Image {
             Layout.alignment: Qt.AlignHCenter
+            // Shrink the image when vertical space is tight
+            Layout.fillHeight: true
+            Layout.minimumHeight: 0
             Layout.preferredHeight: Constants.keycard.shared.imageHeight
+            Layout.maximumHeight: Constants.keycard.shared.imageHeight
             Layout.preferredWidth: Constants.keycard.shared.imageWidth
             source: root.mode === EnterPukState.Mode.EnterPuk
                     || root.mode === EnterPukState.Mode.RepeatPuk && root.pukMismatch


### PR DESCRIPTION
Closes: #22120

### What does the PR do

1. Fixes PIN/PUK input dialog similarly as it's already done for password auth popup.
2. Minor wording fix to make button text shorter

### Affected areas
`EnterPinState`, `EnterPukState`

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/c94f0563-0123-4dab-bdf3-1a6c7e99c201


### Impact on end user

Medium

### How to test

Open Settings -> Keycard -> Read Keycard on Android to trigger the popup

### Risk 
Low
<!-- Described potential risks and worst case scenarios. -->
