### PR TITLE
test(e2e_appium): peer_chat, one phone plus a peer

### DIFF
--- a/test/e2e_appium/conftest.py
+++ b/test/e2e_appium/conftest.py
@@ -11,7 +11,8 @@ import pytest
 from .config import get_config, setup_logging, log_test_start, log_test_end
 from .config.logging_config import get_logger, LoggingConfig
 from .support.screenshot import save_screenshot, save_page_source
-from core.stash_keys import MULTI_DEVICE_MANAGERS_KEY
+from core import peer_containers
+from core.stash_keys import MULTI_DEVICE_MANAGERS_KEY, PEER_REFUSED_KEY
 from core.capacity_reserver import set_shared_pending_counter
 from core.shared_counter import FileBasedCounter, create_shared_counter
 
@@ -277,7 +278,12 @@ def performance_tracker(request):
     return tracker
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
+    refused = item.stash.get(PEER_REFUSED_KEY, None)
+    if refused:
+        pytest.fail(refused, pytrace=False)
+
     test_name = item.name
     test_file = item.location[0] if item.location else "unknown"
 
@@ -288,6 +294,8 @@ def pytest_runtest_setup(item):
     )
 
 
+# trylast so -m deselection has already run.
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):
     """Automatically add single_device marker to tests with device_count(1)."""
     for item in items:
@@ -302,6 +310,26 @@ def pytest_collection_modifyitems(config, items):
                 count = device_count_marker.kwargs["value"]
             if count == 1:
                 item.add_marker(pytest.mark.single_device)
+
+    unrunnable = peer_containers.unrunnable_peer_items(
+        items, bool(config.option.collectonly)
+    )
+    if not unrunnable:
+        return
+    remaining = [i for i in items if not any(i is u for u in unrunnable)]
+    message = peer_containers.peer_provisioning_error(unrunnable)
+    if not remaining:
+        # Nothing would run at all. Refusing beats a lane that reports green
+        # having executed nothing. The refusal is per item, not a raise here:
+        # under xdist this hook runs on a worker and an exception is INTERNALERROR.
+        for item in unrunnable:
+            item.stash[PEER_REFUSED_KEY] = message
+        return
+    # Selections like -m portrait mix peer and non-peer tests; dropping the
+    # peer half keeps the rest runnable without a peer image.
+    get_logger("conftest").warning("Deselected %d test(s) that need a status-backend peer: %s", len(unrunnable), message)
+    config.hook.pytest_deselected(items=unrunnable)
+    items[:] = remaining
 
 
 def pytest_runtest_teardown(item, nextitem):

--- a/test/e2e_appium/core/peer_containers.py
+++ b/test/e2e_appium/core/peer_containers.py
@@ -39,6 +39,24 @@ def enabled() -> bool:
     return bool(image())
 
 
+def unrunnable_peer_items(items, collectonly: bool) -> list:
+    """Selected tests that need a peer while none is provisioned."""
+    if collectonly:
+        return []
+    if enabled():
+        return []
+    return [i for i in items if i.get_closest_marker("backend_peer")]
+
+
+def peer_provisioning_error(unrunnable) -> str:
+    return (
+        f"{len(unrunnable)} selected test(s) need a status-backend peer, but "
+        f"{IMAGE_ENV} is not set. Build an image from the "
+        "vendored status-go with scripts/peer_image.sh. "
+        f"First: {unrunnable[0].nodeid}"
+    )
+
+
 def scratch_dir() -> str:
     """Where the client's bind mounts land; without it they land in the cwd."""
     global _scratch

--- a/test/e2e_appium/core/stash_keys.py
+++ b/test/e2e_appium/core/stash_keys.py
@@ -25,3 +25,9 @@ ESTABLISHED_CHAT_BROKEN_KEY: StashKey[BaseException] = StashKey()
 # the rerun re-raises the sentinel before getting a fresh setup attempt.
 ESTABLISHED_CHAT_FAILURE_COUNT_KEY: StashKey[int] = StashKey()
 
+
+# The same pair for ``peer_chat``: a missing peer binary must not cost every
+# messaging module a full onboarding before it fails.
+PEER_CHAT_BROKEN_KEY: StashKey[BaseException] = StashKey()
+PEER_CHAT_FAILURE_COUNT_KEY: StashKey[int] = StashKey()
+

--- a/test/e2e_appium/core/stash_keys.py
+++ b/test/e2e_appium/core/stash_keys.py
@@ -9,6 +9,12 @@ from pytest import StashKey
 MULTI_DEVICE_MANAGERS_KEY: StashKey[List[Tuple[Any, Any, Any]]] = StashKey()
 
 
+# Set on every selected item when the whole selection needs a status-backend
+# peer and none is provisioned. Raising from collection is an INTERNALERROR
+# under xdist; failing each item at setup is loud on every worker.
+PEER_REFUSED_KEY: StashKey[str] = StashKey()
+
+
 # Cache for messaging fixture (``established_chat``) failure across
 # pytest-rerunfailures reruns. The rerun plugin clears pytest's
 # ``cached_result`` on rerun, so without an external sentinel every
@@ -30,4 +36,3 @@ ESTABLISHED_CHAT_FAILURE_COUNT_KEY: StashKey[int] = StashKey()
 # messaging module a full onboarding before it fails.
 PEER_CHAT_BROKEN_KEY: StashKey[BaseException] = StashKey()
 PEER_CHAT_FAILURE_COUNT_KEY: StashKey[int] = StashKey()
-

--- a/test/e2e_appium/locators/messaging/chat_locators.py
+++ b/test/e2e_appium/locators/messaging/chat_locators.py
@@ -134,6 +134,12 @@ class ChatLocators(BaseLocators):
         "//*[contains(@resource-id, 'StatusChatInputReplyPanel')]"
     )
     REPLY_CLOSE_BUTTON = BaseLocators.resource_id_contains("replyAreaCloseButton")
+    # Edit tag close (StatusChatInput.qml) or the toolbar's cancel
+    # (StatusChatInputToolBar.qml); which one the phone exposes is untested.
+    EDIT_CLOSE_BUTTON = BaseLocators.xpath(
+        "//*[contains(@resource-id,'statusChatInputEditCloseButton') "
+        "or contains(@resource-id,'statusChatInputEditCancelButton')]"
+    )
     REPLY_DETAILS = BaseLocators.tid("StatusMessage_replyDetails")
     REPLY_CORNER = BaseLocators.resource_id_contains("statusMessageReplyCorner")
 
@@ -210,4 +216,13 @@ class ChatLocators(BaseLocators):
             f"[not(ancestor::*[contains(@resource-id,'MessageContextMenuView')])]"
         )
 
-
+    @staticmethod
+    def reaction_on_message_with_text(content: str, emoji_code: str) -> tuple:
+        """The reaction badge on the message carrying ``content``, so a badge an
+        earlier test left on another message cannot satisfy the check."""
+        return BaseLocators.xpath(
+            f"//*[contains(@resource-id,'chatMessageViewDelegate')]"
+            f"[.//*[contains(@content-desc,{xpath_string(content)})]]"
+            f"//*[contains(@resource-id,'messageReaction_{emoji_code}')]"
+            f"[not(ancestor::*[contains(@resource-id,'MessageContextMenuView')])]"
+        )

--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -96,6 +96,10 @@ class ChatPage(BasePage):
             )
         return None
 
+    def listed_chat_names(self) -> list[str]:
+        """Name and label of every listed chat row, for checks that must not infer."""
+        return [f"{name} {label}".strip() for _, name, label in self._chat_rows()]
+
     def wait_for_peer_rows(self, minimum: int, timeout: int = 60) -> bool:
         """Wait until at least ``minimum`` rows other than the support bot's are listed."""
 
@@ -384,6 +388,14 @@ class ChatPage(BasePage):
             return True  # Not in reply mode
         return self.try_click(self.locators.REPLY_CLOSE_BUTTON, timeout=timeout)
 
+    def is_edit_mode_active(self, timeout: int = 5) -> bool:
+        return self.is_element_visible(self.locators.EDIT_CLOSE_BUTTON, timeout=timeout)
+
+    def cancel_edit(self, timeout: int = 5) -> bool:
+        if not self.is_edit_mode_active(timeout=2):
+            return True
+        return self.try_click(self.locators.EDIT_CLOSE_BUTTON, timeout=timeout)
+
     # ===== Message State Verification =====
 
     def message_is_edited(self, content: str, timeout: int = 10) -> bool:
@@ -439,6 +451,11 @@ class ChatPage(BasePage):
         locator = self.locators.reaction_on_message(emoji_code)
         return self.is_element_visible(locator, timeout=timeout)
 
+    def message_has_reaction_on(self, content: str, emoji_code: str, timeout: int = 10) -> bool:
+        """Whether the message carrying ``content`` shows the reaction badge."""
+        locator = self.locators.reaction_on_message_with_text(content, emoji_code)
+        return self.is_element_visible(locator, timeout=timeout)
+
     def message_is_reply(self, content: str, timeout: int = 10) -> bool:
         """Check if a message shows the reply corner indicator.
 
@@ -458,10 +475,7 @@ class ChatPage(BasePage):
             "xpath",
             "//*[contains(@resource-id,'StatusTextMessage_chatText')]",
         )
-        try:
-            return len(self.driver.find_elements(*locator))
-        except Exception:
-            return 0
+        return len(self.driver.find_elements(*locator))
 
     def wait_for_message_count(self, minimum: int, timeout: int = 10) -> bool:
         """Wait until the chat has at least `minimum` messages."""
@@ -575,5 +589,3 @@ class ChatPage(BasePage):
         except Exception as exc:
             self.logger.error("Failed to close chat: %s", exc)
             return False
-
-

--- a/test/e2e_appium/pages/messaging/message_context_menu_page.py
+++ b/test/e2e_appium/pages/messaging/message_context_menu_page.py
@@ -1,4 +1,6 @@
 
+import time
+
 from selenium.webdriver.common.actions import interaction
 from selenium.webdriver.common.actions.action_builder import ActionBuilder
 from selenium.webdriver.common.actions.pointer_input import PointerInput
@@ -56,16 +58,14 @@ class MessageContextMenuPage(BasePage):
         timeout: int = 10,
         duration_ms: int = 1000,
     ) -> bool:
-        """Long-press on a message to open the context menu.
+        """Long-press a message to open the context menu."""
+        # An open keyboard halves the sheet: actions past the first fold get
+        # clipped behind it and in-menu swipes land on the keys.
+        try:
+            self.hide_keyboard()
+        except Exception:
+            pass
 
-        Args:
-            message_content: The text content of the message to long-press.
-            timeout: Maximum wait time to find the message.
-            duration_ms: Duration of the long-press gesture in milliseconds.
-
-        Returns:
-            bool: True if context menu opened successfully.
-        """
         # Try exact match first, then partial match
         locators = (
             self.chat_locators.message_text_exact(message_content),
@@ -73,15 +73,17 @@ class MessageContextMenuPage(BasePage):
             self.chat_locators.message_content_desc_any(message_content),
         )
 
-        element = None
-        for locator in locators:
-            element = self.find_element_safe(locator, timeout=timeout // 2)
-            if element:
-                break
-
+        element = self._find_message(locators, timeout)
         if not element:
             self.logger.error(f"Message '{message_content}' not found")
             return False
+
+        if self._wait_until_settled(element) is None:
+            # The a11y node was replaced under us; press the live one, not the stale handle.
+            element = self._find_message(locators, timeout)
+            if not element:
+                self.logger.error(f"Message '{message_content}' disappeared before the press")
+                return False
 
         # Try W3C Actions first, then mobile: longClickGesture as fallback.
         # Different BrowserStack devices respond to different gesture APIs.
@@ -112,6 +114,35 @@ class MessageContextMenuPage(BasePage):
             self.logger.debug("Context menu not visible after %s long-press (attempt %d)", strategy, attempt)
 
         self.logger.warning("Context menu did not appear after all long-press strategies")
+        return False
+
+    def _find_message(self, locators, timeout):
+        for locator in locators:
+            element = self.find_element_safe(locator, timeout=timeout // 2)
+            if element:
+                return element
+        return None
+
+    def _wait_until_settled(
+        self, element, timeout: float = 5.0, interval: float = 0.3
+    ) -> bool | None:
+        """Wait for the element to stop moving.
+
+        MessageView.qml ignores a press-and-hold while the chat log is
+        scrolling, and a message that has just arrived is exactly what the
+        log is scrolling to.
+        """
+        deadline = time.monotonic() + timeout
+        last = None
+        while time.monotonic() < deadline:
+            try:
+                rect = element.rect
+            except Exception:
+                return None
+            if rect == last:
+                return True
+            last = rect
+            time.sleep(interval)
         return False
 
     def long_press_message_by_element(

--- a/test/e2e_appium/pages/messaging/message_context_menu_page.py
+++ b/test/e2e_appium/pages/messaging/message_context_menu_page.py
@@ -78,12 +78,21 @@ class MessageContextMenuPage(BasePage):
             self.logger.error(f"Message '{message_content}' not found")
             return False
 
-        if self._wait_until_settled(element) is None:
+        settled = self._wait_until_settled(element)
+        if settled is None:
             # The a11y node was replaced under us; press the live one, not the stale handle.
             element = self._find_message(locators, timeout)
             if not element:
                 self.logger.error(f"Message '{message_content}' disappeared before the press")
                 return False
+            settled = self._wait_until_settled(element)
+        if not settled:
+            # MessageView refuses press-and-hold while the log is moving, so this
+            # press will probably be ignored. Attempted anyway: the menu check
+            # below is the real gate, and the list often settles under the press.
+            self.logger.warning(
+                f"Message '{message_content}' never stopped moving; pressing anyway"
+            )
 
         # Try W3C Actions first, then mobile: longClickGesture as fallback.
         # Different BrowserStack devices respond to different gesture APIs.

--- a/test/e2e_appium/pytest.ini
+++ b/test/e2e_appium/pytest.ini
@@ -27,3 +27,4 @@ markers =
     portrait: Verified to work on portrait-orientation phones
     slow: Long-running operations (e.g. password re-encryption, 5-10+ min)
     backend_peer: Tests using a headless status-backend as a chat participant
+    two_phone: Original 2-phone variants kept for occasional full-UI symmetry runs

--- a/test/e2e_appium/support/keyboard_manager.py
+++ b/test/e2e_appium/support/keyboard_manager.py
@@ -29,24 +29,13 @@ class KeyboardManager:
                     self.logger.debug(f"hide_keyboard() attempt {attempt} failed: {e}")
                 time.sleep(delay)
 
-            try:
-                size = self.driver.get_window_size()
-                center_x = size["width"] // 2
-                start_y = int(size["height"] * 0.4)
-                end_y = int(size["height"] * 0.2)
-
-                self.logger.debug(f"Swiping from ({center_x},{start_y}) to ({center_x},{end_y}) to dismiss keyboard")
-                self.gestures.swipe_down(center_x, start_y, 20, end_y, 0.8)
-                time.sleep(delay)
-                if not self.driver.is_keyboard_shown():
-                    self.logger.info("Keyboard hidden using swipe gesture")
-                    return True
-                else:
-                    self.logger.debug("Swipe executed but keyboard still visible")
-            except Exception as e:
-                self.logger.debug(f"Swipe gesture failed: {e}")
-
-            self.logger.warning("All keyboard hiding strategies failed")
+            # No gesture fallback: is_keyboard_shown() reports true on some devices
+            # with no keyboard on screen, and a swipe fired on that scrolls whatever
+            # is under it, which is the content the caller is about to act on.
+            self.logger.warning(
+                f"Keyboard could not be hidden after {retries} attempts "
+                "(is_keyboard_shown may be a false positive)"
+            )
             return False
 
         except Exception as e:

--- a/test/e2e_appium/support/multi_device_helpers.py
+++ b/test/e2e_appium/support/multi_device_helpers.py
@@ -159,6 +159,18 @@ class StepMixin:
         self.device = devices["device_0"]
 
     @property
+    def driver(self):
+        """Driver of the first device.
+
+        conftest's failure hook reads ``item.instance.driver`` to collect the
+        screenshot, page source and logcat. Without this attribute a failing
+        StepMixin test produces no artifacts at all. Multi-device tests get
+        device_0's view; the other devices' state is not captured here.
+        """
+        device = self.device
+        return getattr(device, "driver", None) if device is not None else None
+
+    @property
     def logger(self):
         """Auto-initialize logger on first access."""
         if self._logger is None:

--- a/test/e2e_appium/support/peer_chat_state.py
+++ b/test/e2e_appium/support/peer_chat_state.py
@@ -1,0 +1,109 @@
+"""State recovery for the function-scoped ``peer_chat_ready`` fixture."""
+
+import time
+
+from selenium.common.exceptions import InvalidSessionIdException
+
+from config.logging_config import get_logger
+from core.device_context import DeviceContext
+from pages.app import App
+from pages.messaging.chat_page import ChatPage
+from support.screen_identity import dismiss_introduce_yourself
+
+logger = get_logger("peer_chat_state")
+
+DEEP_LINK_ATTEMPTS = 3
+
+
+def open_peer_chat_by_deeplink(device: DeviceContext, peer, attempts: int = DEEP_LINK_ATTEMPTS) -> bool:
+    """Open the peer's 1:1 through the status-app:// deep link."""
+    driver = device.driver
+    chat_page = ChatPage(driver)
+    package = driver.capabilities.get("appPackage") or "app.status.mobile"
+    for attempt in range(1, attempts + 1):
+        try:
+            driver.execute_script(
+                "mobile: deepLink",
+                {"url": f"status-app://p/{peer.public_key}", "package": package},
+            )
+        except InvalidSessionIdException:
+            raise
+        except Exception as exc:
+            logger.warning("deepLink attempt %d failed: %s", attempt, exc)
+        chat_page.dismiss_backup_prompt(timeout=4)
+        if dismiss_introduce_yourself(chat_page, timeout=1):
+            logger.info("Dismissed introduce-yourself sheet after deep link")
+        if chat_page.wait_for_message_input(timeout=10):
+            return True
+        logger.warning("Peer chat not open after deep link attempt %d", attempt)
+        chat_page.dump_page_source(f"peer_chat_deeplink_a{attempt}")
+    return False
+
+
+def _settles(predicate, timeout: float, interval: float = 1.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        if predicate():
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(interval, remaining))
+
+
+def peer_chat_row_listed(device: DeviceContext, peer) -> bool:
+    """Whether a row named for the peer is listed right now."""
+    wanted = [v for v in (peer.display_name, peer.alias, peer.chat_key[-4:]) if v]
+    names = ChatPage(device.driver).listed_chat_names()
+    return any(any(w in n for w in wanted) for n in names)
+
+
+def peer_chat_row_visible(device: DeviceContext, peer, timeout: int = 45) -> bool:
+    return _settles(lambda: peer_chat_row_listed(device, peer), timeout)
+
+
+def wait_for_peer_chat_row_gone(device: DeviceContext, peer, timeout: int = 10) -> bool:
+    """Absence counts only on the list screen, and only once it has held for a
+    second read: an empty snapshot is also what a different screen, a list
+    still populating and a driver error return."""
+    chat_page = ChatPage(device.driver)
+
+    def _gone() -> bool:
+        return chat_page._is_chat_list_visible(timeout=1) and not peer_chat_row_listed(device, peer)
+
+    if not _settles(_gone, timeout):
+        return False
+    time.sleep(1)
+    return _gone()
+
+
+def ensure_peer_chat_visible(device: DeviceContext, peer) -> ChatPage:
+    """Guarantee the peer's 1:1 is open with the composer visible."""
+    chat_page = ChatPage(device.driver)
+    if chat_page.wait_for_message_input(timeout=2):
+        return _composer_ready(chat_page)
+
+    app = App(device.driver)
+    chat_page.dismiss_backup_prompt(timeout=2)
+    if not app.click_messages_button():
+        logger.warning("Messages tab did not report a click; falling through to the deep link")
+    chat_page.dismiss_backup_prompt(timeout=2)
+    if chat_page.wait_for_message_input(timeout=3):
+        return _composer_ready(chat_page)
+
+    if open_peer_chat_by_deeplink(device, peer):
+        return _composer_ready(chat_page)
+
+    raise RuntimeError(
+        "Could not open the backend peer's chat: neither the Messages tab nor "
+        f"the status-app://p/{peer.public_key[:12]}… deep link reached a composer"
+    )
+
+
+def _composer_ready(chat_page: ChatPage) -> ChatPage:
+    """Clear Reply or Edit left on by a failed test before sending."""
+    if not chat_page.cancel_reply(timeout=2):
+        raise RuntimeError("a reply mode left on by the previous test could not be cancelled")
+    if not chat_page.cancel_edit(timeout=2):
+        raise RuntimeError("an edit mode left on by the previous test could not be cancelled")
+    return chat_page

--- a/test/e2e_appium/tests/messaging/conftest.py
+++ b/test/e2e_appium/tests/messaging/conftest.py
@@ -122,67 +122,19 @@ _FIXTURE_FAILURES_BEFORE_SENTINEL = 2
 PEER_CHAT_SETUP_TIMEOUT_SECONDS = 900
 
 
-def unrunnable_peer_items(items, collectonly: bool) -> list:
-    """Selected tests that need a peer while none is provisioned."""
-    if collectonly:
-        return []
-    from core import peer_containers
-
-    if peer_containers.enabled():
-        return []
-    return [i for i in items if i.get_closest_marker("backend_peer")]
-
-
-def peer_provisioning_error(unrunnable) -> str:
-    from core import peer_containers
-
-    return (
-        f"{len(unrunnable)} selected test(s) need a status-backend peer, but "
-        f"{peer_containers.IMAGE_ENV} is not set. Build an image from the "
-        "vendored status-go with scripts/peer_image.sh. "
-        f"First: {unrunnable[0].nodeid}"
-    )
-
-
-@pytest.hookimpl(trylast=True)
-def pytest_collection_modifyitems(config, items):
-    # trylast so -m deselection has already run: a lane that selected no peer
-    # tests must not be stopped by a missing peer.
-    unrunnable = unrunnable_peer_items(items, bool(config.option.collectonly))
-    if not unrunnable:
-        return
-
-    remaining = [i for i in items if not any(i is u for u in unrunnable)]
-    if not remaining:
-        # Nothing would run at all. Refusing beats a lane that reports green
-        # having executed nothing.
-        raise pytest.UsageError(peer_provisioning_error(unrunnable))
-
-    # Selections like -m portrait mix peer and non-peer tests; dropping the
-    # peer half keeps the rest runnable without a peer image, and no device
-    # session is bought for the dropped ones.
-    logger.warning(
-        "Deselected %d test(s) that need a status-backend peer: %s",
-        len(unrunnable), peer_provisioning_error(unrunnable),
-    )
-    config.hook.pytest_deselected(items=unrunnable)
-    items[:] = remaining
-
-
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     """Track test outcomes for BrowserStack status reporting.
 
-    This hook runs after each test phase (setup, call, teardown) and records
-    outcomes to module-level tracking dicts.
+    Setup failures and skips are recorded because fixture recovery can fail
+    before the call phase.
 
     Note: Page dump capture on failure is handled by the main conftest.py hook.
     """
     outcome = yield
     rep = outcome.get_result()
 
-    # Only track test outcomes from the call phase (actual test execution)
-    if rep.when != "call":
+    if rep.when != "call" and not (rep.when == "setup" and not rep.passed):
         return
 
     module_name = item.module.__name__ if hasattr(item, "module") else "unknown"

--- a/test/e2e_appium/tests/messaging/conftest.py
+++ b/test/e2e_appium/tests/messaging/conftest.py
@@ -22,11 +22,16 @@ from __future__ import annotations
 import asyncio
 import os
 import threading
+import time
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import pytest
 import pytest_asyncio
+
+if TYPE_CHECKING:
+    from core.backend_peer import BackendPeer
 
 from config.logging_config import get_logger
 from core.device_context import DeviceContext
@@ -35,14 +40,16 @@ from core.session_pool import PoolConfig, SessionPool
 from core.stash_keys import (
     ESTABLISHED_CHAT_BROKEN_KEY,
     ESTABLISHED_CHAT_FAILURE_COUNT_KEY,
+    PEER_CHAT_BROKEN_KEY,
+    PEER_CHAT_FAILURE_COUNT_KEY,
 )
 from support.chat_state import ensure_chat_visible
 from support.contact_helpers import (
     establish_contact,
     establish_contacts_admin_to_many,
 )
-from support.timeouts import CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
 from support.generators import generate_account_name
+from support.timeouts import CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
 
 logger = get_logger("messaging_conftest")
 
@@ -109,6 +116,57 @@ _module_pools = []
 # the sentinel before getting a fresh setup attempt.
 _FIXTURE_FAILURES_BEFORE_SENTINEL = 2
 
+# Comfortably covers peer start, one session, phone onboarding and the contact
+# handshake, and leaves room under pytest.ini's per-item timeout so this fires
+# first and the cleanup below actually runs.
+PEER_CHAT_SETUP_TIMEOUT_SECONDS = 900
+
+
+def unrunnable_peer_items(items, collectonly: bool) -> list:
+    """Selected tests that need a peer while none is provisioned."""
+    if collectonly:
+        return []
+    from core import peer_containers
+
+    if peer_containers.enabled():
+        return []
+    return [i for i in items if i.get_closest_marker("backend_peer")]
+
+
+def peer_provisioning_error(unrunnable) -> str:
+    from core import peer_containers
+
+    return (
+        f"{len(unrunnable)} selected test(s) need a status-backend peer, but "
+        f"{peer_containers.IMAGE_ENV} is not set. Build an image from the "
+        "vendored status-go with scripts/peer_image.sh. "
+        f"First: {unrunnable[0].nodeid}"
+    )
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(config, items):
+    # trylast so -m deselection has already run: a lane that selected no peer
+    # tests must not be stopped by a missing peer.
+    unrunnable = unrunnable_peer_items(items, bool(config.option.collectonly))
+    if not unrunnable:
+        return
+
+    remaining = [i for i in items if not any(i is u for u in unrunnable)]
+    if not remaining:
+        # Nothing would run at all. Refusing beats a lane that reports green
+        # having executed nothing.
+        raise pytest.UsageError(peer_provisioning_error(unrunnable))
+
+    # Selections like -m portrait mix peer and non-peer tests; dropping the
+    # peer half keeps the rest runnable without a peer image, and no device
+    # session is bought for the dropped ones.
+    logger.warning(
+        "Deselected %d test(s) that need a status-backend peer: %s",
+        len(unrunnable), peer_provisioning_error(unrunnable),
+    )
+    config.hook.pytest_deselected(items=unrunnable)
+    items[:] = remaining
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -238,7 +296,6 @@ def _report_browserstack_status(pool: SessionPool, status: str, reason: str | No
                 logger.debug("Reported status '%s' for %s via API", status, device_name)
             except Exception as e:
                 logger.warning("Failed to report status for %s: %s", device_name, e)
-
 
 
 async def _setup_established_chat(
@@ -507,6 +564,272 @@ def chat_ready(established_chat) -> EstablishedChatContext:
     ensure_chat_visible(ctx.primary, ctx.secondary_suffix, secondary_display)
     ensure_chat_visible(ctx.secondary, ctx.primary_suffix, primary_display)
     return ctx
+
+
+# ---------------------------------------------------------------------------
+# 1 phone + headless backend peer
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PeerChatContext:
+    """One real phone in a mutual 1:1 with a headless status-backend."""
+
+    device: DeviceContext
+    peer: "BackendPeer"
+    phone_key: str
+    multi_ctx: MultiDeviceContext
+    _keepalives: list["_SessionKeepAlive"] = field(default_factory=list)
+
+    @property
+    def driver(self):
+        return self.device.driver
+
+
+def _peer_log_dir(worker: str) -> str:
+    from config import get_config
+    try:
+        root = get_config().reports_dir
+    except Exception:
+        root = "reports"
+    return os.path.join(root, "backend_peer", f"peer_chat_{worker}")
+
+
+async def _establish_phone_to_peer_contact(device: DeviceContext, peer) -> str:
+    """Phone sends the contact request, peer accepts it over RPC."""
+    from pages.app import App
+    from pages.settings.settings_page import SettingsPage
+
+    app = App(device.driver)
+    settings_page = SettingsPage(device.driver)
+    assert app.click_settings_button(), "Failed to open settings"
+    assert settings_page.is_loaded(timeout=20), "Settings page did not load"
+    messaging_page = settings_page.open_messaging_settings()
+    assert messaging_page is not None, "Failed to open messaging settings"
+    contacts_page = messaging_page.open_contacts()
+    assert contacts_page is not None, "Failed to open contacts"
+    modal = contacts_page.open_send_contact_request_modal()
+    assert modal is not None, "Failed to open contact request modal"
+    assert modal.enter_chat_key(peer.chat_key), "Failed to enter the peer's chat key"
+    # IME sentence-caps the first letter, so the sentinel starts uppercase.
+    assert modal.enter_message("Hello-from-phone"), "Failed to enter request message"
+    assert modal.send(), "Failed to send the contact request"
+
+    deadline = time.monotonic() + CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+    phone_key = ""
+    while not phone_key:
+        phone_key = await asyncio.to_thread(peer.pending_inbound_contact_key)
+        if phone_key:
+            break
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                "Peer never saw the phone's contact request within "
+                f"{CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS}s"
+            )
+        await asyncio.sleep(3)
+
+    await asyncio.to_thread(peer.accept_contact_request_from, phone_key)
+    await peer.await_mutual_contact(phone_key, timeout=60)
+    return phone_key
+
+
+async def _setup_peer_chat(pool: SessionPool, test_nodeid: str, worker: str):
+    from core.backend_peer import BackendPeer
+
+    peer = None
+    keepalives: list[_SessionKeepAlive] = []
+    try:
+        # Every way the peer can fail is an environment fault; starting it
+        # before the session is bought means those cost seconds, not a device.
+        peer = BackendPeer()
+        await peer.onboard()
+        assert peer.node_fleet == peer.fleet, (
+            f"backend peer joined fleet {peer.node_fleet!r}, not {peer.fleet!r}; "
+            "it cannot meet the phone"
+        )
+        await peer.wait_for_peers(min_peers=1, timeout=30)
+
+        drivers = await pool.create_sessions(
+            count=1, test_nodeid=f"{test_nodeid}::peer_setup",
+        )
+        keepalives = [_SessionKeepAlive(d, label=n) for n, d in drivers.items()]
+        for ka in keepalives:
+            ka.start()
+
+        contexts = {
+            name: DeviceContext(driver=driver, device_id=name)
+            for name, driver in drivers.items()
+        }
+        multi_ctx = MultiDeviceContext(contexts)
+        await multi_ctx.onboard_users_parallel(
+            display_names=[generate_account_name(12)], require_all=True,
+        )
+        device = contexts[list(contexts)[0]]
+
+        phone_key = await _establish_phone_to_peer_contact(device, peer)
+
+        ctx = PeerChatContext(
+            device=device, peer=peer, phone_key=phone_key,
+            multi_ctx=multi_ctx, _keepalives=keepalives,
+        )
+        return ctx
+    except BaseException:
+        for ka in keepalives:
+            try:
+                ka.stop()
+            except Exception:
+                pass
+        if peer is not None:
+            # The log lives in the container, so it has to be read before
+            # stopping the peer removes it.
+            try:
+                await asyncio.to_thread(peer.dump_logs, _peer_log_dir(worker))
+            except Exception as exc:
+                logger.warning("Could not dump peer logs after failed setup: %s", exc)
+            try:
+                await peer.stop()
+            except Exception:
+                pass
+        raise
+
+
+@pytest_asyncio.fixture(scope="module")
+async def peer_chat(request, test_environment) -> PeerChatContext:
+    """One phone plus a headless peer, contacts already mutual."""
+    worker = f"{os.getenv('PYTEST_XDIST_WORKER', 'gw0')}_{request.node.name}"
+
+    cached_exc = request.session.stash.get(PEER_CHAT_BROKEN_KEY, None)
+    if cached_exc is not None:
+        logger.info(
+            "peer_chat broken earlier in this session (%s); re-raising the cached "
+            "exception without re-attempting setup",
+            type(cached_exc).__name__,
+        )
+        raise cached_exc
+
+    logger.info("Setting up peer_chat fixture (%s)", worker)
+
+    pool = SessionPool(config=PoolConfig.from_environment(test_environment, parallel=True))
+    try:
+        # pytest-timeout raises in the main thread, outside this coroutine, so
+        # its expiry would skip the cleanup below and leak both the container
+        # and the device session. A bound of our own fails inside the coroutine.
+        ctx = await asyncio.wait_for(
+            _setup_peer_chat(pool, request.node.nodeid, worker),
+            timeout=PEER_CHAT_SETUP_TIMEOUT_SECONDS,
+        )
+    except BaseException as exc:
+        # BaseException, not Exception: a pytest-timeout during setup raises an
+        # OutcomeException, and letting that skip this handler leaks the device
+        # session for the whole idle timeout.
+        stash = request.session.stash
+        failures = stash.get(PEER_CHAT_FAILURE_COUNT_KEY, 0) + 1
+        stash[PEER_CHAT_FAILURE_COUNT_KEY] = failures
+        logger.error(
+            "peer_chat setup failed (attempt %d/%d before sentinel fires): %s",
+            failures, _FIXTURE_FAILURES_BEFORE_SENTINEL, exc,
+        )
+        try:
+            _report_browserstack_status(pool, "failed", f"peer_chat setup failed: {exc}")
+        except Exception:
+            pass
+        try:
+            await pool.cleanup()
+        except Exception as cleanup_err:
+            logger.warning("Cleanup after failed peer_chat setup: %s", cleanup_err)
+        if failures >= _FIXTURE_FAILURES_BEFORE_SENTINEL:
+            stash[PEER_CHAT_BROKEN_KEY] = exc
+        raise
+
+    _module_pools.append(pool)
+    failed = False
+    try:
+        yield ctx
+    except Exception:
+        failed = True
+        raise
+    finally:
+        for ka in ctx._keepalives:
+            try:
+                ka.stop()
+            except Exception:
+                pass
+        module_name = getattr(getattr(request, "module", None), "__name__", "")
+        failed_tests = _module_test_failures.get(module_name, [])
+        died = await _teardown_peer_chat(
+            ctx.peer, failed=failed or bool(failed_tests), log_dir=_peer_log_dir(worker),
+        )
+        skipped_tests = _module_test_skipped.get(module_name, [])
+        passed_tests = _module_test_passed.get(module_name, [])
+        if died is not None:
+            status, reason = "failed", f"peer died: {died}"
+        elif failed or failed_tests:
+            status = "failed"
+            reason = f"{len(failed_tests)} test(s) failed" if failed_tests else "peer_chat fixture failed"
+        elif skipped_tests and not passed_tests:
+            status, reason = "skipped", f"All {len(skipped_tests)} test(s) skipped"
+        else:
+            status, reason = "passed", f"{len(passed_tests)} passed"
+            if skipped_tests:
+                reason += f", {len(skipped_tests)} skipped"
+        _report_browserstack_status(pool, status, reason)
+        logger.info("Reported '%s' to BrowserStack: %s", status, reason)
+        for tracking_dict in (
+            _module_test_failures, _module_test_skipped, _module_test_passed,
+        ):
+            tracking_dict.pop(module_name, None)
+        try:
+            await pool.cleanup()
+        except Exception as exc:
+            logger.warning("Cleanup error (non-fatal): %s", exc)
+        if pool in _module_pools:
+            _module_pools.remove(pool)
+
+
+async def _teardown_peer_chat(peer, *, failed: bool, log_dir: str):
+    """Evidence while the container is still there, then stop it. Returns the
+    exception if the peer had already died, so the module can report it."""
+    from core.backend_peer import PeerDied
+
+    async def _bounded(label, awaitable):
+        try:
+            await asyncio.wait_for(awaitable, timeout=30)
+        except (TimeoutError, asyncio.TimeoutError):
+            logger.warning("peer_chat teardown: %s timed out after 30s", label)
+        except Exception as exc:
+            logger.warning("peer_chat teardown: %s failed: %s", label, exc)
+
+    died = None
+    try:
+        peer.check_alive()
+    except PeerDied as exc:
+        died = exc
+    except Exception as exc:
+        # A docker-side failure is not evidence the peer died, but it must not
+        # skip the stop below and leave the container running.
+        logger.warning("peer_chat teardown: liveness check failed: %s", exc)
+    if failed or died is not None or os.environ.get("STATUS_BACKEND_ALWAYS_CAPTURE"):
+        await _bounded("log capture", asyncio.to_thread(peer.dump_logs, log_dir))
+    # The client removes the container as part of stopping the peer.
+    await _bounded("peer.stop", peer.stop())
+    return died
+
+
+@pytest.fixture
+def peer_chat_ready(request, peer_chat) -> PeerChatContext:
+    """``peer_chat`` with the peer's 1:1 open and the composer visible."""
+    _prepare_peer_chat(getattr(request, "instance", None), peer_chat)
+    return peer_chat
+
+
+def _prepare_peer_chat(instance, ctx: PeerChatContext) -> None:
+    """Hand the device to the failure hook before recovery, so a failure in
+    the recovery itself still produces a screenshot and page source."""
+    from support import peer_chat_state
+
+    if instance is not None:
+        instance.device = ctx.device
+    peer_chat_state.ensure_peer_chat_visible(ctx.device, ctx.peer)
 
 
 # ---------------------------------------------------------------------------

--- a/test/e2e_appium/tests/messaging/peer_base.py
+++ b/test/e2e_appium/tests/messaging/peer_base.py
@@ -1,0 +1,104 @@
+"""Shared setup for the gate's one-phone-plus-backend-peer tests."""
+
+import time
+from contextlib import asynccontextmanager
+
+import pytest
+
+from config.logging_config import get_logger
+from pages.app import App
+from pages.messaging.chat_page import ChatPage
+from support.exceptions import SESSION_FATAL
+from support.peer_chat_state import ensure_peer_chat_visible
+from support.timeouts import CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+
+
+class PeerChatBase:
+    """Wiring for a class whose second participant is a headless backend."""
+
+    UI_TIMEOUT = 30
+    CROSS_DEVICE_TIMEOUT = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+    LIVENESS_SLICE_SECONDS = 10
+
+    @pytest.fixture(autouse=True)
+    def setup(self, peer_chat_ready):
+        self.ctx = peer_chat_ready
+        self.device = peer_chat_ready.device
+        self.driver = peer_chat_ready.device.driver
+        self.peer = peer_chat_ready.peer
+        self.phone_key = peer_chat_ready.phone_key
+
+    @property
+    def logger(self):
+        return get_logger(self.__class__.__name__)
+
+    @asynccontextmanager
+    async def step(self, description: str):
+        self.logger.info("Step: %s", description)
+        yield
+        self.logger.info("Completed: %s", description)
+
+    def chat_page(self) -> ChatPage:
+        """The chat, guaranteed open with the composer visible."""
+        return ensure_peer_chat_visible(self.device, self.peer)
+
+    async def send_from_phone(self, text: str) -> ChatPage:
+        """Send, see it on the phone, and see it reach the peer. The last part
+        is what makes a test in this module a test of two participants rather
+        than of one phone that happens to have a peer in its contacts."""
+        chat_page = self.chat_page()
+        assert chat_page.send_message(text), f"Failed to send message: {text}"
+        if not chat_page.message_exists(text, timeout=self.UI_TIMEOUT):
+            chat_page.dump_page_source(f"msg_not_visible_{text[:20]}")
+            chat_page.take_screenshot(f"msg_not_visible_{text[:20]}")
+            raise AssertionError(f"Message not visible after sending: {text}")
+        await self.await_on_peer(text)
+        return chat_page
+
+    def peer_message_ids(self) -> set[str]:
+        """Ids the peer already holds for this 1:1."""
+        return {m.get("id") for m in self.peer.chat_messages(self.phone_key)}
+
+    async def await_new_message_on_peer(self, known_ids: set[str]) -> dict:
+        """The peer's copy of the next message from the phone, whatever its text."""
+        return await self.peer.await_new_message_from(
+            self.phone_key, known_ids, timeout=self.CROSS_DEVICE_TIMEOUT,
+        )
+
+    def send_from_peer(self, text: str) -> str:
+        """Have the peer send into the shared 1:1; returns the message id."""
+        return self.peer.send_dm(self.phone_key, text)
+
+    async def await_on_peer(self, text: str) -> dict:
+        """The peer's copy of the phone's message, once it has arrived."""
+        return await self.peer.await_chat_message(
+            self.phone_key, text, timeout=self.CROSS_DEVICE_TIMEOUT,
+        )
+
+    async def await_on_phone(
+        self, chat_page: ChatPage, text: str, *, probe=None, describe: str | None = None,
+    ) -> None:
+        """Wait for something the peer did to render, giving up early if the peer died."""
+        check = probe or (lambda timeout: chat_page.message_exists(text, timeout=timeout))
+        what = describe or f"Message {text!r} from the peer"
+        deadline = time.monotonic() + self.CROSS_DEVICE_TIMEOUT
+        while True:
+            self.peer.check_alive()
+            try:
+                _ = self.driver.orientation
+            except SESSION_FATAL as exc:
+                raise RuntimeError(f"Appium session gone while waiting for {what}: {exc}") from exc
+            if check(self.LIVENESS_SLICE_SECONDS):
+                return
+            if time.monotonic() >= deadline:
+                raise AssertionError(
+                    f"{what} never arrived on the phone within {self.CROSS_DEVICE_TIMEOUT}s"
+                )
+
+    def open_chat_list(self) -> ChatPage:
+        """Leave whatever screen is open for the Messages list."""
+        chat_page = ChatPage(self.driver)
+        chat_page.dismiss_backup_prompt(timeout=3)
+        assert App(self.driver).click_messages_button(), "Failed to open the Messages tab"
+        chat_page.dismiss_backup_prompt(timeout=2)
+        return chat_page

--- a/test/e2e_appium/tests/messaging/test_message_received_backend.py
+++ b/test/e2e_appium/tests/messaging/test_message_received_backend.py
@@ -1,0 +1,139 @@
+"""Receiving-side UI, with a headless backend driving the other end."""
+
+import uuid
+
+import pytest
+
+from pages.messaging.message_context_menu_page import MessageContextMenuPage
+from tests.messaging.peer_base import PeerChatBase
+
+
+def _unique_message(prefix: str = "test") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.messaging
+@pytest.mark.backend_peer
+@pytest.mark.portrait
+@pytest.mark.device_count(1)
+@pytest.mark.timeout(1200)
+class TestMessageActionsReceived(PeerChatBase):
+    """What the phone renders for actions taken by the other participant."""
+
+    @pytest.mark.spec("SC-MACT-01")
+    async def test_received_reply_shows_reply_corner(self) -> None:
+        """A reply sent by the other participant renders with its indicator."""
+        original_text = _unique_message("peer-reply-orig")
+        reply_text = _unique_message("peer-reply-body")
+
+        async with self.step("Peer sends a message the phone can see"):
+            chat_page = self.chat_page()
+            original_id = self.send_from_peer(original_text)
+            await self.await_on_phone(chat_page, original_text)
+
+        async with self.step("Peer replies to its own message"):
+            self.peer.send_reply(self.phone_key, reply_text, original_id)
+
+        async with self.step("Phone shows the reply with the reply corner"):
+            await self.await_on_phone(chat_page, reply_text)
+            await self.await_on_phone(
+                chat_page, reply_text,
+                probe=lambda t: chat_page.message_is_reply(reply_text, timeout=t),
+                describe=f"Reply corner on {reply_text!r}",
+            )
+
+    @pytest.mark.spec("SC-MACT-02")
+    async def test_received_edit_updates_text_and_indicator(self) -> None:
+        """An edit made by the other participant updates the rendered message."""
+        original_text = _unique_message("peer-edit-orig")
+        edited_text = original_text + "-v2"
+
+        async with self.step("Peer sends a message the phone can see"):
+            chat_page = self.chat_page()
+            message_id = self.send_from_peer(original_text)
+            await self.await_on_phone(chat_page, original_text)
+
+        async with self.step("Peer edits that message"):
+            self.peer.revise_message(message_id, edited_text)
+
+        async with self.step("Phone shows the edited text and the edited indicator"):
+            await self.await_on_phone(
+                chat_page, edited_text,
+                probe=lambda t: chat_page.message_is_edited(edited_text, timeout=t),
+                describe=f"Edited text {edited_text!r} with its indicator",
+            )
+
+    @pytest.mark.spec("SC-MACT-09")
+    async def test_received_reaction_appears_on_message(self) -> None:
+        """A reaction added by the other participant renders as a badge."""
+        message_text = _unique_message("peer-reaction")
+        emoji_code = "1f600"
+
+        async with self.step("Peer sends a message the phone can see"):
+            chat_page = self.chat_page()
+            message_id = self.send_from_peer(message_text)
+            await self.await_on_phone(chat_page, message_text)
+
+        async with self.step("Peer reacts to its own message"):
+            self.peer.add_reaction(self.phone_key, message_id, emoji_code)
+
+        async with self.step("Phone shows the reaction badge"):
+            await self.await_on_phone(
+                chat_page, message_text,
+                probe=lambda t: chat_page.message_has_reaction_on(
+                    message_text, emoji_code, timeout=t,
+                ),
+                describe=f"Reaction {emoji_code} on {message_text!r}",
+            )
+
+    @pytest.mark.spec("SC-MTYP-04")
+    async def test_received_message_increments_chat(self) -> None:
+        """A message from the other participant lands in the open chat."""
+        async with self.step("Take the phone's baseline message count"):
+            chat_page = self.chat_page()
+            count_before = chat_page.message_count()
+
+        async with self.step("Peer sends an emoji message"):
+            self.send_from_peer("\U0001f44d")
+
+        async with self.step("Phone's chat grows by one"):
+            await self.await_on_phone(
+                chat_page, "emoji",
+                probe=lambda t: chat_page.wait_for_message_count(count_before + 1, timeout=t),
+                describe="Emoji message from the peer",
+            )
+
+    @pytest.mark.spec("SC-MACT-05")
+    async def test_cannot_delete_other_users_message(self) -> None:
+        """Delete is not offered on another participant's message."""
+        other_message = _unique_message("peer-msg")
+        context_menu = MessageContextMenuPage(self.driver)
+
+        async with self.step("Peer sends a message"):
+            chat_page = self.chat_page()
+            self.send_from_peer(other_message)
+            await self.await_on_phone(chat_page, other_message)
+
+        async with self.step("Long-press the other participant's message"):
+            assert context_menu.long_press_message(other_message), (
+                "Failed to open context menu on the peer's message"
+            )
+            assert context_menu.is_displayed(), "Context menu not visible"
+
+        async with self.step("Expand the menu"):
+            # Delete is never in the collapsed row, so without this the
+            # negative below holds for any message.
+            assert context_menu.tap_expand(), "Failed to expand context menu"
+
+        async with self.step("Verify Delete is NOT offered"):
+            # The positive sibling keeps the negative honest: a dismissed or
+            # still-collapsed menu fails here instead of passing below.
+            assert context_menu.is_pin_visible(), (
+                "Expanded menu should show Pin for the peer's message"
+            )
+            assert not context_menu.is_delete_visible(), (
+                "Delete should not be visible for another participant's message"
+            )
+
+        async with self.step("Dismiss context menu"):
+            assert context_menu.dismiss(), "Failed to dismiss context menu"

--- a/test/e2e_appium/tests/messaging/test_messaging_1x1_chat.py
+++ b/test/e2e_appium/tests/messaging/test_messaging_1x1_chat.py
@@ -10,6 +10,7 @@ from pages.settings.settings_page import SettingsPage
 from support.multi_device_helpers import StepMixin
 
 
+@pytest.mark.two_phone
 class TestMessaging1x1Chat(StepMixin):
 
     DM_TIMEOUT = 240


### PR DESCRIPTION
### What does the PR do

Stack 2/3, on #22339. The `peer_chat` fixture the converted gate tests share, and the first converted module.

- `peer_chat` starts the peer before it buys a device session, so a peer failure costs seconds, not a BrowserStack session. It drives the contact handshake from both sides.
- A run without `STATUS_BACKEND_IMAGE` that selects only peer tests fails every selected test at setup with one message. This works under `xdist` on every worker. A mixed selection drops the peer tests and runs the rest.
- A send from the phone is not done until the peer holds the message. A test whose checks are all on the phone screen cannot pass with a dead peer.
- `hide_keyboard()` no longer swipes when the keyboard will not hide. On some devices `is_keyboard_shown()` reports true with no keyboard, and the swipe scrolled the target message away. Two callers read the return value; both only sleep or return on it.
- `long_press_message` hides the keyboard and waits for the message row to stop moving before the press. This applies to the seven gate tests that long-press. It returns `False` instead of raising when the menu does not open.
- Received-side actions converted. The two-phone original keeps its markers. One long-press `xfail` is lifted here.

### How to test

```bash
cd test/e2e_appium
env -u STATUS_BACKEND_IMAGE python -m pytest -n 2 -m backend_peer tests/messaging -q   # 5 errors, one message, no INTERNALERROR
python -m pytest --collect-only -q -m gate | tail -1                                  # 46/114 collected, same set as master
python -m pytest tests/test_backend_peer_core.py -q                                   # 28 passed, 1 skipped
```

A device run on our fork, `-m "gate or backend_peer"` at `-n 2`: 53 collected, 51 passed, 1 xpassed, 0 failed. One BrowserStack session-creation error at setup of `test_drawer_navigation_cycles`; no test ran in that slot. The head differs from the tested tree by a helper move into `core/peer_containers.py`, comments, and one XPath literal that emits a byte-identical expression for the content the suite sends.

### Risk

`hide_keyboard` and `long_press_message` are on the gate path. The run above covered them on device. The received-side conversion is `backend_peer` only; no job selects it yet.
