### PR TITLE
MessageView: prevent closing vkbd on ctx menu opened

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -296,7 +296,9 @@ Loader {
             closeOnPressOutsideRestoreDelay: deferCloseOnPressOutside && delegate?.isMobile ? 1000 : 350,
             // A hover menu must not grab focus, otherwise opening it steals focus from a
             // message whose text is selected and clears that selection just on hover.
-            focus: !closeOnHoverExit
+            // A menu must also not grab focus while the virtual keyboard is open, otherwise
+            // opening it steals focus from the chat input and dismisses the keyboard.
+            focus: !closeOnHoverExit && !d.virtualKeyboardVisible
         }
 
         // Only steal focus (to keep the virtual keyboard closed) for explicitly-invoked
@@ -582,13 +584,19 @@ Loader {
             return (bridgeName === "discord") ? "Discord" : bridgeName
         }
 
+        // Qt.inputMethod.visible is not reliable in some cases, so the android/ios keyboard
+        // visibility is tracked explicitly as a workaround.
+        readonly property bool virtualKeyboardVisible: SystemUtils.androidKeyboardVisible
+                                                       || SystemUtils.iosKeyboardVisible
+                                                       || Qt.inputMethod.visible
+
         // Qt's Popup/Menu stashes the activeFocusItem on open and restores it on close via
         // an internal forceActiveFocus call. It causes that text edit gains focus and opens
         // virtual keyboard even if it was closed before opening popup/menu. To prevent that
         // behavior, if virtual keyboard is not visible focus is changed to message itself.
         // On close focus is restored to message component, without invoking vkbd.
         function preventVirtualKeyboardOpening() {
-            if (!SystemUtils.androidKeyboardVisible && !SystemUtils.iosKeyboardVisible && !Qt.inputMethod.visible) {
+            if (!d.virtualKeyboardVisible) {
                 root.forceActiveFocus()
             }
         }


### PR DESCRIPTION
### What does the PR do

Opening context menu for a message in chat view doesn't close the virtual keyboard which is much handier than the opposite behavior so far.

Closes: #22094

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`MessageView`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/6c2c64f8-f118-4206-9568-59750d6e479a


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Beter UX

### How to test

Go to chat, open virtual keyboard, long press on sent message to trigger context menu.

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

### Risk 
Low
