### PR TITLE
LoginView: native context menu in password input on iOS

### DIFF
--- a/storybook/pages/LoginPasswordInputPage.qml
+++ b/storybook/pages/LoginPasswordInputPage.qml
@@ -1,0 +1,86 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Storybook
+
+import AppLayouts.Onboarding.controls
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        ColumnLayout {
+            SplitView.fillHeight: true
+            SplitView.fillWidth: true
+
+            LoginPasswordInput {
+                Layout.alignment: Qt.AlignCenter
+                Layout.margins: 16
+
+                enabled: enabledCheckBox.checked
+                hasError: hasErrorCheckBox.checked
+                placeholderText: placeholderInput.text
+
+                isBiometricsLogin: biometricsLoginCheckBox.checked
+                biometricsSuccessful: biometricsSuccessfulCheckBox.checked
+                biometricsFailed: biometricsFailedCheckBox.checked
+
+                onBiometricsRequested: logs.logEvent("onBiometricsRequested")
+                onTextEdited: logs.logEvent("onTextEdited", ["text"], [text])
+                onAccepted: logs.logEvent("onAccepted", ["text"], [text])
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 200
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            TextField {
+                id: placeholderInput
+                text: "Password"
+            }
+            CheckBox {
+                id: enabledCheckBox
+                text: "enabled"
+                checked: true
+            }
+            CheckBox {
+                id: hasErrorCheckBox
+                text: "hasError"
+            }
+            CheckBox {
+                id: biometricsLoginCheckBox
+                text: "isBiometricsLogin"
+            }
+            CheckBox {
+                id: biometricsSuccessfulCheckBox
+                text: "biometricsSuccessful"
+                enabled: biometricsLoginCheckBox.checked
+            }
+            CheckBox {
+                id: biometricsFailedCheckBox
+                text: "biometricsFailed"
+                enabled: biometricsLoginCheckBox.checked
+            }
+        }
+    }
+}
+
+// category: Onboarding

--- a/ui/StatusQ/src/StatusQ/Controls/StatusPasswordInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusPasswordInput.qml
@@ -40,6 +40,7 @@ StatusTextField {
     implicitHeight: 44
 
     echoMode: TextInput.Password
+    inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
 
     background: Rectangle {
         color: Theme.palette.baseColor2

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Universal
 
 import StatusQ.Components
 import StatusQ.Core
@@ -33,8 +32,8 @@ TextField {
     HoverHandler {
         id: hoverHandler
         enabled: root.enabled
-        // Build the edit context menu on first hover (see contextMenuLoader).
-        onHoveredChanged: if (hovered && !Utils.isAndroid) contextMenuLoader.active = true
+        // Build the edit context menu on first hover.
+        onHoveredChanged: if (hovered && !Utils.isMobile) contextMenuLoader.active = true
     }
 
     background: Rectangle {
@@ -73,12 +72,10 @@ TextField {
     // dominant instantiation cost (a full StatusMenu with materialised items),
     // paid even when the field is never interacted with — and on Android it is not
     // even attached (Android uses the OS-native text menu). So build it lazily on
-    // first interaction, never on Android. The menu is null until then; a right-click
-    // cannot happen before the triggering hover/focus, so the menu is always present
-    // by the time it opens.
-    // iOS must keep it: an attached ContextMenu with a null menu eats the event,
-    // and Qt shows the UIKit callout only when that event goes unaccepted.
-    onActiveFocusChanged: if (activeFocus && !Utils.isAndroid) contextMenuLoader.active = true
+    // first interaction, never on Android nor iOS. The menu is null until then;
+    // a right-click cannot happen before the triggering hover/focus, so the menu is
+    // always present by the time it opens.
+    onActiveFocusChanged: if (activeFocus && !Utils.isMobile) contextMenuLoader.active = true
 
     Loader {
         id: contextMenuLoader
@@ -87,19 +84,17 @@ TextField {
         sourceComponent: StatusTextEditMenu {
             canCut: !root.readOnly && !root.noSelection
             canCopy: !root.noSelection
-            // Never read TextInput.canPaste on iOS: it reads UIPasteboard and
-            // triggers the "Allow Paste?" prompt. The menu is only built there so
-            // the context-menu event goes unaccepted and UIKit shows its own
-            // callout - this value is never displayed.
-            canPaste: !root.readOnly && (Utils.isIOS || root.canPaste)
+            canPaste: !root.readOnly && root.canPaste
             canSelectAll: root.length > 0
 
             onCutRequested: root.cut()
             onCopyRequested: root.copy()
             onPasteRequested: root.paste()
             onSelectAllRequested: root.selectAll()
+
+            // Top-level binding ContextMenu.menu: contextMenuLoader.item would
+            // assign null (suppressing native menu) if custom menu is not created.
+            Component.onCompleted: root.ContextMenu.menu = this
         }
     }
-
-    ContextMenu.menu: contextMenuLoader.item
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -20,7 +20,11 @@ TextField {
     selectByMouse: true
     selectedTextColor: Theme.palette.directColor1
     selectionColor: Theme.palette.primaryColor2
-    placeholderTextColor: Theme.palette.baseColor1
+
+    // The placeholder is rendered by a custom overlay (see below) instead of
+    // the active QtQuick Controls style, so it looks the same on every platform.
+    // Keep the native placeholder invisible so the two don't compete.
+    placeholderTextColor: StatusColors.transparent
     verticalAlignment: Text.AlignVCenter
     opacity: enabled ? 1 : ThemeUtils.disabledOpacity
 
@@ -53,6 +57,31 @@ TextField {
 
     cursorDelegate: StatusCursorDelegate {
         cursorVisible: root.cursorVisible
+    }
+
+    // Style-independent placeholder overlay. Rendering the placeholder ourselves
+    // avoids relying on the active QtQuick Controls style, whose default differs
+    // per platform. Pinpointing to single style is not possible because it
+    // blocks native context menu on iOS.
+    StatusBaseText {
+        id: placeholder
+
+        x: root.leftPadding
+        y: root.topPadding
+        width: root.width - root.leftPadding - root.rightPadding
+        // Constrain to the editable area and clip/elide so long placeholders
+        // never overflow the input's boundaries.
+        height: root.height - root.topPadding - root.bottomPadding
+        clip: true
+
+        visible: root.length === 0 && root.preeditText === ""
+        text: root.placeholderText
+        textFormat: Text.PlainText
+        color: root.enabled ? Theme.palette.baseColor1 : Theme.palette.directColor9
+        font: root.font
+        horizontalAlignment: root.horizontalAlignment
+        verticalAlignment: root.verticalAlignment
+        elide: Text.ElideRight
     }
 
     // selectedText is not notified correctly when selection is cleared on Android.

--- a/ui/app/AppLayouts/Onboarding/components/LoginPasswordBox.qml
+++ b/ui/app/AppLayouts/Onboarding/components/LoginPasswordBox.qml
@@ -5,7 +5,7 @@ import QtQml.Models
 
 import StatusQ
 import StatusQ.Core
-import StatusQ.Core.Utils
+import StatusQ.Core.Utils as SQUtils
 import StatusQ.Controls
 import StatusQ.Core.Theme
 import StatusQ.Popups.Dialog
@@ -68,6 +68,20 @@ Control {
             onTextEdited: root.passwordEditedManually()
             onBiometricsRequested: root.biometricsRequested()
             onAccepted: root.loginRequested(text)
+
+            // Workaround preventing showing context menu on first tap invoking
+            // virtual keyboard on iOS
+            ContextMenu.onRequested: {
+                if (!SQUtils.Utils.isIOS || InputMethod.visible)
+                    return
+
+                const menu = ContextMenu.menu
+                ContextMenu.menu = null
+
+                Qt.callLater(() => {
+                    ContextMenu.menu = menu
+                })
+            }
         }
         StatusBaseText {
             Layout.fillWidth: true
@@ -133,7 +147,7 @@ Control {
                             let textToCopy = ""
                             for (let i = 0; i < instructionsColumn.children.length; i++) {
                                 if (instructionsColumn.children[i].text)
-                                    textToCopy += StringUtils.plainText(instructionsColumn.children[i].text) + "\n"
+                                    textToCopy += SQUtils.StringUtils.plainText(instructionsColumn.children[i].text) + "\n"
                             }
 
                             ClipboardUtils.setText(textToCopy)

--- a/ui/app/AppLayouts/Onboarding/controls/LoginPasswordInput.qml
+++ b/ui/app/AppLayouts/Onboarding/controls/LoginPasswordInput.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import StatusQ.Core
 import StatusQ.Controls
 import StatusQ.Core.Theme
+import StatusQ.Core.Utils as SQUtils
 
 StatusPasswordInput {
     id: root
@@ -22,6 +23,17 @@ StatusPasswordInput {
     QtObject {
         id: d
         property bool showPassword
+        property bool revealInteraction
+    }
+
+    // workaround to not show ctx menu when switching visibility on iOS
+    ContextMenu.onRequested: {
+        if (!SQUtils.Utils.isIOS || !d.revealInteraction)
+            return
+
+        const menu = root.ContextMenu.menu
+        root.ContextMenu.menu = null
+        Qt.callLater(() => root.ContextMenu.menu = menu)
     }
 
     RowLayout {
@@ -38,13 +50,25 @@ StatusPasswordInput {
             color: hhandler.hovered ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
             HoverHandler {
                 id: hhandler
+                acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
                 cursorShape: hovered ? Qt.PointingHandCursor : undefined
             }
+
             TapHandler {
-                onSingleTapped: d.showPassword = !d.showPassword
+                margin: parent.width * 0.3
+
+                onPressedChanged: {
+                    if (pressed)
+                        d.revealInteraction = true
+                    else
+                        Qt.callLater(() => d.revealInteraction = false)
+                }
+
+                onTapped: d.showPassword = !d.showPassword
+
             }
             StatusToolTip {
-                text: d.showPassword ? qsTr("Hide password") : qsTr("Reveal password")
+                text: hhandler.hovered && d.showPassword ? qsTr("Hide password") : qsTr("Reveal password")
                 visible: hhandler.hovered
             }
         }


### PR DESCRIPTION
### What does the PR do

Enables the native context menu on iOS text fields and fixes the follow-on issues in the login password input. No more jumpy keyboard, ctx menu appearing on hide/show button and other details polished.

- StatusTextField: native ctx menu on iOS — build the custom QML edit menu on desktop only; iOS/Android use the native OS menu. Avoids assigning a null menu that would suppress the native one.
- StatusTextField: style-independent placeholder — render the placeholder via a custom overlay (as done for StatusTextArea) so it positions correctly on Android under the default style.
- StatusPasswordInput: proper input method hints set - suggestions suppressed, no first capital letter
- LoginPasswordBox: suppress ctx menu on first tap — the tap that only raises the keyboard no longer opens the iOS menu.
- LoginPasswordInput: no ctx menu when toggling visibility (iOS) — the native menu is a platform event not possible to mask by qml component, so it's suppressed via a press-time flag set before the request fires.
- LoginPasswordInput: fix of a tooltip polish warning
- LoginPasswordInput: Storybook page added.

Closes: #22318 

### Affected areas
`StatusTextField`, `StatusPasswordInput`, `LoginPasswordBox`
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality


https://github.com/user-attachments/assets/f112833b-a13d-438f-99c1-954d127bf314



### Impact on end user

Much better behavior on iOS, no impact on other platforms

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

iOS: Interact with password input on login page

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

### Risk 

Low
