### PR TITLE
fix(market-tab): tab loading time regression

### DIFF
--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -39,6 +39,7 @@ NIM_TESTS_MODEL_SPY := \
 	assets_adaptor_model_test \
 	collectibles_selector_model_test \
 	grouped_account_assets_model_test \
+	market_leaderboard_model_test \
 	member_model_test \
 	model_sync_move_test \
 	model_sync_unified_test \

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -1,5 +1,6 @@
 import app/modules/shared_models/model_utils
-import nimqml, tables, options
+import app/modules/shared/model_sync
+import nimqml, tables
 
 import app_service/service/market/service as market_service
 
@@ -17,8 +18,9 @@ type
     PriceChangePercentage24h
 
 type
-  # Items are refs the service mutates in place, so values are copied, not items
-  SnapshotRow = object
+  # The service mutates its MarketItem refs in place, so the model keeps its own
+  # value copies: that is what a diff against the previous state runs on.
+  LeaderboardRow = object
     key: string
     name: string
     symbol: string
@@ -28,10 +30,10 @@ type
     totalVolume: float64
     priceChangePercentage24h: float64
 
-proc toSnapshot(items: seq[MarketItem]): seq[SnapshotRow] =
-  result = newSeqOfCap[SnapshotRow](items.len)
+proc toRows(items: seq[MarketItem]): seq[LeaderboardRow] =
+  result = newSeqOfCap[LeaderboardRow](items.len)
   for item in items:
-    result.add(SnapshotRow(
+    result.add(LeaderboardRow(
       key: item.key,
       name: item.name,
       symbol: item.symbol,
@@ -42,20 +44,22 @@ proc toSnapshot(items: seq[MarketItem]): seq[SnapshotRow] =
       priceChangePercentage24h: item.priceChangePercentage24h,
     ))
 
-proc changedRolesFor(item: MarketItem, prev: SnapshotRow): seq[int] =
-  if item.name != prev.name: result.add(ModelRole.Name.int)
-  if item.symbol != prev.symbol: result.add(ModelRole.Symbol.int)
-  if item.image != prev.image: result.add(ModelRole.Image.int)
-  if item.currentPrice != prev.currentPrice: result.add(ModelRole.CurrentPrice.int)
-  if item.marketCap != prev.marketCap: result.add(ModelRole.MarketCap.int)
-  if item.totalVolume != prev.totalVolume: result.add(ModelRole.TotalVolume.int)
-  if item.priceChangePercentage24h != prev.priceChangePercentage24h:
+proc syncKey(it: LeaderboardRow): string = it.key
+proc syncRoles(o, n: LeaderboardRow): seq[int] =
+  result = @[]
+  if o.name != n.name: result.add(ModelRole.Name.int)
+  if o.symbol != n.symbol: result.add(ModelRole.Symbol.int)
+  if o.image != n.image: result.add(ModelRole.Image.int)
+  if o.currentPrice != n.currentPrice: result.add(ModelRole.CurrentPrice.int)
+  if o.marketCap != n.marketCap: result.add(ModelRole.MarketCap.int)
+  if o.totalVolume != n.totalVolume: result.add(ModelRole.TotalVolume.int)
+  if o.priceChangePercentage24h != n.priceChangePercentage24h:
     result.add(ModelRole.PriceChangePercentage24h.int)
 
 QtObject:
   type MarketLeaderboardModel* = ref object of QAbstractListModel
     delegate: io_interface.MarketLeaderboardDataSource
-    snapshot: seq[SnapshotRow]
+    items: seq[LeaderboardRow]
 
   proc setup(self: MarketLeaderboardModel)
   proc delete(self: MarketLeaderboardModel)
@@ -67,7 +71,7 @@ QtObject:
     result.delegate = delegate
 
   method rowCount(self: MarketLeaderboardModel, index: QModelIndex = nil): int =
-    return self.delegate.getMarketLeaderboardList().len
+    return self.items.len
 
   method roleNames(self: MarketLeaderboardModel): Table[int, string] =
     {
@@ -81,18 +85,10 @@ QtObject:
       ModelRole.PriceChangePercentage24h.int:"priceChangePercentage24h",
     }.toTable
 
-  proc getRoleFromName(self: MarketLeaderboardModel, roleName: string): Option[int] =
-    for roleInt, name in self.roleNames():
-      if name == roleName:
-        return some(roleInt)
-    return none(int)
-
   method data(self: MarketLeaderboardModel, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.rowCount(), role, ModelRole)
 
-    # the only way to read items from service is by this single method getMarketLeaderboardList
-
-    let item = self.delegate.getMarketLeaderboardList()[index.row]
+    let item = self.items[index.row]
 
     let enumRole = role.ModelRole
     case enumRole:
@@ -113,47 +109,18 @@ QtObject:
       of ModelRole.PriceChangePercentage24h:
         result = newQVariant(item.priceChangePercentage24h)
 
-  proc sameRowsAsSnapshot(self: MarketLeaderboardModel, items: seq[MarketItem]): bool =
-    if items.len != self.snapshot.len:
-      return false
-    for i in 0 ..< items.len:
-      if items[i].key != self.snapshot[i].key:
-        return false
-    return true
-
+  # Both entry points read the service's current page and diff it against the
+  # rows on display: granular insert/remove for a page change, dataChanged with
+  # the touched roles for a price tick, nothing for an unchanged page.
   proc modelsUpdated*(self: MarketLeaderboardModel) =
-    let items = self.delegate.getMarketLeaderboardList()
-
-    # A reset drops every delegate in the views, so report roles where possible
-    if not self.sameRowsAsSnapshot(items):
-      self.beginResetModel()
-      self.snapshot = toSnapshot(items)
-      self.endResetModel()
-      return
-
-    for i in 0 ..< items.len:
-      let changedRoles = changedRolesFor(items[i], self.snapshot[i])
-      if changedRoles.len > 0:
-        notifyRangeRolesChanged(i, i, changedRoles)
-
-    self.snapshot = toSnapshot(items)
+    self.modelSync(self.items, toRows(self.delegate.getMarketLeaderboardList()))
 
   proc pageUpdated*(self: MarketLeaderboardModel, updates: seq[LeaderboardTokenUpdated]) =
-    for update in updates:
-      var changedRoles: seq[int] = @[]
-      for field in update.changedFields:
-        let roleOpt = self.getRoleFromName(field)
-        if roleOpt.isSome:
-          changedRoles.add(roleOpt.get())
-
-      if changedRoles.len > 0:
-        notifyRangeRolesChanged(update.index, update.index, changedRoles)
-
-    self.snapshot = toSnapshot(self.delegate.getMarketLeaderboardList())
+    self.modelsUpdated()
 
   when defined(testing) or defined(QT_MODEL_SPY):
     proc keysInOrder*(self: MarketLeaderboardModel): seq[string] =
-      for it in self.delegate.getMarketLeaderboardList(): result.add(it.key)
+      for it in self.items: result.add(it.key)
 
   proc setup(self: MarketLeaderboardModel) =
     self.QAbstractListModel.setup

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -151,6 +151,10 @@ QtObject:
 
     self.snapshot = toSnapshot(self.delegate.getMarketLeaderboardList())
 
+  when defined(testing) or defined(QT_MODEL_SPY):
+    proc keysInOrder*(self: MarketLeaderboardModel): seq[string] =
+      for it in self.delegate.getMarketLeaderboardList(): result.add(it.key)
+
   proc setup(self: MarketLeaderboardModel) =
     self.QAbstractListModel.setup
 

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -16,9 +16,46 @@ type
     TotalVolume
     PriceChangePercentage24h
 
+type
+  # Items are refs the service mutates in place, so values are copied, not items
+  SnapshotRow = object
+    key: string
+    name: string
+    symbol: string
+    image: string
+    currentPrice: float64
+    marketCap: float64
+    totalVolume: float64
+    priceChangePercentage24h: float64
+
+proc toSnapshot(items: seq[MarketItem]): seq[SnapshotRow] =
+  result = newSeqOfCap[SnapshotRow](items.len)
+  for item in items:
+    result.add(SnapshotRow(
+      key: item.key,
+      name: item.name,
+      symbol: item.symbol,
+      image: item.image,
+      currentPrice: item.currentPrice,
+      marketCap: item.marketCap,
+      totalVolume: item.totalVolume,
+      priceChangePercentage24h: item.priceChangePercentage24h,
+    ))
+
+proc changedRolesFor(item: MarketItem, prev: SnapshotRow): seq[int] =
+  if item.name != prev.name: result.add(ModelRole.Name.int)
+  if item.symbol != prev.symbol: result.add(ModelRole.Symbol.int)
+  if item.image != prev.image: result.add(ModelRole.Image.int)
+  if item.currentPrice != prev.currentPrice: result.add(ModelRole.CurrentPrice.int)
+  if item.marketCap != prev.marketCap: result.add(ModelRole.MarketCap.int)
+  if item.totalVolume != prev.totalVolume: result.add(ModelRole.TotalVolume.int)
+  if item.priceChangePercentage24h != prev.priceChangePercentage24h:
+    result.add(ModelRole.PriceChangePercentage24h.int)
+
 QtObject:
   type MarketLeaderboardModel* = ref object of QAbstractListModel
     delegate: io_interface.MarketLeaderboardDataSource
+    snapshot: seq[SnapshotRow]
 
   proc setup(self: MarketLeaderboardModel)
   proc delete(self: MarketLeaderboardModel)
@@ -76,9 +113,30 @@ QtObject:
       of ModelRole.PriceChangePercentage24h:
         result = newQVariant(item.priceChangePercentage24h)
 
+  proc sameRowsAsSnapshot(self: MarketLeaderboardModel, items: seq[MarketItem]): bool =
+    if items.len != self.snapshot.len:
+      return false
+    for i in 0 ..< items.len:
+      if items[i].key != self.snapshot[i].key:
+        return false
+    return true
+
   proc modelsUpdated*(self: MarketLeaderboardModel) =
-    self.beginResetModel()
-    self.endResetModel()
+    let items = self.delegate.getMarketLeaderboardList()
+
+    # A reset drops every delegate in the views, so report roles where possible
+    if not self.sameRowsAsSnapshot(items):
+      self.beginResetModel()
+      self.snapshot = toSnapshot(items)
+      self.endResetModel()
+      return
+
+    for i in 0 ..< items.len:
+      let changedRoles = changedRolesFor(items[i], self.snapshot[i])
+      if changedRoles.len > 0:
+        notifyRangeRolesChanged(i, i, changedRoles)
+
+    self.snapshot = toSnapshot(items)
 
   proc pageUpdated*(self: MarketLeaderboardModel, updates: seq[LeaderboardTokenUpdated]) =
     for update in updates:
@@ -90,6 +148,8 @@ QtObject:
 
       if changedRoles.len > 0:
         notifyRangeRolesChanged(update.index, update.index, changedRoles)
+
+    self.snapshot = toSnapshot(self.delegate.getMarketLeaderboardList())
 
   proc setup(self: MarketLeaderboardModel) =
     self.QAbstractListModel.setup

--- a/storybook/pages/MarketLayoutPage.qml
+++ b/storybook/pages/MarketLayoutPage.qml
@@ -48,6 +48,8 @@ SplitView {
                 return LocaleUtils.currencyAmountToLocaleString(abc, options)
             }
             currentPage: -1
+            // the section loader does this in the app
+            Component.onCompleted: fetchMarketTokens(1, pageSize)
             onRequestLaunchSwap: console.warn("Request Launch Swap")
             onFetchMarketTokens: (pageNumber, pageSize) => {
                 console.warn("Fetch Market Tokens with PageSize: %1 and PageNumber:%2".arg(pageSize).arg(pageNumber))

--- a/storybook/qmlTests/tests/tst_MarketLayout.qml
+++ b/storybook/qmlTests/tests/tst_MarketLayout.qml
@@ -45,6 +45,7 @@ Item {
             }
             currentPage: -1
             onFetchMarketTokens: {
+                d.fetchCount++
                 d.startIndex = ((pageNumber - 1) * pageSize) + 1
                 d.endIndex = Math.min(pageNumber * pageSize, totalTokensCount)
                 currentPage = pageNumber
@@ -56,6 +57,7 @@ Item {
         id: d
         property int startIndex: 0
         property int endIndex: 0
+        property int fetchCount: 0
     }
 
     SignalSpy {
@@ -71,7 +73,10 @@ Item {
         when: windowShown
 
         function init() {
+            d.fetchCount = 0
             controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            // The section loader owns fetching, so the test harness plays that part
+            controlUnderTest.fetchMarketTokens(1, controlUnderTest.pageSize)
             signalSpyLaunchSwap.clear()
         }
 
@@ -199,27 +204,59 @@ Item {
             }
         }
 
-        function test_loadingState() {
-            verify(!!controlUnderTest)
+        function test_doesNotFetchOnItsOwn() {
+            d.fetchCount = 0
+            const control = createTemporaryObject(componentUnderTest, root)
+            verify(!!control)
+            compare(d.fetchCount, 0)
+        }
 
-            verify(!controlUnderTest.loading)
-
-            const regularModel = findChild(controlUnderTest, "regularModel")
-            verify(!!regularModel)
+        function test_showsSkeletonsWhenThereIsNothingToShow() {
             const loadingModel = findChild(controlUnderTest, "loadingModel")
             verify(!!loadingModel)
             const tokensList = findChild(controlUnderTest.centerPanel, "tokensList")
             verify(!!tokensList)
 
-            // Loading true
+            // an out of range page leaves the view without any row to show
+            controlUnderTest.fetchMarketTokens(999, controlUnderTest.pageSize)
+            compare(controlUnderTest.tokensModel.count, 0)
+
             controlUnderTest.loading = true
             compare(tokensList.model, loadingModel)
             compare(tokensList.count, 100)
+        }
 
-            // Loading false
+        function test_keepsRowsWhileRefreshing() {
+            const regularModel = findChild(controlUnderTest, "regularModel")
+            verify(!!regularModel)
+            const tokensList = findChild(controlUnderTest.centerPanel, "tokensList")
+            verify(!!tokensList)
+            verify(tokensList.count > 0)
+
+            controlUnderTest.loading = true
+            compare(tokensList.model, regularModel)
+            compare(tokensList.count, controlUnderTest.tokensModel.count)
+
             controlUnderTest.loading = false
             compare(tokensList.model, regularModel)
             compare(tokensList.count, controlUnderTest.tokensModel.count)
+        }
+
+        function test_showsSkeletonsWhenSwitchingPage() {
+            const loadingModel = findChild(controlUnderTest, "loadingModel")
+            verify(!!loadingModel)
+            const tokensList = findChild(controlUnderTest.centerPanel, "tokensList")
+            verify(!!tokensList)
+            const footer = findChild(tokensList, "marketFooter")
+            verify(!!footer)
+
+            footer.switchPage(2)
+            controlUnderTest.loading = true
+            compare(tokensList.model, loadingModel)
+
+            controlUnderTest.loading = false
+            const regularModel = findChild(controlUnderTest, "regularModel")
+            compare(tokensList.model, regularModel)
         }
     }
 }

--- a/test/nim/market_leaderboard_model_test.nim
+++ b/test/nim/market_leaderboard_model_test.nim
@@ -1,0 +1,90 @@
+## Signal-level tests for MarketLeaderboardModel. Compile -d:QT_MODEL_SPY.
+##
+## Acceptance gate: a price tick on a page emits one dataChanged carrying only
+## the changed roles; switching to a page with other tokens emits granular
+## insert/remove and NO reset; a token that only moves keeps its row alive.
+## Only the first load (empty -> N) is allowed to reset.
+
+import unittest, tables
+import nimqml
+
+import app/modules/main/market_section/market_leaderboard_model
+import app/modules/main/market_section/io_interface
+import app_service/service/market/service_items
+import app/modules/shared/qt_model_spy
+
+proc token(key: string, price: float64 = 1.0): MarketItem =
+  MarketItem(key: key, name: key & " coin", symbol: key, image: key & ".png",
+             currentPrice: price, marketCap: 10.0, totalVolume: 5.0,
+             priceChangePercentage24h: 0.5)
+
+suite "MarketLeaderboardModel":
+  var page: seq[MarketItem]
+  let source: MarketLeaderboardDataSource = (
+    getMarketLeaderboardList: proc(): var seq[MarketItem] = page
+  )
+
+  setup:
+    page = @[token("btc", 100.0), token("eth", 10.0), token("sol", 1.0)]
+
+  test "first load resets once and exposes the page":
+    let model = newMarketLeaderboardModel(source)
+    let spy = newQtModelSpy()
+    spy.enable()
+    model.modelsUpdated()
+    spy.disable()
+
+    check spy.countResets() == 1
+    check model.keysInOrder() == @["btc", "eth", "sol"]
+
+  test "a price tick emits one dataChanged with only the changed roles":
+    let model = newMarketLeaderboardModel(source)
+    model.modelsUpdated()
+    var priceRole = -1
+    for role, name in model.roleNames():
+      if name == "currentPrice": priceRole = role
+
+    # the service mutates the same item in place before notifying
+    page[1].currentPrice = 11.0
+    let spy = newQtModelSpy()
+    spy.enable()
+    model.pageUpdated(@[])
+    spy.disable()
+
+    check spy.countResets() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    require spy.countDataChanged() == 1
+    let change = spy.getDataChanged()[0]
+    check change.topLeft == 1
+    check change.bottomRight == 1
+    check change.roles == @[priceRole]
+
+  test "switching page does not reset the model":
+    let model = newMarketLeaderboardModel(source)
+    model.modelsUpdated()
+
+    page = @[token("sol", 1.0), token("ada"), token("dot")]
+    let spy = newQtModelSpy()
+    spy.enable()
+    model.modelsUpdated()
+    spy.disable()
+
+    check spy.countResets() == 0
+    check spy.countInserts() > 0
+    check spy.countRemoves() > 0
+    check model.keysInOrder() == @["sol", "ada", "dot"]
+
+  test "an unchanged page is silent":
+    let model = newMarketLeaderboardModel(source)
+    model.modelsUpdated()
+
+    let spy = newQtModelSpy()
+    spy.enable()
+    model.modelsUpdated()
+    spy.disable()
+
+    check spy.countResets() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    check spy.countDataChanged() == 0

--- a/ui/app/AppLayouts/Market/MarketLayout.qml
+++ b/ui/app/AppLayouts/Market/MarketLayout.qml
@@ -49,10 +49,13 @@ StatusSectionLayout {
 
         // Read-only flag that turns true when the component enters a “compact” layout automatically on resize.
         readonly property bool compactMode: root.width < 600
+
+        // set while the page being loaded is not the one currently on screen
+        property bool pageSwitching: false
     }
 
     onCurrentPageChanged: listView.positionViewAtBeginning()
-    Component.onCompleted: root.fetchMarketTokens(1, root.pageSize)
+    onLoadingChanged: if (!root.loading) d.pageSwitching = false
 
     centerPanel: ColumnLayout {
         anchors.fill: parent
@@ -104,13 +107,16 @@ StatusSectionLayout {
                 pageSize: root.pageSize
                 totalCount: root.totalTokensCount
                 currentPage: root.currentPage
-                onSwitchPage: root.fetchMarketTokens(pageNumber, root.pageSize)
+                onSwitchPage: {
+                    d.pageSwitching = true
+                    root.fetchMarketTokens(pageNumber, root.pageSize)
+                }
                 visible: listView.count > 0 && !root.loading
                 height: visible ? implicitHeight : 0
                 compactMode: d.compactMode
             }
 
-            model: root.loading ? loadingModel: regularModel
+            model: root.loading && (regularModel.count === 0 || d.pageSwitching) ? loadingModel : regularModel
         }
 
         // loading items model


### PR DESCRIPTION
Opening the Market section took ~1.35s from tap to a drawn list on a Redmi 15с
Section created delegates and threw them away, and created again

- Fix double fetch
- Do not show skeleton if we already have instantiated delegates (offline from the DB)
- Inflight refresh doesn't reset model and recreate delegates. Refresh existing roles
- Red tests

Closes https://github.com/status-im/status-app/issues/22187

redmi 15c:

https://github.com/user-attachments/assets/eaeac92c-fa50-4c01-a6de-9b01eea2480f

