### PR TITLE
fix(StatusEmojiPopup): Too small emojis on iOS

### DIFF
--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -255,6 +255,8 @@ StatusDropdown {
                 width: emojiGrid.cellWidth
                 height: emojiGrid.cellHeight
                 padding: d.imageMargin
+                leftPadding: d.imageMargin
+                rightPadding: d.imageMargin
                 highlighted: emojiGrid.activeFocus && index === emojiGrid.currentIndex
                 background: Rectangle {
                     radius: Theme.radius


### PR DESCRIPTION
Closes #22308

### What does the PR do

Fixes emoji picker cell sizing on iOS by explicitly setting the `ItemDelegate` horizontal padding for emoji cells.

Emoji cells already define an intended `44px` cell with a `32px` emoji and `6px` margin. The iOS Qt Quick Controls `ItemDelegate` style provides its own horizontal padding defaults, so the emoji content could be laid out with less horizontal space and appear too small.

### Affected areas

- Chat
- Emoji picker

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

No documentation update needed.

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="428" height="893" alt="Screenshot 2026-09-08 at 15 44 19" src="https://github.com/user-attachments/assets/111f1cec-de80-46d0-a5b5-dc1e7767f48d" />


### Impact on end user

Users on iOS see emoji picker entries at the expected size, making emojis easier to scan and select.

### How to test

1. Open Status on iOS.
2. Open any chat.
3. Open the emoji picker from the message input.
4. Verify emojis in the picker grid are rendered at the expected size.
5. Select an emoji and verify it is inserted correctly.

### Risk

Low.

The change is limited to `StatusEmojiPopup` delegate padding. Worst case: emoji cell horizontal spacing changes slightly in the picker. No backend, persistence, or message-sending logic is affected.