### PR TITLE
ci: run the PR gate on one phone plus a peer

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -246,6 +246,7 @@ pipeline {
                     GIT_REF:      env.BRANCH_NAME,
                     BUILD_SOURCE: urls['Android/arm64'],
                     PYTEST_ARGS:  '-n=2 -m smoke tests',
+                    BACKEND_PEER: false,
                   ]),
                 )
               } }

--- a/ci/Jenkinsfile.test-e2e.android
+++ b/ci/Jenkinsfile.test-e2e.android
@@ -46,12 +46,12 @@ pipeline {
     booleanParam(
       name: 'BACKEND_PEER',
       description: 'Provide the headless status-backend the messaging tests pair a phone with.',
-      defaultValue: params.BACKEND_PEER ?: false
+      defaultValue: true
     )
     string(
       name: 'PYTEST_ARGS',
-      description: 'Pytest flags. Default runs gate tests for PRs. Use "-n=2 -m smoke tests" for nightly/full runs.',
-      defaultValue: '-n=2 -m gate tests'
+      description: 'Pytest flags. Default runs the PR gate on one phone plus a peer. Use "-n=2 -m smoke tests" for nightly/full runs.',
+      defaultValue: '-n=5 -m "(gate and not two_phone) or backend_peer" tests'
     )
   }
 
@@ -109,6 +109,9 @@ pipeline {
           script: "./test/e2e_appium/scripts/peer_image.sh '${env.STATUS_BACKEND_DOCKER_PROJECT}'",
           returnStdout: true
         ).trim()
+        if (!env.STATUS_BACKEND_IMAGE) {
+          error('Peer image stage produced no image')
+        }
       } } }
     }
 
@@ -165,6 +168,11 @@ pipeline {
 
     stage('Run pytest suite') {
       steps{
+        script {
+          if (params.PYTEST_ARGS?.contains('backend_peer') && !env.STATUS_BACKEND_IMAGE) {
+            error('PYTEST_ARGS selects peer tests but no peer image was built. Set BACKEND_PEER.')
+          }
+        }
         lock(resource: 'e2e-android') {
           script {
             env.E2E_RUN_ID = env.BUILD_TAG

--- a/test/e2e_appium/config/environments/browserstack.yaml
+++ b/test/e2e_appium/config/environments/browserstack.yaml
@@ -114,10 +114,10 @@ execution:
     enabled: true
     poll_interval: 20
     timeout: 180
-    parallel_buffer: 1
+    parallel_buffer: 0
     queue_buffer: 1
   pytest:
-    addopts: ["-n", "2"]
+    addopts: ["-n", "5"]
 
 logging:
   level: "INFO"


### PR DESCRIPTION
Turns on the peer lane that #22349 provisions. Until both land, nothing selects the peer tests and #22349 changes nothing at runtime.

## What changed

The PR job swaps the ten two-phone messaging tests for the sixteen that run on one phone plus a headless peer, and goes from two workers to five. `-m "(gate and not two_phone) or backend_peer"` collects 54, and none of them needs more than one device, so five sessions fit the plan's five. The nightly is untouched: it keeps the two-phone originals at `-m smoke`, `-n=2`, and passes `BACKEND_PEER: false` so it builds no image.

- `BACKEND_PEER` now defaults to true. PR builds are triggered with no parameters, so with the old default the image stage never ran on a PR.
- `parallel_buffer: 1` starved the fifth worker whenever the BrowserStack plan API was unreachable. It computes `5 - 4 - 1 = 0`, then polls until it times out. Measured against the reserver: 4 of 5 workers reserve at 1, 5 of 5 at 0. On a healthy plan the buffer makes no difference either way.
- Two guards against a green run that tested half the gate. With no image the suite deselects the peer tests and exits 0. The image stage now fails if it built nothing, and the run refuses to start if `PYTEST_ARGS` selects peer tests and no image was built.

## How to verify

No PR check exercises this file. The Android e2e job is started from `Jenkinsfile.combined` only when the job name contains `nightly`, so green checks here say nothing about the change.

If the `tests-e2e` job loads its pipeline from `GIT_REF` rather than from the branch it is configured on, it can be run against this branch before merge. Please say which it is and I will run it.

Otherwise, after merge:

1. Trigger `tests-e2e` with no parameters. Expect a Peer image stage that echoes `statusgo-peer-<12 hex>`, then `5 workers [54 items]`, and no `Deselected N test(s) that need a status-backend peer` in the log.
2. Trigger it again on the same agent. The image stage should print `already on this agent` and take seconds, because the tag is the vendored status-go commit.
3. Trigger it once with `BACKEND_PEER` unchecked. It must fail straight away with `PYTEST_ARGS selects peer tests but no peer image was built`. This costs no device time.
4. The next nightly should show no Peer image stage, and 32 tests at `-n=2`.

## Risks

- Five sessions is the whole plan, so a competing job on the same BrowserStack account will queue this one.
- The peer set has run at `-n=5` on BrowserStack from a fork, never through Jenkins. Step 1 is the first Jenkins run.

Merge after #22349.
