### PR TITLE
fix: image crop upload

### DIFF
--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -30,6 +30,11 @@ public:
     // iOS: no-op (Show in folder is hidden).
     Q_INVOKABLE void showInFolder(const QString &path) const;
 
+    // Returns an upright copy of the image, carrying no EXIF orientation tag, so that crop
+    // coordinates produced by Qt (which applies the tag) address the same pixels the backend
+    // decodes (which does not). Images with no rotation tag are returned untouched.
+    Q_INVOKABLE QUrl normalizeImageOrientation(const QUrl& imageUrl) const;
+
     Q_INVOKABLE void downloadImageByUrl(const QUrl& url, const QString& path);
     Q_INVOKABLE void synthetizeRightClick(QQuickItem* item, qreal x, qreal y, Qt::KeyboardModifiers modifiers) const;
     Q_INVOKABLE Qt::KeyboardModifiers queryKeyboardModifiers();

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -2,7 +2,10 @@
 
 #include <QDesktopServices>
 #include <QGuiApplication>
+#include <QImage>
+#include <QImageReader>
 #include <QUrl>
+#include <QUuid>
 #include <QMimeDatabase>
 #include <QDir>
 #include <QFile>
@@ -184,6 +187,42 @@ bool SystemUtilsInternal::ensureDirectory(const QString &path) const
     if (dir.exists())
         return true;
     return dir.mkpath(QStringLiteral("."));
+}
+
+QUrl SystemUtilsInternal::normalizeImageOrientation(const QUrl& imageUrl) const
+{
+    if (!imageUrl.isValid() || !imageUrl.isLocalFile())
+        return imageUrl;
+
+    const QString sourcePath = imageUrl.toLocalFile();
+
+    QImageReader reader(sourcePath);
+    reader.setAutoTransform(true);
+
+    // Only JPEG (and TIFF) handlers report a transformation; PNG's eXIf chunk is deliberately
+    // not honoured by Qt, so normalizing PNGs here would introduce the very mismatch we remove.
+    if (reader.transformation() == QImageIOHandler::TransformationNone)
+        return imageUrl;
+
+    const QImage upright = reader.read();
+    if (upright.isNull()) {
+        qWarning() << "SystemUtilsInternal::normalizeImageOrientation: cannot read"
+                   << sourcePath << reader.errorString();
+        return imageUrl;
+    }
+
+    const auto targetPath =
+            QDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation))
+            .filePath(QStringLiteral("statusq_oriented_%1.jpg").arg(
+                          QUuid::createUuid().toString(QUuid::WithoutBraces)));
+
+    if (!upright.save(targetPath, "JPEG", 92)) {
+        qWarning() << "SystemUtilsInternal::normalizeImageOrientation: cannot write"
+                   << targetPath;
+        return imageUrl;
+    }
+
+    return QUrl::fromLocalFile(targetPath);
 }
 
 void SystemUtilsInternal::showInFolder(const QString &path) const

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -1,5 +1,6 @@
 #include "StatusQ/systemutilsinternal.h"
 
+#include <QDateTime>
 #include <QDesktopServices>
 #include <QGuiApplication>
 #include <QImage>
@@ -189,6 +190,28 @@ bool SystemUtilsInternal::ensureDirectory(const QString &path) const
     return dir.mkpath(QStringLiteral("."));
 }
 
+namespace {
+
+constexpr auto normalizedImagePrefix = "statusq_oriented_"_L1;
+
+// A normalized copy outlives the crop dialog - the backend only reads the path once the user
+// saves - so nothing here can know when one is done. Drop leftovers from previous runs instead,
+// sparing recent ones in case a second instance is still holding them.
+void sweepStaleNormalizedImages()
+{
+    const QDir tempDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
+    const auto cutoff = QDateTime::currentDateTime().addDays(-1);
+
+    const auto candidates = tempDir.entryInfoList({QString(normalizedImagePrefix) + u"*.jpg"_s},
+                                                  QDir::Files);
+    for (const auto& candidate : candidates) {
+        if (candidate.lastModified() < cutoff)
+            QFile::remove(candidate.absoluteFilePath());
+    }
+}
+
+} // namespace
+
 QUrl SystemUtilsInternal::normalizeImageOrientation(const QUrl& imageUrl) const
 {
     if (!imageUrl.isValid() || !imageUrl.isLocalFile())
@@ -211,10 +234,13 @@ QUrl SystemUtilsInternal::normalizeImageOrientation(const QUrl& imageUrl) const
         return imageUrl;
     }
 
+    static std::once_flag sweepOnce;
+    std::call_once(sweepOnce, sweepStaleNormalizedImages);
+
     const auto targetPath =
             QDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation))
-            .filePath(QStringLiteral("statusq_oriented_%1.jpg").arg(
-                          QUuid::createUuid().toString(QUuid::WithoutBraces)));
+            .filePath(QString(normalizedImagePrefix)
+                      + QUuid::createUuid().toString(QUuid::WithoutBraces) + u".jpg"_s);
 
     if (!upright.save(targetPath, "JPEG", 92)) {
         qWarning() << "SystemUtilsInternal::normalizeImageOrientation: cannot write"

--- a/ui/imports/shared/popups/ImageCropWorkflow.qml
+++ b/ui/imports/shared/popups/ImageCropWorkflow.qml
@@ -32,16 +32,26 @@ Item {
     }
 
     function cropImage(imageUrl) {
-        imageCropper.source = imageUrl
+        d.pickedImageUrl = imageUrl
+        // The cropper applies the EXIF orientation tag, the backend that consumes cropRect does
+        // not. Crop an already-upright, untagged copy so both agree on the coordinate space.
+        imageCropper.source = SystemUtils.normalizeImageOrientation(imageUrl)
         imageCropperModal.open()
+    }
+
+    QtObject {
+        id: d
+
+        // Where the image was picked from, as opposed to the normalized copy in the temp dir
+        property url pickedImageUrl
     }
 
     StatusFileDialog {
         id: fileDialog
 
         title: root.imageFileDialogTitle
-        currentFolder: imageCropper.source.toString() !== "" ? imageCropper.source.toString().substr(0, imageCropper.source.toString().lastIndexOf("/"))
-                                                             : fileDialog.picturesShortcut
+        currentFolder: d.pickedImageUrl.toString() !== "" ? d.pickedImageUrl.toString().substr(0, d.pickedImageUrl.toString().lastIndexOf("/"))
+                                                          : fileDialog.picturesShortcut
         usePhotoLibrary: true
         nameFilters: [qsTr("Supported image formats (%1)").arg(UrlUtils.validImageNameFilters)]
         onAccepted: {


### PR DESCRIPTION

### What does the PR do

Closes https://github.com/status-im/status-app/issues/20852

Qt applies a JPEG's EXIF orientation tag when it loads the image; status-go does not — `internal/images/decode.go` uses stdlib `jpeg.Decode`, which ignores the tag entirely (there is no EXIF handling anywhere in status-go). For a rotated photo the two therefore disagree on the coordinate space: the cropper shows the image upright and produces a `cropRect` against the transposed dimensions, while status-go crops the raw, unrotated pixels. `images.Crop` then either fails with `crop dimensions out of bounds of image` or cuts the wrong region — which is the disappearing profile picture in #20852.

This normalizes the picked image to an upright, untagged copy before it reaches the cropper, so both sides address the same pixels.

Notes:

- Images that carry no rotation tag are passed through untouched. There is nothing to reconcile for them, and re-encoding would only cost quality. This is orientation normalization, not blanket EXIF stripping — orientation is the only tag that affects crop coordinates.
- PNG is deliberately not normalized: Qt does not honour PNG's `eXIf` chunk, so touching PNGs would introduce the very mismatch this removes.
- The normalized copy is what gets uploaded, and the backend only reads that path once the user hits Save (for token artwork, after the whole signing flow), so nothing on the QML side can know when a copy is done being used. Rather than risk deleting a file that is still needed, leftovers from previous runs are swept from the temp dir on first use, sparing anything less than a day old in case a second instance is still holding it.

### Follow-ups (not in this PR)

- iOS: `statusqWriteImageToTemporaryFile` in `ui/StatusQ/src/ios_utils.mm` encodes with `UIImageJPEGRepresentation`, which preserves `imageOrientation` as an EXIF tag instead of rotating pixels, and only images above 4096px go through `UIGraphicsImageRenderer` (a 4032x3024 iPhone photo does not). Baking the orientation there when `imageOrientation != UIImageOrientationUp` would make this normalization a no-op on the iOS photo-library path and remove a second lossy encode. Thanks @friofry.
- Doing orientation handling in status-go instead would fix it once for all clients, but it needs a new Go EXIF dependency and changes decode semantics — not something to land on a release branch. Worth its own issue. Per @caybro.

### Affected areas

profile picture, community images

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Profile pictures and community images picked from a phone camera (EXIF-rotated JPEGs) no longer disappear when saved.
