### PR TITLE
ci: run the e2e messaging peer as a container

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -246,6 +246,7 @@ pipeline {
                     GIT_REF:      env.BRANCH_NAME,
                     BUILD_SOURCE: urls['Android/arm64'],
                     PYTEST_ARGS:  '-n=2 -m smoke tests',
+                    BACKEND_PEER: false,
                   ]),
                 )
               } }

--- a/ci/Jenkinsfile.test-e2e.android
+++ b/ci/Jenkinsfile.test-e2e.android
@@ -46,12 +46,12 @@ pipeline {
     booleanParam(
       name: 'BACKEND_PEER',
       description: 'Provide the headless status-backend the messaging tests pair a phone with.',
-      defaultValue: params.BACKEND_PEER ?: false
+      defaultValue: true
     )
     string(
       name: 'PYTEST_ARGS',
-      description: 'Pytest flags. Default runs gate tests for PRs. Use "-n=2 -m smoke tests" for nightly/full runs.',
-      defaultValue: '-n=2 -m gate tests'
+      description: 'Pytest flags. Default runs the PR gate on one phone plus a peer. Use "-n=2 -m smoke tests" for nightly/full runs.',
+      defaultValue: '-n=5 -m "(gate and not two_phone) or backend_peer" tests'
     )
   }
 
@@ -109,6 +109,9 @@ pipeline {
           script: "./test/e2e_appium/scripts/peer_image.sh '${env.STATUS_BACKEND_DOCKER_PROJECT}'",
           returnStdout: true
         ).trim()
+        if (!env.STATUS_BACKEND_IMAGE) {
+          error('Peer image stage produced no image')
+        }
       } } }
     }
 
@@ -165,6 +168,11 @@ pipeline {
 
     stage('Run pytest suite') {
       steps{
+        script {
+          if (params.PYTEST_ARGS?.contains('backend_peer') && !env.STATUS_BACKEND_IMAGE) {
+            error('PYTEST_ARGS selects peer tests but no peer image was built. Set BACKEND_PEER.')
+          }
+        }
         lock(resource: 'e2e-android') {
           script {
             env.E2E_RUN_ID = env.BUILD_TAG

--- a/ci/Jenkinsfile.test-e2e.android
+++ b/ci/Jenkinsfile.test-e2e.android
@@ -7,7 +7,13 @@ pipeline {
       label 'linuxcontainer'
       filename 'tests.Dockerfile'
       dir 'ci'
-      args '--user jenkins'
+      /* The messaging tests' second participant is a status-go container the
+       * suite starts and stops itself, reached on 127.0.0.1 at the port the
+       * daemon published. status-go's own functional job runs this way on the
+       * same agent label (_assets/ci/Jenkinsfile.tests-rpc). */
+      args '--volume=/var/run/docker.sock:/var/run/docker.sock ' +
+           '--network=host ' +
+           '--user jenkins'
     }
   }
 
@@ -37,6 +43,11 @@ pipeline {
       description: 'BrowserStack device id to run on (leave empty to use the environment default).',
       choices: ['', 'galaxy_tab_s10p_android_15', 'pixel_8_android_14', 'pixel_7_android_13', 'samsung_s23_android_13']
     )
+    booleanParam(
+      name: 'BACKEND_PEER',
+      description: 'Provide the headless status-backend the messaging tests pair a phone with.',
+      defaultValue: params.BACKEND_PEER ?: false
+    )
     string(
       name: 'PYTEST_ARGS',
       description: 'Pytest flags. Default runs gate tests for PRs. Use "-n=2 -m smoke tests" for nightly/full runs.',
@@ -63,6 +74,7 @@ pipeline {
     TEST_DEVICE_ID = "${params.TEST_DEVICE_ID}"
     BROWSERSTACK_APP_ID = "${params.BROWSERSTACK_APP_ID?.trim() ?: ''}"
     BROWSERSTACK_PROJECT_NAME = "Mobile E2E ${getBuildTypeFromUpstream()}"
+    STATUS_BACKEND_DOCKER_PROJECT = "${env.BUILD_TAG.toLowerCase().replaceAll('[^a-z0-9_.-]', '-')}"
   }
 
   stages {
@@ -84,9 +96,20 @@ pipeline {
             source ${VIRTUAL_ENV}/bin/activate
             pip install --upgrade pip
             pip install -r requirements.txt
+            pip install -r requirements-backend-peer.txt
           """
         }
       }
+    }
+
+    stage('Peer image') {
+      when { expression { params.BACKEND_PEER } }
+      steps { timeout(30) { script {
+        env.STATUS_BACKEND_IMAGE = sh(
+          script: "./test/e2e_appium/scripts/peer_image.sh '${env.STATUS_BACKEND_DOCKER_PROJECT}'",
+          returnStdout: true
+        ).trim()
+      } } }
     }
 
     /* Copies APK from Jenkins build job (skipped when BUILD_SOURCE is a URL) */
@@ -158,7 +181,7 @@ pipeline {
                   variable: 'WALLET_TEST_USER_SEED'
                 )
               ]) {
-                sh "BROWSERSTACK_APP_ID=${appId} ${VIRTUAL_ENV}/bin/python -m pytest --env browserstack ${params.PYTEST_ARGS?.trim() ?: ''}"
+                sh "TMPDIR=${env.WORKSPACE_TMP} BROWSERSTACK_APP_ID=${appId} ${VIRTUAL_ENV}/bin/python -m pytest --env browserstack ${params.PYTEST_ARGS?.trim() ?: ''}"
               }
             }
           }
@@ -178,6 +201,17 @@ pipeline {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
     cleanup {
+      script {
+        if (params.BACKEND_PEER) {
+          sh '''
+            # By label, not name: a name filter is a substring match and one
+            # BUILD_TAG can prefix another's.
+            docker ps -aq --filter "label=com.docker.compose.project=${STATUS_BACKEND_DOCKER_PROJECT}" | xargs -r docker rm -f
+            docker network rm "${STATUS_BACKEND_DOCKER_PROJECT}_default" || true
+            docker volume rm "${STATUS_BACKEND_DOCKER_PROJECT}_wakufleetconfig" || true
+          '''
+        }
+      }
       cleanWs(disableDeferredWipeout: true)
       dir(env.WORKSPACE_TMP) { deleteDir() }
     }

--- a/test/e2e_appium/config/environments/browserstack.yaml
+++ b/test/e2e_appium/config/environments/browserstack.yaml
@@ -114,10 +114,10 @@ execution:
     enabled: true
     poll_interval: 20
     timeout: 180
-    parallel_buffer: 1
+    parallel_buffer: 0
     queue_buffer: 1
   pytest:
-    addopts: ["-n", "2"]
+    addopts: ["-n", "5"]
 
 logging:
   level: "INFO"


### PR DESCRIPTION
### What does the PR do

Gives the Android e2e job a headless status-go peer for the messaging tests, and makes that the job's default gate.

The messaging tests needed two phones, which is why `RUN_E2E` is off for PRs. Pairing one phone with a headless peer makes the gate cheap and steady enough to leave on. This is step one of three: this PR, then a manual run to prove it on Jenkins, then a one-line follow-up setting `RUN_E2E` to true.

**The ask is the two agent flags.** status-go's functional job (`_assets/ci/Jenkinsfile.tests-rpc`) takes both on the same agent label. Without the socket the agent cannot start the peer. Without `--network=host` it cannot reach it, because the test client connects on `127.0.0.1` and the port is published on the host. Checked both ways with stand-in containers, not on a Jenkins agent.

**What changed**

- `BACKEND_PEER` defaults to true and builds one `statusgo-peer-<vendored sha>` image, exported as `STATUS_BACKEND_IMAGE`. Cold build 7-8 min on a GitHub runner, an image lookup after that while the pin does not move. `cleanup` removes the build's containers, network and volume by the client's docker-project label.
- The gate default becomes `-n=5 -m "(gate and not two_phone) or backend_peer"`. That collects 54, none needing more than one device, so five sessions fit the plan's five. The nightly is untouched: `-m smoke` at `-n=2`, `BACKEND_PEER: false`, no image built.
- `parallel_buffer: 1` starved the fifth worker whenever the BrowserStack plan API was unreachable — it computes `5 - 4 - 1 = 0`, then polls until it times out. 4 of 5 workers reserve at 1, 5 of 5 at 0. On a healthy plan it makes no difference either way.
- Two guards against a green run that tested half the gate. With no image the suite deselects the peer tests and exits 0. The image stage now fails if it built nothing, and the run refuses to start if `PYTEST_ARGS` selects peer tests and no image was built.
- `TMPDIR=$WORKSPACE_TMP`, so the scratch path the client bind-mounts exists on the agent host and is removed with the workspace.

**How to verify**

Run the Android build on this PR with `RUN_E2E` checked. Expect a Peer image stage echoing `statusgo-peer-<12 hex>`, then `5 workers [54 items]`, and no `Deselected N test(s) that need a status-backend peer` in the log. That warning is the signature of a run that skipped the peer half.

Two cheaper checks: trigger with `BACKEND_PEER` unchecked and `PYTEST_ARGS` untouched, and it must fail immediately with `PYTEST_ARGS selects peer tests but no peer image was built`. Run the job twice on one agent, and the second image stage should print `already on this agent`.

**Not covered**

- Never run on Jenkins. Timings are from GitHub runners, and the peer set has only run at `-n=5` from a fork.
- GID 999 in `ci/tests.Dockerfile` against the socket's group on a `linuxcontainer` agent is unverified. If it differs, the fix is that line or `--group-add`.
- `--network=host` applies to every run of this job, not only peer runs.
- Five sessions is the whole plan, so a competing job on the same BrowserStack account will queue this one.
