### PR TITLE
fix(wallet): collectibles tab reopen time

### DIFF
--- a/storybook/qmlTests/tests/tst_LazyTabStack.qml
+++ b/storybook/qmlTests/tests/tst_LazyTabStack.qml
@@ -46,6 +46,19 @@ Item {
         }
     }
 
+    // the stack itself created asynchronously, as inside the wallet section
+    Component {
+        id: nestedAsyncComponentUnderTest
+        Loader {
+            anchors.fill: parent
+            asynchronous: true
+            sourceComponent: LazyTabStack {
+                asynchronous: true
+                tabComponents: [tabA, tabB, tabC]
+            }
+        }
+    }
+
     TestCase {
         name: "LazyTabStack"
         when: windowShown
@@ -95,6 +108,17 @@ Item {
             controlUnderTest.currentIndex = 0
             verify(controlUnderTest.itemAt(0).parent.visible)
             verify(!controlUnderTest.itemAt(2).parent.visible)
+        }
+
+        function test_becomesReadyWhenCreatedAsynchronouslyItself() {
+            d.createdA = 0
+            const outer = createTemporaryObject(nestedAsyncComponentUnderTest, root)
+            verify(!!outer)
+            tryCompare(outer, "status", Loader.Ready)
+            const control = outer.item
+            verify(!!control)
+            tryVerify(() => control.currentReady)
+            compare(d.createdA, 1)
         }
 
         function test_reportsReadinessWhileLoadingAsynchronously() {

--- a/storybook/qmlTests/tests/tst_LazyTabStack.qml
+++ b/storybook/qmlTests/tests/tst_LazyTabStack.qml
@@ -1,0 +1,118 @@
+import QtQuick
+import QtTest
+
+import shared.controls
+
+Item {
+    id: root
+    width: 400
+    height: 300
+
+    QtObject {
+        id: d
+        property int createdA: 0
+        property int createdB: 0
+        property int createdC: 0
+    }
+
+    Component {
+        id: tabA
+        Item { Component.onCompleted: d.createdA++ }
+    }
+    Component {
+        id: tabB
+        Item { Component.onCompleted: d.createdB++ }
+    }
+    Component {
+        id: tabC
+        Item { Component.onCompleted: d.createdC++ }
+    }
+
+    Component {
+        id: componentUnderTest
+        LazyTabStack {
+            anchors.fill: parent
+            asynchronous: false
+            tabComponents: [tabA, tabB, tabC]
+        }
+    }
+
+    Component {
+        id: asyncComponentUnderTest
+        LazyTabStack {
+            anchors.fill: parent
+            asynchronous: true
+            tabComponents: [tabA, tabB, tabC]
+        }
+    }
+
+    TestCase {
+        name: "LazyTabStack"
+        when: windowShown
+
+        property LazyTabStack controlUnderTest: null
+
+        function init() {
+            d.createdA = 0
+            d.createdB = 0
+            d.createdC = 0
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+        }
+
+        function test_createsOnlyTheCurrentTab() {
+            verify(!!controlUnderTest)
+            compare(controlUnderTest.currentIndex, 0)
+            compare(d.createdA, 1)
+            compare(d.createdB, 0)
+            compare(d.createdC, 0)
+            verify(controlUnderTest.currentReady)
+            verify(!!controlUnderTest.itemAt(0))
+            compare(controlUnderTest.itemAt(1), null)
+        }
+
+        function test_keepsAViewAliveAcrossSwitches() {
+            controlUnderTest.currentIndex = 1
+            compare(d.createdB, 1)
+            const tabBItem = controlUnderTest.itemAt(1)
+            verify(!!tabBItem)
+
+            controlUnderTest.currentIndex = 0
+            controlUnderTest.currentIndex = 1
+
+            compare(d.createdA, 1)
+            compare(d.createdB, 1)
+            compare(d.createdC, 0)
+            compare(controlUnderTest.itemAt(1), tabBItem)
+            verify(!!controlUnderTest.itemAt(0))
+        }
+
+        function test_showsOnlyTheCurrentTab() {
+            controlUnderTest.currentIndex = 2
+            verify(controlUnderTest.currentReady)
+            verify(!controlUnderTest.itemAt(0).parent.visible)
+            verify(controlUnderTest.itemAt(2).parent.visible)
+
+            controlUnderTest.currentIndex = 0
+            verify(controlUnderTest.itemAt(0).parent.visible)
+            verify(!controlUnderTest.itemAt(2).parent.visible)
+        }
+
+        function test_reportsReadinessWhileLoadingAsynchronously() {
+            d.createdA = 0
+            d.createdB = 0
+            const control = createTemporaryObject(asyncComponentUnderTest, root)
+            verify(!!control)
+            verify(!control.currentReady)
+            tryVerify(() => control.currentReady)
+            compare(d.createdA, 1)
+
+            control.currentIndex = 1
+            verify(!control.currentReady)
+            tryVerify(() => control.currentReady)
+            compare(d.createdB, 1)
+
+            control.currentIndex = 0
+            verify(control.currentReady)
+        }
+    }
+}

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -61,8 +61,11 @@ QtObject {
         4. "description" to "communityDescription"
         in communitiesModule.model so that it can be easily
         joined with the Collectibles model */
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _communitiesModel: !!communitiesModule ? communitiesModule.model : null
+
     readonly property var _renamedCommunitiesModel: RolesRenamingModel {
-        sourceModel: communitiesModule.model
+        sourceModel: root._communitiesModel
         mapping: [
             RoleRename {
                 from: "id"

--- a/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -84,8 +84,11 @@ QtObject {
         4. "description" to "communityDescription"
         in communitiesModule.model so that it can be easily
         joined with the Collectibles model */
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _communitiesModel: !!communitiesModule ? communitiesModule.model : null
+
     readonly property var _renamedCommunitiesModel: RolesRenamingModel {
-        sourceModel: communitiesModule.model
+        sourceModel: root._communitiesModel
         mapping: [
             RoleRename {
                 from: "id"

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -56,8 +56,11 @@ QtObject {
 
     readonly property bool areTestNetworksEnabled: networksModule.areTestNetworksEnabled
 
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _savedAddressesModel: !!walletSectionSavedAddresses ? walletSectionSavedAddresses.model : null
+
     property var savedAddresses: SortFilterProxyModel {
-        sourceModel: walletSectionSavedAddresses.model
+        sourceModel: root._savedAddressesModel
         filters: [
             ValueFilter {
                 roleName: "isTest"

--- a/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
@@ -75,8 +75,11 @@ QtObject {
         4. "description" to "communityDescription"
     in communitiesModule.model so that it can be easily
     joined with the Account Assets model */
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _communitiesModel: !!communitiesModule ? communitiesModule.model : null
+
     readonly property var _renamedCommunitiesModel: RolesRenamingModel {
-        sourceModel: communitiesModule.model
+        sourceModel: root._communitiesModel
         mapping: [
             RoleRename {
                 from: "id"

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -327,7 +327,7 @@ RightTabBaseView {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 Layout.topMargin: Theme.padding
-                active: mainViewLoader.status !== Loader.Ready
+                active: !mainViews.currentReady
                 visible: active
                 sourceComponent: {
                     switch (walletTabBar.currentIndex) {
@@ -438,14 +438,15 @@ RightTabBaseView {
                 }
             }
 
-            Loader {
-                id: mainViewLoader
+            LazyTabStack {
+                id: mainViews
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 Layout.topMargin: Theme.padding
                 asynchronous: true
-                visible: status === Loader.Ready
-                sourceComponent: d.walletViewsMap[walletTabBar.currentIndex]
+                visible: currentReady
+                tabComponents: d.walletViewsMap
+                currentIndex: walletTabBar.currentIndex
 
                 Component {
                     id: assetsView

--- a/ui/imports/shared/controls/LazyTabStack.qml
+++ b/ui/imports/shared/controls/LazyTabStack.qml
@@ -1,0 +1,50 @@
+import QtQuick
+
+/// One loader per tab: a view is created when its tab is first selected and
+/// kept alive, so switching back to it only toggles visibility.
+Item {
+    id: root
+
+    required property var tabComponents
+    property int currentIndex: 0
+    property bool asynchronous: true
+
+    readonly property bool currentReady: d.currentLoader?.status === Loader.Ready
+
+    function itemAt(index) {
+        const loader = repeater.itemAt(index) as Loader
+        return loader ? loader.item : null
+    }
+
+    QtObject {
+        id: d
+
+        readonly property Loader currentLoader: {
+            repeater.count
+            return repeater.itemAt(root.currentIndex) as Loader
+        }
+    }
+
+    Repeater {
+        id: repeater
+
+        model: root.tabComponents.length
+
+        delegate: Loader {
+            id: loader
+
+            required property int index
+            readonly property bool current: root.currentIndex === loader.index
+            property bool activated: false
+
+            anchors.fill: parent
+            asynchronous: root.asynchronous
+            active: loader.activated
+            visible: loader.current && loader.status === Loader.Ready
+            sourceComponent: root.tabComponents[loader.index]
+
+            onCurrentChanged: if (loader.current) loader.activated = true
+            Component.onCompleted: if (loader.current) loader.activated = true
+        }
+    }
+}

--- a/ui/imports/shared/controls/LazyTabStack.qml
+++ b/ui/imports/shared/controls/LazyTabStack.qml
@@ -19,10 +19,7 @@ Item {
     QtObject {
         id: d
 
-        readonly property Loader currentLoader: {
-            repeater.count
-            return repeater.itemAt(root.currentIndex) as Loader
-        }
+        property Loader currentLoader: null
     }
 
     Repeater {
@@ -43,8 +40,15 @@ Item {
             visible: loader.current && loader.status === Loader.Ready
             sourceComponent: root.tabComponents[loader.index]
 
-            onCurrentChanged: if (loader.current) loader.activated = true
-            Component.onCompleted: if (loader.current) loader.activated = true
+            function takeOver() {
+                if (!loader.current)
+                    return
+                loader.activated = true
+                d.currentLoader = loader
+            }
+
+            onCurrentChanged: takeOver()
+            Component.onCompleted: takeOver()
         }
     }
 }

--- a/ui/imports/shared/controls/qmldir
+++ b/ui/imports/shared/controls/qmldir
@@ -25,6 +25,7 @@ ImportKeypairInfo 1.0 ImportKeypairInfo.qml
 InformationTag 1.0 InformationTag.qml
 InformationTile 1.0 InformationTile.qml
 Input 1.0 Input.qml
+LazyTabStack 1.0 LazyTabStack.qml
 LinkPreviewDebugView 1.0 LinkPreviewDebugView.qml
 LoadingTokenDelegate 1.0 LoadingTokenDelegate.qml
 Padding 1.0 Padding.qml

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -32,8 +32,11 @@ QtObject {
     property var tmpActivityController0: walletSection.tmpActivityController0
     readonly property var _tmpActivityController1: walletSection.tmpActivityController1
     readonly property var tempActivityController1Model: _tmpActivityController1.model
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _savedAddressesModel: !!walletSectionSavedAddresses ? walletSectionSavedAddresses.model : null
+
     property var savedAddressesModel: SortFilterProxyModel {
-        sourceModel: walletSectionSavedAddresses.model
+        sourceModel: root._savedAddressesModel
         filters: [
             ValueFilter {
                 roleName: "isTest"


### PR DESCRIPTION
Rebuilding collectibles tab is expensive (lots of delegates). Reduce from 1.8s to 100ms
Fixed race condition which lead to an empty collectibles list

- the first open and its skeleton are unchanged
- add `LazyTabStack`: one Loader per tab, created the first time the tab
  is selected and kept alive
- tests
- the communities model is now read through a store property, which is re-evaluated on registration

> when the wallet section
is restored at startup before the backend registers its context
properties, a proxy bound straight to one of them
(`sourceModel: communitiesModule.model` in CollectiblesStore) fails and,
in the AOT-compiled app, is never re-evaluated once the property is
registered. The LeftJoinModel never initialises and the Collectibles tab
stays empty until restart while the backend already holds every item.
Proxies now read such modules through a store property, which is
re-evaluated on registration; the same construct in WalletAssetsStore,
the profile WalletStore, the wallet RootStore and TransactionStore gets
the same treatment. 

https://github.com/user-attachments/assets/0a4e77e3-a45e-4e8b-9776-3f1e9bcf622c


Closes https://github.com/status-im/status-app/issues/22144