### PR TITLE
fix(chat): dismiss the on-screen keyboard on transcript press or drag

### DIFF
--- a/storybook/qmlTests/tests/tst_ChatMessagesViewKeyboardDismissal.qml
+++ b/storybook/qmlTests/tests/tst_ChatMessagesViewKeyboardDismissal.qml
@@ -1,0 +1,252 @@
+import QtQuick
+import QtTest
+
+import utils
+
+import AppLayouts.Chat.views
+import AppLayouts.Chat.stores as ChatStores
+
+/*
+ Tapping or dragging the transcript dismisses the on-screen keyboard
+ (issue #21743, docs/adr/0011). A desktop test host has no panel for
+ Qt.inputMethod.hide() to retract, so what is pinned here is the gesture
+ wiring: the tap reaches the handler over the message list and does not
+ consume, and the drag gate discriminates a user drag from the programmatic
+ scrolls this view performs on every incoming message.
+*/
+Item {
+    id: root
+
+    width: 800
+    height: 600
+
+    ChatStores.RootStore { id: rootStoreMock }
+
+    ListModel { id: messagesModel }
+
+    QtObject {
+        id: contentModuleMock
+
+        readonly property var chatDetails: QtObject {
+            readonly property string id: "chat-1"
+            readonly property int type: Constants.chatType.oneToOne
+            readonly property bool active: true
+            readonly property bool highlight: false
+            readonly property bool hasUnreadMessages: false
+            readonly property bool canPost: true
+            readonly property bool canView: true
+            readonly property bool canPostReactions: true
+            readonly property string emoji: ""
+        }
+
+        readonly property var messagesModule: QtObject {
+            readonly property var model: messagesModel
+            property bool loading: false
+            property bool keepUnread: false
+
+            signal messageSuccessfullySent()
+            signal sendingMessageFailed(string error)
+            signal reactionActionFailed()
+            signal scrollToMessage(string messageId)
+
+            function getChatId() { return "chat-1" }
+            function loadMoreMessages() {}
+            function updateKeepUnread(flag) {}
+        }
+
+        function markAllMessagesRead() {}
+        function getMyChatId() { return "chat-1" }
+        function amIChatAdmin() { return false }
+    }
+
+    Component {
+        id: contentViewComp
+
+        ChatContentView {
+            width: 800
+            height: 600
+
+            rootStore: rootStoreMock
+            chatContentModule: contentModuleMock
+            chatId: "chat-1"
+            chatType: Constants.chatType.oneToOne
+            usersModel: ListModel {}
+            joined: true
+        }
+    }
+
+    // Stand-ins for the real transcript rows, which all take the exclusive grab
+    // on press: message text is a selectable TextEdit, avatars, media and
+    // stickers carry MouseAreas, and the message header has its own TapHandler.
+    Component {
+        id: grabbingMouseAreaComp
+
+        MouseArea {
+            property int clicks: 0
+
+            anchors.fill: parent
+            onClicked: clicks++
+        }
+    }
+
+    Component {
+        id: selectableTextComp
+
+        TextEdit {
+            anchors.fill: parent
+            text: "a selectable message body"
+            readOnly: true
+            selectByMouse: true
+        }
+    }
+
+    SignalSpy {
+        id: activationSpy
+        signalName: "activeChanged"
+    }
+
+    SignalSpy {
+        id: draggingSpy
+        signalName: "draggingChanged"
+    }
+
+    TestCase {
+        name: "ChatMessagesViewKeyboardDismissal"
+        when: windowShown
+
+        function cleanup() {
+            activationSpy.clear()
+            activationSpy.target = null
+            draggingSpy.clear()
+            draggingSpy.target = null
+            messagesModel.clear()
+        }
+
+        function dismisserOf(item) {
+            return findChild(item, "dismissKeyboardHandler")
+        }
+
+        function createTranscript() {
+            const view = createTemporaryObject(contentViewComp, root)
+            verify(!!view)
+            tryVerify(() => view.chatMessagesLoader.status === Loader.Ready, 10000)
+            const messagesView = view.chatMessagesLoader.item
+            verify(!!messagesView)
+            tryVerify(() => messagesView.visible && messagesView.width > 0)
+            return messagesView
+        }
+
+        // The handler has to sit on the list, not on an ancestor: a flickable
+        // accepts the press itself and delivery stops before reaching an
+        // ancestor's handlers, so a transcript tap would never be seen.
+        function test_tapOverTheMessageListReachesTheHandler() {
+            const messagesView = createTranscript()
+            const handler = dismisserOf(messagesView.chatLogView)
+            verify(!!handler, "the message list must carry the dismissal handler")
+
+            activationSpy.target = handler
+            mouseClick(messagesView, messagesView.width / 2, messagesView.height / 2)
+            compare(activationSpy.count, 2, "one activation on press, one deactivation on release")
+
+            mouseClick(messagesView, messagesView.width / 2, messagesView.height / 2)
+            compare(activationSpy.count, 4, "every transcript press must reach the handler")
+        }
+
+        function test_programmaticScrollIsNotADrag() {
+            const messagesView = createTranscript()
+            const chatLogView = messagesView.chatLogView
+            const handler = dismisserOf(chatLogView)
+
+            draggingSpy.target = chatLogView
+            activationSpy.target = handler
+
+            // the scrolls this view performs on its own: a sent/incoming message
+            // and a jump to a quoted message
+            contentModuleMock.messagesModule.messageSuccessfullySent()
+            chatLogView.positionViewAtBeginning()
+            chatLogView.currentIndex = -1
+
+            compare(draggingSpy.count, 0, "programmatic scrolling must not read as a user drag")
+            compare(activationSpy.count, 0)
+            verify(!chatLogView.dragging)
+        }
+
+        function test_userDragTogglesTheDragGate() {
+            const messagesView = createTranscript()
+            const chatLogView = messagesView.chatLogView
+            const handler = dismisserOf(chatLogView)
+
+            // an empty transcript has nothing to scroll under StopAtBounds;
+            // allow overshoot so the drag gate can be driven at all
+            chatLogView.boundsBehavior = Flickable.DragOverBounds
+
+            draggingSpy.target = chatLogView
+            activationSpy.target = handler
+
+            const x = chatLogView.width / 2
+            const y0 = chatLogView.height / 2
+
+            mousePress(chatLogView, x, y0)
+            for (let y = y0 - 10; y >= y0 - 120; y -= 10)
+                mouseMove(chatLogView, x, y)
+
+            verify(chatLogView.dragging, "a user drag must raise the drag gate")
+            compare(draggingSpy.count, 1, "the gate must be raised exactly once per drag")
+
+            // the flickable taking over the exclusive grab must neither cancel
+            // the dismisser nor make it fire again per move
+            verify(handler.active)
+            compare(activationSpy.count, 1)
+
+            mouseRelease(chatLogView, x, y0 - 120)
+
+            compare(draggingSpy.count, 2)
+            verify(!chatLogView.dragging)
+        }
+
+        // The bug behind this file: delivery stops at the topmost item that
+        // accepts the press, and practically every transcript row does. The
+        // dismisser must still activate, while leaving the row its own click.
+        function test_pressOnAGrabbingChildStillReachesTheHandler() {
+            const messagesView = createTranscript()
+            const chatLogView = messagesView.chatLogView
+            const handler = dismisserOf(chatLogView)
+
+            const area = createTemporaryObject(grabbingMouseAreaComp, chatLogView)
+            verify(!!area)
+
+            activationSpy.target = handler
+
+            const x = chatLogView.width / 2
+            const y = chatLogView.height / 2
+
+            mousePress(chatLogView, x, y)
+            verify(handler.active, "an exclusive grab by a child must not cancel the dismisser")
+            compare(activationSpy.count, 1, "the dismisser must activate once, and stay activated")
+
+            mouseRelease(chatLogView, x, y)
+            compare(area.clicks, 1, "the press must not be consumed: the row keeps its own click")
+        }
+
+        function test_pressOnASelectableTextStillReachesTheHandler() {
+            const messagesView = createTranscript()
+            const chatLogView = messagesView.chatLogView
+            const handler = dismisserOf(chatLogView)
+
+            const textEdit = createTemporaryObject(selectableTextComp, chatLogView)
+            verify(!!textEdit)
+
+            activationSpy.target = handler
+
+            const x = chatLogView.width / 2
+            const y = chatLogView.height / 2
+
+            mousePress(chatLogView, x, y)
+            verify(handler.active, "a selectable message body must not cancel the dismisser")
+            compare(activationSpy.count, 1)
+
+            mouseRelease(chatLogView, x, y)
+            verify(textEdit.activeFocus, "the press must still place the caret in the message body")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ChatMessagesViewKeyboardDismissal.qml
+++ b/storybook/qmlTests/tests/tst_ChatMessagesViewKeyboardDismissal.qml
@@ -8,7 +8,7 @@ import AppLayouts.Chat.stores as ChatStores
 
 /*
  Tapping or dragging the transcript dismisses the on-screen keyboard
- (issue #21743, docs/adr/0011). A desktop test host has no panel for
+ (issue #21743). A desktop test host has no panel for
  Qt.inputMethod.hide() to retract, so what is pinned here is the gesture
  wiring: the tap reaches the handler over the message list and does not
  consume, and the drag gate discriminates a user drag from the programmatic

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -131,6 +131,17 @@ Item {
             markAllMessagesReadIfMostRecentMessageIsInViewport()
         }
 
+        // Skipped when focus is already inside the transcript: a tap on an inline
+        // message editor raises the panel on press, and hiding it on release
+        // would open and close the keyboard under a single tap.
+        function dismissKeyboard() {
+            for (let item = root.Window.activeFocusItem; item; item = item.parent) {
+                if (item === chatLogView)
+                    return
+            }
+            Qt.inputMethod.hide()
+        }
+
         onIsMostRecentMessageInViewportChanged: markAllMessagesReadIfMostRecentMessageIsInViewport()
     }
 
@@ -274,10 +285,39 @@ Item {
 
         model: messageStore.messagesModel
 
+        // Practically every row accepts the press (selectable text, avatars,
+        // media, the header's own handler) and delivery stops at the topmost
+        // acceptor, so the dismisser has to sit above the rows rather than on
+        // the list or an ancestor. PointHandler takes only a passive grab and
+        // never accepts, so the same press still reaches the row beneath it.
+        // Explicitly parented to the list so it covers the viewport instead of
+        // being reparented into the scrolling contentItem.
+        Item {
+            parent: chatLogView
+            anchors.fill: parent
+            z: 1
+
+            PointHandler {
+                objectName: "dismissKeyboardHandler"
+                onActiveChanged: {
+                    if (active)
+                        d.dismissKeyboard()
+                }
+            }
+        }
+
         onContentYChanged: d.loadMoreMessagesIfScrollBelowThreshold()
 
         onMovementEnded: {
             d.isAtBottom = d.isMostRecentMessageInViewport
+        }
+
+        // `dragging`, not `moving`/`flicking`: those are also true for the
+        // programmatic scrolls this view performs, and an incoming message must
+        // never close the keyboard of someone mid-sentence.
+        onDraggingChanged: {
+            if (dragging)
+                d.dismissKeyboard()
         }
 
         onCountChanged: {

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -109,13 +109,25 @@ Control {
     QtObject {
         id: d
 
-        // Whether to send message using Ctrl+Return or just Enter; based on
-        // OSK (virtual keyboard presence)
         // Qt.inputMethod.visible is not reliable in some cases, as a workaround android and ios keyboards
         // are checked directly as well.
-        readonly property int kbdModifierToSendMessage:
-            (SystemUtils.androidKeyboardVisible || SystemUtils.iosKeyboardVisible || Qt.inputMethod.visible)
-                ? Qt.ControlModifier : Qt.NoModifier
+        readonly property bool oskVisible: SystemUtils.androidKeyboardVisible
+                                           || SystemUtils.iosKeyboardVisible
+                                           || Qt.inputMethod.visible
+
+        // Whether to send message using Ctrl+Return or just Enter; based on
+        // OSK (virtual keyboard presence)
+        readonly property int kbdModifierToSendMessage: oskVisible ? Qt.ControlModifier : Qt.NoModifier
+
+        // The suggestion box is caret-driven and cannot dismiss itself, so it leaves
+        // with the keyboard however that went: transcript gesture, back button, chat
+        // switch. The emoji/GIF/sticker popups are deliberate and self-dismissing, and
+        // opening one can itself retract the OSK - closing them here would risk
+        // closing the popup that was just opened.
+        onOskVisibleChanged: {
+            if (!oskVisible)
+                suggestionsBox.shouldHide = true
+        }
 
         property bool emojiPopupOpened: false
         property bool stickersPopupOpened: false
@@ -938,8 +950,15 @@ Control {
                         }
 
                         StatusChatInputSelectionMarker {
+                            id: selectionMarker
+
                             anchors.fill: parent
                             clip: true
+
+                            // The handles are a keyboard affordance and go with it;
+                            // the selection itself survives.
+                            visible: d.oskVisible && selectionMarker.selectionStartRect
+                                     !== selectionMarker.selectionEndRect
 
                             selectionStartRect: {
                                 messageInputField.text


### PR DESCRIPTION
On mobile the keyboard could only be retracted by dragging the chat input down, which is undiscoverable enough that the reporter of #21743 filed a bug for it. A press or drag anywhere on the message transcript now retracts it.

### What does the PR do

Closes https://github.com/status-im/status-app/issues/21743

The dismisser is a transparent overlay carrying a PointHandler, sitting above the rows rather than on the list. Delivery stops at the first item that accepts a press, and practically every row accepts one - message text is a selectable TextEdit, avatars and media carry MouseAreas, the message header has its own TapHandler - so a handler on the list or on an ancestor is never reached. PointHandler takes only a passive grab and never accepts, so the same press still activates whatever sits underneath it.

Dragging dismisses as well, gated on `dragging` rather than `moving` or `flicking`: those are also true for this view's programmatic scrolls, and an arriving message must not close the keyboard of someone mid-sentence. Dismissal is skipped while focus is already inside the transcript, so tapping the inline message editor does not close the keyboard it just raised.

Hiding the panel deliberately does not move focus. Desktop is therefore unaffected without a platform check, and the chat input keeps its caret and its draft. The mention suggestion box and the text selection handles are keyboard affordances, so they leave with the keyboard - the selection itself survives, only its handles go.

### Affected areas

message history

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/010578a5-4152-458f-a227-c4feaa91efb0


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

the keyboard can be dismissed by tap/flick

### How to test

launch the keyboard in the message history view. Tap outside or flick the messages history

### Risk 

low
