### PR TITLE
chore(@e2e): remove custom derivation path account test

### DIFF
--- a/test/e2e/constants/wallet.py
+++ b/test/e2e/constants/wallet.py
@@ -53,10 +53,8 @@ private_key_address_pair_1 = PrivateKeyAddressPair(
 
 
 class DerivationPathName(Enum):
-    CUSTOM = 'Custom'
     ETHEREUM = 'Ethereum'
     ETHEREUM_LEDGER = 'Ethereum (Ledger)'
-    ETHEREUM_LEDGER_LIVE = 'Ethereum (Ledger Live/KeepKey)'
 
     @classmethod
     def xpub_derivation_path_names(cls):

--- a/test/e2e/gui/components/wallet/wallet_account_popups.py
+++ b/test/e2e/gui/components/wallet/wallet_account_popups.py
@@ -157,7 +157,6 @@ class AccountPopup(QObject):
             self._derivation_path_list_item.real_name[
                 'objectName'] = "AddAccountPopup-PreDefinedDerivationPath-" + value
             self._derivation_path_list_item.click()
-            # del self._derivation_path_list_item.real_name['title']
             self._address_combobox_button.click()
             GeneratedAddressesList().select(index)
         else:
@@ -349,3 +348,4 @@ class GeneratedAddressesList(QObject):
                 self.paginator_page.real_name['text'] = selected_page_number
                 self.paginator_page.click()
                 time.sleep(0.5)
+

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -6,8 +6,6 @@ from objectmaphelper import RegularExpression
 statusDesktop_mainWindow = {"name": "mainWindow", "type": "QQuickWindowQmlImpl", "visible": True}
 statusDesktop_mainWindow_overlay = {"container": statusDesktop_mainWindow, "type": "Overlay", "unnamed": 1,
                                     "visible": True}
-statusDesktop_mainWindow_overlay_popup2 = {"container": statusDesktop_mainWindow_overlay, "occurrence": 2,
-                                           "type": "PopupItem", "unnamed": 1, "visible": True}
 statusModal = {"container": statusDesktop_mainWindow_overlay, "objectName": "StatusModal", "type": "PopupItem",
                "visible": True}
 statusStackModal = {"container": statusDesktop_mainWindow_overlay, "objectName": "StatusStackModal",
@@ -644,8 +642,6 @@ addAccountPopup_GeneratedAddress = {"container": statusDesktop_mainWindow_overla
                                     "type": "Rectangle", "visible": True}
 accountAddressSelectionModal = {"container": statusDesktop_mainWindow_overlay, "objectName": "AccountAddressSelection",
                                 "type": "PopupItem", "visible": True}
-address_0x_StatusBaseText = {"container": statusDesktop_mainWindow_overlay_popup2, "text": RegularExpression("0x*"),
-                             "type": "StatusBaseText", "unnamed": 1, "visible": True}
 addAccountPopup_GeneratedAddressesListPageIndicatior_StatusPageIndicator = {
     "container": statusDesktop_mainWindow_overlay, "objectName": "AddAccountPopup-GeneratedAddressesListPageIndicatior",
     "type": "StatusPageIndicator", "visible": True}


### PR DESCRIPTION
### What does the PR do

 Custom derivation path for account is removed from the app, so the test is no longer needed

<img width="480" height="557" alt="image" src="https://github.com/user-attachments/assets/dd059a4d-0887-4f8b-8d72-9cae3640d39c" />
