### PR TITLE
fix(dapps): WalletConnect pairing fixes and diagnostics

### DIFF
--- a/src/app_service/service/accounts/dto/create_account_request.nim
+++ b/src/app_service/service/accounts/dto/create_account_request.nim
@@ -29,6 +29,7 @@ type
 
     logLevel*: Option[string]
     logFilePath*: string
+    walletConnectProjectID*: string
     logEnabled*: bool
 
     previewPrivacy*: bool
@@ -68,6 +69,7 @@ proc toJson*(self: CreateAccountRequest): JsonNode =
     "wakuV2Fleet": self.wakuV2Fleet,
     "wakuV2LightClient": self.wakuV2LightClient,
     "logFilePath": self.logFilePath,
+    "walletConnectProjectID": self.walletConnectProjectID,
     "logEnabled": self.logEnabled,
     "previewPrivacy": self.previewPrivacy,
     "autoRefreshTokensEnabled": self.autoRefreshTokensEnabled,

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -213,6 +213,7 @@ QtObject:
         walletSecretsConfig: buildWalletSecrets(),
         walletConfig: buildWalletConfig(),
         apiConfig: defaultApiConfig(),
+        walletConnectProjectID: main_constants.WALLET_CONNECT_PROJECT_ID,
       )
 
   proc buildCreateAccountRequest(password: string, displayName: string, imagePath: string,

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
@@ -271,11 +271,13 @@ SQUtils.QObject {
         }
     }
 
-    // Timeout for the corner case where the URL was already dismissed and the SDK doesn't respond with an error nor advances with the proposal
+    // Timeout for the corner case where the URL was already dismissed and the SDK doesn't respond with an error nor advances with the proposal.
+    // Covers both the pair RPC and the wait for the dApp's session proposal to
+    // travel through the relay, so it has to tolerate a slow network.
     Timer {
         id: timeoutTimer
 
-        interval: 10000 // (10 seconds)
+        interval: 30000 // (30 seconds)
         running: false
         repeat: false
 


### PR DESCRIPTION
Test build for https://github.com/status-im/status-app/issues/22365

- Raises the pairing timeout from 10s to 30s. The timer covers the pair RPC
  and then the wait for the dApp's session proposal over the relay; 10s was
  tight enough that a slow network showed "Unexpected error occurred" while
  the pairing was still in flight.
- Bumps status-go to status-im/status-go#ab/issue-22365-wc-pairing: clock-skew
  backdate, dismissed-proposal fix, handshake diagnostics.

status-go https://github.com/status-im/status-go/pull/7811


https://github.com/user-attachments/assets/ad7ee148-22e8-4671-87cd-2dda6a0f70c8


