### PR TITLE
fix: Update bot contact request intro message

### DIFF
--- a/src/app/global/local_account_settings.nim
+++ b/src/app/global/local_account_settings.nim
@@ -5,6 +5,7 @@ import ../../constants
 
 # Local Account Settings keys:
 const LS_KEY_STORE_TO_KEYCHAIN* = "storeToKeychain"
+const LS_KEY_FRESH_PROFILE* = "freshProfile"
 const DEFAULT_STORE_TO_KEYCHAIN = "notNow"
 # Local Account Settings values:
 const LS_VALUE_STORE* = "store"
@@ -17,13 +18,13 @@ QtObject:
     currentFileName: string
     settings: QSettings
 
-  proc setup(self: LocalAccountSettings)
+  proc setup(self: LocalAccountSettings, settingsFileDir: string)
   proc delete*(self: LocalAccountSettings)
 
-  proc newLocalAccountSettings*():
+  proc newLocalAccountSettings*(settingsFileDir = os.joinPath(DATADIR, "qt")):
     LocalAccountSettings =
     new(result, delete)
-    result.setup
+    result.setup(settingsFileDir)
 
   proc setFileName*(self: LocalAccountSettings, fileName: string) =
     let
@@ -64,9 +65,28 @@ QtObject:
     write = setStoreToKeychainValue
     notify = storeToKeychainValueChanged
 
-  proc setup(self: LocalAccountSettings) =
+  proc freshProfileChanged*(self: LocalAccountSettings) {.signal.}
+
+  # A profile created in this install with a generated seed phrase; absent for every other origin.
+  proc isFreshProfile*(self: LocalAccountSettings): bool {.slot.} =
+    if self.settings.isNil:
+      return false
+    self.settings.value(LS_KEY_FRESH_PROFILE, newQVariant(false)).boolVal
+
+  # Nim-only on purpose: the origin is decided once at profile creation, never from the UI.
+  proc markProfileFresh*(self: LocalAccountSettings) =
+    if self.settings.isNil:
+      return
+    self.settings.setValue(LS_KEY_FRESH_PROFILE, newQVariant(true))
+    self.freshProfileChanged()
+
+  QtProperty[bool] freshProfile:
+    read = isFreshProfile
+    notify = freshProfileChanged
+
+  proc setup(self: LocalAccountSettings, settingsFileDir: string) =
     self.QObject.setup
-    self.settingsFileDir = os.joinPath(DATADIR, "qt")
+    self.settingsFileDir = settingsFileDir
 
   proc delete*(self: LocalAccountSettings) =
     self.QObject.delete

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -106,8 +106,8 @@ method delete*[T](self: Module[T]) =
   self.controller.delete
 
 method onAppLoaded*[T](self: Module[T], keyUid: string) =
-  # Doesn't do anything since we wait for the Main section to be loaded
-  discard
+  if self.onboardingFlow == OnboardingFlow.CreateProfileWithPassword:
+    singletonInstance.localAccountSettings.markProfileFresh()
 
 method onMainLoaded*[T](self: Module[T]) =
   if self.view.isNil:

--- a/test/nim/local_account_settings_test.nim
+++ b/test/nim/local_account_settings_test.nim
@@ -1,0 +1,47 @@
+## LocalAccountSettings: the fresh-profile flag is written once at profile
+## creation and read back from the per-account ini across restarts.
+
+import unittest, os, nimqml
+import app/global/local_account_settings
+
+suite "LocalAccountSettings fresh profile":
+
+  let dir = getTempDir() / "local_account_settings_test"
+
+  setup:
+    removeDir(dir)
+    createDir(dir)
+
+  teardown:
+    removeDir(dir)
+
+  test "no key reads as an established profile":
+    let s = newLocalAccountSettings(dir)
+    s.setFileName("alice")
+    check not s.isFreshProfile()
+
+  test "no file bound reads as an established profile":
+    let s = newLocalAccountSettings(dir)
+    check not s.isFreshProfile()
+
+  test "markProfileFresh is visible immediately and after reopening the file":
+    block:
+      let s = newLocalAccountSettings(dir)
+      s.setFileName("alice")
+      s.markProfileFresh()
+      check s.isFreshProfile()
+
+    block:
+      let s = newLocalAccountSettings(dir)
+      s.setFileName("alice")
+      check s.isFreshProfile()
+
+  test "flag is per account file":
+    block:
+      let s = newLocalAccountSettings(dir)
+      s.setFileName("alice")
+      s.markProfileFresh()
+
+    let other = newLocalAccountSettings(dir)
+    other.setFileName("bob")
+    check not other.isFreshProfile()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2688,11 +2688,10 @@ Item {
                         appMain.contactsStore.joinPrivateChat(d.supportBotPublicKey)
                         return
                     }
-                    Global.openContactRequestPopupWithDefaultMessage(
-                        d.supportBotPublicKey,
-                        null,
-                        qsTr("Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime")
-                    )
+                    const introMessage = localAccountSettings.freshProfile
+                        ? qsTr("Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime")
+                        : qsTr("Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime")
+                    Global.openContactRequestPopupWithDefaultMessage(d.supportBotPublicKey, null, introMessage)
                 }
 
                 onItemActivated: function(sectionType, sectionId) {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2691,7 +2691,7 @@ Item {
                     Global.openContactRequestPopupWithDefaultMessage(
                         d.supportBotPublicKey,
                         null,
-                        qsTr("Send the Status Team bot a contact request to get useful Status tips, important updates, and share your feedback, ideas, or issues directly with the Status team.")
+                        qsTr("Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime")
                     )
                 }
 

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1831,6 +1831,14 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1995,10 +2003,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     </message>
     <message>
         <source>%1 was removed from your trusted sites.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1831,10 +1831,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Send the Status Team bot a contact request to get useful Status tips, important updates, and share your feedback, ideas, or issues directly with the Status team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Invite People</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1999,6 +1995,10 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     </message>
     <message>
         <source>%1 was removed from your trusted sites.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1843,6 +1843,14 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
         <translation>Tento kanál již neexistuje</translation>
     </message>
     <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation>Pozvat lidi</translation>
     </message>
@@ -2009,10 +2017,6 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
     <message>
         <source>%1 was removed from your trusted sites.</source>
         <translation>%1 bylo odstraněno z vašich důvěryhodných stránek.</translation>
-    </message>
-    <message>
-        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1843,10 +1843,6 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
         <translation>Tento kanál již neexistuje</translation>
     </message>
     <message>
-        <source>Send the Status Team bot a contact request to get useful Status tips, important updates, and share your feedback, ideas, or issues directly with the Status team.</source>
-        <translation>Pošlete botu Status Team žádost o kontakt, abyste získali užitečné tipy, důležité aktualizace a mohli sdílet svou zpětnou vazbu, nápady nebo problémy přímo s týmem Status.</translation>
-    </message>
-    <message>
         <source>Invite People</source>
         <translation>Pozvat lidi</translation>
     </message>
@@ -2013,6 +2009,10 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
     <message>
         <source>%1 was removed from your trusted sites.</source>
         <translation>%1 bylo odstraněno z vašich důvěryhodných stránek.</translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1832,6 +1832,14 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation>Invitar personas</translation>
     </message>
@@ -1997,10 +2005,6 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
     <message>
         <source>%1 was removed from your trusted sites.</source>
         <translation>%1 fue eliminado de tus sitios de confianza.</translation>
-    </message>
-    <message>
-        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1832,10 +1832,6 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Send the Status Team bot a contact request to get useful Status tips, important updates, and share your feedback, ideas, or issues directly with the Status team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Invite People</source>
         <translation>Invitar personas</translation>
     </message>
@@ -2001,6 +1997,10 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
     <message>
         <source>%1 was removed from your trusted sites.</source>
         <translation>%1 fue eliminado de tus sitios de confianza.</translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -1832,10 +1832,6 @@ de &quot;%1&quot; à &quot;%2&quot;</translation>
         <translation>Ce canal n’existe plus</translation>
     </message>
     <message>
-        <source>Send the Status Team bot a contact request to get useful Status tips, important updates, and share your feedback, ideas, or issues directly with the Status team.</source>
-        <translation>Envoyez une demande de contact au bot de l&apos;équipe Status pour obtenir des conseils utiles, des mises à jour importantes et partager vos commentaires, idées ou problèmes directement avec l&apos;équipe Status.</translation>
-    </message>
-    <message>
         <source>Invite People</source>
         <translation>Inviter des personnes</translation>
     </message>
@@ -2001,6 +1997,10 @@ de &quot;%1&quot; à &quot;%2&quot;</translation>
     <message>
         <source>%1 was removed from your trusted sites.</source>
         <translation>%1 a été supprimé de vos sites de confiance.</translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -1832,6 +1832,14 @@ de &quot;%1&quot; à &quot;%2&quot;</translation>
         <translation>Ce canal n’existe plus</translation>
     </message>
     <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation>Inviter des personnes</translation>
     </message>
@@ -1997,10 +2005,6 @@ de &quot;%1&quot; à &quot;%2&quot;</translation>
     <message>
         <source>%1 was removed from your trusted sites.</source>
         <translation>%1 a été supprimé de vos sites de confiance.</translation>
-    </message>
-    <message>
-        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1816,10 +1816,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Send the Status Team bot a contact request to get useful Status tips, important updates, and share your feedback, ideas, or issues directly with the Status team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Invite People</source>
         <translation>사람들 초대하기</translation>
     </message>
@@ -1980,6 +1976,10 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     <message>
         <source>Retrying connection to collectibles providers...</source>
         <translation>수집품 제공자에 다시 연결하는 중...</translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1816,6 +1816,14 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation>사람들 초대하기</translation>
     </message>
@@ -1976,10 +1984,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     <message>
         <source>Retrying connection to collectibles providers...</source>
         <translation>수집품 제공자에 다시 연결하는 중...</translation>
-    </message>
-    <message>
-        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -1843,6 +1843,14 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>Цей канал більше не існує</translation>
     </message>
     <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation>Запросити людей</translation>
     </message>
@@ -2009,10 +2017,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     <message>
         <source>%1 was removed from your trusted sites.</source>
         <translation>%1 видалено з ваших довірених сайтів.</translation>
-    </message>
-    <message>
-        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -1843,10 +1843,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>Цей канал більше не існує</translation>
     </message>
     <message>
-        <source>Send the Status Team bot a contact request to get useful Status tips, important updates, and share your feedback, ideas, or issues directly with the Status team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Invite People</source>
         <translation>Запросити людей</translation>
     </message>
@@ -2013,6 +2009,10 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     <message>
         <source>%1 was removed from your trusted sites.</source>
         <translation>%1 видалено з ваших довірених сайтів.</translation>
+    </message>
+    <message>
+        <source>Send a contact request to the Status Team peer-to-peer bot over the Logos network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Where do you want to go?</source>


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-app/issues/22343

Update the bot contact request intro

### Update

The intro is now split by profile origin: a profile created in this install with a generated seed phrase (`CreateProfileWithPassword`) gets the "welcome messages" copy, every other origin gets the "Status updates" copy. The origin is recorded once by the onboarding module in the per-account `LocalAccountSettings` ini (`freshProfile`) and exposed to QML read-only, since status-go #7807 dropped the backend `support_bot_contact_request_state` setting. Host test: `test/nim/local_account_settings_test.nim`.
