### PR TITLE
fix: Update contact support bot flows

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -62,7 +62,7 @@ QtObject:
     let envVarChatKey = getEnv("STATUS_SUPPORT_BOT_CHAT_KEY")
     if envVarChatKey.len > 0:
       return envVarChatKey
-    return "zQ3shX8r9eRDTEQQhks4qciDunphxdY1w1KjvZ32Pn7dGdWTL"
+    return "zQ3shq8rvVR3BVAnW8jZSK1hJaf2izackG827GKFZfeufKj24"
 
   proc collectLogFilesJson*(self: Utils): string {.slot.} =
     ## Return a JSON array of absolute file paths for all "*.log" files under constants.DATADIR (recursive).

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -106,7 +106,7 @@ method delete*[T](self: Module[T]) =
   self.controller.delete
 
 method onAppLoaded*[T](self: Module[T], keyUid: string) =
-  if self.onboardingFlow == OnboardingFlow.CreateProfileWithPassword:
+  if self.onboardingFlow != OnboardingFlow.Unknown:
     singletonInstance.localAccountSettings.markProfileFresh()
 
 method onMainLoaded*[T](self: Module[T]) =

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -157,6 +157,7 @@ StackLayout {
     signal showUsersListRequested(bool show)
     signal navToMsgDetailsRequested(bool navigate)
     signal navToMsgListRequested(bool navigate)
+    signal supportBotChatRequested()
 
     /*!
         \qmlproperty int StatusSectionLayoutLandscape::leftPanelWidthOverride
@@ -470,6 +471,9 @@ StackLayout {
 
             onNavToMsgDetailsRequested: navigate => root.navToMsgDetailsRequested(navigate)
             onNavToMsgListRequested: navigate => root.navToMsgListRequested(navigate)
+            onSupportBotChatRequested: () => {
+                root.supportBotChatRequested()
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Chat/panels/EmptyChatPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/EmptyChatPanel.qml
@@ -11,6 +11,7 @@ ColumnLayout {
     id: root
 
     signal shareChatKeyClicked()
+    signal supportBotChatRequested()
 
     spacing: 0
 
@@ -38,8 +39,10 @@ ColumnLayout {
 
         Layout.fillWidth: true
 
-        text: qsTr("%1 to connect with or<br>invite your friends to Status.")
+        text: qsTr("%1 to connect with or<br>invite your friends to Status.<br><br><br>%2<br>for welcome messages, how-to tips, or just to share feedback or issues.")
           .arg(Utils.getStyledLink(qsTr("Share your profile"), "#share", hoveredLink,
+                Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
+          .arg(Utils.getStyledLink(qsTr("Chat with the Status Team peer-to-peer bot"), "#supportBot", hoveredLink,
                 Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
 
         horizontalAlignment: Text.AlignHCenter
@@ -54,6 +57,8 @@ ColumnLayout {
         onLinkActivated: link => {
             if (link === "#share")
                 root.shareChatKeyClicked()
+            else if (link === "#supportBot")
+                root.supportBotChatRequested()
         }
 
         HoverHandler {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -101,6 +101,8 @@ Item {
     // Community access related requests:
     signal spectateCommunityRequested(string communityId)
 
+    signal supportBotChatRequested()
+
     // This function is called once `1:1` or `group` chat is created.
     function checkForCreateChatOptions(chatId) {
         if (root.createChatPropertiesStore.createChatStickerHashId !== ""
@@ -439,6 +441,7 @@ Item {
         anchors.fill: parent
         visible: root.activeChatId === "" || root.chatsCount == 0
         onShareChatKeyClicked: Global.shareProfileDialogRequested(userProfile.pubKey)
+        onSupportBotChatRequested: root.supportBotChatRequested()
     }
 
     // This is kind of a solution for applying backend refactored changes with the minimal qml changes.

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -230,6 +230,7 @@ Item {
     signal showUsersListRequested(bool show)
     signal navToMsgDetailsRequested(bool navigate)
     signal navToMsgListRequested(bool navigate)
+    signal supportBotChatRequested()
 
     Connections {
         target: root.rootStore.stickersStore.stickersModule
@@ -538,6 +539,10 @@ Item {
             // Community access related requests:
             onSpectateCommunityRequested: (communityId) => {
                 root.spectateCommunityRequested(communityId)
+            }
+
+            onSupportBotChatRequested: () => {
+                root.supportBotChatRequested()
             }
         }
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1141,6 +1141,21 @@ Item {
                 Global.openNavigationEducationPopupRequested()
             }
         }
+
+        function goToSupportChatBot() {
+            if (!d.supportBotPublicKey) {
+                console.warn("Unable to resolve the Status support bot chat key")
+                return
+            }
+            if (d.supportBotConversationAvailable) {
+                appMain.contactsStore.joinPrivateChat(d.supportBotPublicKey)
+                return
+            }
+            const introMessage = localAccountSettings.freshProfile
+                ? qsTr("Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime")
+                : qsTr("Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime")
+            Global.openContactRequestPopupWithDefaultMessage(d.supportBotPublicKey, null, introMessage)
+        }
     }
 
     Settings {
@@ -2305,6 +2320,9 @@ Item {
                         leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 
                         onOpenAppSearchRequested: appSearch.openSearchPopup()
+                        onSupportBotChatRequested: () => {
+                            d.goToSupportChatBot()
+                        }
                     }
 
                     CommunitiesPortalLoader {
@@ -2495,6 +2513,9 @@ Item {
                             leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 
                             onOpenAppSearchRequested: appSearch.openSearchPopup()
+                            onSupportBotChatRequested: () => {
+                                d.goToSupportChatBot()
+                            }
                         }
                     }
                 }
@@ -2680,18 +2701,7 @@ Item {
                 onSettingsRequested: d.openSettingsRoot()
 
                 onSupportBotChatRequested: {
-                    if (!d.supportBotPublicKey) {
-                        console.warn("Unable to resolve the Status support bot chat key")
-                        return
-                    }
-                    if (d.supportBotConversationAvailable) {
-                        appMain.contactsStore.joinPrivateChat(d.supportBotPublicKey)
-                        return
-                    }
-                    const introMessage = localAccountSettings.freshProfile
-                        ? qsTr("Send a contact request to the Status Team peer-to-peer bot over the decentralised network for welcome messages and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime")
-                        : qsTr("Send a contact request to the Status Team peer-to-peer bot over the decentralised network for Status updates and how-to tips, and to share feedback or issues. See our Privacy Policy for more details about interacting with the bot. Disconnect anytime")
-                    Global.openContactRequestPopupWithDefaultMessage(d.supportBotPublicKey, null, introMessage)
+                    d.goToSupportChatBot()
                 }
 
                 onItemActivated: function(sectionType, sectionId) {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -136,31 +136,27 @@ QtObject {
 
     property var activePopupComponents: []
 
-    property var sharedContactModelEntryLoader: Loader {
-        property string publicKey: ""
-
-        active: false
-
-        sourceComponent: ContactModelEntry {
-            publicKey: sharedContactModelEntryLoader.publicKey
-            contactsModel: root.allContactsModel
-            onPopulateContactDetailsRequested: {
-                root.contactsStore.populateContactDetails(sharedContactModelEntryLoader.publicKey)
-            }
-        }
+    readonly property Component contactModelEntryComponent: ContactModelEntry {
+        contactsModel: root.allContactsModel
+        onPopulateContactDetailsRequested: root.contactsStore.populateContactDetails(publicKey)
     }
 
-    function getContactModelEntry(pubkey) {
-        sharedContactModelEntryLoader.active = false
-        sharedContactModelEntryLoader.publicKey = pubkey
-        sharedContactModelEntryLoader.active = true
-        return sharedContactModelEntryLoader.item
+    // Each popup gets its own live ContactModelEntry
+    function openContactPopup(popupComponent, publicKey, params = {}, cb = null) {
+        const contactEntry = contactModelEntryComponent.createObject(root, { publicKey })
+        const popup = openPopup(popupComponent, Object.assign({ publicKey, contactDetails: contactEntry.contactDetails }, params), cb)
+        if (!popup) {
+            contactEntry.destroy()
+            return null
+        }
+        popup.closed.connect(() => contactEntry.destroy())
+        return popup
     }
 
     property var currentPopup
     function openPopup(popupComponent, params = {}, cb = null) {
         if (root.activePopupComponents.includes(popupComponent)) {
-            return
+            return null
         }
 
         root.currentPopup = popupComponent.createObject(popupParent, params)
@@ -176,6 +172,7 @@ QtObject {
                 root.activePopupComponents.splice(removeIndex, 1)
             }
         })
+        return root.currentPopup
     }
 
     function closePopup() {
@@ -202,35 +199,23 @@ QtObject {
     }
 
     function openProfilePopup(publicKey: string, parentPopup, cb) {
-        openPopup(profilePopupComponent, {publicKey: publicKey, parentPopup: parentPopup}, cb)
+        openContactPopup(profilePopupComponent, publicKey, { parentPopup }, cb)
     }
 
     function openNicknamePopup(publicKey: string, cb) {
-        const contactEntry = getContactModelEntry(publicKey)
-        const properties = { publicKey, contactDetails: contactEntry.contactDetails }
-
-        openPopup(nicknamePopupComponent, properties, cb)
+        openContactPopup(nicknamePopupComponent, publicKey, {}, cb)
     }
 
     function openMarkAsUntrustedPopup(publicKey: string) {
-        const contactEntry = getContactModelEntry(publicKey)
-        const properties = { publicKey, contactDetails: contactEntry.contactDetails }
-
-        openPopup(markAsUntrustedComponent, properties)
+        openContactPopup(markAsUntrustedComponent, publicKey, {})
     }
 
     function openBlockContactPopup(publicKey: string) {
-        const contactEntry = getContactModelEntry(publicKey)
-        const properties = { publicKey, contactDetails: contactEntry.contactDetails }
-
-        openPopup(blockContactConfirmationComponent, properties)
+        openContactPopup(blockContactConfirmationComponent, publicKey, {})
     }
 
     function openUnblockContactPopup(publicKey: string) {
-        const contactEntry = getContactModelEntry(publicKey)
-        const properties = { publicKey, contactDetails: contactEntry.contactDetails }
-
-        openPopup(unblockContactConfirmationComponent, properties)
+        openContactPopup(unblockContactConfirmationComponent, publicKey, {})
     }
 
     function openChangeProfilePicPopup(cb) {
@@ -321,17 +306,11 @@ QtObject {
     }
 
     function openMarkAsIDVerifiedPopup(publicKey, cb) {
-        const contactEntry = getContactModelEntry(publicKey)
-        const properties = { publicKey, contactDetails: contactEntry.contactDetails }
-
-        openPopup(markAsIDVerifiedPopupComponent, properties, cb)
+        openContactPopup(markAsIDVerifiedPopupComponent, publicKey, {}, cb)
     }
 
     function openRemoveIDVerificationDialog(publicKey, cb) {
-        const contactEntry = getContactModelEntry(publicKey)
-        const properties = { publicKey, contactDetails: contactEntry.contactDetails }
-
-        openPopup(removeIDVerificationPopupComponent, properties, cb)
+        openContactPopup(removeIDVerificationPopupComponent, publicKey, {}, cb)
     }
 
     function openInviteFriendsToCommunityPopup(community, communitySectionModule, cb) {
@@ -358,14 +337,7 @@ QtObject {
     }
 
     function openContactRequestPopup(publicKey, cb, defaultMessage = "") {
-        const contactEntry = getContactModelEntry(publicKey)
-        const properties = {
-            publicKey,
-            contactDetails: contactEntry.contactDetails,
-            defaultMessage: defaultMessage || ""
-        }
-
-        openPopup(sendContactRequestPopupComponent, properties, cb)
+        openContactPopup(sendContactRequestPopupComponent, publicKey, { defaultMessage: defaultMessage || "" }, cb)
     }
 
     function openReviewContactRequestPopup(publicKey, cb) {
@@ -376,10 +348,7 @@ QtObject {
                 return
             }
 
-            const contactEntry = getContactModelEntry(publicKey)
-            const properties = { publicKey, contactDetails: contactEntry.contactDetails, crDetails }
-
-            openPopup(reviewContactRequestPopupComponent, properties, cb)
+            openContactPopup(reviewContactRequestPopupComponent, publicKey, { crDetails }, cb)
         } catch (e) {
             console.error("Popups.openReviewContactRequestPopup: error getting or parsing contact request data", e)
         }
@@ -443,10 +412,7 @@ QtObject {
     }
 
     function openRemoveContactConfirmationPopup(publicKey) {
-        const contactEntry = getContactModelEntry(publicKey)
-        const properties = { publicKey, contactDetails: contactEntry.contactDetails }
-
-        openPopup(removeContactConfirmationDialog, properties)
+        openContactPopup(removeContactConfirmationDialog, publicKey, {})
     }
 
     function openDeleteMessagePopup(messageId, messageStore) {
@@ -577,13 +543,14 @@ QtObject {
     }
 
     function openShareProfilePopup(publicKey) {
-        const contactEntry = getContactModelEntry(publicKey)
+        const contactEntry = contactModelEntryComponent.createObject(root, { publicKey })
         const contactDetails = contactEntry.contactDetails
         const emojiHash = root.utilsStore.getEmojiHash(publicKey)
         const linkToProfile = root.contactsStore.getLinkToProfile(publicKey)
 
         openPopup(shareProfileCmp, {isCurrentUser: contactDetails.isCurrentUser, publicKey, emojiHash, colorId: contactDetails.colorId,
                       linkToProfile, displayName: contactDetails.displayName, usesDefaultName: contactDetails.usesDefaultName, largeImage: contactDetails.largeImage})
+        contactEntry.destroy()
     }
 
     function openNavigationEducationPopup() {
@@ -851,11 +818,6 @@ QtObject {
 
                 property string publicKey
                 readonly property bool isCurrentUser: contactDetails.isCurrentUser
-
-                contactDetails: {
-                    const contactEntry = getContactModelEntry(profilePopup.publicKey)
-                    return contactEntry.contactDetails
-                }
 
                 profileStore: root.profileStore
                 contactsStore: root.contactsStore

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -56,6 +56,8 @@ Loader {
     // Bridges the chat profile button to the global app-section navigation.
     signal openAppSearchRequested()
 
+    signal supportBotChatRequested()
+
     // Back-navigation contract for AppMain's back chain. The chrome is
     // interactive while the section item still incubates, so the loader must
     // answer for it during that phase; once loaded, the item leads.
@@ -332,6 +334,9 @@ Loader {
         }
         function onNavToMsgListRequested(navigate) {
             root.rootStore.setNavToMsgListFlag(navigate)
+        }
+        function onSupportBotChatRequested() {
+            root.supportBotChatRequested()
         }
     }
 }

--- a/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
@@ -60,6 +60,7 @@ Loader {
     property real leftPanelWidthOverride: 0
 
     signal openAppSearchRequested()
+    signal supportBotChatRequested()
 
     // Back-navigation contract for AppMain's back chain. The chrome is
     // interactive while the section item still incubates, so the loader must
@@ -420,6 +421,9 @@ Loader {
         }
         function onNavToMsgDetailsRequested(navigate) {
             root.rootStore.setNavToMsgDetailsFlag(navigate)
+        }
+        function onSupportBotChatRequested() {
+            root.supportBotChatRequested()
         }
     }
 }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6917,11 +6917,15 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EmptyChatPanel</name>
     <message>
+        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.&lt;br&gt;&lt;br&gt;&lt;br&gt;%2&lt;br&gt;for welcome messages, how-to tips, or just to share feedback or issues.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share your profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.</source>
+        <source>Chat with the Status Team peer-to-peer bot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6958,12 +6958,16 @@ Keycard bude vyžadována pro podepisování</translation>
 <context>
     <name>EmptyChatPanel</name>
     <message>
+        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.&lt;br&gt;&lt;br&gt;&lt;br&gt;%2&lt;br&gt;for welcome messages, how-to tips, or just to share feedback or issues.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share your profile</source>
         <translation>Sdílejte svůj profil</translation>
     </message>
     <message>
-        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.</source>
-        <translation>%1 pro spojení s&lt;br&gt;nebo pozvání přátel do Statusu.</translation>
+        <source>Chat with the Status Team peer-to-peer bot</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -6928,11 +6928,15 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EmptyChatPanel</name>
     <message>
+        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.&lt;br&gt;&lt;br&gt;&lt;br&gt;%2&lt;br&gt;for welcome messages, how-to tips, or just to share feedback or issues.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share your profile</source>
         <translation type="unfinished">Comparte tu perfil</translation>
     </message>
     <message>
-        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.</source>
+        <source>Chat with the Status Team peer-to-peer bot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -6927,12 +6927,16 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EmptyChatPanel</name>
     <message>
+        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.&lt;br&gt;&lt;br&gt;&lt;br&gt;%2&lt;br&gt;for welcome messages, how-to tips, or just to share feedback or issues.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share your profile</source>
         <translation>Partagez votre profil</translation>
     </message>
     <message>
-        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.</source>
-        <translation>%1 pour vous connecter ou&lt;br/&gt;inviter vos amis à rejoindre Status.</translation>
+        <source>Chat with the Status Team peer-to-peer bot</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6899,11 +6899,15 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EmptyChatPanel</name>
     <message>
+        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.&lt;br&gt;&lt;br&gt;&lt;br&gt;%2&lt;br&gt;for welcome messages, how-to tips, or just to share feedback or issues.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share your profile</source>
         <translation type="unfinished">프로필 공유하기</translation>
     </message>
     <message>
-        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.</source>
+        <source>Chat with the Status Team peer-to-peer bot</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -6957,12 +6957,16 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EmptyChatPanel</name>
     <message>
+        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.&lt;br&gt;&lt;br&gt;&lt;br&gt;%2&lt;br&gt;for welcome messages, how-to tips, or just to share feedback or issues.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share your profile</source>
         <translation>Поділитися профілем</translation>
     </message>
     <message>
-        <source>%1 to connect with or&lt;br&gt;invite your friends to Status.</source>
-        <translation>%1, щоб зв’язатися з друзями або&lt;br&gt;запросити їх до Status.</translation>
+        <source>Chat with the Status Team peer-to-peer bot</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/imports/shared/popups/CommonContactDialog.qml
+++ b/ui/imports/shared/popups/CommonContactDialog.qml
@@ -14,13 +14,15 @@ import shared.controls.chat
 import shared.stores
 import utils
 
+import AppLayouts.Profile.helpers
+
 StatusDialog {
     id: root
 
     required property UtilsStore utilsStore
 
     required property string publicKey
-    required property var contactDetails
+    required property ContactDetails contactDetails
     property bool loadingContactDetails
 
     default property alias content: contentLayout.children

--- a/ui/imports/shared/popups/ProfileDialog.qml
+++ b/ui/imports/shared/popups/ProfileDialog.qml
@@ -6,12 +6,15 @@ import StatusQ.Popups.Dialog
 import shared.views
 import shared.controls
 
+import AppLayouts.Profile.helpers
+
 StatusDialog {
     id: root
 
     property var parentPopup
 
-    property alias contactDetails: profileView.contactDetails
+    // Not an alias: required-via-alias isn't credited when set through createObject initial properties
+    required property ContactDetails contactDetails
 
     property alias profileStore: profileView.profileStore
     property alias contactsStore: profileView.contactsStore
@@ -62,6 +65,8 @@ StatusDialog {
 
     contentItem: ProfileDialogView {
         id: profileView
+
+        contactDetails: root.contactDetails
 
         onCloseRequested: root.close()
         onNavigationRequested: root.navigationRequested()

--- a/ui/imports/shared/popups/SendContactRequestModal.qml
+++ b/ui/imports/shared/popups/SendContactRequestModal.qml
@@ -9,7 +9,6 @@ import StatusQ.Core.Theme
 import StatusQ.Controls
 import StatusQ.Controls.Validators
 import StatusQ.Popups.Dialog
-import StatusQ.Core.Utils as SQUtils
 
 import AppLayouts.stores as AppLayoutStores
 
@@ -54,9 +53,6 @@ CommonContactDialog {
         function onContactInfoRequestFinished(publicKey, ok) {
             if (publicKey !== root.publicKey) {
                 return
-            }
-            if (ok) {
-                root.contactDetails = SQUtils.ModelUtils.getByKey(root.contactsStore.contactsModel, "pubKey", root.publicKey)
             }
             root.loadingContactDetails = false
         }


### PR DESCRIPTION

### What does the PR do

Closes #22342

- empty chat view gets a copy update with a hyperlink to open the contact request or the bot chat
- fix contact details object lifetime in Popups.qml and avoid overriding it with imperative model lookups (fixing an issue where the contact name would go to "undefined" after initial fetch)
- bump status-go to include a fix where the bot contact request is not sent automatically for new users

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/49c46a67-9334-481d-8ff2-dd4e1f7b530a


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

