### PR TITLE
test(e2e_appium): headless status-backend peer

### DIFF
--- a/test/e2e_appium/README.md
+++ b/test/e2e_appium/README.md
@@ -20,6 +20,38 @@ Repository administrators need to set:
 2. Run tests using `e2e-appium-android.yml` workflow
 3. Use artifact name: `Status-x86_64`
 
+## A headless status-backend as a chat participant
+
+`core/backend_peer.py` drives a headless `status-backend` through status-go's own
+test client, as a chat participant that is not a phone. It runs as a container
+the client starts and stops, from an image named after the status-go commit this
+checkout vendors; `core/peer_containers.py` refuses an image built from any other
+commit. The tests marked `backend_peer` need only Docker: two peers exchange a
+message on the real fleet, and five peers run side by side.
+
+```bash
+# from the repo root, with docker running
+export STATUS_BACKEND_DOCKER_PROJECT=peer-local
+IMAGE=$(test/e2e_appium/scripts/peer_image.sh "$STATUS_BACKEND_DOCKER_PROJECT")
+
+cd test/e2e_appium
+pip install -r requirements.txt -r requirements-backend-peer.txt
+STATUS_BACKEND_IMAGE="$IMAGE" pytest -m backend_peer tests
+```
+
+The first build takes several minutes; after that the image is already on the
+host and the script only looks it up. Without `STATUS_BACKEND_IMAGE` the tests
+are skipped. On Docker Desktop the script finds the daemon through the docker
+context but the test client reads only `DOCKER_HOST`, so set it first:
+
+```bash
+export DOCKER_HOST=$(docker context inspect -f '{{.Endpoints.docker.Host}}')
+```
+
+Peer container logs are written to `logs/backend_peer/` for CI artifact
+collection. All peers created in one pytest process must use the same fleet
+because the status-go client's `Config` is process-global.
+
 ## Test Selection
 
 **By markers:**

--- a/test/e2e_appium/core/backend_peer.py
+++ b/test/e2e_appium/core/backend_peer.py
@@ -1,0 +1,389 @@
+"""Relay-mode status-backend as an e2e chat participant."""
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from collections.abc import Callable
+
+from config.logging_config import get_logger
+from core import peer_containers
+from core.status_go_tf import load_tf_client
+
+logger = get_logger(__name__)
+
+CONTAINER_START_ATTEMPTS = 3
+_config_lock = threading.Lock()
+_process_fleet: str | None = None
+
+
+class PeerDied(RuntimeError):
+    """The peer's container has gone away; carries its name and state."""
+
+
+def _start_container_backend(client):
+    """Retry a backend whose health check failed because the process was still
+    starting; up to CONTAINER_START_ATTEMPTS."""
+    for attempt in range(1, CONTAINER_START_ATTEMPTS + 1):
+        try:
+            return client.StatusBackend()
+        except Exception as exc:
+            if attempt == CONTAINER_START_ATTEMPTS:
+                raise
+            logger.warning("peer container attempt %s failed (%s); retrying", attempt, exc)
+            time.sleep(2)
+
+
+def login_identity(backend) -> dict:
+    """The identity settings the login reported. When the client missed the
+    login signal it rebuilds the event from RPC state with only the public key
+    and mnemonic, so the rest is read from the settings service."""
+    settings = dict((getattr(backend, "node_login_event", None) or {}).get("event", {}).get("settings", {}))
+    service = getattr(backend, "settings_service", None)
+    if not settings.get("compressedKey") and service is not None:
+        settings = {**(service.get_settings() or {}), **settings}
+    return settings
+
+
+async def onboarded(display_name: str, fleet: str = "status.prod") -> BackendPeer:
+    """A peer that is logged in and connected to the fleet. A peer whose
+    onboarding fails is stopped before the error propagates, so no container
+    outlives it."""
+    peer = BackendPeer(fleet=fleet, display_name=display_name)
+    try:
+        await peer.onboard()
+        assert peer.node_fleet == peer.fleet, (
+            f"{display_name} joined fleet {peer.node_fleet!r}, not {peer.fleet!r}"
+        )
+        await peer.wait_for_peers(min_peers=1, timeout=60)
+    except BaseException:
+        await peer.stop()
+        raise
+    return peer
+
+
+async def stop_all(*peers) -> list[BaseException]:
+    """Stop every peer; teardown errors must not replace the test's own failure.
+    Leaked containers show up in the log and in ``docker ps``."""
+    results = await asyncio.gather(
+        *(peer.stop() for peer in peers if peer is not None), return_exceptions=True,
+    )
+    failures = [result for result in results if isinstance(result, BaseException)]
+    for exc in failures:
+        logger.error("peer teardown failed: %r", exc)
+    return failures
+
+
+def _claim_process_fleet(fleet: str) -> None:
+    """The client reads ``Config.waku_fleet`` at login, long after construction,
+    so peers of one process cannot each have their own."""
+    global _process_fleet
+    if _process_fleet is not None and _process_fleet != fleet:
+        raise RuntimeError(
+            f"this process already runs peers on {_process_fleet!r}, not {fleet!r}; "
+            "the client's Config is process-global"
+        )
+    _process_fleet = fleet
+
+
+class BackendPeer:
+    """A relay-mode status-backend acting as the non-phone chat participant."""
+
+    def __init__(self, fleet: str = "status.prod", display_name: str = "RelayPeer"):
+        self.fleet = fleet
+        self.display_name = display_name
+        self._sync = None
+        self._identity: dict = {}
+
+    async def onboard(self, url: str | None = None, password: str = "BackendPeer123!") -> BackendPeer:
+        """Bring the peer up and log it in. Without a url the client starts a
+        container instead, and owns it."""
+        client = load_tf_client()
+
+        def _sync_onboard():
+            with _config_lock:
+                _claim_process_fleet(self.fleet)
+                if url:
+                    client.Config.status_backend_urls = iter([url])
+                else:
+                    peer_containers.configure(client.Config)
+                client.Config.waku_fleet = self.fleet
+                client.Config.waku_fleets_config = ""
+                client.Config.disable_override_networks = True
+                be = client.StatusBackend() if url else _start_container_backend(client)
+            # Held before the calls below can raise: the client starts a
+            # websocket thread in its constructor, and only stop() ends it.
+            self._sync = be
+            be.init_status_backend()
+            be.create_account_and_login(
+                password=password, display_name=self.display_name, waku_light_client=False
+            )
+            be.wait_for_login()
+            self._identity = login_identity(be)
+            # Without start_messenger the waku engine never starts: no
+            # subscriptions, no delivery, and the failure is silent.
+            be.wakuext_service.start_messenger()
+            return be
+
+        self._sync = await asyncio.to_thread(_sync_onboard)
+        assert self.chat_key.startswith("zQ3") and self.public_key.startswith("0x04"), (
+            f"login reported no usable identity: {self._settings!r}"
+        )
+        return self
+
+    async def stop(self) -> None:
+        if self._sync is not None:
+            # Releases the client's own temp datadir and stops the websocket
+            # reconnect loop. Without it the loop keeps dialling the port, and
+            # ports are reused, so it can latch onto the next peer.
+            await asyncio.to_thread(self._sync.shutdown)
+            self._sync = None
+
+    @property
+    def _settings(self) -> dict:
+        if not self._identity and self._sync is not None:
+            self._identity = login_identity(self._sync)
+        return self._identity
+
+    @property
+    def chat_key(self) -> str:
+        return self._settings.get("compressedKey", "")
+
+    @property
+    def public_key(self) -> str:
+        return self._settings.get("public-key", "")
+
+    @property
+    def alias(self) -> str:
+        return self._settings.get("alias", "") or ""
+
+    @property
+    def node_fleet(self) -> str:
+        """Fleet as reported by the node's login event (not the constructor arg)."""
+        return self._settings.get("fleet", "")
+
+    def check_alive(self) -> None:
+        self._check_liveness()
+
+    def _check_liveness(self) -> None:
+        """The client holds the only handle to the peer, so its container is
+        the only place liveness can be read. A peer reached over a url has no
+        container and nothing to check."""
+        container = self._container()
+        if container is None:
+            return
+        container.reload()
+        if container.status != "running":
+            raise PeerDied(
+                f"peer container {container.name} is {container.status}, not running"
+                + self._log_tail(container)
+            )
+
+    def _container(self):
+        return getattr(getattr(self._sync, "container", None), "container", None)
+
+    def _log_tail(self, container, limit: int = 4000) -> str:
+        try:
+            tail = container.logs(tail=200).decode("utf-8", "replace")
+        except Exception as exc:
+            return f"\n(container log unavailable: {exc})"
+        return "\n--- peer container log tail ---\n" + tail[-limit:]
+
+    def dump_logs(self, dest_dir: str) -> None:
+        """The peer's own log, kept before the container is removed."""
+        container = self._container()
+        if container is None:
+            return
+        os.makedirs(dest_dir, exist_ok=True)
+        path = os.path.join(dest_dir, f"{container.name}.log")
+        try:
+            with open(path, "wb") as fh:
+                fh.write(container.logs())
+        except Exception as exc:
+            logger.warning("peer log capture failed for %s: %s", container.name, exc)
+
+    def request_contact(self, contact_key: str, message: str = "Hello"):
+        """Named apart from ``CreateChatPage.send_contact_request``, which
+        reports bool success while this returns the RPC payload."""
+        return self._sync.wakuext_service.send_contact_request(contact_key, message)
+
+    def accept_contact_request_from(self, sender_public_key: str):
+        return self._sync.wakuext_service.accept_latest_contact_request_for_contact(sender_public_key)
+
+    def _sent_message_id(self, result: dict, **fields) -> str:
+        messages = (result or {}).get("messages") or []
+        mine = [
+            m for m in messages
+            if m.get("from") == self.public_key
+            and all(m.get(k) == v for k, v in fields.items())
+        ]
+        if not mine:
+            raise RuntimeError(
+                f"send returned no message authored by this peer matching {fields!r}; "
+                f"payload held {[(m.get('id'), m.get('text')) for m in messages]!r}"
+            )
+        return max(mine, key=lambda m: m.get("clock", 0))["id"]
+
+    def send_dm(self, contact_key: str, text: str) -> str:
+        """rpc_request hands back the already-unwrapped JSON-RPC result."""
+        result = self._sync.wakuext_service.send_one_to_one_message(contact_key, text)
+        return self._sent_message_id(result, text=text)
+
+    def has_contact(self, public_key: str, require_mutual: bool = False) -> bool:
+        """Contacts are keyed by the 0x04 legacy key, but the payload also
+        carries the zQ3 compressedKey; callers may hold either form."""
+        contacts = self._sync.wakuext_service.get_contacts() or []
+        for c in contacts:
+            if public_key not in (c.get("id"), c.get("compressedKey")):
+                continue
+            if not require_mutual:
+                return True
+            # Older payloads carry an explicit "mutual"; newer ones imply it
+            # via added + hasAddedUs.
+            return bool(c.get("mutual")) or (
+                bool(c.get("added")) and bool(c.get("hasAddedUs"))
+            )
+        return False
+
+    def pending_inbound_contact_key(self) -> str:
+        """Public key of a contact who has added us but whom we have not added
+        back, i.e. an unanswered inbound request. Empty string when there is
+        none. Polled rather than awaited so a peer without a signal client can
+        still complete a handshake."""
+        for c in self._sync.wakuext_service.get_contacts() or []:
+            if c.get("hasAddedUs") and not c.get("added"):
+                return c.get("id") or ""
+        return ""
+
+    async def await_inbound_contact_request(self, timeout: int = 120) -> str:
+        return await self._await(
+            "an inbound contact request", self.pending_inbound_contact_key, timeout,
+        )
+
+    async def await_mutual_contact(self, public_key: str, timeout: int = 60) -> None:
+        await self._await(
+            f"contact {public_key[:12]}… mutual", lambda: self.has_contact(public_key, True), timeout,
+        )
+
+    @staticmethod
+    def dm_chat_id(public_key: str) -> str:
+        """status-go keys a 1:1 chat by the other party's 0x04 public key."""
+        return public_key
+
+    def chat_messages(self, contact_key: str, limit: int = 30) -> list[dict]:
+        payload = self._sync.wakuext_service.chat_messages(
+            self.dm_chat_id(contact_key), limit=limit,
+        ) or {}
+        return payload.get("messages") or []
+
+    def chat_message_texts(self, contact_key: str, limit: int = 20) -> list[str]:
+        return [m.get("text", "") for m in self.chat_messages(contact_key, limit)]
+
+    def find_message(self, contact_key: str, text: str, limit: int = 30) -> dict | None:
+        return next((m for m in self.chat_messages(contact_key, limit) if m.get("text") == text), None)
+
+    async def await_chat_message(self, contact_key: str, text: str, timeout: int = 120) -> dict:
+        try:
+            return await self._await(
+                f"{text!r} on the peer", lambda: self.find_message(contact_key, text), timeout,
+            )
+        except TimeoutError:
+            texts = self.chat_message_texts(contact_key)
+            raise TimeoutError(
+                f"{text!r} never reached the peer within {timeout}s; "
+                f"its last {len(texts)} message(s): {texts!r}"
+            ) from None
+
+    async def await_new_message_from(
+        self, contact_key: str, known_ids: set[str], timeout: int = 120,
+    ) -> dict:
+        """The peer's copy of the next message from ``contact_key``, whatever its
+        text. For sends whose text the sender chooses, like an emoji picker."""
+
+        def probe():
+            for message in self.chat_messages(contact_key):
+                if message.get("id") not in known_ids and message.get("from") == contact_key:
+                    return message
+            return None
+
+        return await self._await(
+            f"a new message from {contact_key[:12]}…", probe, timeout,
+        )
+
+    def reactions_on(self, contact_key: str, message_id: str) -> list[dict]:
+        return self._sync.wakuext_service.emoji_reactions_by_chat_id_message_id(
+            self.dm_chat_id(contact_key), message_id,
+        ) or []
+
+    async def await_reaction(self, contact_key: str, message_id: str, timeout: int = 120) -> list[dict]:
+        return await self._await(
+            f"a reaction on {message_id}", lambda: self.reactions_on(contact_key, message_id), timeout,
+        )
+
+    def send_reply(self, contact_key: str, text: str, response_to: str) -> str:
+        result = self._sync.wakuext_service.send_chat_message(
+            self.dm_chat_id(contact_key), text, responseTo=response_to,
+        )
+        return self._sent_message_id(result, text=text, responseTo=response_to)
+
+    def revise_message(self, message_id: str, new_text: str):
+        """Edit a message the peer already sent. Named apart from the page
+        objects' ``submit_message_edit`` because that reports bool success
+        while this returns the RPC payload."""
+        return self._sync.wakuext_service.edit_message(message_id, new_text)
+
+    def add_reaction(self, contact_key: str, message_id: str, emoji_code: str):
+        """``emoji_code`` is the unicode hex the UI keys its reaction buttons on
+        ("1f600"). wakuext_sendEmojiReaction takes that string; the older
+        EmojiReaction_Type enum is deprecated."""
+        return self._sync.wakuext_service.send_emoji_reaction(
+            self.dm_chat_id(contact_key), message_id, emoji_code,
+        )
+
+    def purge_chat_history(self, contact_key: str):
+        """Clear the peer's own copy of the conversation. Named apart from
+        ``ChatPage.clear_history``, which reports bool success."""
+        return self._sync.wakuext_service.clear_history(self.dm_chat_id(contact_key))
+
+    def deactivate_dm(self, contact_key: str, preserve_history: bool = True):
+        """Close the chat on the peer only. Named apart from
+        ``ChatPage.close_chat``, which reports bool success."""
+        return self._sync.wakuext_service.deactivate_chat(
+            self.dm_chat_id(contact_key), preserve_history,
+        )
+
+    def dm_is_active(self, contact_key: str) -> bool:
+        chat_id = self.dm_chat_id(contact_key)
+        for chat in self._sync.wakuext_service.active_chats() or []:
+            if chat.get("id") == chat_id:
+                return True
+        return False
+
+    def peers(self) -> dict:
+        """Connected waku peers (peer-id -> protocols/addresses). Only
+        available once start_messenger has run."""
+        return self._sync.wakuext_service.rpc_request("peers") or {}
+
+    async def wait_for_peers(self, min_peers: int = 1, timeout: int = 30) -> dict:
+        return await self._await(
+            f"{min_peers} waku peer(s)",
+            lambda: (lambda p: p if len(p) >= min_peers else None)(self.peers()), timeout,
+        )
+
+    async def _await(self, describe: str, probe: Callable, timeout: int, interval: float = 2.0):
+        deadline = time.monotonic() + timeout
+        while True:
+            self._check_liveness()
+            try:
+                found = await asyncio.to_thread(probe)
+            except Exception:
+                # A probe that fails because the peer died should say so, with
+                # the peer's log, rather than surface as a bare connection error.
+                self._check_liveness()
+                raise
+            if found:
+                return found
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"no {describe} within {timeout}s")
+            await asyncio.sleep(interval)

--- a/test/e2e_appium/core/backend_peer.py
+++ b/test/e2e_appium/core/backend_peer.py
@@ -58,7 +58,11 @@ async def onboarded(display_name: str, fleet: str = "status.prod") -> BackendPee
         )
         await peer.wait_for_peers(min_peers=1, timeout=60)
     except BaseException:
-        await peer.stop()
+        try:
+            await peer.stop()
+        except Exception as cleanup_exc:
+            # Never let a cleanup failure replace the reason onboarding failed.
+            logger.error("peer cleanup after a failed onboard also failed: %r", cleanup_exc)
         raise
     return peer
 

--- a/test/e2e_appium/core/peer_containers.py
+++ b/test/e2e_appium/core/peer_containers.py
@@ -1,0 +1,144 @@
+"""Container mode for the headless peer.
+
+status-go's own test client can run status-backend in a container it starts,
+which leaves it owning the lifecycle, the shared library and the ports. All
+this module does is point the client at our image and network.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+import threading
+
+IMAGE_ENV = "STATUS_BACKEND_IMAGE"
+PROJECT_ENV = "STATUS_BACKEND_DOCKER_PROJECT"
+
+# scripts/peer_image.sh names the image statusgo-peer-<commit>, so the name is
+# the peer's provenance and can be checked against the vendored pin. A tag or
+# digest after the name is the registry's business, not the commit's.
+MIN_SHA_PREFIX = 7
+_REF_SUFFIX = re.compile(r"(:[\w][\w.\-]*)?(@sha256:[0-9a-f]{64})?$")
+_SHA_IN_NAME = re.compile(r"statusgo-peer-([0-9a-f]{%d,40})$" % MIN_SHA_PREFIX)
+
+
+class PeerProvenanceError(RuntimeError):
+    pass
+
+_scratch: str | None = None
+_lock = threading.RLock()
+_configured: tuple[str, str] | None = None
+
+
+def image() -> str:
+    return os.environ.get(IMAGE_ENV, "").strip()
+
+
+def enabled() -> bool:
+    return bool(image())
+
+
+def scratch_dir() -> str:
+    """Where the client's bind mounts land; without it they land in the cwd."""
+    global _scratch
+    with _lock:
+        if _scratch is None:
+            _scratch = tempfile.mkdtemp(prefix="e2e-peer-containers-")
+        return _scratch
+
+
+def e2e_root() -> str:
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def peer_logs_dir() -> str:
+    return os.path.join(e2e_root(), "logs", "backend_peer")
+
+
+def check_docker_resources(image_ref: str, project: str, docker_client=None) -> None:
+    """Check resources before the client starts a peer: it maps a missing
+    image to a plain RuntimeError before callers can distinguish it from a
+    transient start failure."""
+    import docker
+    import docker.errors
+
+    client = docker_client or docker.from_env()
+    try:
+        client.images.get(image_ref)
+    except docker.errors.ImageNotFound as exc:
+        raise RuntimeError(
+            f"the peer image {image_ref!r} is not on this host. "
+            "scripts/peer_image.sh <project> builds it."
+        ) from exc
+    try:
+        client.networks.get(f"{project}_default")
+    except docker.errors.NotFound as exc:
+        raise RuntimeError(
+            f"the docker network {project}_default is missing; "
+            f"scripts/peer_image.sh {project} creates it."
+        ) from exc
+
+
+def vendored_status_go_sha(repo_root: str) -> str:
+    """The status-go commit the app vendors, from the index rather than the checkout."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo_root, "ls-tree", "HEAD", "vendor/status-go"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise PeerProvenanceError(f"could not read the vendored status-go pin: {exc}") from exc
+    if out.returncode != 0 or not out.stdout.strip():
+        raise PeerProvenanceError(
+            f"could not read the vendored status-go pin from {repo_root}: "
+            f"{out.stderr.strip() or 'no gitlink entry for vendor/status-go'}"
+        )
+    return out.stdout.split()[2]
+
+
+def check_provenance(image_ref: str, vendored_sha: str) -> str:
+    """The image has to come from the status-go commit this checkout vendors.
+    That binds the peer to the checkout; nothing here reads the phone's APK."""
+    name = _REF_SUFFIX.sub("", image_ref)
+    match = _SHA_IN_NAME.search(name)
+    if not match:
+        raise PeerProvenanceError(
+            f"{IMAGE_ENV}={image_ref!r} does not name the status-go commit it was "
+            f"built from, so the peer's provenance is unknown. Build it with "
+            f"scripts/peer_image.sh, which names it statusgo-peer-<commit>."
+        )
+    declared = match.group(1)
+    if not vendored_sha.startswith(declared):
+        raise PeerProvenanceError(
+            f"the peer image {image_ref!r} was built from {declared} but this "
+            f"checkout vendors {vendored_sha}. Rebuild it from the vendored pin."
+        )
+    return declared
+
+
+def configure(config) -> None:
+    """Switch the client from an external URL to a container of our image."""
+    global _configured
+    with _lock:
+        image_ref = image()
+        project = os.environ.get(PROJECT_ENV, "").strip()
+        if _configured == (image_ref, project):
+            return
+        if not project:
+            raise RuntimeError(
+                f"{IMAGE_ENV} is set but {PROJECT_ENV} is not. The client attaches "
+                "every container to <project>_default, so the name has to match the "
+                "network the pipeline created."
+            )
+        from core.status_go_tf import repo_root
+
+        check_provenance(image_ref, vendored_status_go_sha(repo_root()))
+        check_docker_resources(image_ref, project)
+
+        config.status_backend_urls = None
+        config.docker_project_name = project
+        config.docker_image = image_ref
+        config.codecov_dir = os.path.join(scratch_dir(), "coverage")
+        config.logs_dir = peer_logs_dir()
+        _configured = (image_ref, project)

--- a/test/e2e_appium/core/peer_containers.py
+++ b/test/e2e_appium/core/peer_containers.py
@@ -48,12 +48,17 @@ def scratch_dir() -> str:
         return _scratch
 
 
-def e2e_root() -> str:
-    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-
 def peer_logs_dir() -> str:
-    return os.path.join(e2e_root(), "logs", "backend_peer")
+    """Where the client writes each peer container's log. Under the run's
+    reports directory, which CI archives, rather than a path only this module
+    knows about."""
+    from config import get_config
+
+    try:
+        root = get_config().reports_dir
+    except Exception:
+        root = "reports"
+    return os.path.join(root, "backend_peer")
 
 
 def check_docker_resources(image_ref: str, project: str, docker_client=None) -> None:

--- a/test/e2e_appium/core/peer_containers.py
+++ b/test/e2e_appium/core/peer_containers.py
@@ -123,18 +123,20 @@ def configure(config) -> None:
     with _lock:
         image_ref = image()
         project = os.environ.get(PROJECT_ENV, "").strip()
-        if _configured == (image_ref, project):
-            return
         if not project:
             raise RuntimeError(
                 f"{IMAGE_ENV} is set but {PROJECT_ENV} is not. The client attaches "
                 "every container to <project>_default, so the name has to match the "
                 "network the pipeline created."
             )
-        from core.status_go_tf import repo_root
+        # Only the checks are cached. The Config writes below run every time:
+        # a peer reached over a url leaves status_backend_urls set, and the next
+        # container peer has to clear it or the client stays in url mode.
+        if _configured != (image_ref, project):
+            from core.status_go_tf import repo_root
 
-        check_provenance(image_ref, vendored_status_go_sha(repo_root()))
-        check_docker_resources(image_ref, project)
+            check_provenance(image_ref, vendored_status_go_sha(repo_root()))
+            check_docker_resources(image_ref, project)
 
         config.status_backend_urls = None
         config.docker_project_name = project

--- a/test/e2e_appium/core/status_go_tf.py
+++ b/test/e2e_appium/core/status_go_tf.py
@@ -1,0 +1,170 @@
+"""Locating and importing the status-go functional-test client."""
+from __future__ import annotations
+
+import functools
+import importlib
+import importlib.util
+import inspect
+import os
+import sys
+from typing import NamedTuple
+
+import requests
+
+_TF_LAYOUTS = ("test/functional",)
+_CLIENT_PACKAGES = ("clients", "resources", "utils")
+
+# The client posts without a timeout, so a peer that accepts a connection and
+# never answers would otherwise hold a worker until the test timeout.
+RPC_TIMEOUT_SECONDS = int(os.environ.get("STATUS_BACKEND_RPC_TIMEOUT", "60"))
+
+
+class BoundedSession(requests.Session):
+    """A session that supplies a timeout unless the caller passed one."""
+
+    def __init__(self, timeout=(5, RPC_TIMEOUT_SECONDS)):
+        super().__init__()
+        self._timeout = timeout
+
+    def request(self, method, url, **kwargs):
+        kwargs.setdefault("timeout", self._timeout)
+        return super().request(method, url, **kwargs)
+
+
+class TfClient(NamedTuple):
+    StatusBackend: type
+    Config: type
+
+
+def repo_root() -> str:
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.abspath(os.path.join(here, "..", "..", ".."))
+
+
+def tf_candidates(root: str | None = None) -> list[str]:
+    """Where the functional-test client lives under the vendored submodule."""
+    base = os.path.join(root or repo_root(), "vendor", "status-go")
+    return [os.path.abspath(os.path.join(base, layout)) for layout in _TF_LAYOUTS]
+
+
+def tf_root(root: str | None = None) -> str:
+    """Resolve the functional-test client directory."""
+    env = os.environ.get("STATUS_GO_TESTS_FUNCTIONAL")
+    if env:
+        return os.path.abspath(env)
+
+    candidates = tf_candidates(root)
+    for candidate in candidates:
+        if os.path.isdir(os.path.join(candidate, "clients")):
+            return candidate
+
+    raise RuntimeError(
+        "status-go functional-test client not found. Looked for a 'clients' "
+        "directory under: " + ", ".join(candidates) + ". The vendored "
+        "submodule is probably not checked out (git submodule update --init "
+        "vendor/status-go); if it is, status-go has moved the tree and "
+        "_TF_LAYOUTS needs the new path. Set STATUS_GO_TESTS_FUNCTIONAL to "
+        "point at it directly."
+    )
+
+
+_cached: TfClient | None = None
+
+
+def _import_client(tf: str):
+    """Import the client with its tree first on the path, then put back any of
+    this suite's packages that share a top-level name. The client's modules keep
+    the objects they bound at import; its only lazy import is of its own
+    ``clients`` package, which nothing here shares."""
+    colliding = set()
+    for name in _CLIENT_PACKAGES:
+        try:
+            found = importlib.util.find_spec(name) is not None
+        except ValueError:
+            found = True
+        if found:
+            colliding.add(name)
+    saved = {k: sys.modules.pop(k) for k in list(sys.modules)
+             if k.split(".")[0] in colliding}
+    sys.path.insert(0, tf)
+    try:
+        sb = importlib.import_module("clients.status_backend")
+        cfg = importlib.import_module("utils.config")
+    finally:
+        sys.path.remove(tf)
+        sys.path.append(tf)
+        for k in [k for k in sys.modules if k.split(".")[0] in colliding]:
+            del sys.modules[k]
+        sys.modules.update(saved)
+    return sb, cfg
+
+
+def load_tf_client() -> TfClient:
+    global _cached
+    if _cached is not None:
+        return _cached
+
+    tf = tf_root()
+    try:
+        sb, cfg = _import_client(tf)
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            f"status-go functional-test client at {tf} could not be imported: {exc}. "
+            "Its dependencies are not in the e2e_appium gate install; "
+            "run pip install -r requirements-backend-peer.txt."
+        ) from exc
+
+    bind_session_constructors(sb.StatusBackend)
+    assert_session_constructors_bound(sb.StatusBackend)
+    _cached = TfClient(sb.StatusBackend, cfg.Config)
+    return _cached
+
+
+def session_constructors(backend: type) -> list[type]:
+    """The classes in the backend's ancestry whose own constructor takes the
+    HTTP session, in resolution order. Each one assigns it, and the last
+    assignment wins, so every one of them has to be bound."""
+    found = []
+    for cls in backend.__mro__:
+        init = vars(cls).get("__init__")
+        if init is not None and "client" in inspect.signature(init).parameters:
+            found.append(cls)
+    return found
+
+
+def bind_session_constructors(backend: type) -> None:
+    for cls in session_constructors(backend):
+        _bind_request_timeouts(cls)
+
+
+def assert_session_constructors_bound(backend: type) -> None:
+    """Raise if any constructor that installs a session is still unbounded."""
+    unbound = [
+        cls.__name__ for cls in session_constructors(backend)
+        if not getattr(cls.__init__, "_bounded", False)
+    ]
+    if unbound:
+        raise RuntimeError(
+            f"{', '.join(unbound)} would give {backend.__name__} an unbounded "
+            "HTTP session; a peer that accepts a connection and never answers "
+            "would then hold a worker until the test timeout."
+        )
+
+
+def _bind_request_timeouts(cls: type) -> None:
+    """The client builds its session inside its own constructor and health-checks
+    with it before a caller can replace it, so the timeout has to be installed
+    there rather than on the object afterwards."""
+    if getattr(cls.__init__, "_bounded", False):
+        return
+    unbounded = cls.__init__
+
+    @functools.wraps(unbounded)
+    def __init__(self, *args, **kwargs):
+        # The client never passes a session positionally; one that did would get
+        # a TypeError here rather than a silently unbounded session.
+        kwargs.setdefault("client", BoundedSession())
+        unbounded(self, *args, **kwargs)
+
+    __init__._bounded = True
+    cls.__init__ = __init__

--- a/test/e2e_appium/pytest.ini
+++ b/test/e2e_appium/pytest.ini
@@ -26,3 +26,4 @@ markers =
     spec(id): Links test to a specification scenario (e.g. SC-DM-06)
     portrait: Verified to work on portrait-orientation phones
     slow: Long-running operations (e.g. password re-encryption, 5-10+ min)
+    backend_peer: Tests using a headless status-backend as a chat participant

--- a/test/e2e_appium/requirements-backend-peer.txt
+++ b/test/e2e_appium/requirements-backend-peer.txt
@@ -1,0 +1,19 @@
+# Extra dependencies for the backend-peer lane only.
+#
+# Importing the status-go functional-test client (core/status_go_tf.py) needs
+# these; they stay out of requirements.txt so the ordinary gate install does
+# not grow a matplotlib and docker dependency it never uses. Versions track
+# vendor/status-go's test/functional/requirements.txt except websocket-client:
+# status-go pins ~=1.4.2, while Selenium already installs ~=1.9.0 here.
+#
+#   pip install -r requirements.txt -r requirements-backend-peer.txt
+
+tenacity~=9.0.0
+websockets~=12.0
+matplotlib>=3.5.0
+docker~=7.1.0
+faker~=37.6.0
+base58~=2.1.1
+# Selenium pulls this in today; the client imports it directly and must not
+# depend on that accident.
+websocket-client~=1.9.0

--- a/test/e2e_appium/scripts/peer_image.sh
+++ b/test/e2e_appium/scripts/peer_image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build the status-go image the messaging tests pair a phone with, tagged with
+# the vendored commit so an unmoved pin reuses the agent's image, and create
+# the network the client attaches it to. Only the tag goes to stdout.
+set -euo pipefail
+
+project="${1:?usage: peer_image.sh <docker-project-name>}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${root}"
+
+command -v docker >/dev/null || { echo "docker is not on PATH" >&2; exit 1; }
+
+sha="$(git ls-tree HEAD vendor/status-go | awk '{print $3}')"
+if [ -z "${sha}" ]; then
+  echo "vendor/status-go is not a submodule of this tree" >&2
+  exit 1
+fi
+image="statusgo-peer-${sha:0:12}"
+
+# The client that drives the peer lives in the submodule, so the checkout is
+# needed whether or not the image has to be built; it is fetched only when it
+# is absent or at another commit.
+if [ "$(git -C vendor/status-go rev-parse HEAD 2>/dev/null)" != "${sha}" ]; then
+  git submodule update --init --depth 1 vendor/status-go >&2
+fi
+
+if docker image inspect "${image}" >/dev/null 2>&1; then
+  echo "peer image ${image} is already on this agent" >&2
+else
+  echo "building ${image} from status-go ${sha}" >&2
+  docker build vendor/status-go --tag "${image}" >&2
+fi
+
+docker network inspect "${project}_default" >/dev/null 2>&1 \
+  || docker network create "${project}_default" >&2
+
+echo "${image}"

--- a/test/e2e_appium/tests/test_backend_peer_containers.py
+++ b/test/e2e_appium/tests/test_backend_peer_containers.py
@@ -25,6 +25,7 @@ DELIVERY_TIMEOUT = 180
 async def test_two_container_peers_exchange_a_message():
     sender = await onboarded("ContainerPeerSender")
     receiver = None
+    body_passed = False
     try:
         receiver = await onboarded("ContainerPeerReceiver")
 
@@ -44,5 +45,10 @@ async def test_two_container_peers_exchange_a_message():
             sender.public_key, text, timeout=DELIVERY_TIMEOUT,
         )
         assert arrived["from"] == sender.public_key
+        body_passed = True
     finally:
-        await stop_all(sender, receiver)
+        failures = await stop_all(sender, receiver)
+        if body_passed and failures:
+            # A leaked container or websocket thread poisons the next
+            # test on this runner, so it cannot be a silent pass.
+            raise failures[0]

--- a/test/e2e_appium/tests/test_backend_peer_containers.py
+++ b/test/e2e_appium/tests/test_backend_peer_containers.py
@@ -1,0 +1,48 @@
+"""Two container peers become mutual contacts on the real fleet and exchange a
+1:1 message. No phone or Appium session. Needs STATUS_BACKEND_IMAGE and
+STATUS_BACKEND_DOCKER_PROJECT (see scripts/peer_image.sh); skipped without them.
+"""
+import asyncio
+import uuid
+
+import pytest
+
+from core import peer_containers
+from core.backend_peer import onboarded, stop_all
+
+pytestmark = [
+    pytest.mark.backend_peer,
+    pytest.mark.skipif(
+        not peer_containers.enabled(),
+        reason="STATUS_BACKEND_IMAGE is not set; nothing to start a peer container from",
+    ),
+]
+
+CONTACT_TIMEOUT = 180
+DELIVERY_TIMEOUT = 180
+
+
+async def test_two_container_peers_exchange_a_message():
+    sender = await onboarded("ContainerPeerSender")
+    receiver = None
+    try:
+        receiver = await onboarded("ContainerPeerReceiver")
+
+        await asyncio.to_thread(
+            sender.request_contact, receiver.public_key, "Hello from the sender",
+        )
+        seen = await receiver.await_inbound_contact_request(timeout=CONTACT_TIMEOUT)
+        assert seen == sender.public_key, (
+            f"receiver saw a request from {seen} rather than the sender {sender.public_key}"
+        )
+        await asyncio.to_thread(receiver.accept_contact_request_from, seen)
+        await sender.await_mutual_contact(receiver.public_key, timeout=CONTACT_TIMEOUT)
+
+        text = f"container-smoke-{uuid.uuid4().hex[:8]}"
+        await asyncio.to_thread(sender.send_dm, receiver.public_key, text)
+        arrived = await receiver.await_chat_message(
+            sender.public_key, text, timeout=DELIVERY_TIMEOUT,
+        )
+        assert arrived["from"] == sender.public_key
+    finally:
+        await stop_all(sender, receiver)

--- a/test/e2e_appium/tests/test_backend_peer_containers_lane.py
+++ b/test/e2e_appium/tests/test_backend_peer_containers_lane.py
@@ -26,6 +26,7 @@ async def test_five_peer_containers_run_side_by_side():
         return_exceptions=True,
     )
     peers = [r for r in results if isinstance(r, BackendPeer)]
+    body_passed = False
     try:
         failures = [r for r in results if not isinstance(r, BackendPeer)]
         assert not failures, f"{len(failures)} of {SLOTS} peers failed to start: {failures!r}"
@@ -34,5 +35,10 @@ async def test_five_peer_containers_run_side_by_side():
         assert len({peer.chat_key for peer in peers}) == SLOTS, (
             f"expected {SLOTS} distinct peers, got {[p.chat_key for p in peers]!r}"
         )
+        body_passed = True
     finally:
-        await stop_all(*peers)
+        failures = await stop_all(*peers)
+        if body_passed and failures:
+            # A leaked container or websocket thread poisons the next
+            # test on this runner, so it cannot be a silent pass.
+            raise failures[0]

--- a/test/e2e_appium/tests/test_backend_peer_containers_lane.py
+++ b/test/e2e_appium/tests/test_backend_peer_containers_lane.py
@@ -1,0 +1,38 @@
+"""Five peer containers alive at once on one docker network, what a messaging
+gate at -n 5 asks of the agent. Started from one test so xdist scheduling
+cannot hide a collision. Same requirements as test_backend_peer_containers.py.
+"""
+import asyncio
+
+import pytest
+
+from core import peer_containers
+from core.backend_peer import BackendPeer, onboarded, stop_all
+
+pytestmark = [
+    pytest.mark.backend_peer,
+    pytest.mark.skipif(
+        not peer_containers.enabled(),
+        reason="STATUS_BACKEND_IMAGE is not set; nothing to start a peer container from",
+    ),
+]
+
+SLOTS = 5
+
+
+async def test_five_peer_containers_run_side_by_side():
+    results = await asyncio.gather(
+        *(onboarded(f"ContainerPeerSlot{slot}") for slot in range(SLOTS)),
+        return_exceptions=True,
+    )
+    peers = [r for r in results if isinstance(r, BackendPeer)]
+    try:
+        failures = [r for r in results if not isinstance(r, BackendPeer)]
+        assert not failures, f"{len(failures)} of {SLOTS} peers failed to start: {failures!r}"
+        for peer in peers:
+            peer.check_alive()
+        assert len({peer.chat_key for peer in peers}) == SLOTS, (
+            f"expected {SLOTS} distinct peers, got {[p.chat_key for p in peers]!r}"
+        )
+    finally:
+        await stop_all(*peers)

--- a/test/e2e_appium/tests/test_backend_peer_core.py
+++ b/test/e2e_appium/tests/test_backend_peer_core.py
@@ -206,7 +206,9 @@ def test_configure_runs_once_per_process(monkeypatch):
             future.result()
 
     assert len(calls) == 1
-    assert config.logs_dir.endswith(os.path.join("logs", "backend_peer"))
+    # Under the run's reports dir, which CI already archives.
+    assert config.logs_dir.endswith("backend_peer")
+    assert "reports" in config.logs_dir
     assert config.status_backend_urls is None
 
 

--- a/test/e2e_appium/tests/test_backend_peer_core.py
+++ b/test/e2e_appium/tests/test_backend_peer_core.py
@@ -210,6 +210,28 @@ def test_configure_runs_once_per_process(monkeypatch):
     assert config.status_backend_urls is None
 
 
+def test_configure_reapplies_the_config_when_the_checks_are_cached(monkeypatch):
+    """A peer reached over a url leaves status_backend_urls set. The next
+    container peer must clear it, or the client never starts a container."""
+    monkeypatch.setenv(peer_containers.IMAGE_ENV, "statusgo-peer-27bca1fc5ce8")
+    monkeypatch.setenv(peer_containers.PROJECT_ENV, "peer-test")
+    monkeypatch.setattr(peer_containers, "vendored_status_go_sha", lambda _root: VENDORED)
+    monkeypatch.setattr(peer_containers, "check_docker_resources", lambda *_: None)
+    monkeypatch.setattr(peer_containers, "_configured", None)
+
+    class _Cfg:
+        pass
+
+    config = _Cfg()
+    peer_containers.configure(config)
+    config.status_backend_urls = iter(["http://peer:3333"])
+
+    peer_containers.configure(config)
+
+    assert config.status_backend_urls is None
+    assert config.docker_image == "statusgo-peer-27bca1fc5ce8"
+
+
 @pytest.mark.asyncio
 async def test_stop_all_reports_but_does_not_raise_teardown_failures():
     class _GoodPeer:

--- a/test/e2e_appium/tests/test_backend_peer_core.py
+++ b/test/e2e_appium/tests/test_backend_peer_core.py
@@ -210,6 +210,26 @@ def test_configure_runs_once_per_process(monkeypatch):
     assert config.status_backend_urls is None
 
 
+@pytest.mark.asyncio
+async def test_a_failed_onboard_reports_its_own_error_not_the_cleanup_error(monkeypatch):
+    """The reason onboarding failed is the useful one; a cleanup failure on top
+    of it must not replace it."""
+    class _Peer:
+        def __init__(self, *_a, **_k):
+            self.fleet = "status.prod"
+            self.node_fleet = ""
+
+        async def onboard(self):
+            raise RuntimeError("login never completed")
+
+        async def stop(self):
+            raise RuntimeError("docker daemon went away")
+
+    monkeypatch.setattr(backend_peer, "BackendPeer", _Peer)
+    with pytest.raises(RuntimeError, match="login never completed"):
+        await backend_peer.onboarded("AnyPeer")
+
+
 def test_configure_reapplies_the_config_when_the_checks_are_cached(monkeypatch):
     """A peer reached over a url leaves status_backend_urls set. The next
     container peer must clear it, or the client never starts a container."""

--- a/test/e2e_appium/tests/test_backend_peer_core.py
+++ b/test/e2e_appium/tests/test_backend_peer_core.py
@@ -1,0 +1,351 @@
+"""Device-free checks on the peer core: image provenance, the request-timeout
+bind on the status-go client, container start-up errors, liveness on a failing
+probe, and identity recovery when the login signal was missed."""
+import importlib
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from core import backend_peer, peer_containers
+from core.backend_peer import BackendPeer, PeerDied
+from core.peer_containers import PeerProvenanceError, check_provenance
+from core.status_go_tf import (
+    BoundedSession,
+    assert_session_constructors_bound,
+    bind_session_constructors,
+    session_constructors,
+    tf_candidates,
+)
+
+VENDORED = "27bca1fc5ce82a3fc5022bfde93c0fd32c1dc997"
+DIGEST = "@sha256:" + "a" * 64
+
+
+# --- provenance: the tag names the commit, whatever reference form wraps it ---
+
+@pytest.mark.parametrize("ref", [
+    "statusgo-peer-27bca1fc5ce8",
+    "statusgo-peer-27bca1fc5ce8:latest",
+    "statusgo-peer-27bca1fc5ce8:v1",
+    "localhost:5000/statusgo-peer-27bca1fc5ce8:latest",
+    "statusgo-peer-27bca1fc5ce8" + DIGEST,
+    "statusgo-peer-27bca1fc5ce8:latest" + DIGEST,
+])
+def test_every_reference_form_of_the_built_image_is_accepted(ref):
+    assert check_provenance(ref, VENDORED) == "27bca1fc5ce8"
+
+
+@pytest.mark.parametrize("ref", [
+    "statusgo:latest",
+    "statusgo-peer",
+    "random-image-27bca1fc5ce8",
+    "statusgo" + DIGEST,
+])
+def test_an_image_that_names_no_commit_is_refused_as_unknown(ref):
+    with pytest.raises(PeerProvenanceError, match="provenance is unknown"):
+        check_provenance(ref, VENDORED)
+
+
+def test_a_digest_is_never_read_as_the_commit():
+    with pytest.raises(PeerProvenanceError, match="provenance is unknown") as info:
+        check_provenance("statusgo" + DIGEST, VENDORED)
+    assert "built from aaaa" not in str(info.value)
+
+
+@pytest.mark.parametrize("ref", [
+    "statusgo-peer-deadbeef",
+    "statusgo-peer-deadbeef:latest",
+])
+def test_an_image_from_another_commit_is_refused(ref):
+    with pytest.raises(PeerProvenanceError, match="vendors"):
+        check_provenance(ref, VENDORED)
+
+
+def test_a_too_short_prefix_is_refused():
+    with pytest.raises(PeerProvenanceError, match="provenance is unknown"):
+        check_provenance("statusgo-peer-27bca", VENDORED)
+
+
+# --- the timeout bind: every constructor that installs a session -------------
+
+def _unbound_api_init(self, api_url, client=None):
+    self.api_url = api_url
+    self.client = client
+
+
+def _backend_shape():
+    """The pinned client's shape, built fresh so binding one test's classes
+    cannot leak into another: the composite calls the rpc constructor, then the
+    api constructor, and the second assigns the session again."""
+    class Api:
+        __init__ = _unbound_api_init
+
+    class Rpc(Api):
+        def __init__(self, client=None):
+            self.client = client
+
+    class Signal:
+        def __init__(self, url):
+            self.url = url
+
+    class Backend(Rpc, Signal, Api):
+        def __init__(self, url="http://peer"):
+            Rpc.__init__(self)
+            Signal.__init__(self, url)
+            Api.__init__(self, url)
+
+    return Backend, Rpc, Api
+
+
+def test_the_session_constructors_are_the_ones_that_take_a_client():
+    backend, rpc, api = _backend_shape()
+    assert session_constructors(backend) == [rpc, api]
+
+
+def test_binding_reaches_the_last_assignment_of_the_session():
+    backend, _, _ = _backend_shape()
+    bind_session_constructors(backend)
+    assert isinstance(backend().client, BoundedSession)
+
+
+def test_an_unbound_session_constructor_is_reported_by_name():
+    backend, _rpc, api = _backend_shape()
+    bind_session_constructors(backend)
+    api.__init__ = _unbound_api_init
+    with pytest.raises(RuntimeError, match="Api"):
+        assert_session_constructors_bound(backend)
+
+
+@pytest.mark.skipif(
+    not any(os.path.isdir(os.path.join(c, "clients")) for c in tf_candidates())
+    and not os.environ.get("STATUS_GO_TESTS_FUNCTIONAL"),
+    reason="the status-go functional-test client is not checked out",
+)
+def test_the_vendored_client_loads_with_every_session_constructor_bound():
+    from core.status_go_tf import load_tf_client
+
+    client = load_tf_client()
+    names = {cls.__name__ for cls in session_constructors(client.StatusBackend)}
+    assert names == {"RpcClient", "ApiClient"}
+    assert_session_constructors_bound(client.StatusBackend)
+
+
+# --- container start-up ------------------------------------------------------
+
+class _Client:
+    def __init__(self, exc):
+        self.calls = 0
+        self.exc = exc
+
+    def StatusBackend(self):
+        self.calls += 1
+        raise self.exc
+
+
+def test_a_missing_image_is_refused_before_starting_a_peer():
+    docker = pytest.importorskip("docker")
+
+    class _Images:
+        def get(self, _image_ref):
+            raise docker.errors.ImageNotFound("x")
+
+    class _Docker:
+        images = _Images()
+
+    with pytest.raises(RuntimeError, match="peer_image.sh"):
+        peer_containers.check_docker_resources("statusgo-peer-image", "peer", _Docker())
+
+
+def test_a_missing_network_is_refused_before_starting_a_peer():
+    docker = pytest.importorskip("docker")
+
+    class _Images:
+        def get(self, _image_ref):
+            return object()
+
+    class _Networks:
+        def get(self, _network):
+            raise docker.errors.NotFound("x")
+
+    class _Docker:
+        images = _Images()
+        networks = _Networks()
+
+    with pytest.raises(RuntimeError, match="peer_image.sh"):
+        peer_containers.check_docker_resources("statusgo-peer-image", "peer", _Docker())
+
+
+def test_a_backend_that_is_still_starting_is_retried(monkeypatch):
+    monkeypatch.setattr(backend_peer.time, "sleep", lambda _s: None)
+    client = _Client(RuntimeError("health check failed"))
+    with pytest.raises(RuntimeError, match="health check"):
+        backend_peer._start_container_backend(client)
+    assert client.calls == backend_peer.CONTAINER_START_ATTEMPTS
+
+
+def test_configure_runs_once_per_process(monkeypatch):
+    monkeypatch.setenv(peer_containers.IMAGE_ENV, "statusgo-peer-27bca1fc5ce8")
+    monkeypatch.setenv(peer_containers.PROJECT_ENV, "peer-test")
+    monkeypatch.setattr(peer_containers, "vendored_status_go_sha", lambda _root: VENDORED)
+    calls = []
+    monkeypatch.setattr(
+        peer_containers, "check_docker_resources",
+        lambda image_ref, project: calls.append((image_ref, project)),
+    )
+    monkeypatch.setattr(peer_containers, "_configured", None)
+
+    class _Cfg:
+        pass
+
+    config = _Cfg()
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        futures = [pool.submit(peer_containers.configure, config) for _ in range(5)]
+        for future in futures:
+            future.result()
+
+    assert len(calls) == 1
+    assert config.logs_dir.endswith(os.path.join("logs", "backend_peer"))
+    assert config.status_backend_urls is None
+
+
+@pytest.mark.asyncio
+async def test_stop_all_reports_but_does_not_raise_teardown_failures():
+    class _GoodPeer:
+        async def stop(self):
+            return None
+
+    class _BadPeer:
+        async def stop(self):
+            raise RuntimeError("teardown failed")
+
+    failures = await backend_peer.stop_all(_GoodPeer(), _BadPeer())
+    assert len(failures) == 1
+    assert isinstance(failures[0], RuntimeError)
+
+
+def test_peers_in_one_process_must_share_a_fleet(monkeypatch):
+    monkeypatch.setattr(backend_peer, "_process_fleet", "status.prod")
+    with pytest.raises(RuntimeError, match="process-global"):
+        backend_peer._claim_process_fleet("status.test")
+    backend_peer._claim_process_fleet("status.prod")
+
+
+def test_the_client_is_imported_even_when_this_suite_has_a_utils_package(tmp_path, monkeypatch):
+    suite = tmp_path / "suite"
+    suite_utils = suite / "utils"
+    suite_utils.mkdir(parents=True)
+    (suite_utils / "__init__.py").write_text("")
+    (suite_utils / "other.py").write_text("X = 1\n")
+
+    tf = tmp_path / "tf"
+    clients = tf / "clients"
+    tf_utils = tf / "utils"
+    clients.mkdir(parents=True)
+    tf_utils.mkdir(parents=True)
+    (clients / "__init__.py").write_text("")
+    (clients / "status_backend.py").write_text(
+        "from utils.config import Config\n"
+        "class StatusBackend:\n"
+        "    def __init__(self): pass\n"
+    )
+    (tf_utils / "__init__.py").write_text("")
+    (tf_utils / "config.py").write_text('class Config:\n    marker = "client"\n')
+
+    saved_modules = {
+        name: module for name, module in sys.modules.items()
+        if name.split(".")[0] in {"clients", "utils"}
+    }
+    for name in list(saved_modules):
+        sys.modules.pop(name)
+    monkeypatch.syspath_prepend(str(suite))
+    monkeypatch.setenv("STATUS_GO_TESTS_FUNCTIONAL", str(tf))
+    from core import status_go_tf
+
+    status_go_tf._cached = None
+    try:
+        client = status_go_tf.load_tf_client()
+        assert client.Config.marker == "client"
+        assert importlib.import_module("utils.other").X == 1
+        assert str(suite) in sys.modules["utils"].__file__
+    finally:
+        status_go_tf._cached = None
+        for name in list(sys.modules):
+            if name.split(".")[0] in {"clients", "utils"}:
+                sys.modules.pop(name)
+        sys.modules.update(saved_modules)
+
+
+# --- a probe that fails because the peer died says so --------------------------
+
+class _Container:
+    name = "peer-x-status-backend"
+
+    def __init__(self):
+        self.status = "running"
+        self.reloads = 0
+
+    def reload(self):
+        self.reloads += 1
+        if self.reloads > 1:
+            self.status = "exited"
+
+    def logs(self, tail=None):
+        return b"fatal: out of memory"
+
+
+async def test_a_dead_peer_is_reported_even_when_the_probe_raised():
+    peer = BackendPeer()
+    container = _Container()
+    peer._container = lambda: container
+
+    def probe():
+        raise ConnectionError("connection refused")
+
+    with pytest.raises(PeerDied, match="out of memory"):
+        await peer._await("anything", probe, timeout=5)
+
+
+# --- identity when the login signal was missed -------------------------------
+
+class _Settings:
+    def __init__(self, settings):
+        self.settings = settings
+        self.calls = 0
+
+    def get_settings(self):
+        self.calls += 1
+        return self.settings
+
+
+class _Backend:
+    def __init__(self, event, settings):
+        self.node_login_event = event
+        self.settings_service = _Settings(settings)
+
+
+FULL = {"compressedKey": "zQ3shPeer", "public-key": "0x04peer", "fleet": "status.prod", "alias": "a b c"}
+
+
+def test_identity_comes_from_the_login_signal_when_it_carries_it():
+    be = _Backend({"event": {"settings": FULL}}, {})
+    assert backend_peer.login_identity(be) == FULL
+    assert be.settings_service.calls == 0
+
+
+def test_identity_is_read_from_the_backend_when_nothing_cached_it():
+    peer = BackendPeer()
+    peer._sync = _Backend({"event": {"settings": FULL}}, {})
+    assert peer.public_key == "0x04peer"
+    assert peer.chat_key == "zQ3shPeer"
+
+
+def test_identity_is_recovered_from_settings_when_the_signal_was_rebuilt_over_rpc():
+    rebuilt = {"public-key": "0x04peer", "mnemonic": "m"}
+    be = _Backend({"event": {"settings": rebuilt}}, FULL)
+    identity = backend_peer.login_identity(be)
+    assert identity["compressedKey"] == "zQ3shPeer"
+    assert identity["fleet"] == "status.prod"
+    assert identity["mnemonic"] == "m"
+    assert be.settings_service.calls == 1


### PR DESCRIPTION
### What does the PR do

Stack 1/3. The messaging gate buys two BrowserStack sessions per test because both chat participants are phones. Only one of them needs to be a phone. This adds the other side: a headless `status-backend` from status-go's functional-test client, run as a Docker container.

- `core/status_go_tf.py` loads the vendored client and binds a request timeout into every HTTP session it opens.
- `core/peer_containers.py` checks that the image name carries the vendored status-go commit, and refuses any other image. It also checks the image and network exist before the first start.
- `core/backend_peer.py` adds the chat verbs the conversions need: send, reply, edit, react, clear, close, and waits that fail when the peer container dies instead of at the test timeout.
- `scripts/peer_image.sh` builds the image and the network. Cold build is 7 to 8 minutes on a GitHub runner.
- Two Docker-only tests: two peers exchange a 1:1 message; five peers run at once from one test.

Nothing selects the new tests yet. `-m gate` collects the same 46 nodeids as master. All peers in one pytest process share one fleet, because the client reads its process-global config at login.

### How to test

```bash
cd test/e2e_appium
python -m pytest tests/test_backend_peer_core.py -q          # 28 passed, 1 skipped (skip: vendored status-go client not checked out)
python -m pytest --collect-only -q -m gate | tail -1          # 46/109 collected
STATUS_BACKEND_IMAGE=statusgo-peer-<commit> python -m pytest tests/test_backend_peer_containers.py tests/test_backend_peer_containers_lane.py
```

A run on our fork (`peer-proof.yml`, image built from the vendored commit): 31 passed, 0 failed, 0 skipped in 60 s. The head differs from the tested tree only by comments and one unused-variable rename.

### Risk

No device test changes. The new code runs only when a test imports it or `STATUS_BACKEND_IMAGE` is set.
