### PR TITLE
fix: swap transaction layout in the history tab

### DIFF
--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -508,16 +508,7 @@ StatusListItem {
                         case Constants.TransactionType.Receive:
                             return "+" + root.transactionValue
                         case Constants.TransactionType.Swap:
-                            let outValue = root.outTransactionValue
-                            outValue = outValue.replace('<', '&lt;')
-                            let inValue = root.inTransactionValue
-                            inValue = inValue.replace('<', '&lt;')
-                            return "<font color=\"%1\">-%2</font> <font color=\"%3\">/</font> <font color=\"%4\">+%5</font>"
-                                          .arg(Theme.palette.directColor1)
-                                          .arg(outValue)
-                                          .arg(Theme.palette.baseColor1)
-                                          .arg(Theme.palette.successColor1)
-                                          .arg(inValue)
+                            return "−" + root.outTransactionValue
                         case Constants.TransactionType.Bridge:
                         case Constants.TransactionType.Approve:
                         default:
@@ -533,7 +524,6 @@ StatusListItem {
 
                         switch(d.txType) {
                         case Constants.TransactionType.Receive:
-                        case Constants.TransactionType.Swap:
                             return Theme.palette.successColor1
                         default:
                             return Theme.palette.directColor1
@@ -558,8 +548,7 @@ StatusListItem {
                         case Constants.TransactionType.Receive:
                             return "+" + root.currenciesStore.formatCurrencyAmount(root.fiatValue, root.currentCurrency)
                         case Constants.TransactionType.Swap:
-                            return "-%1 / +%2".arg(root.currenciesStore.formatCurrencyAmount(root.outFiatValue, root.currentCurrency))
-                                              .arg(root.currenciesStore.formatCurrencyAmount(root.inFiatValue, root.currentCurrency))
+                            return "+" + root.inTransactionValue
                         case Constants.TransactionType.Bridge:
                         case Constants.TransactionType.Approve:
                         default:
@@ -567,7 +556,8 @@ StatusListItem {
                         }
                     }
                     font.pixelSize: root.loading ? d.loadingPixelSize : 12
-                    customColor: Theme.palette.baseColor1
+                    customColor: d.txType === Constants.TransactionType.Swap ?
+                                     Theme.palette.successColor1 : Theme.palette.baseColor1
                     loading: root.loading
                 }
             }


### PR DESCRIPTION
Fixes #22214 

<img width="1814" height="351" alt="image" src="https://github.com/user-attachments/assets/25ecf8d6-48e0-47ff-9484-e9130fa2e394" />

<img width="626" height="449" alt="image" src="https://github.com/user-attachments/assets/6e30cbaf-77c3-4b77-8534-24d261ee9b51" />
