### PR TITLE
test(e2e_appium): gate messaging with a peer

### DIFF
--- a/test/e2e_appium/tests/messaging/test_emoji_and_media.py
+++ b/test/e2e_appium/tests/messaging/test_emoji_and_media.py
@@ -18,6 +18,7 @@ def _unique_message(prefix: str) -> str:
 @pytest.mark.portrait
 @pytest.mark.smoke
 @pytest.mark.device_count(2)
+@pytest.mark.two_phone
 class TestEmojiAndMedia:
     """Emoji and media coverage for 1:1 chats."""
 

--- a/test/e2e_appium/tests/messaging/test_message_actions_backend.py
+++ b/test/e2e_appium/tests/messaging/test_message_actions_backend.py
@@ -1,0 +1,234 @@
+"""Message actions taken ON the phone, with a headless backend as counterparty."""
+
+import uuid
+
+import pytest
+
+from pages.messaging.chat_page import ChatPage
+from pages.messaging.message_context_menu_page import MessageContextMenuPage
+from tests.messaging.peer_base import PeerChatBase
+
+
+def _unique_message(prefix: str = "test") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.messaging
+@pytest.mark.backend_peer
+@pytest.mark.portrait
+@pytest.mark.device_count(1)
+@pytest.mark.timeout(1200)
+class TestMessageActions(PeerChatBase):
+    """The phone's own message actions, with the peer holding the other copy."""
+
+    async def test_context_menu_own_message_actions(self) -> None:
+        """Own messages offer Reply, Edit, Copy, Pin and Delete."""
+        test_message = _unique_message("ctx_menu_test")
+        context_menu = MessageContextMenuPage(self.driver)
+
+        async with self.step("Send test message"):
+            await self.send_from_phone(test_message)
+
+        async with self.step("Long-press to open context menu"):
+            assert context_menu.long_press_message(test_message), (
+                "Failed to open context menu"
+            )
+            assert context_menu.is_displayed(), "Context menu not visible"
+
+        async with self.step("Verify collapsed quick actions"):
+            assert not context_menu.is_expanded(), (
+                "Menu should open collapsed on long-press"
+            )
+            assert context_menu.is_reply_visible(), "Reply action not visible"
+            assert context_menu.is_edit_visible(), "Edit action not visible (own message)"
+            assert context_menu.is_copy_visible(), "Copy action not visible"
+
+        async with self.step("Expand the menu"):
+            assert context_menu.tap_expand(), "Failed to expand context menu"
+
+        async with self.step("Verify full own-message action set"):
+            assert context_menu.is_reply_visible(), "Reply not in expanded menu"
+            assert context_menu.is_edit_visible(), "Edit not in expanded menu"
+            assert context_menu.is_copy_visible(), "Copy not in expanded menu"
+            assert context_menu.is_mark_unread_visible(), "Mark as unread not in expanded menu"
+            assert context_menu.is_pin_visible(), "Pin action not visible"
+            assert context_menu.is_delete_visible(), "Delete action not visible (own message)"
+
+        async with self.step("Dismiss context menu"):
+            assert context_menu.dismiss(), "Failed to dismiss context menu"
+
+    @pytest.mark.spec("SC-MACT-09")
+    async def test_add_reaction_to_message(self) -> None:
+        """A quick reaction can be added and closes the menu."""
+        test_message = _unique_message("react_test")
+        context_menu = MessageContextMenuPage(self.driver)
+
+        async with self.step("Send test message"):
+            await self.send_from_phone(test_message)
+
+        async with self.step("Add reaction via context menu"):
+            assert context_menu.long_press_message(test_message), (
+                "Failed to open context menu"
+            )
+            assert context_menu.tap_grin(), "Failed to add grin reaction"
+
+        async with self.step("Verify menu closed after reaction"):
+            assert context_menu.wait_until_hidden(timeout=5), (
+                "Context menu should close after adding reaction"
+            )
+
+    @pytest.mark.spec("SC-MACT-11")
+    async def test_copy_message_action(self) -> None:
+        """Copy is offered and closes the menu."""
+        test_message = _unique_message("copy_test")
+        context_menu = MessageContextMenuPage(self.driver)
+
+        async with self.step("Send test message"):
+            await self.send_from_phone(test_message)
+
+        async with self.step("Copy message via context menu"):
+            assert context_menu.long_press_message(test_message), (
+                "Failed to open context menu"
+            )
+            assert context_menu.tap_copy(), "Failed to tap Copy action"
+
+        async with self.step("Verify menu closed after copy"):
+            assert context_menu.wait_until_hidden(timeout=5), (
+                "Context menu should close after copying"
+            )
+
+    @pytest.mark.spec("SC-MACT-01")
+    async def test_reply_shows_reply_corner_on_sender(self) -> None:
+        """Replying marks the reply with the reply-corner indicator."""
+        test_message = _unique_message("reply_test")
+        reply_text = _unique_message("reply_body")
+        context_menu = MessageContextMenuPage(self.driver)
+
+        async with self.step("Send the message that will be replied to"):
+            chat_page = await self.send_from_phone(test_message)
+            original = await self.await_on_peer(test_message)
+
+        async with self.step("Open context menu and tap Reply"):
+            assert context_menu.long_press_message(test_message), (
+                "Failed to open context menu"
+            )
+            assert context_menu.tap_reply(), "Failed to tap Reply action"
+
+        async with self.step("Verify reply mode is active"):
+            assert context_menu.wait_until_hidden(timeout=5), (
+                "Context menu should close after Reply"
+            )
+            assert chat_page.is_reply_mode_active(timeout=5), (
+                "Reply mode should be active after tapping Reply"
+            )
+
+        async with self.step("Send reply message"):
+            assert chat_page.send_message(reply_text), (
+                f"Failed to send reply: {reply_text}"
+            )
+            assert chat_page.message_exists(reply_text, timeout=self.UI_TIMEOUT), (
+                "Reply message not visible after sending"
+            )
+
+        async with self.step("Verify reply indicator"):
+            assert chat_page.message_is_reply(reply_text, timeout=self.UI_TIMEOUT), (
+                "Reply message should show the reply corner indicator"
+            )
+
+        async with self.step("Verify the reply reached the other participant as a reply"):
+            reply = await self.await_on_peer(reply_text)
+            assert reply.get("responseTo") == original["id"], (
+                f"the peer holds {reply_text!r} but not as a reply to {test_message!r}"
+            )
+
+    @pytest.mark.spec("SC-MACT-02")
+    async def test_edit_shows_edited_indicator_on_sender(self) -> None:
+        """Editing updates the text and marks the message edited."""
+        original_text = _unique_message("edit_orig")
+        edited_text = original_text + " v2"
+        context_menu = MessageContextMenuPage(self.driver)
+
+        async with self.step("Send original message"):
+            chat_page = await self.send_from_phone(original_text)
+            original = await self.await_on_peer(original_text)
+
+        async with self.step("Long-press message and tap Edit"):
+            assert context_menu.long_press_message(original_text), (
+                "Failed to open context menu"
+            )
+            assert context_menu.tap_edit(), "Failed to tap Edit action"
+
+        async with self.step("Modify text and submit edit"):
+            assert chat_page.submit_message_edit(edited_text), (
+                "Failed to submit message edit"
+            )
+
+        async with self.step("Verify edited message"):
+            assert chat_page.message_is_edited(edited_text, timeout=self.UI_TIMEOUT), (
+                "Edit indicator should be visible for the edited message"
+            )
+
+        async with self.step("Verify the edit reached the other participant as an edit"):
+            edited = await self.await_on_peer(edited_text)
+            assert edited["id"] == original["id"], (
+                f"the peer holds {edited_text!r} as a new message, not an edit of {original_text!r}"
+            )
+            assert self.peer.find_message(self.phone_key, original_text) is None, (
+                "the peer still holds the pre-edit text"
+            )
+
+    @pytest.mark.spec("SC-MACT-09")
+    async def test_reaction_badge_appears_on_sender(self) -> None:
+        """The reaction badge renders on the reacted-to message."""
+        test_message = _unique_message("reaction_sent")
+        context_menu = MessageContextMenuPage(self.driver)
+        emoji_code = "1f600"
+
+        async with self.step("Send test message"):
+            await self.send_from_phone(test_message)
+            message = await self.await_on_peer(test_message)
+
+        async with self.step("Add reaction via context menu"):
+            assert context_menu.long_press_message(test_message), (
+                "Failed to open context menu"
+            )
+            assert context_menu.tap_grin(), "Failed to add grin reaction"
+            assert context_menu.wait_until_hidden(timeout=5), (
+                "Context menu should close after adding reaction"
+            )
+
+        async with self.step("Verify reaction badge on the message"):
+            chat_page = ChatPage(self.driver)
+            assert chat_page.message_has_reaction_on(
+                test_message, emoji_code, timeout=self.UI_TIMEOUT,
+            ), f"Reaction {emoji_code} should appear on {test_message!r} after adding"
+
+        async with self.step("Verify the reaction reached the other participant"):
+            reactions = await self.peer.await_reaction(
+                self.phone_key, message["id"], timeout=self.CROSS_DEVICE_TIMEOUT,
+            )
+            assert any(r.get("from") == self.phone_key for r in reactions), (
+                f"the peer holds reactions on the message, none from the phone: {reactions!r}"
+            )
+
+    @pytest.mark.spec("SC-MTYP-04")
+    async def test_send_emoji_via_picker(self) -> None:
+        """An emoji chosen from the picker is posted to the chat."""
+        chat_page = self.chat_page()
+
+        async with self.step("Send emoji from the picker"):
+            count_before = chat_page.message_count()
+            known = self.peer_message_ids()
+            assert chat_page.send_emoji_to_chat("thumbsup", timeout=self.UI_TIMEOUT), (
+                "Failed to send emoji via picker"
+            )
+
+        async with self.step("Verify the emoji message appears"):
+            assert chat_page.wait_for_message_count(
+                count_before + 1, timeout=self.UI_TIMEOUT,
+            ), "Emoji message should appear in the chat"
+
+        async with self.step("Verify it reached the other participant"):
+            # The picker chooses the text, so the peer is matched on "new from
+            # the phone" rather than on a sentinel.
+            await self.await_new_message_on_peer(known)

--- a/test/e2e_appium/tests/messaging/test_message_actions_backend.py
+++ b/test/e2e_appium/tests/messaging/test_message_actions_backend.py
@@ -22,7 +22,7 @@ class TestMessageActions(PeerChatBase):
     """The phone's own message actions, with the peer holding the other copy."""
 
     async def test_context_menu_own_message_actions(self) -> None:
-        """Own messages offer Reply, Edit, Copy, Pin and Delete."""
+        """Own messages offer Reply, Edit, Copy, Mark as unread, Pin and Delete."""
         test_message = _unique_message("ctx_menu_test")
         context_menu = MessageContextMenuPage(self.driver)
 

--- a/test/e2e_appium/tests/messaging/test_message_context_menu.py
+++ b/test/e2e_appium/tests/messaging/test_message_context_menu.py
@@ -36,6 +36,7 @@ def _unique_message(prefix: str = "test") -> str:
 @pytest.mark.device_count(2)
 @pytest.mark.timeout(1200)
 @pytest.mark.flaky(reruns=1, reruns_delay=5)
+@pytest.mark.two_phone
 class _MessageContextMenuBase:
     """Shared helpers + setup for context-menu test classes.
 

--- a/test/e2e_appium/tests/messaging/test_z_chat_management.py
+++ b/test/e2e_appium/tests/messaging/test_z_chat_management.py
@@ -25,6 +25,7 @@ def _unique_message(prefix: str = "test") -> str:
 @pytest.mark.device_count(2)
 @pytest.mark.timeout(1200)
 @pytest.mark.flaky(reruns=1, reruns_delay=5)
+@pytest.mark.two_phone
 class TestChatManagement:
     """Tests for chat-level management actions.
 

--- a/test/e2e_appium/tests/messaging/test_z_chat_management_backend.py
+++ b/test/e2e_appium/tests/messaging/test_z_chat_management_backend.py
@@ -108,6 +108,9 @@ class TestChatManagementBackend(PeerChatBase):
             assert chat_page.message_count() == 0, (
                 "No messages should remain after clearing history"
             )
+            # A propagated clear would arrive after the click returns, so the
+            # absence below only means anything once the window has passed.
+            await asyncio.sleep(NON_PROPAGATION_SETTLE_SECONDS)
             assert marker in self.peer.chat_message_texts(self.phone_key), (
                 "clearing on the phone must not clear the other participant's copy"
             )
@@ -122,8 +125,20 @@ class TestChatManagementBackend(PeerChatBase):
     @pytest.mark.spec("SC-DM-06")
     async def test_close_chat_removes_it_from_the_chat_list(self) -> None:
         """Closing on the phone removes the row."""
-        async with self.step("Ensure the chat is open"):
+        marker = _unique_message("close_chat")
+
+        async with self.step("Confirm the chat is open, listed, and live"):
             chat_page = self.chat_page()
+            # wait_for_peer_chat_row_gone accepts an absent row, so without this
+            # the case would pass on a run where the row was never there.
+            self.open_chat_list()
+            assert peer_chat_row_visible(self.device, self.peer, timeout=self.UI_TIMEOUT), (
+                "The chat row is not listed to begin with, so its later absence "
+                "would say nothing about closing"
+            )
+            chat_page = self.chat_page()
+            self.send_from_peer(marker)
+            await self.await_on_phone(chat_page, marker)
 
         async with self.step("Close the chat"):
             assert chat_page.close_chat(timeout=self.UI_TIMEOUT), "Failed to close chat"
@@ -133,6 +148,9 @@ class TestChatManagementBackend(PeerChatBase):
             assert wait_for_peer_chat_row_gone(self.device, self.peer, timeout=10), (
                 "Chat should not be listed after closing it"
             )
+
+        async with self.step("The other participant still has the chat open"):
+            await asyncio.sleep(NON_PROPAGATION_SETTLE_SECONDS)
             assert self.peer.dm_is_active(self.phone_key), (
                 "closing on the phone must not close the other participant's chat"
             )

--- a/test/e2e_appium/tests/messaging/test_z_chat_management_backend.py
+++ b/test/e2e_appium/tests/messaging/test_z_chat_management_backend.py
@@ -1,0 +1,138 @@
+"""Clear-history and close-chat, with a headless backend as counterparty."""
+
+import asyncio
+import uuid
+
+import pytest
+
+from support.peer_chat_state import peer_chat_row_visible, wait_for_peer_chat_row_gone
+from tests.messaging.peer_base import PeerChatBase
+
+
+def _unique_message(prefix: str = "test") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+# Long enough for a propagated deletion to have shown up if one were coming.
+# These two cases assert an absence, so the wait is the assertion's strength.
+NON_PROPAGATION_SETTLE_SECONDS = 20
+
+
+@pytest.mark.messaging
+@pytest.mark.backend_peer
+@pytest.mark.portrait
+@pytest.mark.device_count(1)
+@pytest.mark.timeout(1200)
+class TestChatManagementBackend(PeerChatBase):
+    """Chat-level management actions."""
+
+    @pytest.mark.spec("SC-DM-07")
+    async def test_peer_clear_history_leaves_phone_messages(self) -> None:
+        """The other participant clearing their history does not clear ours."""
+        marker = _unique_message("peer_clear")
+
+        async with self.step("Peer sends a marker the phone can see"):
+            chat_page = self.chat_page()
+            self.send_from_peer(marker)
+            await self.await_on_phone(chat_page, marker)
+
+        async with self.step("Peer clears its own history"):
+            self.peer.purge_chat_history(self.phone_key)
+            # Without this the case asserts the absence of an effect that may
+            # never have been triggered, and passes however broken the RPC is.
+            assert marker not in self.peer.chat_message_texts(self.phone_key), (
+                "The peer still has the marker, so its history was not cleared "
+                "and this case cannot say anything about propagation"
+            )
+            await asyncio.sleep(NON_PROPAGATION_SETTLE_SECONDS)
+
+        async with self.step("Phone still shows the marker"):
+            assert chat_page.message_exists(marker, timeout=self.UI_TIMEOUT), (
+                "Phone lost the marker after the peer cleared its history; "
+                "clear history must be local to the device that ran it"
+            )
+
+    @pytest.mark.spec("SC-DM-06")
+    async def test_peer_close_chat_leaves_phone_chat_row(self) -> None:
+        """The other participant closing the chat does not close ours."""
+        marker = _unique_message("peer_close")
+
+        async with self.step("Confirm the chat is open and the two are talking"):
+            chat_page = self.chat_page()
+            assert self.peer.dm_is_active(self.phone_key), (
+                "The peer does not have the chat open to begin with"
+            )
+            # The control for the absence asserted below: without it, a pair
+            # that propagates nothing at all would pass this case.
+            self.send_from_peer(marker)
+            await self.await_on_phone(chat_page, marker)
+
+        async with self.step("Peer closes the chat on its side"):
+            self.peer.deactivate_dm(self.phone_key)
+            assert not self.peer.dm_is_active(self.phone_key), (
+                "The peer still lists the chat as active, so it was not closed "
+                "and this case cannot say anything about propagation"
+            )
+            await asyncio.sleep(NON_PROPAGATION_SETTLE_SECONDS)
+
+        async with self.step("Phone still lists the chat"):
+            self.chat_page()
+            self.open_chat_list()
+            await asyncio.sleep(0.5)
+            assert peer_chat_row_visible(self.device, self.peer, timeout=self.UI_TIMEOUT), (
+                "Phone lost the chat row after the peer closed the chat; "
+                "closing must be local to the device that ran it"
+            )
+
+    @pytest.mark.spec("SC-DM-07")
+    async def test_clear_history_empties_chat_but_keeps_it_listed(self) -> None:
+        """Clearing on the phone empties the chat and keeps it in the list."""
+        marker = _unique_message("clear_hist")
+
+        async with self.step("Send a marker message"):
+            chat_page = await self.send_from_phone(marker)
+
+        async with self.step("Clear history"):
+            assert chat_page.clear_history(timeout=self.UI_TIMEOUT), (
+                "Failed to clear chat history"
+            )
+
+        async with self.step("No messages remain"):
+            await asyncio.sleep(1)
+            if not chat_page.is_element_visible(
+                chat_page.locators.MESSAGE_INPUT, timeout=3,
+            ):
+                chat_page = self.chat_page()
+            assert not chat_page.message_exists(marker, timeout=5), (
+                "Marker should be gone after clearing history"
+            )
+            assert chat_page.message_count() == 0, (
+                "No messages should remain after clearing history"
+            )
+            assert marker in self.peer.chat_message_texts(self.phone_key), (
+                "clearing on the phone must not clear the other participant's copy"
+            )
+
+        async with self.step("Chat is still in the chat list"):
+            self.open_chat_list()
+            await asyncio.sleep(0.5)
+            assert peer_chat_row_visible(self.device, self.peer, timeout=self.UI_TIMEOUT), (
+                "Chat should still be listed after clearing its history"
+            )
+
+    @pytest.mark.spec("SC-DM-06")
+    async def test_close_chat_removes_it_from_the_chat_list(self) -> None:
+        """Closing on the phone removes the row."""
+        async with self.step("Ensure the chat is open"):
+            chat_page = self.chat_page()
+
+        async with self.step("Close the chat"):
+            assert chat_page.close_chat(timeout=self.UI_TIMEOUT), "Failed to close chat"
+
+        async with self.step("Chat is no longer listed"):
+            self.open_chat_list()
+            assert wait_for_peer_chat_row_gone(self.device, self.peer, timeout=10), (
+                "Chat should not be listed after closing it"
+            )
+            assert self.peer.dm_is_active(self.phone_key), (
+                "closing on the phone must not close the other participant's chat"
+            )

--- a/test/e2e_appium/tests/messaging/test_z_chat_management_backend.py
+++ b/test/e2e_appium/tests/messaging/test_z_chat_management_backend.py
@@ -75,7 +75,8 @@ class TestChatManagementBackend(PeerChatBase):
             await asyncio.sleep(NON_PROPAGATION_SETTLE_SECONDS)
 
         async with self.step("Phone still lists the chat"):
-            self.chat_page()
+            # Deliberately not chat_page(): reopening would recreate the row via
+            # the deep link and hide a close that had propagated.
             self.open_chat_list()
             await asyncio.sleep(0.5)
             assert peer_chat_row_visible(self.device, self.peer, timeout=self.UI_TIMEOUT), (


### PR DESCRIPTION
### What does the PR do

Stack 3/3, on #22340. The two remaining gate messaging modules, converted the same way: the phone drives the UI, the peer is the other participant, and every delivery claim reads the peer's own copy.

- Sent-side message actions: context menu with all six expanded actions, reply, edit, reaction, copy, emoji picker.
- Chat management: clear history and close chat, with the chat-list checks. Close chat has a positive control, so a pair that syncs nothing cannot pass.
- The emoji picker picks its own text, so its check matches the next message from the phone by id, not by text.
- No `xfail` marks. The two remaining long-press `xfail` marks are lifted here; #81's settle wait removed the cause.
- The two-phone originals keep their markers until the converted set has green nightlies.

### How to test

```bash
cd test/e2e_appium
python -m pytest --collect-only -q -m backend_peer | tail -1   # 18/125
python -m pytest --collect-only -q -m gate | tail -1           # 46/125, same set as master
env -u STATUS_BACKEND_IMAGE python -m pytest -n 2 -m backend_peer tests/messaging -q   # 16 errors, one message, no INTERNALERROR
```

A device run on our fork, `-m "(gate and not two_phone) or backend_peer"` at `-n 5` (the selection the lane is built for): 54 passed in 686 s. The head differs from the tested tree only by comments and one XPath literal that emits a byte-identical expression for the content the suite sends. The run before it, same selection, was 52 passed, 1 xpassed, 1 failed in `test_drawer_navigation_cycles` cycle 2; the stack does not touch that path.

### Risk

Test-only. The converted tests carry `backend_peer` and no job selects them yet. Gate node set is unchanged.
