### PR TITLE
fix: different swap related issues

### DIFF
--- a/src/app/modules/main/wallet_section/all_tokens/controller.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/controller.nim
@@ -85,6 +85,15 @@ proc getGroupsForChain*(self: Controller): var seq[TokenGroupItem] =
 proc getGroupsForChainTo*(self: Controller): var seq[TokenGroupItem] =
   return self.tokenService.getGroupsForChainTo()
 
+proc getAllChainsTokenGroups*(self: Controller): var seq[TokenGroupItem] =
+  return self.tokenService.getAllTokenGroups()
+
+proc fetchAllChainsTokenGroups*(self: Controller) =
+  self.tokenService.asyncFetchAllTokenGroups()
+
+proc getAllChainsTokenGroupsLoading*(self: Controller): bool =
+  return self.tokenService.getAllTokenGroupsLoading()
+
 proc getGroupsOfInterest*(self: Controller): var seq[TokenGroupItem] =
   return self.tokenService.getGroupsOfInterest()
 

--- a/src/app/modules/main/wallet_section/all_tokens/io_interface.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/io_interface.nim
@@ -66,6 +66,12 @@ method getTokenGroupsModelDataSource*(self: AccessInterface): TokenGroupsModelDa
 method getTokenGroupsForChainModelDataSource*(self: AccessInterface): TokenGroupsModelDataSource {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getTokenGroupsAllChainsModelDataSource*(self: AccessInterface): TokenGroupsModelDataSource {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method fetchAllChainsTokenGroups*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getTokenGroupsForChainToModelDataSource*(self: AccessInterface): TokenGroupsModelDataSource {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/wallet_section/all_tokens/module.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/module.nim
@@ -78,6 +78,8 @@ method load*(self: Module) =
     self.view.onGroupsForChainLoaded()
   self.events.on(SIGNAL_GROUPS_FOR_CHAIN_TO_LOADED) do(e: Args):
     self.view.onGroupsForChainToLoaded()
+  self.events.on(SIGNAL_ALL_TOKEN_GROUPS_LOADED) do(e: Args):
+    self.view.onAllChainsGroupsLoaded()
 
   self.controller.init()
   self.view.load()
@@ -139,6 +141,19 @@ method getTokenGroupsForChainToModelDataSource*(self: Module): TokenGroupsModelD
     getTokensMarketValuesLoading: proc(): bool = self.controller.getTokensMarketValuesLoading(),
   )
 
+method getTokenGroupsAllChainsModelDataSource*(self: Module): TokenGroupsModelDataSource =
+  return (
+    getAllTokenGroups: proc(): var seq[TokenGroupItem] = self.controller.getAllChainsTokenGroups(),
+    getTokenDetails: proc(tokenKey: string): TokenDetailsItem = self.controller.getTokenDetails(tokenKey),
+    getTokenPreferences: proc(groupKey: string): TokenPreferencesItem = self.controller.getTokenPreferences(groupKey),
+    getCommunityTokenDescription: proc(chainId: int, address: string): string = self.controller.getCommunityTokenDescription(chainId, address),
+    getTokensDetailsLoading: proc(): bool = self.controller.getTokensDetailsLoading(),
+    getTokensMarketValuesLoading: proc(): bool = self.controller.getTokensMarketValuesLoading(),
+  )
+
+method fetchAllChainsTokenGroups*(self: Module) =
+  self.controller.fetchAllChainsTokenGroups()
+
 method getTokenMarketValuesDataSource*(self: Module): TokenMarketValuesDataSource =
   return (
     getMarketValuesForToken: proc(tokenKey: string): TokenMarketValuesItem = self.controller.getMarketValuesForToken(tokenKey),
@@ -163,6 +178,12 @@ proc getTokenGroupsForChainToModelObj*(self: Module): TokenGroupsModel =
   self.view.getTokenGroupsForChainToModelObj()
 proc getSearchResultModelObj*(self: Module): TokenGroupsModel =
   self.view.getSearchResultModelObj()
+proc getTokenGroupsAllChainsModelObj*(self: Module): TokenGroupsModel =
+  self.view.getTokenGroupsAllChainsModelObj()
+proc isAllChainsTokenGroupsLoading*(self: Module): bool =
+  self.controller.getAllChainsTokenGroupsLoading()
+proc fetchAllChainsTokenGroupsForKeys*(self: Module, mandatoryGroupKeys: seq[string]) =
+  self.view.fetchAllChainsTokenGroupsForKeys(mandatoryGroupKeys)
 
 method getTokenByKeyOrGroupKeyFromAllTokens*(self: Module, key: string): TokenItem =
   return self.controller.getTokenByKeyOrGroupKeyFromAllTokens(key)

--- a/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
@@ -442,31 +442,34 @@ QtObject:
     return false
 
   proc fetchMore*(self: TokenGroupsModel) {.slot.} =
+    if ModelMode.UseLazyLoading notin self.modelModes:
+      return
     if not self.getHasMoreItems() or self.isLoadingMore:
       return
     self.setIsLoadingMore(true)
 
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
     let sourceModel = self.getSourceModel()
-    let first = self.rowCount()
-    let last = min(first + self.lazyLoadingBatchSize - 1, sourceModel.len - 1)
-    self.beginInsertRows(parentModelIndex, first, last)
-    defer:
+    var batch: seq[TokenGroupItem] = @[]
+    for item in sourceModel:
+      if self.loadedKeys.hasKey(item.key):
+        continue
+      batch.add(item)
+      if batch.len >= self.lazyLoadingBatchSize:
+        break
+
+    if batch.len > 0:
+      let parentModelIndex = newQModelIndex()
+      defer: parentModelIndex.delete
+      let first = self.rowCount()
+      self.beginInsertRows(parentModelIndex, first, first + batch.len - 1)
+      for item in batch:
+        self.loadedKeys[item.key] = true
+        self.loadedItems.add(item)
       self.endInsertRows()
-      self.setIsLoadingMore(false)
-      self.hasMoreItemsChanged()
+      self.rebuildMarketDetails(self.getDisplayModel())
 
-    if ModelMode.UseLazyLoading in self.modelModes:
-      for index in countup(first, last):
-        let key = sourceModel[index].key
-        if self.loadedKeys.hasKey(key):
-          continue
-        self.loadedKeys[key] = true
-        self.loadedItems.add(sourceModel[index])
-
-    self.rebuildMarketDetails(self.getDisplayModel())
+    self.setIsLoadingMore(false)
+    self.hasMoreItemsChanged()
 
   proc getSearchRelevance(item: TokenGroupItem, keywordLower: string): int =
     if keywordLower.len == 0:

--- a/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
@@ -418,6 +418,29 @@ QtObject:
 
     self.rebuildMarketDetails(self.getDisplayModel())
 
+  proc ensureKeyLoaded*(self: TokenGroupsModel, key: string): bool =
+    if ModelMode.UseLazyLoading notin self.modelModes:
+      for item in self.getDisplayModel():
+        if item.key == key:
+          return true
+      return false
+    if self.loadedKeys.hasKey(key):
+      return true
+    let sourceModel = self.getSourceModel()
+    for item in sourceModel:
+      if item.key == key:
+        let parentModelIndex = newQModelIndex()
+        defer: parentModelIndex.delete
+        let idx = self.loadedItems.len
+        self.beginInsertRows(parentModelIndex, idx, idx)
+        self.loadedKeys[key] = true
+        self.loadedItems.add(item)
+        self.endInsertRows()
+        self.rebuildMarketDetails(self.getDisplayModel())
+        self.hasMoreItemsChanged()
+        return true
+    return false
+
   proc fetchMore*(self: TokenGroupsModel) {.slot.} =
     if not self.getHasMoreItems() or self.isLoadingMore:
       return
@@ -505,6 +528,10 @@ QtObject:
         self.fullSearchResults.add(scoredItem[2])
 
     self.modelsUpdated(resetModelSize = true)
+
+  proc refreshSearch*(self: TokenGroupsModel) =
+    if ModelMode.IsSearchResult in self.modelModes and self.searchKeyword.len > 0:
+      self.search(self.searchKeyword)
 
   proc tokensMarketValuesUpdated*(self: TokenGroupsModel) =
     if ModelMode.NoMarketDetails in self.modelModes:

--- a/src/app/modules/main/wallet_section/all_tokens/view.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/view.nim
@@ -16,12 +16,14 @@ QtObject:
       groupsForChainToLoading: bool
       pendingMandatoryGroupKeys: seq[string]
       pendingMandatoryGroupKeysTo: seq[string]
+      pendingMandatoryGroupKeysAllChains: seq[string]
 
       tokenListsModel: TokenListsModel
       tokenGroupsModel: TokenGroupsModel # refers to tokens of interest for active networks mode
       tokenGroupsForChainModel: TokenGroupsModel # all tokens for the source (pay) chain
       tokenGroupsForChainToModel: TokenGroupsModel # all tokens for the destination (receive) chain (swap+bridge)
-      searchResultModel: TokenGroupsModel # refers to tokens that match the search keyword
+      tokenGroupsAllChainsModel: TokenGroupsModel # ALL tokens across the active chains (on-demand fetch), for the "All" chip
+      searchResultModel: TokenGroupsModel # tokens matching the search keyword, scanned over the same cross-chain catalog
 
   ## Forward declaration
   proc modelsUpdated*(self: View)
@@ -49,8 +51,14 @@ QtObject:
       modelModes = @[ModelMode.NoMarketDetails, ModelMode.UseLazyLoading],
       lazyLoadingBatchSize = LAZY_LOADING_BATCH_SIZE,
       lazyLoadingInitialCount = LAZY_LOADING_INITIAL_COUNT)
+    result.tokenGroupsAllChainsModel = newTokenGroupsModel(
+      delegate.getTokenGroupsAllChainsModelDataSource(),
+      delegate.getTokenMarketValuesDataSource(),
+      modelModes = @[ModelMode.NoMarketDetails, ModelMode.UseLazyLoading],
+      lazyLoadingBatchSize = LAZY_LOADING_BATCH_SIZE,
+      lazyLoadingInitialCount = LAZY_LOADING_INITIAL_COUNT)
     result.searchResultModel = newTokenGroupsModel(
-      delegate.getTokenGroupsForChainModelDataSource(),
+      delegate.getTokenGroupsAllChainsModelDataSource(),
       delegate.getTokenMarketValuesDataSource(),
       modelModes = @[ModelMode.NoMarketDetails, ModelMode.UseLazyLoading, ModelMode.IsSearchResult],
       lazyLoadingBatchSize = LAZY_LOADING_BATCH_SIZE,
@@ -180,6 +188,23 @@ QtObject:
     self.tokenGroupsForChainToModel.modelsUpdated(resetModelSize = true, self.pendingMandatoryGroupKeysTo)
     self.tokenGroupsForChainToModelChanged()
 
+  proc fetchAllChainsTokenGroupsForKeys*(self: View, mandatoryGroupKeys: seq[string]) =
+    if mandatoryGroupKeys.len > 0:
+      self.pendingMandatoryGroupKeysAllChains = mandatoryGroupKeys
+    else:
+      self.pendingMandatoryGroupKeysAllChains = self.delegate.getMandatoryTokenGroupKeys()
+    self.delegate.fetchAllChainsTokenGroups()
+
+  proc fetchAllChainsTokenGroups*(self: View, mandatoryGroupKeysString: string) {.slot.} =
+    var keys: seq[string] = @[]
+    if mandatoryGroupKeysString.len > 0:
+      keys = mandatoryGroupKeysString.split("$$")
+    self.fetchAllChainsTokenGroupsForKeys(keys)
+
+  proc onAllChainsGroupsLoaded*(self: View) =
+    self.searchResultModel.refreshSearch()
+    self.tokenGroupsAllChainsModel.modelsUpdated(resetModelSize = true, self.pendingMandatoryGroupKeysAllChains)
+
   proc getTokenByKeyOrGroupKeyFromAllTokens*(self: View, key: string): string {.slot.} =
     let token = self.delegate.getTokenByKeyOrGroupKeyFromAllTokens(key)
     if token.isNil:
@@ -196,6 +221,8 @@ QtObject:
     self.tokenGroupsForChainToModel
   proc getSearchResultModelObj*(self: View): TokenGroupsModel =
     self.searchResultModel
+  proc getTokenGroupsAllChainsModelObj*(self: View): TokenGroupsModel =
+    self.tokenGroupsAllChainsModel
 
   proc modelsUpdated*(self: View) =
     self.tokenGroupsModel.modelsUpdated()

--- a/src/app/modules/main/wallet_section/token_selector/module.nim
+++ b/src/app/modules/main/wallet_section/token_selector/module.nim
@@ -139,8 +139,7 @@ method createModelForKind*(self: Module, kind: int): tuple[id: int, model: Token
   let searchModel = atm.getSearchResultModelObj()
 
   var source: TokenSelectorSource
-  # Search source (send + swap + bridge receive): snapshot the lazy search-result
-  # model. The search catalog is chain-agnostic, shared across the swap sides.
+  # Search source (send + swap + bridge receive): snapshot the lazy search-result model.
   if kind == KIND_SEND or kind == KIND_SWAP or kind == KIND_SWAP_TO:
     source.getSearch = proc(): seq[PopularGroup] = self.toPopularGroups(searchModel.getLoadedGroups())
     source.doSearch = proc(keyword: string) = searchModel.search(keyword)
@@ -155,6 +154,13 @@ method createModelForKind*(self: Module, kind: int): tuple[id: int, model: Token
     let popularModel = if kind == KIND_SWAP_TO: atm.getTokenGroupsForChainToModelObj()
                        else: atm.getTokenGroupsForChainModelObj()
     source.getPopular = proc(): seq[PopularGroup] = self.toPopularGroups(popularModel.getLoadedGroups())
+    let allChainsModel = atm.getTokenGroupsAllChainsModelObj()
+    source.getPopularAllChains = proc(): seq[PopularGroup] = self.toPopularGroups(allChainsModel.getLoadedGroups())
+    source.fetchMoreAllChains = proc() = allChainsModel.fetchMore()
+    source.hasMoreAllChains = proc(): bool = allChainsModel.hasMoreItemsForSource()
+    source.isLoadingMoreAllChains = proc(): bool =
+      allChainsModel.isLoadingMoreForSource() or atm.isAllChainsTokenGroupsLoading()
+    source.pinGroup = proc(key: string): bool = popularModel.ensureKeyLoaded(key)
     source.fetchMore = proc(searching: bool) =
       if searching: searchModel.fetchMore() else: popularModel.fetchMore()
     source.hasMore = proc(searching: bool): bool =
@@ -184,6 +190,8 @@ method createModelForKind*(self: Module, kind: int): tuple[id: int, model: Token
   # Seed with the current owned source so the model is populated immediately.
   let (groups, networks) = self.buildOwnedSource()
   model.setOwnedSource(groups, networks)
+  if kind == KIND_SEND or kind == KIND_SWAP or kind == KIND_SWAP_TO:
+    atm.fetchAllChainsTokenGroupsForKeys(groups.mapIt(it.key))
   return (id, model)
 
 method releaseModel*(self: Module, id: int) =
@@ -205,6 +213,8 @@ method load*(self: Module) =
   self.events.on(SIGNAL_GROUPS_FOR_CHAIN_LOADED) do(e: Args):
     self.refreshModels()
   self.events.on(SIGNAL_GROUPS_FOR_CHAIN_TO_LOADED) do(e: Args):
+    self.refreshModels()
+  self.events.on(SIGNAL_ALL_TOKEN_GROUPS_LOADED) do(e: Args):
     self.refreshModels()
 
   self.controller.init()

--- a/src/app/modules/shared_models/token_selector_builder.nim
+++ b/src/app/modules/shared_models/token_selector_builder.nim
@@ -140,6 +140,17 @@ proc mergePopularWithOwned*(popular: seq[PopularGroup],
           chains.incl(t.chainId)
     result.add(item)
 
+proc filterToEnabledChains(items: seq[TokenSelectorItem],
+    enabledChainIds: seq[int]): seq[TokenSelectorItem] =
+  if enabledChainIds.len == 0:
+    return items
+  let chainSet = enabledChainIds.toHashSet
+  items.filter(proc(item: TokenSelectorItem): bool =
+    for t in item.tokens:
+      if t.chainId in chainSet:
+        return true
+    false)
+
 proc buildDisplayItems*(
     ownedGroups: seq[AggTokenGroup], networks: seq[NetworkInfo],
     params: TokenSelectorParams, mode: TokenSelectorMode, searchActive: bool,
@@ -155,11 +166,15 @@ proc buildDisplayItems*(
   ##   - Owned (send), no search -> just the owned tokens.
   let owned = buildTokenSelectorItems(ownedGroups, networks, params)
   if searchActive:
-    let merged = mergePopularWithOwned(searchGroups, owned, params.showCommunityAssets)
+    let merged = filterToEnabledChains(
+      mergePopularWithOwned(searchGroups, owned, params.showCommunityAssets),
+      params.enabledChainIds)
     if mode == TokenSelectorMode.Owned:
       let ownedKeys = owned.mapIt(it.key).toHashSet
       return merged.filterIt(it.key in ownedKeys)
     return merged
   if mode == TokenSelectorMode.AllTokens:
-    return mergePopularWithOwned(popularGroups, owned, params.showCommunityAssets)
+    return filterToEnabledChains(
+      mergePopularWithOwned(popularGroups, owned, params.showCommunityAssets),
+      params.enabledChainIds)
   return owned

--- a/src/app/modules/shared_models/token_selector_model.nim
+++ b/src/app/modules/shared_models/token_selector_model.nim
@@ -47,12 +47,17 @@ type
     ## model can (re)read the popular/search rows and drive their lazy loading
     ## without middleware coupling. All optional: send owns no popular list, buy
     ## has no search source. `searching` selects which lazy list to act on.
-    getPopular*: proc(): seq[PopularGroup] {.closure.}          ## loaded popular rows (AllTokens mode)
+    getPopular*: proc(): seq[PopularGroup] {.closure.}          ## loaded popular rows (AllTokens mode), chain-scoped catalog
+    getPopularAllChains*: proc(): seq[PopularGroup] {.closure.} ## cross-chain popular rows, used when no chain filter is set ("All")
+    fetchMoreAllChains*: proc() {.closure.}                     ## lazy passthrough for the cross-chain catalog
+    hasMoreAllChains*: proc(): bool {.closure.}
+    isLoadingMoreAllChains*: proc(): bool {.closure.}
     getSearch*: proc(): seq[PopularGroup] {.closure.}           ## loaded search rows
     doSearch*: proc(keyword: string) {.closure.}               ## trigger a backend search
     fetchMore*: proc(searching: bool) {.closure.}              ## grow the active lazy list
     hasMore*: proc(searching: bool): bool {.closure.}
     isLoadingMore*: proc(searching: bool): bool {.closure.}
+    pinGroup*: proc(key: string): bool {.closure.}             ## pin a group from the full popular source into the lazy window
 
 QtObject:
   type
@@ -215,6 +220,11 @@ QtObject:
   proc hasMoreItemsChanged(self: TokenSelectorModel) {.signal.}
   proc isLoadingMoreChanged(self: TokenSelectorModel) {.signal.}
 
+  proc allChainsScope(self: TokenSelectorModel): bool =
+    self.mode == TokenSelectorMode.AllTokens and
+      self.params.enabledChainIds.len == 0 and
+      self.source.getPopularAllChains != nil
+
   proc recompute(self: TokenSelectorModel) =
     let searching = self.searchKeyword.len > 0
     var popularGroups: seq[PopularGroup] = @[]
@@ -222,8 +232,11 @@ QtObject:
     if searching:
       if self.source.getSearch != nil:
         searchGroups = self.source.getSearch()
-    elif self.mode == TokenSelectorMode.AllTokens and self.source.getPopular != nil:
-      popularGroups = self.source.getPopular()
+    elif self.mode == TokenSelectorMode.AllTokens:
+      if self.allChainsScope():
+        popularGroups = self.source.getPopularAllChains()
+      elif self.source.getPopular != nil:
+        popularGroups = self.source.getPopular()
     self.setSourceItems(buildDisplayItems(
       self.ownedGroups, self.networks, self.params, self.mode, searching,
       popularGroups, searchGroups))
@@ -265,6 +278,8 @@ QtObject:
     if chains == self.params.enabledChainIds: return
     self.params.enabledChainIds = chains
     self.recompute()
+    self.hasMoreItemsChanged()
+    self.isLoadingMoreChanged()
   proc getEnabledChainId(self: TokenSelectorModel): int {.slot.} =
     if self.params.enabledChainIds.len == 0: -1 else: self.params.enabledChainIds[0]
   QtProperty[int] enabledChainId:
@@ -291,11 +306,16 @@ QtObject:
     read = getShowCommunityAssets
     write = setShowCommunityAssets
 
+  proc searchStringChanged*(self: TokenSelectorModel) {.signal.}
+
   proc search*(self: TokenSelectorModel, keyword: string) {.slot.} =
     let kw = keyword.strip()
     if self.source.doSearch != nil:
       self.source.doSearch(kw)
+    let kwChanged = kw != self.searchKeyword
     self.searchKeyword = kw
+    if kwChanged:
+      self.searchStringChanged()
     self.recompute()
     self.hasMoreItemsChanged()
     self.isLoadingMoreChanged()
@@ -304,25 +324,45 @@ QtObject:
     return self.searchKeyword
   QtProperty[string] searchString:
     read = getSearchString
+    notify = searchStringChanged
+
+  proc pinGroup*(self: TokenSelectorModel, key: string): bool {.slot.} =
+    if self.source.pinGroup == nil:
+      return false
+    if not self.source.pinGroup(key):
+      return false
+    self.recompute()
+    self.hasMoreItemsChanged()
+    self.isLoadingMoreChanged()
+    return true
 
   proc fetchMore*(self: TokenSelectorModel) {.slot.} =
     let searching = self.searchKeyword.len > 0
-    if self.source.fetchMore != nil:
+    if not searching and self.allChainsScope():
+      if self.source.fetchMoreAllChains != nil:
+        self.source.fetchMoreAllChains()  # grows the cross-chain lazy window
+    elif self.source.fetchMore != nil:
       self.source.fetchMore(searching)  # grows the underlying lazy list in place
     self.recompute()
     self.hasMoreItemsChanged()
     self.isLoadingMoreChanged()
 
   proc getHasMoreItems*(self: TokenSelectorModel): bool {.slot.} =
+    let searching = self.searchKeyword.len > 0
+    if not searching and self.allChainsScope():
+      return self.source.hasMoreAllChains != nil and self.source.hasMoreAllChains()
     if self.source.hasMore == nil: return false
-    return self.source.hasMore(self.searchKeyword.len > 0)
+    return self.source.hasMore(searching)
   QtProperty[bool] hasMoreItems:
     read = getHasMoreItems
     notify = hasMoreItemsChanged
 
   proc getIsLoadingMore*(self: TokenSelectorModel): bool {.slot.} =
+    let searching = self.searchKeyword.len > 0
+    if not searching and self.allChainsScope():
+      return self.source.isLoadingMoreAllChains != nil and self.source.isLoadingMoreAllChains()
     if self.source.isLoadingMore == nil: return false
-    return self.source.isLoadingMore(self.searchKeyword.len > 0)
+    return self.source.isLoadingMore(searching)
   QtProperty[bool] isLoadingMore:
     read = getIsLoadingMore
     notify = isLoadingMoreChanged

--- a/src/app/modules/shared_models/token_selector_model.nim
+++ b/src/app/modules/shared_models/token_selector_model.nim
@@ -257,6 +257,7 @@ QtObject:
       self.source.doSearch(self.searchKeyword)
     self.recompute()
     self.hasMoreItemsChanged()
+    self.isLoadingMoreChanged()
 
   # The params are exposed as read+write QtProperties so the QML sites can drive
   # them declaratively (Binding onto the picker model); the write setters guard

--- a/src/app_service/service/eth/utils.nim
+++ b/src/app_service/service/eth/utils.nim
@@ -128,3 +128,18 @@ proc stripLeadingZeros*(value: string): string =
   while cidx < value.len - 1 and value[cidx] == '0':
     cidx.inc
   value[cidx .. ^1]
+
+proc normalizedWeiHexValue*(weiHex: string): string =
+  if weiHex.len < 3 or weiHex[0] != '0' or weiHex[1] notin {'x', 'X'}:
+    raise newException(ValueError, "expected a 0x-prefixed hex quantity with at least one digit")
+  let digits = weiHex[2 .. ^1]
+  for c in digits:
+    if c notin HexDigits:
+      raise newException(ValueError, "invalid hex digit in quantity")
+  let significant = stripLeadingZeros(digits)
+  if significant.len > 64:  # 64 hex digits == 256 bits
+    raise newException(ValueError, "hex quantity exceeds 256 bits")
+  "0x" & significant.toLowerAscii
+
+proc gweiToWeiHexValue*(gwei: float64): string =
+  "0x" & stripLeadingZeros(stint.u256(int64(gwei * 1e9)).toHex)

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -162,6 +162,7 @@ proc asyncBuildGroupsForChainTask*(argEncoded: string) {.gcsafe, nimcall.} =
   finally:
     if res.isNil:
       res = TokenGroupsApplyResult(error: "internal: groups-for-chain result assembly produced no result")
+    res.chainId = arg.chainId
     arg.finishTyped(res)
 
 type

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -64,6 +64,8 @@ QtObject:
     tokenListsLoading: bool
     groupsForChainLoading: bool
     groupsForChainToLoading: bool
+    groupsForChainRequestedChainId: int
+    groupsForChainToRequestedChainId: int
     tokenDetailsTable: Table[string, TokenDetailsItem] # [tokenKey, TokenDetailsItem]
     tokenMarketValuesTable: Table[string, TokenMarketValuesItem] # [tokenKey, TokenMarketValuesItem]
     tokenPriceTable: Table[string, float64] # [tokenKey, price]

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -342,6 +342,7 @@ proc buildGroupsForChain*(self: Service, chainId: int) =
   if chainId <= 0:
     warn "invalid chainId", chainId = chainId
     return
+  self.groupsForChainRequestedChainId = chainId
   self.groupsForChainLoading = true
   let arg = AsyncBuildGroupsForChainTaskArg(
     tptr: asyncBuildGroupsForChainTask,
@@ -355,8 +356,10 @@ proc onAsyncBuildGroupsForChainDone(self: Service, response: string) {.slot.} =
   # The worker already decoded + built the name-sorted groups; MOVE them into state
   # (never copy — see applyRefreshTokensResult) with no GUI-thread JSON parse or
   # group build. `res` is nil only if the handoff was drained at shutdown.
-  self.groupsForChainLoading = false
   let res = takeTyped[TokenGroupsApplyResult](response)
+  if not res.isNil and res.chainId != self.groupsForChainRequestedChainId:
+    return
+  self.groupsForChainLoading = false
   if res.isNil:
     self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_LOADED, Args())
     return
@@ -374,6 +377,7 @@ proc buildGroupsForChainTo*(self: Service, chainId: int) =
   if chainId <= 0:
     warn "invalid chainId", chainId = chainId
     return
+  self.groupsForChainToRequestedChainId = chainId
   self.groupsForChainToLoading = true
   let arg = AsyncBuildGroupsForChainTaskArg(
     tptr: asyncBuildGroupsForChainTask,
@@ -386,8 +390,10 @@ proc buildGroupsForChainTo*(self: Service, chainId: int) =
 proc onAsyncBuildGroupsForChainToDone(self: Service, response: string) {.slot.} =
   # Same typed handoff as the source-chain slot: the worker already built the
   # name-sorted groups; MOVE them into state (never copy).
-  self.groupsForChainToLoading = false
   let res = takeTyped[TokenGroupsApplyResult](response)
+  if not res.isNil and res.chainId != self.groupsForChainToRequestedChainId:
+    return
+  self.groupsForChainToLoading = false
   if res.isNil:
     self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_TO_LOADED, Args())
     return
@@ -402,6 +408,8 @@ proc getGroupsForChainToLoading*(self: Service): bool =
   return self.groupsForChainToLoading
 
 proc asyncFetchAllTokenGroups*(self: Service) =
+  if self.allTokenGroupsLoading:
+    return
   self.allTokenGroupsLoading = true
   let arg = AsyncFetchAllTokenGroupsTaskArg(
     tptr: asyncFetchAllTokenGroupsTask,
@@ -425,6 +433,9 @@ proc onAsyncFetchAllTokenGroupsDone(self: Service, response: string) {.slot.} =
   self.events.emit(SIGNAL_ALL_TOKEN_GROUPS_LOADED, Args())
 
 proc getAllTokenGroupsForActiveNetworksMode*(self: Service): seq[TokenGroupItem] =
+  return self.allTokenGroupsForActiveNetworks
+
+proc getAllTokenGroups*(self: Service): var seq[TokenGroupItem] =
   return self.allTokenGroupsForActiveNetworks
 
 proc getAllTokenGroupsLoading*(self: Service): bool =

--- a/src/app_service/service/token/token_apply_builder.nim
+++ b/src/app_service/service/token/token_apply_builder.nim
@@ -47,6 +47,7 @@ type
     ## those tasks gate on a plain loading bool, not the refresh coordinator.
     error*: string                                       ## non-empty -> slot skips apply
     groups*: seq[TokenGroupItem]
+    chainId*: int                                        ## chain the groups were built for; 0 for the all-networks fetch. Lets the slot drop completions superseded by a newer request
 
 proc createTokenGroupsFromTokens(tokens: seq[TokenItem], groupsByKey: var Table[string, TokenGroupItem]) =
   # Byte-identical replica of the private helper in service_main.nim (grouping by

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -14,6 +14,17 @@ import app/modules/shared_models/currency_amount
 include  app_service/common/json_utils
 
 type
+  EstimatedTime* {.pure.} = enum
+    Unknown = 0
+    LessThanThirtySecs
+    LessThanOneMin
+    LessThanTwoMins
+    LessThanThreeMins
+    LessThanFourMins
+    LessThanFiveMins
+    MoreThanFiveMins
+
+type
   SendType* {.pure.} = enum
     Transfer
     ENSRegister

--- a/src/app_service/service/transaction/dtoV2.nim
+++ b/src/app_service/service/transaction/dtoV2.nim
@@ -65,6 +65,7 @@ type
     txBonderFees*: UInt256
     txTokenFees*: UInt256
     txEstimatedTime*: int
+    routeExecutionDuration*: int
 
     txFee*: UInt256
     txL1Fee*: UInt256
@@ -145,6 +146,7 @@ proc toTransactionPathDtoV2*(jsonObj: JsonNode): TransactionPathDtoV2 =
   result.txBonderFees = stint.fromHex(UInt256, jsonObj{"TxBonderFees"}.getStr)
   result.txTokenFees = stint.fromHex(UInt256, jsonObj{"TxTokenFees"}.getStr)
   discard jsonObj.getProp("TxEstimatedTime", result.txEstimatedTime)
+  discard jsonObj.getProp("RouteExecutionDuration", result.routeExecutionDuration)
   result.txFee = stint.fromHex(UInt256, jsonObj{"TxFee"}.getStr)
   result.txL1Fee = stint.fromHex(UInt256, jsonObj{"TxL1Fee"}.getStr)
   discard jsonObj.getProp("ApprovalRequired", result.approvalRequired)

--- a/src/app_service/service/transaction/dto_conversion.nim
+++ b/src/app_service/service/transaction/dto_conversion.nim
@@ -9,17 +9,23 @@ proc sortAsc[T](t1, t2: T): int =
   elif (t1.fromNetwork.chainId < t2.fromNetwork.chainId): return -1
   else: return 0
 
-proc estimatedTimeFlagFromSeconds(seconds: int): int =
+proc estimatedTimeFlagFromSeconds*(seconds: int): EstimatedTime =
   if seconds <= 0:
-    return 0 # Unknown
+    return EstimatedTime.Unknown
+  elif seconds < 30:
+    return EstimatedTime.LessThanThirtySecs
   elif seconds < 60:
-    return 1 # LessThanOneMin
+    return EstimatedTime.LessThanOneMin
+  elif seconds < 120:
+    return EstimatedTime.LessThanTwoMins
   elif seconds < 180:
-    return 2 # LessThanThreeMins
+    return EstimatedTime.LessThanThreeMins
+  elif seconds < 240:
+    return EstimatedTime.LessThanFourMins
   elif seconds <= 300:
-    return 3 # LessThanFiveMins
+    return EstimatedTime.LessThanFiveMins
   else:
-    return 4 # MoreThanFiveMins
+    return EstimatedTime.MoreThanFiveMins
 
 proc convertToOldRoute*(route: seq[TransactionPathDtoV2]): seq[TransactionPathDto] =
   const
@@ -75,9 +81,11 @@ proc convertToOldRoute*(route: seq[TransactionPathDtoV2]): seq[TransactionPathDt
       trPath.amountInLocked = p.amountInLocked
       trPath.gasAmount = p.txGasAmount
 
-      # The approval and main tx run sequentially, so sum their (seconds) estimates before bucketing.
-      # approvalEstimatedTime is 0 when no approval is needed.
-      trPath.estimatedTime = estimatedTimeFlagFromSeconds(p.txEstimatedTime + p.approvalEstimatedTime)
+      # Approval tx, main tx and the route execution (e.g. bridging) run
+      # sequentially, so sum their (seconds) estimates before bucketing.
+      # approvalEstimatedTime is 0 when no approval is needed and
+      # routeExecutionDuration is 0 when the provider reports none.
+      trPath.estimatedTime = estimatedTimeFlagFromSeconds(p.txEstimatedTime + p.approvalEstimatedTime + p.routeExecutionDuration).int
 
       value = conversion.wei2Eth(p.suggestedLevelsForMaxFeesPerGas.medium,  decimals = ethDecimals)
       trPath.approvalGasFees = parseFloat(value) * float64(p.approvalGasAmount)

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -65,14 +65,6 @@ proc toTokenTransferMetadata*(jsonObj: JsonNode): TokenTransferMetadata =
   discard jsonObj.getProp("isOwnerToken", result.isOwnerToken)
 
 type
-  EstimatedTime* {.pure.} = enum
-    Unknown = 0
-    LessThanOneMin
-    LessThanThreeMins
-    LessThanFiveMins
-    MoreThanFiveMins
-
-type
   TransactionMinedArgs* = ref object of Args
     data*: string
     transactionHash*: string
@@ -502,14 +494,6 @@ QtObject:
     except CatchableError as e:
       error "setCustomTxDetails", exception=e.msg
       return e.msg
-
-  proc getEstimatedTime*(self: Service, chainId: int, maxFeePerGas: string): EstimatedTime =
-    try:
-      let response = backend.getTransactionEstimatedTime(chainId, maxFeePerGas).result.getInt
-      return EstimatedTime(response)
-    except Exception as e:
-      error "Error estimating transaction time", message = e.msg
-      return EstimatedTime.Unknown
 
   proc getEstimatedTimeV2*(self: Service, chainId: int, gasPrice: string, maxFeePerGas: string, priorityFee: string): int =
     try:

--- a/src/app_service/service/wallet_connect/async_tasks.nim
+++ b/src/app_service/service/wallet_connect/async_tasks.nim
@@ -11,7 +11,7 @@ type
     topic: string
     chainId: int
     maxFeePerGasHex: string
-  
+
   AsyncSuggestedFeesArgs = ref object of QObjectTaskArg
     topic: string
     chainId: int
@@ -29,34 +29,28 @@ proc asyncGetEstimatedTimeTask(argsEncoded: string) {.gcsafe, nimcall.} =
     "estimatedTime": EstimatedTime.Unknown.int,
   }
   try:
-    # in gwei, matching the units of suggestedFees below
-    var maxFeePerGas: float64
+    var maxFeePerGasWeiHex: string
     if arg.maxFeePerGasHex.isEmptyOrWhitespace:
       let chainFeesResult = eth.suggestedFees(arg.chainId).result
       let chainFees = chainFeesResult.toSuggestedFeesDto()
       if chainFees.isNil:
-        arg.finish(result)
+        raise newException(Exception, "chainFees is nil")
 
       # For non-EIP-1559 chains, we use the high fee
-      if chainFees.eip1559Enabled:
-        maxFeePerGas = chainFees.maxFeePerGasM
-      else:
-        maxFeePerGas = chainFees.maxFeePerGasL
+      let maxFeePerGasGwei = if chainFees.eip1559Enabled: chainFees.maxFeePerGasM
+                             else: chainFees.maxFeePerGasL
+      maxFeePerGasWeiHex = eth_utils.gweiToWeiHexValue(maxFeePerGasGwei)
     else:
       try:
-        let maxFeePerGasInt = parseHexInt(arg.maxFeePerGasHex)
-        maxFeePerGas = maxFeePerGasInt.float
+        maxFeePerGasWeiHex = eth_utils.normalizedWeiHexValue(arg.maxFeePerGasHex)
       except ValueError:
-        error "failed to parse maxFeePerGasHex", msg = arg.maxFeePerGasHex
-        arg.finish(result)
+        raise newException(Exception, "failed to parse maxFeePerGasHex " & arg.maxFeePerGasHex)
 
-    let maxFeePerGasWeiHex = "0x" & eth_utils.stripLeadingZeros(stint.u256(int64(maxFeePerGas * 1e9)).toHex)
     let seconds = backend.getTransactionEstimatedTimeV2(arg.chainId, "0x0", maxFeePerGasWeiHex, "0x0").result.getInt
     result["estimatedTime"] = %estimatedTimeFlagFromSeconds(seconds).int
-    arg.finish(result)
   except Exception as e:
     error "asyncGetEstimatedTime failed: ", msg=e.msg
-    arg.finish(result)
+  arg.finish(result)
 
 proc asyncSuggestedFeesTask(argsEncoded: string) {.gcsafe, nimcall.} =
     let arg = decode[AsyncSuggestedFeesArgs](argsEncoded)

--- a/src/app_service/service/wallet_connect/async_tasks.nim
+++ b/src/app_service/service/wallet_connect/async_tasks.nim
@@ -1,5 +1,10 @@
+import stint
+
 import backend/backend
 import backend/eth
+
+import app_service/service/eth/utils as eth_utils
+import app_service/service/transaction/dto_conversion
 
 type
   AsyncGetEstimatedTimeArgs = ref object of QObjectTaskArg
@@ -21,9 +26,10 @@ proc asyncGetEstimatedTimeTask(argsEncoded: string) {.gcsafe, nimcall.} =
   let result = %*{
     "topic": arg.topic,
     "chainId": arg.chainId,
-    "estimatedTime": EstimatedTime.Unknown,
+    "estimatedTime": EstimatedTime.Unknown.int,
   }
   try:
+    # in gwei, matching the units of suggestedFees below
     var maxFeePerGas: float64
     if arg.maxFeePerGasHex.isEmptyOrWhitespace:
       let chainFeesResult = eth.suggestedFees(arg.chainId).result
@@ -44,8 +50,9 @@ proc asyncGetEstimatedTimeTask(argsEncoded: string) {.gcsafe, nimcall.} =
         error "failed to parse maxFeePerGasHex", msg = arg.maxFeePerGasHex
         arg.finish(result)
 
-    let estimatedTime = backend.getTransactionEstimatedTime(arg.chainId, $(maxFeePerGas)).result.getInt
-    result["estimatedTime"] = %estimatedTime
+    let maxFeePerGasWeiHex = "0x" & eth_utils.stripLeadingZeros(stint.u256(int64(maxFeePerGas * 1e9)).toHex)
+    let seconds = backend.getTransactionEstimatedTimeV2(arg.chainId, "0x0", maxFeePerGasWeiHex, "0x0").result.getInt
+    result["estimatedTime"] = %estimatedTimeFlagFromSeconds(seconds).int
     arg.finish(result)
   except Exception as e:
     error "asyncGetEstimatedTime failed: ", msg=e.msg

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -126,10 +126,6 @@ rpc(fetchMarketValues, "wallet"):
 rpc(startWallet, "wallet"):
   discard
 
-rpc(getTransactionEstimatedTime, "wallet"):
-  chainId: int
-  maxFeePerGas: string
-
 rpc(getTransactionEstimatedTimeV2, "wallet"):
   chainId: int
   gasPrice: string

--- a/storybook/pages/SwapSignModalPage.qml
+++ b/storybook/pages/SwapSignModalPage.qml
@@ -101,6 +101,17 @@ SplitView {
                     accountEmoji: priv.selectedAccount.emoji
                     accountColor: Utils.getColorForId(Theme.palette, priv.selectedAccount.colorId)
 
+                    toAccountName: priv.selectedAccount.name
+                    toAccountAddress: priv.selectedAccount.address
+                    toAccountEmoji: priv.selectedAccount.emoji
+                    toAccountColor: Utils.getColorForId(Theme.palette, priv.selectedAccount.colorId)
+
+                    toNetworkName: priv.selectedNetwork.chainName
+                    toNetworkShortName: priv.selectedNetwork.shortName
+                    toNetworkIconPath: Assets.svg(priv.selectedNetwork.iconUrl)
+                    toNetworkBlockExplorerUrl: priv.selectedNetwork.blockExplorerURL
+                    toNetworkChainId: priv.selectedNetwork.chainId
+
                     networkShortName: priv.selectedNetwork.shortName
                     networkName: priv.selectedNetwork.chainName
                     networkIconPath: Assets.svg(priv.selectedNetwork.iconUrl)

--- a/storybook/qmlTests/tests/tst_DerivationPathInput.qml
+++ b/storybook/qmlTests/tests/tst_DerivationPathInput.qml
@@ -159,4 +159,53 @@ Item {
             verify(/^<style>(?:\.[a-zA-Z]{[a-zA-Z0-9#:;]+})+<\/style>(?:<span\sclass=["']\w["']>[\/\d'm]+<\/span>)+$/.test(res), `The generated html is valid and optimum (no extra spaces or CSS long names) - "${res}"`)
         }
     }
+
+    Component {
+        id: inputComponent
+        DerivationPathInput {
+            width: 500
+        }
+    }
+
+    TestCase {
+        name: "DerivationPathInputImCommitTests"
+        when: windowShown
+
+        property DerivationPathInput control: null
+
+        function init() {
+            control = createTemporaryObject(inputComponent, root)
+            verify(!!control)
+            verify(control.resetDerivationPath("m/44'/60'/0'/0", "m/44'/60'/0'/0/5"))
+            control.input.edit.forceActiveFocus()
+            tryVerify(() => control.input.edit.activeFocus)
+        }
+
+        // Virtual keyboards commit characters through the input method instead
+        // of key events; edit.insert() takes the same non-Keys path into the
+        // control, making it a faithful stand-in.
+        function test_imCommitAppendsDigit() {
+            compare(control.derivationPath, "m/44'/60'/0'/0/5")
+            control.input.edit.insert(control.input.cursorPosition, "3")
+            compare(control.derivationPath, "m/44'/60'/0'/0/53")
+        }
+
+        // The mobile repro: delete the last index with backspace (delivered as
+        // a key event even by virtual keyboards), then type its replacement
+        // (delivered as an IM commit)
+        function test_imCommitAfterRemovingLastIndex() {
+            keyClick(Qt.Key_Backspace)
+            verify(control.derivationPath !== "m/44'/60'/0'/0/5")
+
+            control.input.edit.insert(control.input.cursorPosition, "7")
+            compare(control.derivationPath, "m/44'/60'/0'/0/7")
+        }
+
+        // Anything but a clean insertion still reverts to the model
+        function test_externalReplacementReverted() {
+            control.input.edit.selectAll()
+            control.input.edit.remove(0, control.input.edit.length)
+            compare(control.derivationPath, "m/44'/60'/0'/0/5")
+        }
+    }
 }

--- a/storybook/qmlTests/tests/tst_SearchableAssetsPanel.qml
+++ b/storybook/qmlTests/tests/tst_SearchableAssetsPanel.qml
@@ -229,6 +229,36 @@ Item {
             }
         }
 
+        // A search with no matches shows the placeholder where the list would
+        // be — below the search box, never above it.
+        function test_emptySearchResultShowsPlaceholderInListArea() {
+            const control = createTemporaryObject(panelCmp, root)
+
+            const listView = findChild(control, "assetsListView")
+            waitForRendering(listView)
+
+            const searchBox = findChild(control, "searchBox")
+            const placeholder = findChild(control, "emptyListPlaceholder")
+            verify(!!placeholder)
+            verify(!placeholder.visible, "placeholder hidden while the list has rows")
+
+            control.searchKeyword = "no-such-token"
+            searchBox.text = "no-such-token"
+            waitForRendering(listView)
+
+            compare(listView.count, 0)
+            verify(placeholder.visible, "placeholder replaces the empty list")
+            verify(searchBox.visible, "the search box stays usable above it")
+            verify(placeholder.mapToItem(control, 0, 0).y >
+                   searchBox.mapToItem(control, 0, 0).y,
+                   "the placeholder sits below the search box, not on top of the panel")
+
+            control.searchKeyword = ""
+            searchBox.text = ""
+            waitForRendering(listView)
+            verify(!placeholder.visible)
+        }
+
         function test_highlightedKey() {
             const control = createTemporaryObject(panelCmp, root)
             control.panel.highlightedKey = "dai_key"

--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls
 import QtTest
 
 import StatusQ
@@ -110,6 +111,53 @@ Item {
 
             compare(controlUnderTest.listChainFilter, -1)
             compare(controlUnderTest.listCatalogChainId, d.goOptChainId)
+            compare(networkSpy.count, 0)
+        }
+
+        // The chip row is pure browse state: it opens on the panel's selected
+        // chain, the user may wander (another chain, "All"), and closing the
+        // dropdown snaps it back — never touching the selected chain or token.
+        function test_chainFilterFollowsTheSelectedChain() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            verify(!!controlUnderTest)
+
+            // closed state: the filter mirrors the selected chain
+            compare(controlUnderTest.listChainFilter, d.goOptChainId)
+
+            // ...and tracks it when the selection moves
+            controlUnderTest.selectedNetworkChainId = 1
+            compare(controlUnderTest.listChainFilter, 1)
+            controlUnderTest.selectedNetworkChainId = d.goOptChainId
+            compare(controlUnderTest.listChainFilter, d.goOptChainId)
+
+            const holdingSelector = findChild(controlUnderTest, "holdingSelector")
+            verify(!!holdingSelector)
+            const button = findChild(controlUnderTest, "tokenSelectorButton")
+            verify(!!button)
+
+            const networkSpy = createTemporaryQmlObject(
+                    "import QtTest; SignalSpy {}", root)
+            networkSpy.target = controlUnderTest
+            networkSpy.signalName = "networkSelected"
+
+            // browsing starts on the selected chain
+            mouseClick(button)
+            tryVerify(() => holdingSelector.dropdownOpened)
+            compare(controlUnderTest.listChainFilter, d.goOptChainId)
+
+            // wander off to "All" — a display choice, not a selection
+            const chainFilter = findChild(controlUnderTest.Overlay.overlay, "chainFilter")
+            verify(!!chainFilter)
+            chainFilter.chainSelected(-1)
+            compare(controlUnderTest.listChainFilter, -1)
+            compare(controlUnderTest.selectedNetworkChainId, d.goOptChainId)
+            compare(networkSpy.count, 0)
+
+            // closing without a pick leaves no trace of the browsing
+            keyClick(Qt.Key_Escape)
+            tryVerify(() => !holdingSelector.dropdownOpened)
+            compare(controlUnderTest.listChainFilter, d.goOptChainId)
+            compare(controlUnderTest.selectedNetworkChainId, d.goOptChainId)
             compare(networkSpy.count, 0)
         }
 

--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -556,6 +556,7 @@ Item {
             verify(!!holdingSelector)
             mouseClick(holdingSelector)
             waitForRendering(holdingSelector)
+            tryVerify(() => holdingSelector.dropdownOpened, 2000, "dropdown did not open")
 
             const assetSelectorList = findChild(holdingSelector, "assetsListView")
             verify(!!assetSelectorList)
@@ -566,7 +567,11 @@ Item {
             assetSelectorList.positionViewAtIndex(delegateIndex, ListView.Center)
             const sttDelegate = assetSelectorList.itemAtIndex(delegateIndex)
             verify(!!sttDelegate)
-            mouseClick(sttDelegate)
+            // activate through the delegate's own entry point (the same path
+            // Enter/Return takes, incl. the enabled guard) — a raw mouseClick
+            // at this list position is unreliable on the offscreen platform
+            verify(sttDelegate.rowAt(0).enabled)
+            sttDelegate.selectFirst()
 
             tryCompare(controlUnderTest, "selectedHoldingId", sttGroupKey)
 

--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -278,6 +278,41 @@ Item {
             tryCompare(controlUnderTest, "selectedHoldingId", ethGroupKey)
         }
 
+        // Symbols are not token identities — an unrelated (or malicious)
+        // contract can share one. When the selected group key is absent from
+        // the settled catalog, the panel must fall back to the configured
+        // default/native GROUP KEY, never to "some group with the same symbol".
+        function test_absentSelectionNeverRemapsToASameSymbolImpostor() {
+            const store = d.adaptor.walletAssetsStore.walletTokensStore
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, {groupKey: sttGroupKey})
+            store.buildGroupsForChain(d.goOptChainId)
+            verify(!!controlUnderTest)
+            tryCompare(controlUnderTest, "selectedHoldingId", sttGroupKey)
+
+            // settle on a catalog that lacks the selected group but offers an
+            // impostor sharing its symbol, plus the configured default
+            const fresh = store.createTokenSelectorModel(3).model
+            verify(!!fresh)
+            controlUnderTest.tokenSelectorLoading = true
+            controlUnderTest.tokenSelectorModel = fresh
+            fresh.sourceData = [{
+                key: "11155420-0xevil", name: "Totally Legit STT", symbol: "STT",
+                logoUri: "", decimals: 18, cryptoPrice: 1, currentBalance: 0,
+                currencyBalance: 0, sectionName: "",
+                balances: [], tokens: [{ key: "11155420-0xevil", chainId: d.goOptChainId }]
+            }, {
+                key: ethGroupKey, name: "Ether", symbol: "ETH", logoUri: "",
+                decimals: 18, cryptoPrice: 1, currentBalance: 0,
+                currencyBalance: 0, sectionName: "",
+                balances: [], tokens: [{ key: "1-native", chainId: d.goOptChainId }]
+            }]
+            controlUnderTest.tokenSelectorLoading = false
+
+            tryCompare(controlUnderTest, "selectedHoldingId", ethGroupKey)
+            verify(controlUnderTest.selectedHoldingId !== "11155420-0xevil",
+                   "a same-symbol group is not the selected token")
+        }
+
         function test_multiChainTokenRefsStillResolveSelection() {
             const store = d.adaptor.walletAssetsStore.walletTokensStore
             controlUnderTest = createTemporaryObject(componentUnderTest, root, {groupKey: ethGroupKey})

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -891,7 +891,7 @@ Item {
             // fee-reservation interplay: the adaptor derives maxFeesToReserveRaw
             // from the best path's max gas fees (independent of owned balance)
             let bestPath = SQUtils.ModelUtils.get(txRoutes2.suggestedRoutes, 0, "route")
-            const totalMaxFees = Math.ceil(bestPath.gasFees.maxFeePerGasM) * bestPath.gasAmount
+            const totalMaxFees = Math.ceil(bestPath.gasFees.maxFeePerGasM * bestPath.gasAmount)
             const totalMaxFeesInEth = SQUtils.AmountsArithmetic.div(
                                         SQUtils.AmountsArithmetic.fromString(totalMaxFees),
                                         SQUtils.AmountsArithmetic.fromNumber(1, 9))

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -1967,8 +1967,8 @@ Item {
 
         // The handler destroys the modal and then resets the form, and the reset
         // clears the source chain before the destination one — a transient bridge
-        // state. Building the destination picker for it (an expensive terminal
-        // model) only to throw it away is pure waste on every plain-swap close.
+        // state. Building any picker for it (an expensive terminal model) only to
+        // throw it away is pure waste on every close.
         function test_noBridgePickerIsBuiltWhileClosing() {
             const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
 
@@ -2085,24 +2085,32 @@ Item {
             closeAndVerfyModal()
         }
 
-        // A destination picker built lazily (the user switches the receive chain
-        // after the modal is open) must be seeded like the ones createPickers
-        // builds, otherwise it starts on whatever the producer's last search was.
-        function test_lazyBridgePickerIsSeeded() {
+        // The receive side always gets its own destination picker on open (so
+        // browsing either side's list can't disturb the other), seeded like the
+        // pay one; switching to a bridge afterwards must not build anything new.
+        function test_receivePickerIsBuiltAndSeededOnOpen() {
             const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
+            store.createdKinds = []
 
             launchAndVerfyModal()
 
             const receivePanel = findChild(controlUnderTest, "receivePanel")
             verify(!!receivePanel)
+            tryVerify(() => !!receivePanel.tokenSelectorModel, 2000,
+                      "destination picker built on open")
+            verify(store.createdKinds.indexOf(3) !== -1,
+                   "a kind-3 (destination catalog) picker was created, got kinds: "
+                   + JSON.stringify(store.createdKinds))
+
+            const receiveModel = receivePanel.tokenSelectorModel
+            tryCompare(receiveModel, "searchCallCount", 1) // seeded
 
             store.createdKinds = []
             root.swapFormData.toNetworkChainId = 10 // != source chain => bridge
-
-            compare(store.createdKinds.indexOf(3), 0, "destination picker built")
-            const bridgeModel = receivePanel.tokenSelectorModel
-            verify(!!bridgeModel, "the receive panel is switched to it")
-            compare(bridgeModel.searchCallCount, 1, "and it is seeded")
+            compare(store.createdKinds.length, 0,
+                    "switching to a bridge builds no new picker")
+            compare(receivePanel.tokenSelectorModel, receiveModel,
+                    "the receive panel keeps its picker across the bridge switch")
 
             closeAndVerfyModal()
         }

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -1466,11 +1466,13 @@ Item {
             waitForRendering(payPanel)
             waitForRendering(receivePanel)
 
-            // verify form values
+            // verify form values: tokens swap sides, but the ENTERED amount
+            // stays on the pay side and the receive amount (a quote for the
+            // old direction) is cleared pending a fresh quote
             compare(root.swapFormData.fromGroupKey, expectedToTokenKey)
-            compare(root.swapFormData.fromTokenAmount, data.toTokenAmount)
+            compare(root.swapFormData.fromTokenAmount, data.fromTokenAmount)
             compare(root.swapFormData.toGroupKey, expectedFromTokenKey)
-            compare(root.swapFormData.toTokenAmount, data.fromTokenAmount)
+            compare(root.swapFormData.toTokenAmount, "")
 
             paytokenSelectorContentItemText = findChild(payPanel, "tokenSelectorContentItemText")
             verify(!!paytokenSelectorContentItemText)
@@ -1483,7 +1485,7 @@ Item {
 
             // verify pay values
             compare(payPanel.groupKey, expectedToTokenKey)
-            compare(payPanel.tokenAmount, data.toTokenAmount)
+            compare(payPanel.tokenAmount, data.fromTokenAmount)
             verify(payAmountToSendInput.cursorVisible)
             const swappedFromToken = !!root.swapFormData.fromGroupKey ? SQUtils.ModelUtils.getByKey(payTokenModel, "key", root.swapFormData.fromGroupKey) : null
             const swappedToToken = !!root.swapFormData.toGroupKey ? SQUtils.ModelUtils.getByKey(receiveTokenModel, "key", root.swapFormData.toGroupKey) : null
@@ -1495,7 +1497,7 @@ Item {
 
             // verify receive values
             compare(receivePanel.groupKey, expectedFromTokenKey)
-            compare(receivePanel.tokenAmount, data.fromTokenAmount)
+            compare(receivePanel.tokenAmount, "")
             verify(!receiveAmountToSendInput.cursorVisible)
             compare(receivetokenSelectorContentItemText.text, swappedToToken ? swappedToToken.symbol : qsTr("Select asset"))
             if(!!receivetokenSelectorIcon) {

--- a/storybook/qmlTests/tests/tst_SwapSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapSignModal.qml
@@ -37,6 +37,17 @@ Item {
             accountEmoji: "🚗"
             accountColor: Utils.getColorForId(Theme.palette, Constants.walletAccountColors.primary)
 
+            toAccountName: "Cold wallet"
+            toAccountAddress: "0x1A47C2e98a4BBf5487E6fb082eC2D9Ab0E6d1234"
+            toAccountEmoji: "🧊"
+            toAccountColor: Utils.getColorForId(Theme.palette, Constants.walletAccountColors.army)
+
+            toNetworkName: "Optimism"
+            toNetworkShortName: Constants.networkShortChainNames.optimism
+            toNetworkIconPath: Assets.svg("network/optimism")
+            toNetworkBlockExplorerUrl: "https://optimistic.etherscan.io/"
+            toNetworkChainId: 10
+
             networkShortName: Constants.networkShortChainNames.mainnet
             networkName: "Mainnet"
             networkIconPath: Assets.svg("network/ethereum")
@@ -118,7 +129,10 @@ Item {
             // info box
             const headerText = findChild(controlUnderTest.contentItem, "headerText")
             verify(!!headerText)
-            compare(headerText.text, qsTr("Swap 1,000.12 SNT to 1.42 %3 in %1 on %2").arg(controlUnderTest.accountName).arg(controlUnderTest.networkName).arg(data.toTokenSymbol))
+            compare(headerText.text, qsTr("From %1 1,000.12 SNT on %2 to %3 1.42 %4 on %5")
+                    .arg(controlUnderTest.accountName).arg(controlUnderTest.networkName)
+                    .arg(controlUnderTest.toAccountName).arg(data.toTokenSymbol)
+                    .arg(controlUnderTest.toNetworkName))
             const fromImage = findChild(controlUnderTest.contentItem, "fromImageIdenticon")
             verify(!!fromImage)
             compare(fromImage.asset.name, Constants.tokenIcon(controlUnderTest.fromTokenSymbol))
@@ -141,6 +155,10 @@ Item {
             compare(receiveBox.secondaryText,
                     data.toTokenSymbol === "ETH" ? ""
                                                  : SQUtils.Utils.elideAndFormatWalletAddress(controlUnderTest.toTokenContractAddress))
+
+            // each side badges its own network — they differ when bridging
+            compare(payBox.badge, controlUnderTest.networkIconPath)
+            compare(receiveBox.badge, controlUnderTest.toNetworkIconPath)
         }
 
         function test_accountInfo() {
@@ -150,42 +168,29 @@ Item {
             const accountBox = findChild(controlUnderTest.contentItem, "accountBox")
             verify(!!accountBox)
 
-            compare(accountBox.caption, qsTr("In account"))
+            compare(accountBox.caption, qsTr("From account"))
             compare(accountBox.primaryText, controlUnderTest.accountName)
             compare(accountBox.secondaryText, SQUtils.Utils.elideAndFormatWalletAddress(controlUnderTest.accountAddress))
             compare(accountBox.asset.emoji, controlUnderTest.accountEmoji)
             compare(accountBox.asset.color, controlUnderTest.accountColor)
+
+            // to-account box
+            const toAccountBox = findChild(controlUnderTest.contentItem, "toAccountBox")
+            verify(!!toAccountBox)
+
+            compare(toAccountBox.caption, qsTr("To account"))
+            compare(toAccountBox.primaryText, controlUnderTest.toAccountName)
+            compare(toAccountBox.secondaryText, SQUtils.Utils.elideAndFormatWalletAddress(controlUnderTest.toAccountAddress))
+            compare(toAccountBox.asset.emoji, controlUnderTest.toAccountEmoji)
+            compare(toAccountBox.asset.color, controlUnderTest.toAccountColor)
         }
 
-        function test_networkInfo() {
+        function test_removedRepeatedBoxes() {
             verify(!!controlUnderTest)
 
-            // network box
-            const networkBox = findChild(controlUnderTest.contentItem, "networkBox")
-            verify(!!networkBox)
-
-            compare(networkBox.caption, qsTr("Network"))
-            compare(networkBox.primaryText, controlUnderTest.networkName)
-            compare(networkBox.icon, controlUnderTest.networkIconPath)
-        }
-
-        function test_feesInfo() {
-            verify(!!controlUnderTest)
-
-            // fees box
-            const feesBox = findChild(controlUnderTest.contentItem, "feesBox")
-            verify(!!feesBox)
-
-            compare(feesBox.caption, qsTr("Fees"))
-            compare(feesBox.primaryText, qsTr("Max. fees on %1").arg(controlUnderTest.networkName))
-
-            const fiatFeesText = findChild(feesBox, "fiatFeesText")
-            verify(!!fiatFeesText)
-            compare(fiatFeesText.text, controlUnderTest.fiatFees)
-
-            const cryptoFeesText = findChild(feesBox, "cryptoFeesText")
-            verify(!!cryptoFeesText)
-            compare(cryptoFeesText.text, controlUnderTest.cryptoFees)
+            // network and fees info moved to the footer/route views — no boxes here
+            verify(!findChild(controlUnderTest.contentItem, "networkBox"))
+            verify(!findChild(controlUnderTest.contentItem, "feesBox"))
         }
 
         function test_loginType_data() {
@@ -220,20 +225,10 @@ Item {
             verify(!!footerFiatFeesText)
             compare(footerFiatFeesText.loading, false)
 
-            const fiatFeesText = findChild(controlUnderTest.contentItem, "fiatFeesText")
-            verify(!!fiatFeesText)
-            compare(fiatFeesText.loading, false)
-
-            const cryptoFeesText = findChild(controlUnderTest.contentItem, "cryptoFeesText")
-            verify(!!cryptoFeesText)
-            compare(cryptoFeesText.loading, false)
-
             controlUnderTest.feesLoading = true
 
             compare(signButton.interactive, false)
             compare(footerFiatFeesText.loading, true)
-            compare(fiatFeesText.loading, true)
-            compare(cryptoFeesText.loading, true)
         }
 
         function test_footerInfo() {

--- a/storybook/qmlTests/tests/tst_TokenSelectorAssetDelegate.qml
+++ b/storybook/qmlTests/tests/tst_TokenSelectorAssetDelegate.qml
@@ -169,9 +169,10 @@ Item {
                 tokensModel: tokens
             })
 
-            // no balances and no catalog chain: nothing to resolve against
-            compare(control.tokenAddress, "")
-            compare(control.hasAddressChip, false)
+            // no balances and no catalog chain: the token's own first
+            // deployment stands in
+            compare(control.tokenAddress, root.tokenAddress)
+            compare(control.hasAddressChip, true)
 
             // the catalog chain picks the matching per-chain deployment
             control.fallbackChainId = 10
@@ -182,10 +183,12 @@ Item {
             compare(control.tokenAddress, root.tokenAddress)
             compare(control.hasAddressChip, true)
 
-            // a chain the group has no entry for resolves to no chip
+            // a chain the group has no entry for is ignored — the row shows its
+            // own chain's deployment instead (an unscoped "All" list mixes in
+            // tokens from other chains)
             control.fallbackChainId = 42161
-            compare(control.tokenAddress, "")
-            compare(control.hasAddressChip, false)
+            compare(control.tokenAddress, root.tokenAddress)
+            compare(control.hasAddressChip, true)
         }
 
         // a chain switch rebuilds the tokens submodel in place with an
@@ -200,14 +203,43 @@ Item {
             })
             compare(control.tokenAddress, root.tokenAddress)
 
-            // the catalog now holds another chain's deployment; same row count
+            // the catalog now holds another chain's deployment; same row count.
+            // Until the rebuild lands the row keeps showing its own (only)
+            // deployment; afterwards it follows the new content.
             control.fallbackChainId = 10
-            compare(control.tokenAddress, "")
+            compare(control.tokenAddress, root.tokenAddress)
             tokens.setProperty(0, "chainId", 10)
             tokens.setProperty(0, "key", "10-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
             compare(control.tokenAddress, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
             compare(control.hasAddressChip, true)
+        }
+
+        // a row without a per-chain balance badges its RESOLVED chain's icon
+        // (looked up in the networks catalog), not the generic default — on an
+        // unscoped "All" list a BSC-only token must show the BSC badge
+        function test_networkBadgeFollowsTheResolvedChain() {
+            const tokens = Qt.createQmlObject("import QtQuick; ListModel {}", root)
+            tokens.append({ chainId: 56, key: "56-" + root.tokenAddress })
+
+            const networks = Qt.createQmlObject("import QtQuick; ListModel {}", root)
+            networks.append({ chainId: 1, iconUrl: "network/Network=Ethereum" })
+            networks.append({ chainId: 56, iconUrl: "network/Network=BSC" })
+
+            const control = createTemporaryObject(delegateCmp, root, {
+                tokensModel: tokens,
+                flatNetworksModel: networks,
+                defaultNetworkIcon: "network/Network=Ethereum",
+                fallbackChainId: 1 // the panel's chain; the token isn't on it
+            })
+
+            compare(control.resolvedChainId, 56)
+            compare(control.effectiveNetworkIcon, "network/Network=BSC")
+            compare(control.tokenAddress, root.tokenAddress)
+
+            // without the networks catalog the generic default still applies
+            control.flatNetworksModel = null
+            compare(control.effectiveNetworkIcon, "network/Network=Ethereum")
         }
 
         function test_zeroAddressHasNoChip() {

--- a/storybook/src/Mocks/TokensStoreMock.qml
+++ b/storybook/src/Mocks/TokensStoreMock.qml
@@ -32,10 +32,12 @@ TokensStore {
 
     function createTokenSelectorModel(kind) {
         root.createdKinds = root.createdKinds.concat([kind])
-        // Mirror the producer's per-kind source: swap (1) uses the source-chain
-        // groups, bridge receive (3) uses the destination-chain groups, send (0) /
-        // buy (2) use the full groups. If a caller pre-seeded tokenSelectorStubData,
-        // use that static set instead.
+        // Mirror the producer's per-kind source: swap pay (1) uses the
+        // source-chain groups, swap receive (3) the destination-chain groups,
+        // send (0) / buy (2) the full groups. (The real producer additionally
+        // swaps in the cross-chain groups while no chain filter is set — the
+        // "All" chip; that path is covered by the Nim model tests.) If a caller
+        // pre-seeded tokenSelectorStubData, use that static set instead.
         let props = {}
         if (!!root.tokenSelectorStubData && root.tokenSelectorStubData.length > 0)
             props = { sourceData: root.tokenSelectorStubData }
@@ -62,16 +64,25 @@ TokensStore {
 
     property var builtChainIds: []
 
+    // Like the real token service, each side's build touches only its own
+    // catalog — the receive panel drives buildGroupsForChainTo itself.
     function buildGroupsForChain(chainId) {
         root.builtChainIds = root.builtChainIds.concat([chainId])
         root._buildGroupsInto(root.tokenGroupsForChainModel, chainId)
-        // keep the destination model in sync so receive-panel tests have data
-        if (root.tokenGroupsForChainToModel)
-            root._buildGroupsInto(root.tokenGroupsForChainToModel, chainId)
     }
 
+    property var builtToChainIds: []
+
     function buildGroupsForChainTo(chainId) {
+        root.builtToChainIds = root.builtToChainIds.concat([chainId])
         root._buildGroupsInto(root.tokenGroupsForChainToModel, chainId)
+    }
+
+    // The real store triggers the on-demand cross-chain catalog fetch here;
+    // in storybook the mock models are static, so this only records the call.
+    property int fetchAllChainsTokenGroupsCallCount: 0
+    function fetchAllChainsTokenGroups(mandatoryKeys) {
+        root.fetchAllChainsTokenGroupsCallCount++
     }
 
     function _buildGroupsInto(targetModel, chainId) {

--- a/test/nim/eth_utils_fee_hex_test.nim
+++ b/test/nim/eth_utils_fee_hex_test.nim
@@ -1,0 +1,61 @@
+## Regression tests for the dApp estimated-time fee path (wallet_connect
+## asyncGetEstimatedTimeTask): a dApp transaction's maxFeePerGas/gasPrice is
+## already denominated in wei and must reach getTransactionEstimatedTimeV2
+## unscaled, while the gwei values reported by eth_suggestedFees are converted
+## to wei exactly once. The task itself is `include`d into the wallet_connect
+## service (not importable), so these cover the conversion helpers it calls
+## verbatim — normalizedWeiHexValue / gweiToWeiHexValue.
+
+import unittest, strutils
+
+import app_service/service/eth/utils as eth_utils
+
+suite "eth_utils - fee hex conversion (dApp estimated-time path)":
+
+  test "a supplied wei hex value passes through unscaled":
+    # 0x2540be400 == 10^10 wei == 10 gwei; multiplying it by 1e9 again (the
+    # old bug) would claim a 10-billion-gwei fee
+    check eth_utils.normalizedWeiHexValue("0x2540be400") == "0x2540be400"
+
+  test "normalization canonicalizes form only, never the value":
+    check eth_utils.normalizedWeiHexValue("0x0002540BE400") == "0x2540be400"
+    check eth_utils.normalizedWeiHexValue("0x0") == "0x0"
+
+  test "the suggested gwei fee converts to wei exactly once":
+    check eth_utils.gweiToWeiHexValue(10.0) == "0x2540be400"   # 10 gwei
+    check eth_utils.gweiToWeiHexValue(1.5) == "0x59682f00"     # 1.5 gwei
+    check eth_utils.gweiToWeiHexValue(0.0) == "0x0"
+
+  test "wei values beyond int64 survive without overflow":
+    # 2^70 wei — parseHexInt/int64 (the old path) cannot represent this
+    check eth_utils.normalizedWeiHexValue("0x400000000000000000") ==
+      "0x400000000000000000"
+    # the full UInt256 range round-trips
+    let maxHex = "0x" & repeat('f', 64)
+    check eth_utils.normalizedWeiHexValue(maxHex) == maxHex
+
+  test "leading zeros never count against the 256-bit width":
+    # 65 digits, but only one significant — a padded zero is still zero
+    check eth_utils.normalizedWeiHexValue("0x" & repeat('0', 65)) == "0x0"
+    check eth_utils.normalizedWeiHexValue("0x" & repeat('0', 63) & "2540be400") ==
+      "0x2540be400"
+
+  test "malformed input raises instead of silently degrading":
+    expect ValueError:
+      discard eth_utils.normalizedWeiHexValue("0xnot-a-number")
+    # bare prefix must not read as zero
+    expect ValueError:
+      discard eth_utils.normalizedWeiHexValue("0x")
+    expect ValueError:
+      discard eth_utils.normalizedWeiHexValue("")
+    # no prefix, no deal — a bare quantity is ambiguous
+    expect ValueError:
+      discard eth_utils.normalizedWeiHexValue("2540be400")
+
+  test "values wider than 256 bits are rejected, not wrapped":
+    # 65 significant digits: stint's fromHex would reduce this mod 2^256 to
+    # ZERO — i.e. a huge malformed fee silently becoming the lowest one
+    expect ValueError:
+      discard eth_utils.normalizedWeiHexValue("0x1" & repeat('0', 64))
+    expect ValueError:
+      discard eth_utils.normalizedWeiHexValue("0x" & repeat('f', 65))

--- a/test/nim/token_groups_model_test.nim
+++ b/test/nim/token_groups_model_test.nim
@@ -303,3 +303,70 @@ suite "token_groups_model - tokens submodel lifetime":
     gGroups = @[mkGroup2("a"), mkGroup("b")]  # a's token set changes
     m.modelsUpdated()
     check tokensModelResetCount == before + 1 # exactly the submodel's own reset
+
+suite "token_groups_model - lazy pagination with pinned rows":
+
+  proc newLazyModel(batch = 10, initial = 10): TokenGroupsModel =
+    newTokenGroupsModel(groupsDataSource(), marketValuesDataSource(),
+      modelModes = @[ModelMode.NoMarketDetails, ModelMode.UseLazyLoading],
+      lazyLoadingBatchSize = batch, lazyLoadingInitialCount = initial)
+
+  proc seedSource(count: int) =
+    gGroups = @[]
+    for i in 0 ..< count:
+      gGroups.add(mkGroup("k" & $(100 + i)))  # k100.. keeps keys same-width
+
+  proc paginateToExhaustion(m: TokenGroupsModel): int =
+    ## Fetches until the model reports no more items; returns the number of
+    ## fetch rounds. Bounded and break-on-stall (unittest's `check` records a
+    ## failure but keeps executing, so it must never be the loop's only exit):
+    ## a regression fails the callers' `not hasMoreItemsForSource()` assertion
+    ## promptly instead of hanging the test run.
+    const maxRounds = 20
+    while m.hasMoreItemsForSource() and result < maxRounds:
+      let before = m.getLoadedGroups().len
+      m.fetchMore()
+      result.inc
+      let progressed = m.getLoadedGroups().len > before
+      check progressed                      # a stalled round is a regression
+      if not progressed:
+        break
+    check result < maxRounds                # and so is never finishing
+
+  test "pinning a row beyond page one doesn't skip or duplicate source rows":
+    seedSource(25)
+    let m = newLazyModel()
+    m.modelsUpdated(resetModelSize = true)
+    check m.getLoadedGroups().len == 10
+
+    # pin a row from the third page (ensureKeyLoaded path)
+    check m.ensureKeyLoaded("k122")
+    check m.getLoadedGroups().len == 11
+
+    discard m.paginateToExhaustion()
+
+    let keys = m.getLoadedGroups().mapIt(it.key)
+    check keys.len == 25                       # nothing skipped
+    check keys.deduplicate().len == 25         # nothing inserted twice
+    check not m.hasMoreItemsForSource()        # and it terminates for good
+
+  test "mandatory keys beyond page one paginate to full coverage too":
+    seedSource(25)
+    let m = newLazyModel()
+    m.modelsUpdated(resetModelSize = true, mandatoryKeys = @["k123", "k110"])
+
+    discard m.paginateToExhaustion()
+
+    let keys = m.getLoadedGroups().mapIt(it.key)
+    check keys.len == 25
+    check keys.deduplicate().len == 25
+    check not m.hasMoreItemsForSource()
+
+  test "a pinned last row still lets pagination finish exactly once":
+    seedSource(11)
+    let m = newLazyModel()
+    m.modelsUpdated(resetModelSize = true)
+    check m.ensureKeyLoaded("k110")            # the single row of page two
+    check not m.hasMoreItemsForSource()        # everything is loaded already
+    m.fetchMore()                              # must be a clean no-op
+    check m.getLoadedGroups().len == 11

--- a/test/nim/token_selector_model_test.nim
+++ b/test/nim/token_selector_model_test.nim
@@ -324,6 +324,74 @@ suite "TokenSelectorModel - producer-driven recompute":
     m.search("")
     check m.keysInOrder() == @["ETH"]
 
+  test "an active chain filter scopes search results to tokens on that chain":
+    let m = newTokenSelectorModel(TokenSelectorMode.AllTokens)
+    var source: TokenSelectorSource
+    source.getSearch = proc(): seq[PopularGroup] =
+      @[PopularGroup(key: "1-0xaehron", name: "Aehron", symbol: "AEHRON",
+                     tokens: @[(key: "1-0xaehron", chainId: 1)]),
+        PopularGroup(key: "bsc-native", name: "BNB", symbol: "BNB",
+                     tokens: @[(key: "56-native", chainId: 56)])]
+    m.setSource(source)
+    m.setOwnedSource(@[], networks)
+    m.search("n")
+    # no filter: the chain-agnostic search shows both
+    check m.keysInOrder() == @["1-0xaehron", "bsc-native"]
+    # BSC filter: the mainnet-only token is not offered
+    m.setEnabledChainId(56)
+    check m.keysInOrder() == @["bsc-native"]
+    m.setEnabledChainId(-1)
+    check m.keysInOrder() == @["1-0xaehron", "bsc-native"]
+
+  test "an active chain filter scopes the popular catalog to tokens on that chain":
+    let m = newTokenSelectorModel(TokenSelectorMode.AllTokens)
+    var source: TokenSelectorSource
+    source.getPopular = proc(): seq[PopularGroup] =
+      @[PopularGroup(key: "1-0xaehron", name: "Aehron", symbol: "AEHRON",
+                     tokens: @[(key: "1-0xaehron", chainId: 1)]),
+        PopularGroup(key: "bsc-native", name: "BNB", symbol: "BNB",
+                     tokens: @[(key: "56-native", chainId: 56)])]
+    m.setSource(source)
+    m.setOwnedSource(@[], networks)
+    m.setEnabledChainId(56)
+    check m.keysInOrder() == @["bsc-native"]
+    m.setEnabledChainId(1)
+    check m.keysInOrder() == @["1-0xaehron"]
+
+  test "\"All\" (no chain filter) draws the cross-chain popular source when wired":
+    let m = newTokenSelectorModel(TokenSelectorMode.AllTokens)
+    var fetchMoreCalls = 0
+    var fetchMoreAllCalls = 0
+    var source: TokenSelectorSource
+    source.getPopular = proc(): seq[PopularGroup] =
+      @[PopularGroup(key: "1-0xchain", name: "ChainScoped", symbol: "CHX",
+                     tokens: @[(key: "1-0xchain", chainId: 1)])]
+    source.getPopularAllChains = proc(): seq[PopularGroup] =
+      @[PopularGroup(key: "1-0xchain", name: "ChainScoped", symbol: "CHX",
+                     tokens: @[(key: "1-0xchain", chainId: 1)]),
+        PopularGroup(key: "bsc-native", name: "BNB", symbol: "BNB",
+                     tokens: @[(key: "56-native", chainId: 56)])]
+    source.hasMore = proc(searching: bool): bool = true
+    source.fetchMore = proc(searching: bool) = fetchMoreCalls.inc
+    source.hasMoreAllChains = proc(): bool = true
+    source.fetchMoreAllChains = proc() = fetchMoreAllCalls.inc
+    m.setSource(source)
+    m.setOwnedSource(@[], networks)
+    # no filter -> the cross-chain source, spanning every chain
+    check m.keysInOrder() == @["1-0xchain", "bsc-native"]
+    # lazy passthrough routes to the cross-chain closures in this scope
+    check m.getHasMoreItems()
+    m.fetchMore()
+    check fetchMoreAllCalls == 1
+    check fetchMoreCalls == 0
+    # a concrete filter -> back to the chain-scoped catalog and its lazy source
+    m.setEnabledChainId(1)
+    check m.keysInOrder() == @["1-0xchain"]
+    check m.getHasMoreItems()
+    m.fetchMore()
+    check fetchMoreCalls == 1
+    check fetchMoreAllCalls == 1
+
   test "tokens submodel exposes per-chain token refs for a row":
     let m = newTokenSelectorModel(TokenSelectorMode.Owned)
     var g = AggTokenGroup(key: "ETH", name: "ETH", symbol: "ETH", decimals: 18,

--- a/test/nim/transaction_route_time_bucket_test.nim
+++ b/test/nim/transaction_route_time_bucket_test.nim
@@ -1,0 +1,101 @@
+## Tests that the provider-reported route execution duration (e.g. LI.FI
+## bridging time) is parsed from the router's path payload and included in
+## the estimated-time bucket shown by the UI, on top of the gas-based
+## source-chain inclusion estimate.
+
+import unittest, json, strutils
+
+import app_service/service/transaction/dto
+import app_service/service/transaction/dtoV2
+import app_service/service/transaction/dto_conversion
+
+const networkJson = """{
+  "chainId": 42161, "chainName": "Arbitrum", "blockExplorerUrl": "https://arbiscan.io/",
+  "iconUrl": "network/arbitrum", "nativeCurrencyName": "Ether", "nativeCurrencySymbol": "ETH",
+  "nativeCurrencyDecimals": 18, "isTest": false, "layer": 2, "enabled": true,
+  "chainColor": "#51D0F0", "shortName": "arb1", "relatedChainId": 421614,
+  "isActive": true, "isDeactivatable": true, "eip1559Enabled": true
+}"""
+
+const tokenJson = """{
+  "crossChainId": "eth-native", "chainId": 42161,
+  "address": "0x0000000000000000000000000000000000000000", "decimals": 18,
+  "name": "Ethereum", "symbol": "ETH", "logoUri": "", "custom": false
+}"""
+
+# Mirrors the wallet.suggested.routes event payload (trimmed to the fields the
+# parser reads). routeExecutionDurationJson is spliced in whole so the
+# field-absent case can be exercised too.
+proc makePathJson(txEstimatedTime, approvalEstimatedTime: int, routeExecutionDurationJson: string): string =
+  result = """{
+    "RouterInputParamsUuid": "test-uuid", "ProcessorName": "LiFi", "Tool": "across",
+    "FromChain": $1, "ToChain": $1, "FromToken": $2, "ToToken": $2,
+    "AmountIn": "0x1bf5b92a61e000", "AmountInLocked": false, "AmountOut": "0x1bae0c8d37c8d9",
+    "SuggestedNonEIP1559Fees": null,
+    "SuggestedLevelsForMaxFeesPerGas": {
+      "low": "0x1391e33", "lowPriority": "0x0", "lowEstimatedTime": 0,
+      "medium": "0x4e478cf", "mediumPriority": "0x0", "mediumEstimatedTime": 0,
+      "high": "0xc3b2e08", "highPriority": "0x0", "highEstimatedTime": 0
+    },
+    "MaxFeesPerGas": "0x0", "SuggestedMinPriorityFee": "0x0", "SuggestedMaxPriorityFee": "0x0",
+    "CurrentBaseFee": "0x1317b20", "SuggestedTxNonce": "0x80", "SuggestedTxGasAmount": 228990,
+    "SuggestedApprovalTxNonce": "0x0", "SuggestedApprovalGasAmount": 0,
+    "UsedContractAddress": "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
+    "TxNonce": "0x80", "TxGasPrice": "0x0", "TxGasFeeMode": 0,
+    "TxMaxFeesPerGas": "0x1391e33", "TxBaseFee": "0x1317b20", "TxPriorityFee": "0x0",
+    "TxGasAmount": 228990, "TxBonderFees": "0x0", "TxTokenFees": "0x0",
+    "TxEstimatedTime": $3,$5
+    "TxFee": "0x4461192f71a", "TxL1Fee": "0x0",
+    "ApprovalRequired": false, "ApprovalAmountRequired": "0x0",
+    "ApprovalContractAddress": "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae",
+    "ApprovalTxNonce": "0x0", "ApprovalGasPrice": "0x0", "ApprovalGasFeeMode": 0,
+    "ApprovalMaxFeesPerGas": "0x0", "ApprovalBaseFee": "0x0", "ApprovalPriorityFee": "0x0",
+    "ApprovalGasAmount": 0, "ApprovalEstimatedTime": $4,
+    "ApprovalFee": "0x0", "ApprovalL1Fee": "0x0", "TxTotalFee": "0x4461192f71a"
+  }""" % [networkJson, tokenJson, $txEstimatedTime, $approvalEstimatedTime, routeExecutionDurationJson]
+
+proc parsePath(txEstimatedTime, approvalEstimatedTime, routeExecutionDuration: int): TransactionPathDtoV2 =
+  makePathJson(txEstimatedTime, approvalEstimatedTime,
+               " \"RouteExecutionDuration\": " & $routeExecutionDuration & ",").parseJson.toTransactionPathDtoV2()
+
+proc timeBucket(txEstimatedTime, approvalEstimatedTime, routeExecutionDuration: int): EstimatedTime =
+  let converted = convertToOldRoute(@[parsePath(txEstimatedTime, approvalEstimatedTime, routeExecutionDuration)])
+  check converted.len == 1
+  return EstimatedTime(converted[0].estimatedTime)
+
+suite "route estimated time bucketing":
+
+  test "RouteExecutionDuration is parsed from the payload":
+    check parsePath(72, 0, 420).routeExecutionDuration == 420
+
+  test "missing RouteExecutionDuration defaults to 0":
+    let path = makePathJson(72, 0, "").parseJson.toTransactionPathDtoV2()
+    check path.routeExecutionDuration == 0
+
+  test "no route duration keeps the inclusion-only bucket":
+    # 72s inclusion estimate alone (typical mainnet medium-fee case)
+    check timeBucket(72, 0, 0) == EstimatedTime.LessThanTwoMins
+
+  test "route duration extends the bucket":
+    # same inclusion estimate, but a 7-minute bridge on top
+    check timeBucket(72, 0, 420) == EstimatedTime.MoreThanFiveMins
+
+  test "all three components are summed":
+    # 50 + 40 + 100 = 190s; each alone would bucket lower
+    check timeBucket(50, 40, 100) == EstimatedTime.LessThanFourMins
+
+  test "short route duration can keep a low bucket":
+    check timeBucket(20, 0, 30) == EstimatedTime.LessThanOneMin # 50s in total
+
+  test "bucket boundaries":
+    check timeBucket(29, 0, 0) == EstimatedTime.LessThanThirtySecs
+    check timeBucket(30, 0, 0) == EstimatedTime.LessThanOneMin
+    check timeBucket(119, 0, 0) == EstimatedTime.LessThanTwoMins
+    check timeBucket(120, 0, 0) == EstimatedTime.LessThanThreeMins
+    check timeBucket(239, 0, 0) == EstimatedTime.LessThanFourMins
+    check timeBucket(240, 0, 0) == EstimatedTime.LessThanFiveMins
+    check timeBucket(300, 0, 0) == EstimatedTime.LessThanFiveMins # inclusive upper bound
+    check timeBucket(301, 0, 0) == EstimatedTime.MoreThanFiveMins
+
+  test "zero everything stays unknown":
+    check timeBucket(0, 0, 0) == EstimatedTime.Unknown

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -79,10 +79,16 @@ QtObject {
         switch(estimatedFlag) {
         case Constants.TransactionEstimatedTime.Unknown:
             return qsTr("~ Unknown")
+        case Constants.TransactionEstimatedTime.LessThanThirtySecs:
+            return shortForm ? qsTr("< 30 sec") : qsTr("< 30 seconds")
         case Constants.TransactionEstimatedTime.LessThanOneMin :
             return shortForm ? qsTr("< 1 min") : qsTr("< 1 minute")
+        case Constants.TransactionEstimatedTime.LessThanTwoMins:
+            return shortForm ? qsTr("< 2 min") : qsTr("< 2 minutes")
         case Constants.TransactionEstimatedTime.LessThanThreeMins :
             return shortForm ? qsTr("< 3 min") : qsTr("< 3 minutes")
+        case Constants.TransactionEstimatedTime.LessThanFourMins:
+            return shortForm ? qsTr("< 4 min") : qsTr("< 4 minutes")
         case Constants.TransactionEstimatedTime.LessThanFiveMins:
             return shortForm ? qsTr("< 5 min") : qsTr("< 5 minutes")
         default:

--- a/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
@@ -1,6 +1,8 @@
 import QtQuick
 import QtQuick.Controls
 
+import QtModelsToolkit
+
 import StatusQ.Controls
 import StatusQ.Core.Utils
 
@@ -38,6 +40,11 @@ Control {
     property string defaultNetworkIcon
 
     readonly property bool isSelected: button.selected
+
+    readonly property bool dropdownOpened: dropdown.opened
+
+    signal dropdownAboutToOpen()
+    signal dropdownClosed()
 
     signal search(string keyword)
     /** chainId is -1 when the row didn't pin one down; the caller then picks it **/
@@ -127,8 +134,24 @@ Control {
                     return
                 }
 
+                let resolvedChainId = chainId
+                if (resolvedChainId === -1) {
+                    const refs = entry.tokens ?? entry.balances
+                    if (!!refs && refs.ModelCount.count > 0) {
+                        if (root.selectedChainId !== -1 && ModelUtils.contains(refs, "chainId", root.selectedChainId))
+                            resolvedChainId = root.selectedChainId
+                        else {
+                            const firstChain = ModelUtils.get(refs, 0, "chainId")
+                            if (firstChain !== undefined)
+                                resolvedChainId = firstChain
+                        }
+                    } else if (root.selectedChainId !== -1) {
+                        resolvedChainId = root.selectedChainId
+                    }
+                }
+
                 setCurrentAndClose(entry.symbol, entry.logoUri || Constants.tokenIcon(entry.symbol), entry.key)
-                root.selected(entry.key, chainId)
+                root.selected(entry.key, resolvedChainId)
             }
 
             onSearch: function(keyword) {
@@ -136,8 +159,11 @@ Control {
             }
         }
 
+        onAboutToShow: root.dropdownAboutToOpen()
+
         onClosed: {
             searchableAssetsPanel.clearSearch()
+            root.dropdownClosed()
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
@@ -124,14 +124,6 @@ Control {
     contentItem: ColumnLayout {
         spacing: 0
 
-        StatusBaseText {
-            Layout.alignment: Qt.AlignHCenter
-            Layout.bottomMargin: 4
-            text: qsTr("Your assets will appear here")
-            color: Theme.palette.baseColor1
-            visible: !listView.count && !searchBox.text
-        }
-
         RowLayout {
             Layout.fillWidth: true
             spacing: Theme.halfPadding
@@ -187,6 +179,16 @@ Control {
         StatusDialogDivider {
             Layout.fillWidth: true
             visible: listView.count
+        }
+
+        StatusBaseText {
+            objectName: "emptyListPlaceholder"
+            Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: Theme.padding
+            Layout.bottomMargin: Theme.padding
+            text: qsTr("Your assets will appear here")
+            color: Theme.palette.baseColor1
+            visible: !listView.count && !root.isLoadingMore
         }
 
         StatusListView {
@@ -283,6 +285,7 @@ Control {
                                                                      : root.highlightedChainId
                         currentBalance: !!modelData ? modelData.balance : (holding.currentBalance ?? 0)
                         defaultNetworkIcon: root.defaultNetworkIcon
+                        flatNetworksModel: root.flatNetworksModel
 
                         onClicked: root.selected(holding.key, rowChainId)
 

--- a/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
@@ -110,6 +110,17 @@ Control {
         }
     }
 
+    TapHandler {
+        enabled: Qt.inputMethod.visible
+        onTapped: (eventPoint) => {
+            const local = root.mapToItem(searchBox, eventPoint.position.x, eventPoint.position.y)
+            if (local.x >= 0 && local.y >= 0 && local.x < searchBox.width && local.y < searchBox.height)
+                return
+            root.forceActiveFocus()
+            Qt.inputMethod.hide()
+        }
+    }
+
     contentItem: ColumnLayout {
         spacing: 0
 

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -48,6 +48,7 @@ Control {
 
     property int selectedNetworkChainId: -1
     onSelectedNetworkChainIdChanged: {
+        d.syncChainFilterToSelection()
         reevaluateSelectedId()
     }
     property string selectedAccountAddress
@@ -181,7 +182,10 @@ Control {
             !chainName ? qsTr("Your assets") : qsTr("Your assets on %1").arg(chainName),
             qsTr("Popular assets"))
     }
-    Component.onCompleted: root.updateSectionNames()
+    Component.onCompleted: {
+        d.syncChainFilterToSelection()
+        root.updateSectionNames()
+    }
 
     enum SwapSide {
         Pay = 0,
@@ -201,6 +205,13 @@ Control {
 
         property string selectedHoldingId: root.groupKey
         property string selectedHoldingTokenKey: ""
+
+        function syncChainFilterToSelection() {
+            if (holdingSelector.dropdownOpened)
+                return
+            if (root.selectedNetworkChainId !== -1)
+                root.listChainFilter = root.selectedNetworkChainId
+        }
 
         onSelectedHoldingIdChanged: {
             Qt.callLater(d.clampAmountToBalance)
@@ -227,14 +238,33 @@ Control {
         onListSettledChanged: if (listSettled) root.reevaluateSelectedId()
 
         readonly property bool catalogJudgesSelection: root.listCatalogChainId === root.selectedNetworkChainId
+                                                       && !holdingSelector.dropdownOpened
+
+        function listSettledNow() {
+            return d.listSettled
+                   && !!root.tokenSelectorModel
+                   && root.tokenSelectorModel.searchString === ""
+        }
 
         function reevaluateSelectedId() {
-            if (!d.listSettled)
+            if (!d.listSettledNow())
                 return
             if (d.catalogJudgesSelection
                     && !SQUtils.ModelUtils.contains(root.tokenSelectorModel, "key", d.selectedHoldingId)) {
-                // Token doesn't exist in destination chain
-                d.selectedHoldingId = root.defaultGroupKey
+                if (!!d.selectedHoldingId
+                        && !!root.tokenSelectorModel.pinGroup
+                        && root.tokenSelectorModel.pinGroup(d.selectedHoldingId)) {
+                    d.setHoldingToSelector()
+                    return
+                }
+                const remapped = d.lastShownSymbol
+                               ? SQUtils.ModelUtils.getByKey(root.tokenSelectorModel, "symbol", d.lastShownSymbol, "key")
+                               : undefined
+                const defaultIfPresent = SQUtils.ModelUtils.contains(root.tokenSelectorModel, "key", root.defaultGroupKey)
+                                       ? root.defaultGroupKey : undefined
+                const nativeFallback = SQUtils.ModelUtils.getByKey(root.tokenSelectorModel, "symbol",
+                                                                   Utils.getNativeTokenSymbol(root.listCatalogChainId), "key")
+                d.selectedHoldingId = remapped ?? defaultIfPresent ?? nativeFallback ?? root.defaultGroupKey
             }
             d.setHoldingToSelector()
         }
@@ -253,6 +283,8 @@ Control {
                    ? d.selectedHolding.item.tokens : null
             onRevisionChanged: d.setHoldingToSelector()
         }
+
+        property string lastShownSymbol
 
         function setHoldingToSelector() {
             if (!root.tokenSelectorModel)
@@ -273,13 +305,14 @@ Control {
                 }
 
                 d.selectedHoldingTokenKey = tokenKey
+                d.lastShownSymbol = selectedHolding.item.symbol
 
                 holdingSelector.setSelection(selectedHolding.item.symbol,
                                              selectedHolding.item.logoUri || Constants.tokenIcon(selectedHolding.item.symbol),
                                              selectedHolding.item.key)
                 return
             }
-            if (d.listSettled && d.catalogJudgesSelection)
+            if (d.listSettledNow() && d.catalogJudgesSelection)
                 holdingSelector.reset()
         }
 
@@ -308,12 +341,18 @@ Control {
 
 
         function adoptChainForToken(key) {
-            const balances = SQUtils.ModelUtils.getByKey(root.tokenSelectorModel, "key", key, "balances")
-            if (!balances)
+            const refs = SQUtils.ModelUtils.getByKey(root.tokenSelectorModel, "key", key, "tokens")
+                         ?? SQUtils.ModelUtils.getByKey(root.tokenSelectorModel, "key", key, "balances")
+            if (root.listChainFilter !== -1
+                    && (!refs || SQUtils.ModelUtils.contains(refs, "chainId", root.listChainFilter))) {
+                root.networkSelected(root.listChainFilter)
                 return
-            if (SQUtils.ModelUtils.contains(balances, "chainId", root.selectedNetworkChainId))
+            }
+            if (!refs)
                 return
-            const firstChain = SQUtils.ModelUtils.get(balances, 0, "chainId")
+            if (SQUtils.ModelUtils.contains(refs, "chainId", root.selectedNetworkChainId))
+                return
+            const firstChain = SQUtils.ModelUtils.get(refs, 0, "chainId")
             if (!!firstChain && firstChain !== root.selectedNetworkChainId)
                 root.networkSelected(firstChain)
         }
@@ -588,6 +627,12 @@ Control {
                 highlightedChainId: root.selectedNetworkChainId
                 onChainSelected: chainId => root.listChainFilter = chainId
 
+                onDropdownAboutToOpen: d.syncChainFilterToSelection()
+                onDropdownClosed: {
+                    d.syncChainFilterToSelection()
+                    root.reevaluateSelectedId()
+                }
+
                 onSearch: function(keyword) {
                     if (root.tokenSelectorModel)
                         root.tokenSelectorModel.search(keyword)
@@ -602,12 +647,12 @@ Control {
                     if (key === "")
                         return
                     d.selectedHoldingId = key
-                    if (chainId !== -1)
+                    if (chainId !== -1) {
+                        root.listChainFilter = chainId
                         root.networkSelected(chainId)
-                    else if (root.listChainFilter !== -1)
-                        root.networkSelected(root.listChainFilter)
-                    else
+                    } else {
                         d.adoptChainForToken(key)
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -213,18 +213,6 @@ Control {
                 root.listChainFilter = root.selectedNetworkChainId
         }
 
-        onSelectedHoldingIdChanged: {
-            Qt.callLater(d.clampAmountToBalance)
-        }
-
-        function clampAmountToBalance() {
-            if (root.swapSide !== SwapInputPanel.SwapSide.Pay)
-                return
-            if (d.maxSafeCryptoValue <= 0)
-                return
-            if (amountToSendInput.balanceExceeded)
-                root.setAmount(d.maxSafeCryptoValue)
-        }
 
         // Only a settled list answers "is this token available here?": it is empty
         // while the catalog is (re)built, holds search results while searching, and

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -133,6 +133,7 @@ Control {
     readonly property double maxCryptoBalance: d.maxCryptoBalance
     readonly property double maxSafeCryptoValue: d.maxSafeCryptoValue
     readonly property alias fiatMode: amountToSendInput.fiatMode
+    readonly property Item amountInputItem: amountToSendInput
 
     /** `value` is a crypto amount, also while the input displays fiat **/
     function setAmount(value) {

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -122,6 +122,8 @@ Control {
                                        (swapSide === SwapInputPanel.SwapSide.Pay ? !amountEnteredGreaterThanBalance : true)
     readonly property bool amountEnteredGreaterThanBalance: amountToSendInput.balanceExceeded
 
+    property bool balanceExceededErrorEnabled: true
+
     readonly property double maxCryptoBalance: d.maxCryptoBalance
     readonly property double maxSafeCryptoValue: d.maxSafeCryptoValue
     readonly property alias fiatMode: amountToSendInput.fiatMode
@@ -480,7 +482,9 @@ Control {
             Layout.fillWidth: true
 
             interactive: root.interactive
-            markAsInvalid: (root.swapSide === SwapInputPanel.SwapSide.Pay && (balanceExceeded || d.maxInputBalance === 0)) || (!!text && !valid)
+            markAsInvalid: (root.swapSide === SwapInputPanel.SwapSide.Pay
+                            && ((balanceExceeded && root.balanceExceededErrorEnabled) || d.maxInputBalance === 0))
+                           || (!!text && !valid)
             fiatInputInteractive: root.fiatInputInteractive
             multiplierIndex: d.isSelectedHoldingValidAsset && !!d.selectedHolding.item.decimals ? d.selectedHolding.item.decimals : 18
             cryptoPrice: d.isSelectedHoldingValidAsset && !!d.selectedHolding.item.cryptoPrice ? d.selectedHolding.item.cryptoPrice : 0

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -257,14 +257,12 @@ Control {
                     d.setHoldingToSelector()
                     return
                 }
-                const remapped = d.lastShownSymbol
-                               ? SQUtils.ModelUtils.getByKey(root.tokenSelectorModel, "symbol", d.lastShownSymbol, "key")
-                               : undefined
                 const defaultIfPresent = SQUtils.ModelUtils.contains(root.tokenSelectorModel, "key", root.defaultGroupKey)
                                        ? root.defaultGroupKey : undefined
-                const nativeFallback = SQUtils.ModelUtils.getByKey(root.tokenSelectorModel, "symbol",
-                                                                   Utils.getNativeTokenSymbol(root.listCatalogChainId), "key")
-                d.selectedHoldingId = remapped ?? defaultIfPresent ?? nativeFallback ?? root.defaultGroupKey
+                const nativeGroupKey = Utils.getNativeTokenGroupKey(root.listCatalogChainId)
+                const nativeIfPresent = SQUtils.ModelUtils.contains(root.tokenSelectorModel, "key", nativeGroupKey)
+                                      ? nativeGroupKey : undefined
+                d.selectedHoldingId = defaultIfPresent ?? nativeIfPresent ?? root.defaultGroupKey
             }
             d.setHoldingToSelector()
         }
@@ -283,8 +281,6 @@ Control {
                    ? d.selectedHolding.item.tokens : null
             onRevisionChanged: d.setHoldingToSelector()
         }
-
-        property string lastShownSymbol
 
         function setHoldingToSelector() {
             if (!root.tokenSelectorModel)
@@ -305,7 +301,6 @@ Control {
                 }
 
                 d.selectedHoldingTokenKey = tokenKey
-                d.lastShownSymbol = selectedHolding.item.symbol
 
                 holdingSelector.setSelection(selectedHolding.item.symbol,
                                              selectedHolding.item.logoUri || Constants.tokenIcon(selectedHolding.item.symbol),

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -47,9 +47,13 @@ Control {
     }
 
     property int selectedNetworkChainId: -1
-    onSelectedNetworkChainIdChanged: reevaluateSelectedId()
+    onSelectedNetworkChainIdChanged: {
+        reevaluateSelectedId()
+    }
     property string selectedAccountAddress
-    onSelectedAccountAddressChanged: reevaluateSelectedId()
+    onSelectedAccountAddressChanged: {
+        reevaluateSelectedId()
+    }
     property string nonInteractiveGroupKey
     property int nonInteractiveChainId: -1
 
@@ -122,7 +126,9 @@ Control {
                                        (swapSide === SwapInputPanel.SwapSide.Pay ? !amountEnteredGreaterThanBalance : true)
     readonly property bool amountEnteredGreaterThanBalance: amountToSendInput.balanceExceeded
 
-    property bool balanceExceededErrorEnabled: true
+    property bool balanceInsufficientError: false
+
+    property bool accountBalanceVisible: true
 
     readonly property double maxCryptoBalance: d.maxCryptoBalance
     readonly property double maxSafeCryptoValue: d.maxSafeCryptoValue
@@ -195,7 +201,9 @@ Control {
         property string selectedHoldingId: root.groupKey
         property string selectedHoldingTokenKey: ""
 
-        onSelectedHoldingIdChanged: Qt.callLater(d.clampAmountToBalance)
+        onSelectedHoldingIdChanged: {
+            Qt.callLater(d.clampAmountToBalance)
+        }
 
         function clampAmountToBalance() {
             if (root.swapSide !== SwapInputPanel.SwapSide.Pay)
@@ -275,7 +283,14 @@ Control {
         }
 
         readonly property bool isSelectedHoldingValidAsset: selectedHolding.available && !!selectedHolding.item
+
+        readonly property SQUtils.ModelChangeTracker selectedBalancesTracker: SQUtils.ModelChangeTracker {
+            model: d.selectedHolding.available && !!d.selectedHolding.item
+                   ? d.selectedHolding.item.balances : null
+        }
+
         readonly property double maxCryptoBalance: {
+            selectedBalancesTracker.revision
             if (!isSelectedHoldingValidAsset || !selectedHolding.item.balances)
                 return 0
             const onChain = SQUtils.ModelUtils.getByKey(selectedHolding.item.balances, "chainId",
@@ -465,8 +480,9 @@ Control {
         }
 
         AmountToSend {
-            readonly property bool balanceExceeded:
-                SQUtils.AmountsArithmetic.fromNumber(d.maxSafeCryptoValue, multiplierIndex).cmp(amount) === -1
+            readonly property bool balanceExceeded: SQUtils.AmountsArithmetic.fromNumber(d.maxSafeCryptoValue, multiplierIndex).cmp(amount) === -1
+
+            readonly property bool rawBalanceExceeded: SQUtils.AmountsArithmetic.fromNumber(d.maxCryptoBalance, multiplierIndex).cmp(amount) === -1
 
             // from `amount` rather than the text: that is fiat in fiat mode
             readonly property double asNumber: {
@@ -483,7 +499,7 @@ Control {
 
             interactive: root.interactive
             markAsInvalid: (root.swapSide === SwapInputPanel.SwapSide.Pay
-                            && ((balanceExceeded && root.balanceExceededErrorEnabled) || d.maxInputBalance === 0))
+                            && (rawBalanceExceeded || root.balanceInsufficientError || d.maxInputBalance === 0))
                            || (!!text && !valid)
             fiatInputInteractive: root.fiatInputInteractive
             multiplierIndex: d.isSelectedHoldingValidAsset && !!d.selectedHolding.item.decimals ? d.selectedHolding.item.decimals : 18
@@ -501,7 +517,7 @@ Control {
             bottomRightComponent: RowLayout {
                 objectName: "balanceLine"
                 spacing: Theme.halfPadding
-                visible: d.isSelectedHoldingValidAsset
+                visible: d.isSelectedHoldingValidAsset && root.accountBalanceVisible
 
                 StatusIcon {
                     Layout.alignment: Qt.AlignVCenter

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -287,6 +287,13 @@ StatusDialog {
         value: root.swapInputParamsForm.selectedNetworkChainId
     }
 
+    ModelEntry {
+        id: toNetworkEntry
+        sourceModel: root.swapAdaptor.networksStore.activeNetworks
+        key: "chainId"
+        value: d.effectiveToChainId
+    }
+
     Connections {
         target: root.swapInputParamsForm
         function onFormValuesChanged() {
@@ -1014,8 +1021,10 @@ StatusDialog {
         SwapSignModal {
             destroyOnClose: true
 
-            title: root.swapAdaptor.swapOutputData.approvalNeeded && root.swapAdaptor.approvalSuccessful? qsTr("Swap") : qsTr("Sign Swap")
-            signButtonText: root.swapAdaptor.swapOutputData.approvalNeeded && root.swapAdaptor.approvalSuccessful? qsTr("Swap") : qsTr("Sign")
+            title: root.swapAdaptor.swapOutputData.approvalNeeded && root.swapAdaptor.approvalSuccessful
+                   ? d.modalTitle : qsTr("Sign %1").arg(d.modalTitle)
+            signButtonText: root.swapAdaptor.swapOutputData.approvalNeeded && root.swapAdaptor.approvalSuccessful
+                            ? d.modalTitle : qsTr("Sign")
 
             formatBigNumber: (number, symbol, noSymbolOption) => root.swapAdaptor.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
 
@@ -1042,11 +1051,25 @@ StatusDialog {
             accountEmoji: d.selectedAccount.emoji
             accountColor: Utils.getColorForId(Theme.palette, d.selectedAccount.colorId)
 
+            // a pasted address resolves to no account/saved entry — show it elided
+            toAccountName: !!d.toAccount && !!d.toAccount.name
+                           ? d.toAccount.name
+                           : SQUtils.Utils.elideAndFormatWalletAddress(toAccountAddress)
+            toAccountAddress: root.swapInputParamsForm.toAccountAddress || root.swapInputParamsForm.selectedAccountAddress
+            toAccountEmoji: !!d.toAccount ? d.toAccount.emoji ?? "" : ""
+            toAccountColor: Utils.getColorForId(Theme.palette, !!d.toAccount ? d.toAccount.colorId ?? "" : "")
+
             networkShortName: fromNetworkEntry.item.shortName
             networkName: fromNetworkEntry.item.chainName
             networkIconPath: Assets.svg(fromNetworkEntry.item.iconUrl)
             networkBlockExplorerUrl: fromNetworkEntry.item.blockExplorerURL
             networkChainId: root.swapInputParamsForm.selectedNetworkChainId
+
+            toNetworkName: !!toNetworkEntry.item ? toNetworkEntry.item.chainName : ""
+            toNetworkShortName: !!toNetworkEntry.item ? toNetworkEntry.item.shortName : ""
+            toNetworkIconPath: !!toNetworkEntry.item ? Assets.svg(toNetworkEntry.item.iconUrl) : ""
+            toNetworkBlockExplorerUrl: !!toNetworkEntry.item ? toNetworkEntry.item.blockExplorerURL : ""
+            toNetworkChainId: d.effectiveToChainId
 
             fiatFees: {
                 let fees = root.swapAdaptor.swapOutputData.txFeesInFiat

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -537,15 +537,13 @@ StatusDialog {
                     enabled: !!root.swapInputParamsForm.fromGroupKey || !!root.swapInputParamsForm.toGroupKey
                     onClicked: {
                         const tempPayToken = root.swapInputParamsForm.fromGroupKey
-                        const tempPayAmount = root.swapInputParamsForm.fromTokenAmount
                         const tempFromChain = root.swapInputParamsForm.selectedNetworkChainId
                         root.swapInputParamsForm.selectedNetworkChainId = d.effectiveToChainId
                         root.swapInputParamsForm.toNetworkChainId = tempFromChain
                         // accounts deliberately stay put — the exchange swaps only chains and tokens
                         root.swapInputParamsForm.fromGroupKey = root.swapInputParamsForm.toGroupKey
-                        root.swapInputParamsForm.fromTokenAmount = !!root.swapAdaptor.swapOutputData.toTokenAmount ? root.swapAdaptor.swapOutputData.toTokenAmount : root.swapInputParamsForm.toTokenAmount
                         root.swapInputParamsForm.toGroupKey = tempPayToken
-                        root.swapInputParamsForm.toTokenAmount = tempPayAmount
+                        root.swapInputParamsForm.toTokenAmount = ""
                         d.rebuildGroupsForChain(payPanel.listCatalogChainId)
                         d.rebuildGroupsForChain(receivePanel.listCatalogChainId, true)
                         payPanel.forceActiveFocus()

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -45,12 +45,11 @@ StatusDialog {
 
     Component.onDestruction: {
         const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
-        const ids = [d.payTokenSelector, d.receiveTokenSelector, d.receiveTokenSelectorTo]
+        const ids = [d.payTokenSelector, d.receiveTokenSelector]
         .filter(sel => !!sel).map(sel => sel.id)
 
         d.payTokenSelector = null
         d.receiveTokenSelector = null
-        d.receiveTokenSelectorTo = null
 
         ids.forEach(id => store.releaseTokenSelectorModel(id))
     }
@@ -84,37 +83,16 @@ StatusDialog {
 
         property var payTokenSelector: null
         property var receiveTokenSelector: null
-        property var receiveTokenSelectorTo: null
-
-        property bool pickersInitialized: false
 
         function createPickers() {
             const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
             if (!d.payTokenSelector) {
                 d.payTokenSelector = store.createTokenSelectorModel(1)
-                d.receiveTokenSelector = store.createTokenSelectorModel(1)
+                d.receiveTokenSelector = store.createTokenSelectorModel(3)
             }
-            d.pickersInitialized = true
-            if (d.isBridge)
-                d.ensureBridgePicker()
             payPanel.reset()
             receivePanel.reset()
         }
-
-        function ensureBridgePicker() {
-            if (d.receiveTokenSelectorTo)
-                return
-            d.receiveTokenSelectorTo = root.swapAdaptor.walletAssetsStore.walletTokensStore.createTokenSelectorModel(3)
-            receivePanel.reset()
-        }
-
-        // The chain the destination catalog has to be built for, -1 while there is no
-        // bridge picker to fill. Folding both conditions into the value means a pay-side
-        // change that turns a plain swap into a bridge triggers the build too, which
-        // watching the receive chain alone would miss. rebuildGroupsForChain ignores -1.
-        readonly property int toCatalogChainId: d.isBridge && !!d.receiveTokenSelectorTo
-                                                ? receivePanel.listCatalogChainId : -1
-        onToCatalogChainIdChanged: d.rebuildGroupsForChain(toCatalogChainId, true)
 
         property var debounceFetchSuggestedRoutes: Backpressure.debounce(root, 1000, function() {
             root.swapAdaptor.fetchSuggestedRoutes(payPanel.rawValue)
@@ -179,13 +157,6 @@ StatusDialog {
 
         readonly property bool isSameChainSwap: root.swapInputParamsForm.selectedNetworkChainId === root.swapInputParamsForm.toNetworkChainId
         readonly property bool isBridge: root.swapInputParamsForm.toNetworkChainId !== -1 && !isSameChainSwap
-        onIsBridgeChanged: {
-            // `opened` also excludes teardown: the handler resets the form one
-            // field at a time, which flickers through a bridge state that would
-            // otherwise build a picker for the modal being destroyed.
-            if (isBridge && d.pickersInitialized && root.opened)
-                d.ensureBridgePicker()
-        }
 
         readonly property string modalTitle: {
             const fromKey = root.swapInputParamsForm.fromGroupKey
@@ -311,9 +282,6 @@ StatusDialog {
             d.fetchSuggestedRoutes()
         }
 
-        function onSelectedNetworkChainIdChanged() {
-            d.rebuildGroupsForChain(payPanel.listCatalogChainId)
-        }
 
         function onFromGroupKeyChanged() {
             payPanel.groupKey = root.swapInputParamsForm.fromGroupKey
@@ -331,8 +299,10 @@ StatusDialog {
         value: payPanel.amountEnteredGreaterThanBalance
     }
 
-    // the destination catalog follows d.toCatalogChainId, which is still -1 here
-    Component.onCompleted: d.rebuildGroupsForChain(payPanel.listCatalogChainId)
+    Component.onCompleted: {
+        d.rebuildGroupsForChain(payPanel.listCatalogChainId)
+        d.rebuildGroupsForChain(receivePanel.listCatalogChainId, true)
+    }
 
     onOpened: {
         // Defer the terminal picker model creation + seed off the open critical
@@ -517,35 +487,21 @@ StatusDialog {
 
                     currencyStore: root.swapAdaptor.currencyStore
                     flatNetworksModel: root.swapAdaptor.networksStore.activeNetworks
-                    // plain swap reuses the source-chain picker; only a bridge uses the destination one
-                    // (both null until the deferred createPickers/ensureBridgePicker run post-open)
-                    tokenSelectorModel: {
-                        if (d.isSameChainSwap)
-                            return d.receiveTokenSelector ? d.receiveTokenSelector.model : null
-                        return d.receiveTokenSelectorTo ? d.receiveTokenSelectorTo.model : null
-                    }
+                    tokenSelectorModel: d.receiveTokenSelector ? d.receiveTokenSelector.model : null
 
                     groupKey: root.swapInputParamsForm.toGroupKey
                     defaultGroupKey: root.swapInputParamsForm.defaultToGroupKey
                     oppositeSideGroupKey: root.swapInputParamsForm.fromGroupKey
                     tokenAmount: root.swapAdaptor.validSwapProposalReceived && root.swapAdaptor.toToken ? root.swapAdaptor.swapOutputData.toTokenAmount: root.swapInputParamsForm.toTokenAmount
 
-                    selectedNetworkChainId: root.swapInputParamsForm.toNetworkChainId
+                    selectedNetworkChainId: d.effectiveToChainId
                     onNetworkSelected: function(chainId) {
                         root.swapInputParamsForm.toNetworkChainId = chainId
                         payPanel.forceActiveFocus()
                     }
 
-                    // A plain swap shares the pay side's picker, whose catalog follows
-                    // the PAY chain filter — so it can be scoped to a chain this side
-                    // knows nothing about.
-                    catalogChainId: d.isSameChainSwap ? d.lastRequestedChainId
-                                                      : d.lastRequestedChainIdTo
-
-                    onListChainFilterChanged: {
-                        if (listChainFilter !== -1)
-                            root.swapInputParamsForm.toNetworkChainId = listChainFilter
-                    }
+                    catalogChainId: d.lastRequestedChainIdTo
+                    onListCatalogChainIdChanged: d.rebuildGroupsForChain(listCatalogChainId, true)
 
                     selectedAccountAddress: root.swapInputParamsForm.toAccountAddress || root.swapInputParamsForm.selectedAccountAddress
                     accountBalanceVisible: toAccountEntry.available
@@ -561,9 +517,7 @@ StatusDialog {
                     swapSide: SwapInputPanel.SwapSide.Receive
                     swapExchangeButtonWidth: swapExchangeButton.width
 
-                    tokenSelectorLoading: d.isSameChainSwap
-                                          ? root.swapAdaptor.walletAssetsStore.walletTokensStore.groupsForChainLoading
-                                          : root.swapAdaptor.walletAssetsStore.walletTokensStore.groupsForChainToLoading
+                    tokenSelectorLoading: root.swapAdaptor.walletAssetsStore.walletTokensStore.groupsForChainToLoading
                     mainInputLoading: root.swapAdaptor.swapProposalLoading
                     bottomTextLoading: root.swapAdaptor.swapProposalLoading
 
@@ -585,19 +539,15 @@ StatusDialog {
                         const tempPayToken = root.swapInputParamsForm.fromGroupKey
                         const tempPayAmount = root.swapInputParamsForm.fromTokenAmount
                         const tempFromChain = root.swapInputParamsForm.selectedNetworkChainId
-                        root.swapInputParamsForm.selectedNetworkChainId = root.swapInputParamsForm.toNetworkChainId
+                        root.swapInputParamsForm.selectedNetworkChainId = d.effectiveToChainId
                         root.swapInputParamsForm.toNetworkChainId = tempFromChain
-                        if (!!root.swapInputParamsForm.toAccountAddress && toAccountEntry.available) {
-                            const tempFromAccount = root.swapInputParamsForm.selectedAccountAddress
-                            root.swapInputParamsForm.selectedAccountAddress = root.swapInputParamsForm.toAccountAddress
-                            root.swapInputParamsForm.toAccountAddress = tempFromAccount
-                        }
+                        // accounts deliberately stay put — the exchange swaps only chains and tokens
                         root.swapInputParamsForm.fromGroupKey = root.swapInputParamsForm.toGroupKey
                         root.swapInputParamsForm.fromTokenAmount = !!root.swapAdaptor.swapOutputData.toTokenAmount ? root.swapAdaptor.swapOutputData.toTokenAmount : root.swapInputParamsForm.toTokenAmount
                         root.swapInputParamsForm.toGroupKey = tempPayToken
                         root.swapInputParamsForm.toTokenAmount = tempPayAmount
-                        payPanel.listChainFilter = -1
-                        receivePanel.listChainFilter = -1
+                        d.rebuildGroupsForChain(payPanel.listCatalogChainId)
+                        d.rebuildGroupsForChain(receivePanel.listCatalogChainId, true)
                         payPanel.forceActiveFocus()
                     }
                 }
@@ -886,7 +836,7 @@ StatusDialog {
                     RowLayout {
                         Layout.fillWidth: true
                         Layout.minimumWidth: 0
-                        spacing: Theme.halfPadding
+                        spacing: Theme.bigPadding
                         visible: !!root.swapInputParamsForm.fromTokenAmount
 
                         StatusButton {

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -142,6 +142,8 @@ StatusDialog {
             Qt.inputMethod.hide()
         }
 
+        property var activeChildPopup: null
+
         readonly property bool isError: root.swapAdaptor.errorMessage !== ""
 
         readonly property BuyCryptoParamsForm buyFormData: BuyCryptoParamsForm {
@@ -292,6 +294,15 @@ StatusDialog {
         sourceModel: root.swapAdaptor.networksStore.activeNetworks
         key: "chainId"
         value: d.effectiveToChainId
+    }
+
+    Connections {
+        target: Global
+        function onLinkOpenedExternally(link) {
+            if (!!d.activeChildPopup)
+                d.activeChildPopup.close()
+            root.close()
+        }
     }
 
     Connections {
@@ -969,6 +980,12 @@ StatusDialog {
         SwapApproveCapModal {
             destroyOnClose: true
 
+            onOpened: d.activeChildPopup = this
+            onClosed: {
+                if (d.activeChildPopup === this)
+                    d.activeChildPopup = null
+            }
+
             formatBigNumber: (number, symbol, noSymbolOption) => root.swapAdaptor.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
 
             keyUid: !!d.selectedAccount ? d.selectedAccount.keyUid : ""
@@ -1020,6 +1037,12 @@ StatusDialog {
         id: swapSignModalComponent
         SwapSignModal {
             destroyOnClose: true
+
+            onOpened: d.activeChildPopup = this
+            onClosed: {
+                if (d.activeChildPopup === this)
+                    d.activeChildPopup = null
+            }
 
             title: root.swapAdaptor.swapOutputData.approvalNeeded && root.swapAdaptor.approvalSuccessful
                    ? d.modalTitle : qsTr("Sign %1").arg(d.modalTitle)

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -395,9 +395,7 @@ StatusDialog {
         TapHandler {
             enabled: Qt.inputMethod.visible
             onTapped: (eventPoint) => {
-                // the panels own their tap-to-focus behaviour; leave them alone
-                if (d.tapLandedOn(payPanel, eventPoint.position)
-                        || d.tapLandedOn(receivePanel, eventPoint.position))
+                if (d.tapLandedOn(payPanel.amountInputItem, eventPoint.position))
                     return
                 d.dismissKeyboard()
             }

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -649,6 +649,7 @@ StatusDialog {
                     interval: 1000
                     repeat: true
                     running: swapFooter.hasProposal && !swapFooter.loading && root.visible
+                             && !root.swapAdaptor.approvalPending
                     onTriggered: {
                         if (swapFooter.secondsLeft <= 1)
                             swapFooter.refresh()
@@ -925,7 +926,9 @@ StatusDialog {
                             Layout.preferredHeight: signButton.height
                             icon.name: "refresh"
                             type: StatusBaseButton.Type.Normal
-                            enabled: swapFooter.hasProposal && !swapFooter.loading
+                            enabled: (swapFooter.hasProposal || root.swapAdaptor.swapOutputData.hasError)
+                                     && !swapFooter.loading
+                                     && !root.swapAdaptor.approvalPending
                             onClicked: swapFooter.refresh()
                         }
                     }

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -447,6 +447,8 @@ StatusDialog {
                     tokenAmount: root.swapInputParamsForm.fromTokenAmount
 
                     cryptoFeesToReserve: root.swapAdaptor.swapOutputData.maxFeesToReserveRaw
+                    balanceExceededErrorEnabled: !root.swapAdaptor.validSwapProposalReceived
+                                                 && !root.swapAdaptor.swapProposalLoading
 
                     selectedNetworkChainId: root.swapInputParamsForm.selectedNetworkChainId
                     onNetworkSelected: function(chainId) {

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -447,8 +447,7 @@ StatusDialog {
                     tokenAmount: root.swapInputParamsForm.fromTokenAmount
 
                     cryptoFeesToReserve: root.swapAdaptor.swapOutputData.maxFeesToReserveRaw
-                    balanceExceededErrorEnabled: !root.swapAdaptor.validSwapProposalReceived
-                                                 && !root.swapAdaptor.swapProposalLoading
+                    balanceInsufficientError: root.swapAdaptor.isBalanceInsufficientForSwap
 
                     selectedNetworkChainId: root.swapInputParamsForm.selectedNetworkChainId
                     onNetworkSelected: function(chainId) {
@@ -533,6 +532,7 @@ StatusDialog {
                     }
 
                     selectedAccountAddress: root.swapInputParamsForm.toAccountAddress || root.swapInputParamsForm.selectedAccountAddress
+                    accountBalanceVisible: toAccountEntry.available
                     nonInteractiveGroupKey: payPanel.selectedHoldingId
                     nonInteractiveChainId: root.swapInputParamsForm.selectedNetworkChainId
 
@@ -580,6 +580,8 @@ StatusDialog {
                         root.swapInputParamsForm.fromTokenAmount = !!root.swapAdaptor.swapOutputData.toTokenAmount ? root.swapAdaptor.swapOutputData.toTokenAmount : root.swapInputParamsForm.toTokenAmount
                         root.swapInputParamsForm.toGroupKey = tempPayToken
                         root.swapInputParamsForm.toTokenAmount = tempPayAmount
+                        payPanel.listChainFilter = -1
+                        receivePanel.listChainFilter = -1
                         payPanel.forceActiveFocus()
                     }
                 }

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -61,9 +61,13 @@ QObject {
 
         readonly property bool isRouteTokenBalanceInsufficient: root.validSwapProposalReceived && root.swapOutputData.errCode === Constants.routerErrorCodes.router.errNotEnoughTokenBalance
 
+        readonly property bool amountExceedsSafeBalance: !root.validSwapProposalReceived
+                                                         && !root.swapProposalLoading
+                                                         && root.amountEnteredGreaterThanBalance
+
         readonly property bool isTokenBalanceInsufficient: {
             if (!!root.fromToken && !!root.fromToken.symbol) {
-                return (root.amountEnteredGreaterThanBalance || isRouteTokenBalanceInsufficient) &&
+                return (amountExceedsSafeBalance || isRouteTokenBalanceInsufficient) &&
                         root.fromToken.symbol !== nativeTokenSymbol
             }
             return false
@@ -71,7 +75,7 @@ QObject {
 
         readonly property bool isEthBalanceInsufficient: {
             if (!!root.fromToken && !!root.fromToken.symbol) {
-                return (root.amountEnteredGreaterThanBalance && root.fromToken.symbol === nativeTokenSymbol) ||
+                return (amountExceedsSafeBalance && root.fromToken.symbol === nativeTokenSymbol) ||
                         isRouteEthBalanceInsufficient
             }
             return false
@@ -79,7 +83,7 @@ QObject {
 
         readonly property bool isBalanceInsufficientForSwap: {
             if (!!root.fromToken && !!root.fromToken.symbol) {
-                return (root.amountEnteredGreaterThanBalance && root.fromToken.symbol === nativeTokenSymbol) ||
+                return (amountExceedsSafeBalance && root.fromToken.symbol === nativeTokenSymbol) ||
                         (isTokenBalanceInsufficient && root.fromToken.symbol !== nativeTokenSymbol)
             }
             return false
@@ -164,7 +168,7 @@ QObject {
                 const txApprovalFeesNative = Utils.nativeTokenRawToDecimal(root.swapFormData.selectedNetworkChainId, root.swapOutputData.approvalTxFeesWei)
                 root.swapOutputData.approvalTxFeesFiat = root.currencyStore.getFiatValue(txApprovalFeesNative, d.nativeTokenKey)
 
-                const totalMaxFeesInGasUnit = Math.ceil(bestPath.gasFees.maxFeePerGasM) * bestPath.gasAmount
+                const totalMaxFeesInGasUnit = Math.ceil(bestPath.gasFees.maxFeePerGasM * bestPath.gasAmount)
                 root.swapOutputData.maxFeesToReserveRaw = Utils.nativeTokenGasToRaw(root.swapFormData.selectedNetworkChainId, totalMaxFeesInGasUnit).toString()
 
                 root.swapOutputData.approvalNeeded = !!bestPath ? bestPath.approvalRequired: false

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -45,6 +45,7 @@ QObject {
     readonly property string errorMessage: d.errorMessage
     readonly property bool isEthBalanceInsufficient: d.isEthBalanceInsufficient
     readonly property bool isTokenBalanceInsufficient: d.isTokenBalanceInsufficient
+    readonly property bool isBalanceInsufficientForSwap: d.isBalanceInsufficientForSwap
 
     QtObject {
         id: d

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
@@ -32,6 +32,17 @@ SignTransactionModalBase {
     required property string accountEmoji
     required property color accountColor
 
+    required property string toAccountName
+    required property string toAccountAddress
+    required property string toAccountEmoji
+    required property color toAccountColor
+
+    required property string toNetworkName
+    required property string toNetworkShortName
+    required property string toNetworkIconPath
+    required property string toNetworkBlockExplorerUrl
+    required property int toNetworkChainId
+
     required property string networkShortName // e.g. "oeth"
     required property string networkName // e.g. "Optimism"
     required property string networkIconPath // e.g. `Assets.svg("network/optimism")`
@@ -55,9 +66,14 @@ SignTransactionModalBase {
     fromImageSource: Constants.tokenIcon(root.fromTokenSymbol)
     toImageSource: Constants.tokenIcon(root.toTokenSymbol)
 
-    //: e.g. "Swap 100 DAI to 100 USDT in <account name> on <network chain name>"
-    headerMainText: qsTr("Swap %1 to %2 in %3 on %4").arg(formatBigNumber(root.fromTokenAmount, root.fromTokenSymbol))
-        .arg(formatBigNumber(root.toTokenAmount, root.toTokenSymbol)).arg(root.accountName).arg(root.networkName)
+    //: e.g. "From <account name> 100 DAI on Ethereum to <account name> 100 USDT on Optimism"
+    headerMainText: qsTr("From %1 %2 on %3 to %4 %5 on %6")
+        .arg(root.accountName)
+        .arg(formatBigNumber(root.fromTokenAmount, root.fromTokenSymbol))
+        .arg(root.networkName)
+        .arg(root.toAccountName)
+        .arg(formatBigNumber(root.toTokenAmount, root.toTokenSymbol))
+        .arg(root.toNetworkName)
     headerSubTextLayout: [
         SwapProvidersTermsAndConditionsText {
             Layout.fillWidth: true
@@ -66,7 +82,6 @@ SignTransactionModalBase {
             onLinkClicked: root.requestOpenLink(root.serviceProviderURL)
         }
     ]
-    infoTagText: qsTr("Review all details before signing")
 
     headerIconComponent: StatusSmartIdenticon {
         asset.name: "filled-account"
@@ -156,28 +171,28 @@ SignTransactionModalBase {
         objectName: "receiveBox"
         caption: qsTr("Receive")
         primaryText: formatBigNumber(root.toTokenAmount, root.toTokenSymbol)
-        secondaryText: root.toTokenSymbol !== Utils.getNativeTokenSymbol(root.networkChainId) ? SQUtils.Utils.elideAndFormatWalletAddress(root.toTokenContractAddress) : ""
+        secondaryText: root.toTokenSymbol !== Utils.getNativeTokenSymbol(root.toNetworkChainId) ? SQUtils.Utils.elideAndFormatWalletAddress(root.toTokenContractAddress) : ""
         icon: Constants.tokenIcon(root.toTokenSymbol)
-        badge: root.networkIconPath
+        badge: root.toNetworkIconPath
         components: [
             ContractInfoButtonWithMenu {
-                visible: root.toTokenSymbol !== Utils.getNativeTokenSymbol(root.networkChainId)
+                visible: root.toTokenSymbol !== Utils.getNativeTokenSymbol(root.toNetworkChainId)
                 symbol: root.toTokenSymbol
                 contractAddress: root.toTokenContractAddress
-                networkName: root.networkName
-                networkShortName: root.networkShortName
-                networkBlockExplorerUrl: root.networkBlockExplorerUrl
+                networkName: root.toNetworkName
+                networkShortName: root.toNetworkShortName
+                networkBlockExplorerUrl: root.toNetworkBlockExplorerUrl
                 onOpenLink: (link) => root.requestOpenLink(link)
             }
         ]
     }
 
-    // Account
+    // From account
     SignInfoBox {
         Layout.fillWidth: true
         Layout.bottomMargin: Theme.bigPadding
         objectName: "accountBox"
-        caption: qsTr("In account")
+        caption: qsTr("From account")
         primaryText: root.accountName
         secondaryText: SQUtils.Utils.elideAndFormatWalletAddress(root.accountAddress)
         asset.name: "filled-account"
@@ -186,46 +201,17 @@ SignTransactionModalBase {
         asset.isLetterIdenticon: !!root.accountEmoji
     }
 
-    // Network
+    // To account
     SignInfoBox {
         Layout.fillWidth: true
         Layout.bottomMargin: Theme.bigPadding
-        objectName: "networkBox"
-        caption: qsTr("Network")
-        primaryText: root.networkName
-        icon: root.networkIconPath
-    }
-
-    // Fees
-    SignInfoBox {
-        Layout.fillWidth: true
-        Layout.bottomMargin: Theme.bigPadding
-        objectName: "feesBox"
-        caption: qsTr("Fees")
-        primaryText: qsTr("Max. fees on %1").arg(root.networkName)
-        primaryTextCustomColor: Theme.palette.baseColor1
-        secondaryText: " "
-        components: [
-            ColumnLayout {
-                spacing: 2
-                StatusTextWithLoadingState {
-                    objectName: "fiatFeesText"
-                    Layout.alignment: Qt.AlignRight
-                    text: loading ? Constants.dummyText : root.fiatFees
-                    horizontalAlignment: Text.AlignRight
-                    font.pixelSize: Theme.additionalTextSize
-                    loading: root.feesLoading
-                }
-                StatusTextWithLoadingState {
-                    objectName: "cryptoFeesText"
-                    Layout.alignment: Qt.AlignRight
-                    text: loading ? Constants.dummyText : root.cryptoFees
-                    horizontalAlignment: Text.AlignRight
-                    font.pixelSize: Theme.additionalTextSize
-                    customColor: Theme.palette.baseColor1
-                    loading: root.feesLoading
-                }
-            }
-        ]
+        objectName: "toAccountBox"
+        caption: qsTr("To account")
+        primaryText: root.toAccountName
+        secondaryText: SQUtils.Utils.elideAndFormatWalletAddress(root.toAccountAddress)
+        asset.name: "filled-account"
+        asset.emoji: root.toAccountEmoji
+        asset.color: root.toAccountColor
+        asset.isLetterIdenticon: !!root.toAccountEmoji
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -20,7 +20,7 @@ QtObject {
     readonly property var _tokenSelectorModule: !!walletSectionTokenSelector ? walletSectionTokenSelector : null
 
     /* Creates a terminal token-selector picker model for the given kind
-       (0=send, 1=swap, 2=buy, 3=swap-to/bridge receive — destination-chain
+       (0=send, 1=swap pay side, 2=buy, 3=swap receive side — destination-chain
        catalog). Returns { model, id }: the producer keeps the
        model updated with the owned source and the caller sets its per-modal
        params; the id must be passed to releaseTokenSelectorModel when the owning
@@ -146,6 +146,10 @@ QtObject {
 
     function buildGroupsForChainTo(chainId, mandatoryKeys) {
         root._allTokensModule.buildGroupsForChainTo(chainId, mandatoryKeys)
+    }
+
+    function fetchAllChainsTokenGroups(mandatoryKeys) {
+        root._allTokensModule.fetchAllChainsTokenGroups(mandatoryKeys)
     }
 
     // Due to performance reasons, use this function as the last option, when you're sure the token is not present in the models.

--- a/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
@@ -59,10 +59,10 @@ ItemDelegate {
         let chain = root.chainId
         if (chain < 0 && !!balancesModel && balancesModel.ModelCount.count > 0)
             chain = SQUtils.ModelUtils.get(root.balancesModel, 0, "chainId")
-        if (chain < 0)
+        if (chain < 0 && root.fallbackChainId >= 0 && SQUtils.ModelUtils.contains(tokensModel, "chainId", root.fallbackChainId))
             chain = root.fallbackChainId
-        if (chain < 0 && tokensCount === 1)
-            chain = SQUtils.ModelUtils.get(tokensModel, 0, "chainId")
+        if (chain < 0)
+            chain = SQUtils.ModelUtils.get(tokensModel, 0, "chainId") ?? -1
         return chain
     }
 
@@ -74,6 +74,7 @@ ItemDelegate {
         return !!key ? Utils.getChainAndAddressFromTokenKey(key).address : ""
     }
     property string defaultNetworkIcon
+    property var flatNetworksModel
 
     readonly property SQUtils.ModelChangeTracker balancesTracker: SQUtils.ModelChangeTracker {
         model: root.balancesModel
@@ -83,7 +84,17 @@ ItemDelegate {
         model: root.tokensModel
     }
 
-    readonly property string effectiveNetworkIcon: !!networkIconUrl ? networkIconUrl : defaultNetworkIcon
+    readonly property string effectiveNetworkIcon: {
+        if (networkIconUrl)
+            return networkIconUrl
+        if (resolvedChainId >= 0 && !!flatNetworksModel) {
+            const icon = SQUtils.ModelUtils.getByKey(flatNetworksModel, "chainId",
+                                                     resolvedChainId, "iconUrl")
+            if (icon)
+                return icon
+        }
+        return defaultNetworkIcon
+    }
     readonly property bool hasNetworkBadge: !!effectiveNetworkIcon
     readonly property bool hasAddressChip: !!tokenAddress && tokenAddress !== Constants.zeroAddress
 

--- a/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
@@ -147,7 +147,7 @@ ItemDelegate {
 
             RowLayout {
                 Layout.fillWidth: true
-                spacing: Theme.halfPadding
+                spacing: Theme.bigPadding
 
                 StatusBaseText {
                     text: root.symbol

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1128,10 +1128,12 @@ Item {
                     !d.isBrowserEnabled ||
                     !appMain.rootStore.thirdpartyServicesEnabled) {
                 Qt.openUrlExternally(link)
+                Global.linkOpenedExternally(link)
                 return
             }
             globalConns.onAppSectionBySectionTypeChanged(Constants.appSection.browser)
             Qt.callLater(() => browserLayoutContainer.item.openUrlInNewTab(link))
+            Global.linkOpenedExternally(link)
         }
 
         function tryOpenNavigationEducationPopup() {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1666,6 +1666,7 @@ QtObject {
 
                 onBuildGroupsForChain: {
                     WalletStores.RootStore.tokensStore.buildGroupsForChain(selectedNetworkChainId, "")
+                    WalletStores.RootStore.tokensStore.fetchAllChainsTokenGroups("")
                 }
 
                 onAccepted: {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -19085,6 +19085,14 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt; 30 sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 30 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 1 minute</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19093,11 +19101,27 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt; 2 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 2 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 3 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt; 3 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -17016,7 +17016,7 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sign Swap</source>
+        <source>Sign %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -17125,12 +17125,8 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Swap %1 to %2 in %3 on %4</source>
-        <extracomment>e.g. &quot;Swap 100 DAI to 100 USDT in &lt;account name&gt; on &lt;network chain name&gt;&quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Review all details before signing</source>
+        <source>From %1 %2 on %3 to %4 %5 on %6</source>
+        <extracomment>e.g. &quot;From &lt;account name&gt; 100 DAI on Ethereum to &lt;account name&gt; 100 USDT on Optimism&quot;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -17150,19 +17146,11 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In account</source>
+        <source>From account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Network</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max. fees on %1</source>
+        <source>To account</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -17115,8 +17115,8 @@ selhalo</translation>
         <translation>Schválit limit útraty %1 pro Swap</translation>
     </message>
     <message>
-        <source>Sign Swap</source>
-        <translation>Podepsat Swap</translation>
+        <source>Sign %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign</source>
@@ -17224,13 +17224,9 @@ selhalo</translation>
         <translation>%1 na %2</translation>
     </message>
     <message>
-        <source>Swap %1 to %2 in %3 on %4</source>
-        <extracomment>e.g. &quot;Swap 100 DAI to 100 USDT in &lt;account name&gt; on &lt;network chain name&gt;&quot;</extracomment>
-        <translation>Swapovat %1 na %2 v %3 na %4</translation>
-    </message>
-    <message>
-        <source>Review all details before signing</source>
-        <translation>Před podpisem zkontrolujte všechny podrobnosti</translation>
+        <source>From %1 %2 on %3 to %4 %5 on %6</source>
+        <extracomment>e.g. &quot;From &lt;account name&gt; 100 DAI on Ethereum to &lt;account name&gt; 100 USDT on Optimism&quot;</extracomment>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Max fees:</source>
@@ -17249,20 +17245,12 @@ selhalo</translation>
         <translation>Přijmout</translation>
     </message>
     <message>
-        <source>In account</source>
-        <translation>Na účtu</translation>
+        <source>From account</source>
+        <translation type="unfinished">Z účtu</translation>
     </message>
     <message>
-        <source>Network</source>
-        <translation>Síť</translation>
-    </message>
-    <message>
-        <source>Fees</source>
-        <translation>Poplatky</translation>
-    </message>
-    <message>
-        <source>Max. fees on %1</source>
-        <translation>Max. poplatky na %1</translation>
+        <source>To account</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -19199,6 +19199,14 @@ Pokud je ve frontě transakce s nižším nonce, transakce s vyšším nonce zů
         <translation>~ Neznámé</translation>
     </message>
     <message>
+        <source>&lt; 30 sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 30 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 1 minute</source>
         <translation>&lt; 1 minuta</translation>
     </message>
@@ -19207,12 +19215,28 @@ Pokud je ve frontě transakce s nižším nonce, transakce s vyšším nonce zů
         <translation>&lt; 1 min</translation>
     </message>
     <message>
+        <source>&lt; 2 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 2 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 3 minutes</source>
         <translation>&lt; 3 minuty</translation>
     </message>
     <message>
         <source>&lt; 3 min</source>
         <translation>&lt; 3 min</translation>
+    </message>
+    <message>
+        <source>&lt; 4 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 minutes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt; 5 minutes</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -19113,6 +19113,14 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
         <translation>~ Desconocido</translation>
     </message>
     <message>
+        <source>&lt; 30 sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 30 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 1 minute</source>
         <translation>&lt; 1 minuto</translation>
     </message>
@@ -19121,11 +19129,27 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt; 2 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 2 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 3 minutes</source>
         <translation>&lt; 3 minutos</translation>
     </message>
     <message>
         <source>&lt; 3 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -17044,8 +17044,8 @@ al cargar</translation>
         <translation>Aprobar límite de gasto de %1 para Swap</translation>
     </message>
     <message>
-        <source>Sign Swap</source>
-        <translation>Firmar Swap</translation>
+        <source>Sign %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign</source>
@@ -17141,13 +17141,9 @@ al cargar</translation>
         <translation>%1 a %2</translation>
     </message>
     <message>
-        <source>Swap %1 to %2 in %3 on %4</source>
-        <extracomment>e.g. &quot;Swap 100 DAI to 100 USDT in &lt;account name&gt; on &lt;network chain name&gt;&quot;</extracomment>
-        <translation>Swap %1 a %2 en %3 en %4</translation>
-    </message>
-    <message>
-        <source>Review all details before signing</source>
-        <translation>Revisa todos los detalles antes de firmar</translation>
+        <source>From %1 %2 on %3 to %4 %5 on %6</source>
+        <extracomment>e.g. &quot;From &lt;account name&gt; 100 DAI on Ethereum to &lt;account name&gt; 100 USDT on Optimism&quot;</extracomment>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Max fees:</source>
@@ -17166,20 +17162,12 @@ al cargar</translation>
         <translation>Recibir</translation>
     </message>
     <message>
-        <source>In account</source>
-        <translation>En cuenta</translation>
+        <source>From account</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Network</source>
-        <translation>Red</translation>
-    </message>
-    <message>
-        <source>Fees</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Max. fees on %1</source>
-        <translation>Comisiones máx. en %1</translation>
+        <source>To account</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -19113,6 +19113,14 @@ Si une transaction avec un nonce inférieur est en attente, les transactions ave
         <translation>~ Inconnu</translation>
     </message>
     <message>
+        <source>&lt; 30 sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 30 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 1 minute</source>
         <translation>&lt; 1 minute</translation>
     </message>
@@ -19121,12 +19129,28 @@ Si une transaction avec un nonce inférieur est en attente, les transactions ave
         <translation>&lt; 1 min</translation>
     </message>
     <message>
+        <source>&lt; 2 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 2 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 3 minutes</source>
         <translation>&lt; 3 minutes</translation>
     </message>
     <message>
         <source>&lt; 3 min</source>
         <translation>&lt; 3 min</translation>
+    </message>
+    <message>
+        <source>&lt; 4 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 minutes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt; 5 minutes</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -17044,8 +17044,8 @@ avec un retour à la ligne</translation>
         <translation>Approuver le plafond de dépenses de %1 pour Swap</translation>
     </message>
     <message>
-        <source>Sign Swap</source>
-        <translation>Signer l’échange</translation>
+        <source>Sign %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign</source>
@@ -17141,13 +17141,9 @@ avec un retour à la ligne</translation>
         <translation>%1 à %2</translation>
     </message>
     <message>
-        <source>Swap %1 to %2 in %3 on %4</source>
-        <extracomment>e.g. &quot;Swap 100 DAI to 100 USDT in &lt;account name&gt; on &lt;network chain name&gt;&quot;</extracomment>
-        <translation>Échanger %1 contre %2 sur %3 via %4</translation>
-    </message>
-    <message>
-        <source>Review all details before signing</source>
-        <translation>Vérifiez tous les détails avant de signer</translation>
+        <source>From %1 %2 on %3 to %4 %5 on %6</source>
+        <extracomment>e.g. &quot;From &lt;account name&gt; 100 DAI on Ethereum to &lt;account name&gt; 100 USDT on Optimism&quot;</extracomment>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Max fees:</source>
@@ -17166,20 +17162,12 @@ avec un retour à la ligne</translation>
         <translation>Recevoir</translation>
     </message>
     <message>
-        <source>In account</source>
-        <translation>Dans le compte</translation>
+        <source>From account</source>
+        <translation type="unfinished">Compte d&apos;origine</translation>
     </message>
     <message>
-        <source>Network</source>
-        <translation>Réseau</translation>
-    </message>
-    <message>
-        <source>Fees</source>
-        <translation>Frais</translation>
-    </message>
-    <message>
-        <source>Max. fees on %1</source>
-        <translation>Frais max. sur %1</translation>
+        <source>To account</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -19028,6 +19028,14 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation>~ 알 수 없음</translation>
     </message>
     <message>
+        <source>&lt; 30 sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 30 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 1 minute</source>
         <translation>&lt; 1분</translation>
     </message>
@@ -19036,11 +19044,27 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt; 2 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 2 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 3 minutes</source>
         <translation>&lt; 3분</translation>
     </message>
     <message>
         <source>&lt; 3 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -16953,8 +16953,8 @@ to load</source>
         <translation>교환을 위해 %1 지출 한도를 승인</translation>
     </message>
     <message>
-        <source>Sign Swap</source>
-        <translation>스왑 서명</translation>
+        <source>Sign %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign</source>
@@ -17062,13 +17062,9 @@ to load</source>
         <translation type="unfinished">%1에서 %2로</translation>
     </message>
     <message>
-        <source>Swap %1 to %2 in %3 on %4</source>
-        <extracomment>e.g. &quot;Swap 100 DAI to 100 USDT in &lt;account name&gt; on &lt;network chain name&gt;&quot;</extracomment>
-        <translation type="unfinished">%4에서 %3의 %1을 %2로 스왑</translation>
-    </message>
-    <message>
-        <source>Review all details before signing</source>
-        <translation>서명하기 전에 모든 내용을 확인하세요</translation>
+        <source>From %1 %2 on %3 to %4 %5 on %6</source>
+        <extracomment>e.g. &quot;From &lt;account name&gt; 100 DAI on Ethereum to &lt;account name&gt; 100 USDT on Optimism&quot;</extracomment>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Max fees:</source>
@@ -17087,20 +17083,12 @@ to load</source>
         <translation>받기</translation>
     </message>
     <message>
-        <source>In account</source>
-        <translation>계정 내</translation>
+        <source>From account</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Network</source>
-        <translation>네트워크</translation>
-    </message>
-    <message>
-        <source>Fees</source>
-        <translation>수수료</translation>
-    </message>
-    <message>
-        <source>Max. fees on %1</source>
-        <translation>최대 수수료 한도: %1</translation>
+        <source>To account</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -17127,8 +17127,8 @@ to load</source>
         <translation>Схвалити ліміт витрат %1 для обміну</translation>
     </message>
     <message>
-        <source>Sign Swap</source>
-        <translation>Підписати обмін</translation>
+        <source>Sign %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign</source>
@@ -17224,13 +17224,9 @@ to load</source>
         <translation>%1 на %2</translation>
     </message>
     <message>
-        <source>Swap %1 to %2 in %3 on %4</source>
-        <extracomment>e.g. &quot;Swap 100 DAI to 100 USDT in &lt;account name&gt; on &lt;network chain name&gt;&quot;</extracomment>
-        <translation>Обміняти %1 на %2 у %3 в мережі %4</translation>
-    </message>
-    <message>
-        <source>Review all details before signing</source>
-        <translation>Перевірте всі дані перед підписанням</translation>
+        <source>From %1 %2 on %3 to %4 %5 on %6</source>
+        <extracomment>e.g. &quot;From &lt;account name&gt; 100 DAI on Ethereum to &lt;account name&gt; 100 USDT on Optimism&quot;</extracomment>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Max fees:</source>
@@ -17249,20 +17245,12 @@ to load</source>
         <translation>Отримати</translation>
     </message>
     <message>
-        <source>In account</source>
-        <translation>На рахунку</translation>
+        <source>From account</source>
+        <translation type="unfinished">З рахунку</translation>
     </message>
     <message>
-        <source>Network</source>
-        <translation>Мережа</translation>
-    </message>
-    <message>
-        <source>Fees</source>
-        <translation>Комісії</translation>
-    </message>
-    <message>
-        <source>Max. fees on %1</source>
-        <translation>Макс. комісії в %1</translation>
+        <source>To account</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -19203,6 +19203,14 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation>~ Невідомо</translation>
     </message>
     <message>
+        <source>&lt; 30 sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 30 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 1 minute</source>
         <translation>&lt; 1 хвилини</translation>
     </message>
@@ -19211,11 +19219,27 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt; 2 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 2 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&lt; 3 minutes</source>
         <translation>&lt; 3 хвилин</translation>
     </message>
     <message>
         <source>&lt; 3 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; 4 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/imports/shared/popups/addaccount/panels/DerivationPathInput.qml
+++ b/ui/imports/shared/popups/addaccount/panels/DerivationPathInput.qml
@@ -75,11 +75,57 @@ Item {
 
         property bool expectTextUpdate: false
 
-        /// Updates input text with elements content
+        // Updates input text with elements content
         function updateText(elements, cursorOffset = 0) {
             d.cursorPositionToRestore = input.cursorPosition + cursorOffset
             expectTextUpdate = true
             input.text = controller.generateHtmlFromElements(elements)
+        }
+
+        // Plain text corresponding to the current data model
+        function modelText() {
+            return elements.map(e => e.content).join("")
+        }
+
+        // Checks whether input.text was changed by simply inserting characters
+        // into the model's text. Mobile virtual keyboards deliver characters this way,
+        // without ever producing the key events this control is built around.
+        // \return {text, position} describing the inserted characters, or null
+        function externalInsertion() {
+            const modelText = d.modelText()
+            const currentText = input.edit.getText(0, input.text.length)
+            if (currentText.length <= modelText.length)
+                return null
+            var prefix = 0
+            while (prefix < modelText.length && modelText[prefix] === currentText[prefix])
+                prefix++
+            var suffix = 0
+            while (suffix < modelText.length - prefix
+                   && modelText[modelText.length - 1 - suffix] === currentText[currentText.length - 1 - suffix])
+                suffix++
+            if (prefix + suffix !== modelText.length)
+                return null
+            return { text: currentText.slice(prefix, currentText.length - suffix), position: prefix }
+        }
+
+        // Applies characters that arrived as an input-method commit as if they
+        // had been typed one by one: each character goes through the same
+        // controller operations as in Keys.onPressed, so the data model stays
+        // the single source of truth regardless of how the text was entered.
+        // \param insertion the {text, position} object built by externalInsertion()
+        function replayInsertion(insertion) {
+            input.cursorPosition = insertion.position
+            for (const character of insertion.text) {
+                if (character === '/' || character === '\\'
+                        || character === "'" || character === '`') {
+                    const newElementIndex = controller.tryAddAndFixSeparators(d.elements, d.currentIndex, d.elements[d.currentIndex].startIndex === input.cursorPosition)
+                    if (newElementIndex > -1)
+                        d.updateText(d.elements, d.elements[newElementIndex].endIndex - input.cursorPosition)
+                } else if (d.currentIndex >= 0 && d.currentIndex < d.elements.length) {
+                    controller.insertContent(d.elements, d.currentIndex, character, input.cursorPosition)
+                    d.updateText(d.elements, 1)
+                }
+            }
         }
     }
 
@@ -99,6 +145,7 @@ Item {
         anchors.fill: parent
 
         edit.textFormat: TextEdit.RichText
+        edit.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
 
         topPadding: 11
         bottomPadding: 11
@@ -213,12 +260,14 @@ Item {
         }
 
         onTextChanged: {
-            // Ignore external text update (paste and delete events)
             if(d.expectTextUpdate) {
                 d.expectTextUpdate = false
             } else {
+                const insertion = d.externalInsertion()
                 d.cursorPositionToRestore = prevCursorPosition
                 d.updateText(d.elements)
+                if (insertion)
+                    d.replayInsertion(insertion)
                 return
             }
             const currentText = edit.getText(0, text.length)

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -272,7 +272,6 @@ Control {
 
                 readOnly: !root.interactive
                 activeFocusOnPress: root.interactive
-                enabled: root.interactive
 
                 color: text.length === 0 || (root.valid && !root.markAsInvalid)
                        ? Theme.palette.directColor1

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -271,6 +271,8 @@ Control {
                 inputMethodHints: Qt.ImhFormattedNumbersOnly | Qt.ImhNoPredictiveText
 
                 readOnly: !root.interactive
+                activeFocusOnPress: root.interactive
+                enabled: root.interactive
 
                 color: text.length === 0 || (root.valid && !root.markAsInvalid)
                        ? Theme.palette.directColor1

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1484,8 +1484,11 @@ QtObject {
     // Mirrors src/app_service/service/transaction/service.nim -> EstimatedTime
     enum TransactionEstimatedTime {
         Unknown = 0,
+        LessThanThirtySecs,
         LessThanOneMin,
+        LessThanTwoMins,
         LessThanThreeMins,
+        LessThanFourMins,
         LessThanFiveMins,
         MoreThanFiveMins
     }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -62,6 +62,7 @@ QtObject {
     signal openConfirmHideCollectiblePopup(string collectibleSymbol, string collectibleName, string collectibleImage, bool isCommunityToken)
 
     signal requestOpenLink(string link)
+    signal linkOpenedExternally(string link)
     signal activateDeepLink(string link)
 
     signal setNthEnabledSectionActive(int nthSection)


### PR DESCRIPTION
### false "Insufficient funds" error in swap modal

Changes:
- ceiling the total max fees instead of the per-gas value
- gating the local balance under !validSwapProposalReceived && !swapProposalLoading
- the amount input's red (error) state follows the same condition

Fixes #22323

----

### when there is an error, the "Refresh" quote button is disabled

Any response can be refreshed with the same parameters.

Fixes #22324

----

### account's balance doesn't update on account change

- if the account is know to the wallet the account's balance is getting updated on the account change
- if the account is not known the balance is hidden

Fixes #22325

----

### update the confirmation screen to include the receiving address and chain

<img width="509" height="825" alt="s+b" src="https://github.com/user-attachments/assets/fa4fa986-fc46-4840-b74a-7f115f835c12" />

Fixes #22326

----

### opening the token smart contract link doesn't open in a fully-operational in-app browser

Fixes #22327

----

### can't change derivation path for account on mobile

Fixes #22332

----

### check the three options under the "Swap route" menu actually work

No issues per #22328 all handled properly. 
While checking this, I found that we're calling the same LiFi request for each swap route, and that's handled in the below-mentioned PR, and also included the `executionDuration` parameter from the LiFi response into the total estimated time. 

Corresponding `status-go` PR: 
- https://github.com/status-im/status-go/pull/7808

