### PR TITLE
fix(ios): don't prompt for paste permissions

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -87,7 +87,11 @@ TextField {
         sourceComponent: StatusTextEditMenu {
             canCut: !root.readOnly && !root.noSelection
             canCopy: !root.noSelection
-            canPaste: !root.readOnly && root.canPaste
+            // Never read TextInput.canPaste on iOS: it reads UIPasteboard and
+            // triggers the "Allow Paste?" prompt. The menu is only built there so
+            // the context-menu event goes unaccepted and UIKit shows its own
+            // callout - this value is never displayed.
+            canPaste: !root.readOnly && (Utils.isIOS || root.canPaste)
             canSelectAll: root.length > 0
 
             onCutRequested: root.cut()

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1175,8 +1175,12 @@ Control {
         sourceComponent: StatusTextEditMenu {
             canCut: !messageInputField.readOnly && !messageInputField.noSelection
             canCopy: !messageInputField.noSelection
-            canPaste: !messageInputField.readOnly && (ClipboardUtils.hasText
-                      || (root.imageFeaturesEnabled && ClipboardUtils.hasImage))
+            // Never probe the clipboard on iOS: any read triggers the
+            // "Allow Paste?" prompt. Keep Paste enabled and let the actual
+            // paste be the only, user-initiated, read.
+            canPaste: !messageInputField.readOnly
+                      && (StatusQUtils.Utils.isIOS || ClipboardUtils.hasText
+                          || (root.imageFeaturesEnabled && ClipboardUtils.hasImage))
             canSelectAll: messageInputField.length > 0
 
             onCutRequested: messageInputField.cutSelection()


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-app/issues/22317

Don't probe the clipboard on IOS

### Affected areas

IOS paste

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

