### PR TITLE
fix(android-browser): focus on search input

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -357,7 +357,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG c61e5d45fca60babca12e8ba0610bca0817d9af9
+      GIT_TAG 10429c13aa3e2f7e877e953a6699ba1705226fef
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)


### PR DESCRIPTION
Bumps mobilewebview to status-im/mobilewebview@10429c1

the re-shown native WebView no longer steals Android focus from a Qt text input, so typing lands in the find bar right after opening it from the menu

fixes #22141 
Redmi 15c

https://github.com/user-attachments/assets/d808d81f-5b6e-4360-a6cb-8798ca729601


