### PR TITLE
fix(chat): close context menu on swipe in portrait mode

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
 
-import StatusQ 0.1
+import StatusQ
 import StatusQ.Core.Theme
 
 /*!

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -10,7 +10,6 @@ import StatusQ.Controls
 
 import utils
 import shared
-import shared.stores as SharedStores
 import shared.popups
 import shared.status
 import shared.controls

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -12,7 +12,6 @@ import StatusQ.Popups.Dialog
 
 import utils
 import shared
-import shared.stores as SharedStores
 import shared.views
 import shared.panels
 import shared.popups
@@ -21,7 +20,6 @@ import shared.controls
 import shared.views.chat
 
 import AppLayouts.Chat.stores
-import AppLayouts.stores as AppLayoutStores
 
 import "../controls"
 import "../panels"

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -615,6 +615,31 @@ Loader {
                 d.contextMenu?.close() // will run destruction/cleanup
             }
         }
+
+        // In portrait mode, StatusSectionLayout doesn't unload the left/center/right panels when
+        // swiping between them: it slides all three horizontally inside a shared SwipeView, so
+        // chatLogView (and this delegate) stay alive and "visible" throughout, only their actual
+        // screen position moves. This walks the ancestor chain summing up every "x", to detect
+        // that slide reactively (and only that slide: normal vertical list scrolling only ever
+        // touches "y"). This lets the menu close itself without any app-wide signal.
+        //
+        // Note: this can NOT be written as root.chatLogView.mapToItem(null, 0, 0).x — mapToItem()
+        // computes the position through the private transform node, bypassing the QML property
+        // system, so a binding built on it never re-evaluates even though the returned value does
+        // change from call to call (verified against Qt 6.11). Touching ".x"/".parent" directly at
+        // every level, on the other hand, goes through the meta-object system, so the binding
+        // engine's dependency capture kicks in and the property correctly re-evaluates on every
+        // ancestor's move, however many levels up the chain it happens to be.
+        readonly property real _chatLogViewAncestorXTrace: {
+            let sum = 0
+            let p = root?.chatLogView ?? null
+            while (p) {
+                sum += p.x
+                p = p.parent
+            }
+            return sum
+        }
+        on_ChatLogViewAncestorXTraceChanged: contextMenu?.close() // will run destruction/cleanup
     }
 
     Timer {


### PR DESCRIPTION
### What does the PR do

- track the lateral `x` position, and close the ctx menu when the swipe happens
- clear some unused (store) imports

Fixes #22252

### Affected areas

Chat

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/504dc20f-e9a5-44e3-b046-89d89ad415bb

### Impact on end user

Better mobile UX

### How to test

- long press to invoke the message context menu in portrait view
- swipe to the right to get to the left channel list panel
- menu should close

### Risk 

low
