### PR TITLE
test(e2e): migrate the local e2e fleet to a logos-delivery image

### DIFF
--- a/docker-compose.waku.yml
+++ b/docker-compose.waku.yml
@@ -1,12 +1,12 @@
 services:
   boot-1:
-    image: wakuorg/nwaku:v0.38.1
+    image: harbor.status.im/wakuorg/nwaku:v0.39.0-rc.2
     ports:
       - "39001"
       - "8645"
       - "49000/udp"
     entrypoint: [
-      "/usr/bin/wakunode",
+      "/usr/local/bin/logosdeliverynode",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=49000",
@@ -43,19 +43,21 @@ services:
       retries: 10
 
   store:
-    image: wakuorg/nwaku:v0.38.1
+    image: harbor.status.im/wakuorg/nwaku:v0.39.0-rc.2
     ports:
       - "39002"
       - "8646"
       - "49001/udp"
     entrypoint: [
-      "/usr/bin/wakunode",
+      "/usr/local/bin/logosdeliverynode",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=49001",
       "--cluster-id=16",
       "--num-shards-in-network=0",
       "--dns-addrs-name-server=127.0.0.11",
+      "--filter=false",
+      "--lightpush=false",
       "--log-level=INFO",
       "--max-connections=18000",
       "--max-msg-size=1024KiB",
@@ -86,19 +88,21 @@ services:
       retries: 10
 
   store-2:
-    image: wakuorg/nwaku:v0.38.1
+    image: harbor.status.im/wakuorg/nwaku:v0.39.0-rc.2
     ports:
       - "39003"
       - "8647"
       - "49002/udp"
     entrypoint: [
-      "/usr/bin/wakunode",
+      "/usr/local/bin/logosdeliverynode",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=49002",
       "--cluster-id=16",
       "--num-shards-in-network=0",
       "--dns-addrs-name-server=127.0.0.11",
+      "--filter=false",
+      "--lightpush=false",
       "--log-level=INFO",
       "--max-connections=18000",
       "--max-msg-size=1024KiB",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -271,7 +271,7 @@ Per-run screenshots and data: `local_run_results/run_<date>/`.
 
 ## Local Waku fleet (optional)
 
-Run against a local **nwaku** stack instead of `status.prod`. Works on **Linux, Windows, and macOS** — same env vars and compose file everywhere.
+Run against a local **logos-delivery** stack instead of `status.prod`. Works on **Linux, Windows, and macOS** — same env vars and compose file everywhere.
 
 **Prerequisites:** Docker installed and running (`docker ps` must work). On Mac/Windows use [Docker Desktop](https://www.docker.com/products/docker-desktop/) and wait until it is fully started before running compose.
 


### PR DESCRIPTION
Mirrors status-im/status-go#7799, which does the same migration for the `tests-functional` fleet.

### What does the PR do

1. Swaps `boot-1`, `store` and `store-2` from `wakuorg/nwaku:v0.38.1` to `harbor.status.im/wakuorg/nwaku:v0.39.0-rc.2`.
2. Points the entrypoints at `/usr/local/bin/logosdeliverynode` rather than the `/usr/bin/wakunode` compat symlink the image still ships.
3. Pins `--filter=false --lightpush=false` on both store nodes. Both default to true in `logosdeliverynode` where they defaulted to false in `wakunode2`, so without this the store nodes silently start serving filter and lightpush as well as store.
4. Renames the one `nwaku` reference in `test/e2e/README.md` to logos-delivery.

### Affected areas

The local e2e Waku fleet (`docker-compose.waku.yml`), used by `ci/Jenkinsfile.tests-e2e`, `ci/Jenkinsfile.tests-e2e.windows` and the `E2E_LOCAL_WAKU_FLEET=1` local flow. No production fleet or app code is touched.

### Quality checklist

- [x] I have updated the necessary documentation if needed

### Impact on end user

None. Test infrastructure only.

### How to test

```bash
docker compose -f ./docker-compose.waku.yml up --build --remove-orphans
python3 test/e2e/scripts/scan_waku_fleet.py --project <compose-project>
E2E_LOCAL_WAKU_FLEET=1 pytest -m critical   # from test/e2e
```

### Risk

Low. The node configuration is otherwise unchanged (cluster 16, static sharding, shards 1/32/64/128/256) and the CLI surface is compatible: comparing `wakunode2` v0.38.1 against `logosdeliverynode` v0.39.0-rc.2, the only removed option is `--reliability`, which this fleet does not use.

The one behavioural difference found is the filter/lightpush default flip addressed in point 3.

<details>
<summary>AI-made decisions</summary>

- Chose to preserve the v0.38.1 service split (boot-1 serves filter/lightpush, the store nodes serve store) rather than adopt the new defaults, so the migration is behaviour-preserving. Drop the four pinned lines if the fleet is meant to serve filter/lightpush from all three nodes.
- Did not pass `--entry-layer`. logos-messaging/logos-delivery#4076 made `kernel` the default, which is the transport-only layer this fleet wants.
- Did not use the `status.prod` preset. It appends its entry nodes to the node's static-node and DNS-discovery lists and no flag removes them, so the fleet would dial the real `boot-01.*.status.prod.status.im` nodes and bootstrap into the Status production network.
- The `wget`-based healthchecks keep working: the new image is still Alpine and still ships `wget`.
- Watch item, not introduced here: on one cold start `store-2` lost the race to dial `boot-1` (compose starts `boot-1` last), reported `CannotConnect`, and only joined after the peer manager's 120s backoff expired; the healthchecks pass immediately regardless, so CI would not wait for it. Not reproduced in 3/3 repeat runs, which meshed in ~5s, same as v0.38.1.

</details>
