### PR TITLE
fix(KeycardManagementPopup): properly wrap long texts in KeycardProgressState

### DIFF
--- a/storybook/pages/KeycardManagementPopupPage.qml
+++ b/storybook/pages/KeycardManagementPopupPage.qml
@@ -173,7 +173,11 @@ SplitView {
         Constants.keycard.flow.setOrChangePuk,
         Constants.keycard.flow.rename,
         Constants.keycard.flow.unblockWithPuk,
-        Constants.keycard.flow.unblockWithRecoveryPhrase
+        Constants.keycard.flow.unblockWithRecoveryPhrase,
+
+        Constants.keycard.flow.onboardingLoginWithKeycard,
+        Constants.keycard.flow.onboardingImportNewKeyPair,
+        Constants.keycard.flow.onboardingImportSeedPhrase
     ]
 
     property string currentFlow: Constants.keycard.flow.readKeycard
@@ -258,13 +262,13 @@ SplitView {
 
     LogsAndControlsPanel {
         id: controls
-        SplitView.preferredWidth: 360
+        SplitView.preferredWidth: 300
         SplitView.fillHeight: true
 
         logsView.logText: logs.logText
 
         ColumnLayout {
-            Layout.fillWidth: true
+            anchors.fill: parent
 
             Label { text: "Flow:" }
             ComboBox {
@@ -355,6 +359,8 @@ SplitView {
                     mockStore.keycardAddKeyPairError(err)
                 }
             }
+
+            Item { Layout.fillHeight: true }
         }
     }
 

--- a/ui/imports/shared/popups/keycard_new/states/EnterKeyPairNameState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/EnterKeyPairNameState.qml
@@ -40,7 +40,7 @@ Control {
         StatusInput {
             id: nameInput
             objectName: "keycardKeyPairNameInput"
-            Layout.preferredWidth: Constants.keycard.general.keycardNameInputWidth
+            Layout.preferredWidth: Math.min(parent.width, Constants.keycard.general.keycardNameInputWidth)
             Layout.alignment: Qt.AlignHCenter
             charLimit: Constants.keypair.nameLengthMax
             validators: Constants.validators.keypairName

--- a/ui/imports/shared/popups/keycard_new/states/KeycardProgressState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/KeycardProgressState.qml
@@ -50,31 +50,34 @@ Control {
 
         Image {
             id: image
+            Layout.fillHeight: true
+            Layout.minimumHeight: 0
             Layout.alignment: Qt.AlignHCenter
             Layout.preferredHeight: Constants.keycard.shared.imageHeight
             Layout.preferredWidth: Constants.keycard.shared.imageWidth
+            Layout.maximumHeight: Constants.keycard.shared.imageHeight
             fillMode: Image.PreserveAspectFit
             mipmap: true
         }
 
-        Row {
+        StatusLoadingIndicator {
             Layout.alignment: Qt.AlignHCenter
-            spacing: Theme.halfPadding
+            Layout.preferredWidth: 30
+            Layout.preferredHeight: 30
+            visible: root.processing
+                     && state !== "waiting-for-reader"
+                     && state !== "waiting-for-card"
+                     && state !== "reading-card"
+        }
 
-            StatusLoadingIndicator {
-                visible: root.processing
-                         && root.state !== "waiting-for-reader"
-                         && root.state !== "waiting-for-card"
-                         && root.state !== "reading-card"
-            }
-
-            StatusBaseText {
-                id: title
-                objectName: "keycardProgressTitle"
-                wrapMode: Text.WordWrap
-                font.weight: Font.Bold
-                font.pixelSize: Theme.fontSize(22)
-            }
+        StatusBaseText {
+            id: title
+            Layout.fillWidth: true
+            objectName: "keycardProgressTitle"
+            wrapMode: Text.WordWrap
+            font.weight: Font.Bold
+            font.pixelSize: Theme.fontSize(22)
+            horizontalAlignment: Text.AlignHCenter
         }
 
         StatusBaseText {


### PR DESCRIPTION
### What does the PR do

- set the width so that texts can wrap/elide; also allow to shrink the image
- adjust the SB page

Fixes #22122

### Affected areas

KeycardManagementPopup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="758" height="1212" alt="Snímek obrazovky z 2026-09-03 18-19-23" src="https://github.com/user-attachments/assets/b535fb9d-e92d-40f7-96bd-82924d02e379" />

### Impact on end user

Better mobile UX

### Risk 

low
