### PR TITLE
SignTransactionsPopup: migrate to StatusAdaptiveDialog

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/SignTransactionsPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/SignTransactionsPopup.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQml.Models
 
-import StatusQ.Core.Theme
 import StatusQ.Controls
 import StatusQ.Popups.Dialog
 
@@ -10,19 +9,19 @@ import utils
 import AppLayouts.Communities.controls
 import AppLayouts.Communities.panels
 
-StatusDialog {
+StatusAdaptiveDialog {
     id: root
 
-    // expected roles:
+    // expected model roles:
     //
     // title (string)
     // feeText (string)
     // error (bool), optional
-    property alias model: feesPanel.model
+    property var model
 
-    property alias errorText: footer.errorText
-    property alias totalFeeText: footer.totalFeeText
-    property alias accountName: footer.accountName
+    property string errorText
+    property string totalFeeText
+    property string accountName
 
     property string keyUid: ""
     property bool migratedToColdWallet: false
@@ -30,45 +29,38 @@ StatusDialog {
     signal signTransactionClicked()
     signal cancelClicked()
 
-    QtObject {
-        id: d
+    maximumWidthOverride: 600 // by design
 
-        property int minTextWidth: 50
-    }
-
-    implicitWidth: 600 // by design
-
-    contentItem: FeesPanel {
-        id: feesPanel
-
+    contentComponent: FeesPanel {
         highlightFees: false
 
+        model: root.model
+
         footer: FeesSummaryFooter {
-            id: footer
+            errorText: root.errorText
+            totalFeeText: root.totalFeeText
+            accountName: root.accountName
         }
     }
 
-    footer: StatusDialogFooter {
-        spacing: Theme.padding
-        rightButtons: ObjectModel {
-            StatusButton {
-                objectName: "cancelButton"
-                text: qsTr("Cancel")
-                type: StatusBaseButton.Type.Danger
-                onClicked: {
-                    root.cancelClicked()
-                    root.close()
-                }
+    footerRightButtons: ObjectModel {
+        StatusButton {
+            objectName: "cancelButton"
+            text: qsTr("Cancel")
+            type: StatusBaseButton.Type.Danger
+            onClicked: {
+                root.cancelClicked()
+                root.close()
             }
-            StatusButton {
-                objectName: "signTransactionButton"
-                enabled: root.errorText === "" && !root.isFeeLoading
-                icon.name: Utils.resolveAuthSignIcon(root.keyUid, root.migratedToColdWallet, Constants.AuthSignPurpose.General)
-                text: qsTr("Sign transaction")
-                onClicked: {
-                    root.signTransactionClicked()
-                    root.close()
-                }
+        }
+        StatusButton {
+            objectName: "signTransactionButton"
+            enabled: root.errorText === ""
+            icon.name: Utils.resolveAuthSignIcon(root.keyUid, root.migratedToColdWallet, Constants.AuthSignPurpose.General)
+            text: qsTr("Sign transaction")
+            onClicked: {
+                root.signTransactionClicked()
+                root.close()
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

Refactors `SignTransactionsPopup` to be derived from `StatusAdaptiveDialog`. It solves problem of "jumpy" height. At startup it was presented as a full screen and adjusted after a while to proper size. Now the size is correct from the very beginning.

Closes: #20797

### Affected areas
`SignTransactionsPopup`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/88648c39-7181-4187-bccb-72801de10b17" />

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Low, only visual

### How to test

1. Go to settings of owned community on mobile (needs to be created on desktop)
2. Airdrops -> New Airdrop
3. Fill the form
4. Click "Create airdrop"

### Risk 

Low
