### PR TITLE
feat(swap): support for the search tokens by contract address

### DIFF
--- a/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
@@ -471,7 +471,19 @@ QtObject:
     self.setIsLoadingMore(false)
     self.hasMoreItemsChanged()
 
-  proc getSearchRelevance(item: TokenGroupItem, keywordLower: string): int =
+  proc addressSearchNeedle(keywordLower: string): string =
+    var needle = keywordLower
+    let prefixed = needle.startsWith("0x")
+    if prefixed:
+      needle = needle[2 .. ^1]
+    if needle.len == 0 or (not prefixed and needle.len < 4): # at least 4 characters are required for a valid address
+      return ""
+    for c in needle:
+      if c notin HexDigits:
+        return ""
+    needle
+
+  proc getTextSearchRelevance(item: TokenGroupItem, keywordLower: string): int =
     if keywordLower.len == 0:
       return 0
 
@@ -504,16 +516,44 @@ QtObject:
 
     return -1
 
+  proc addressSearchMatch(item: TokenGroupItem,
+      addrNeedle: string): tuple[relevance: int, tokens: seq[TokenItem]] =
+    result.relevance = -1
+    if addrNeedle.len == 0:
+      return
+    for token in item.tokens:
+      var address = token.address.toLowerAscii()
+      if address.startsWith("0x"):
+        address = address[2 .. ^1]
+      var score = -1
+      if address == addrNeedle:
+        score = 100  # a full address is an exact identity
+      elif address.startsWith(addrNeedle):
+        score = 80
+      elif address.find(addrNeedle) > 0:
+        score = 55
+      if score >= 0:
+        result.tokens.add(token)
+        result.relevance = max(result.relevance, score)
+
   proc search*(self: TokenGroupsModel, keyword: string) {.slot.} =
     self.searchKeyword = keyword.strip()
     self.fullSearchResults = @[]
     if self.searchKeyword.len > 0:
       let keywordLower = self.searchKeyword.toLowerAscii()
+      let addrNeedle = addressSearchNeedle(keywordLower)
       var scoredResults: seq[(int, int, TokenGroupItem)] = @[]
       for index, item in self.delegate.getAllTokenGroups():
-        let relevance = getSearchRelevance(item, keywordLower)
-        if relevance >= 0:
-          scoredResults.add((relevance, index, item))
+        let textRelevance = getTextSearchRelevance(item, keywordLower)
+        let (addrRelevance, addrTokens) = addressSearchMatch(item, addrNeedle)
+        let relevance = max(textRelevance, addrRelevance)
+        if relevance < 0:
+          continue
+        var resultItem = item
+        if textRelevance < 0 and addrTokens.len < item.tokens.len:
+          resultItem = TokenGroupItem(key: item.key, name: item.name, symbol: item.symbol, decimals: item.decimals,
+            logoUri: item.logoUri, tokens: addrTokens)
+        scoredResults.add((relevance, index, resultItem))
 
       scoredResults.sort(proc(a, b: (int, int, TokenGroupItem)): int =
         if a[0] > b[0]:

--- a/src/app/modules/shared_models/token_selector_builder.nim
+++ b/src/app/modules/shared_models/token_selector_builder.nim
@@ -103,7 +103,8 @@ type
     AllTokens  ## swap/buy: base list = the popular list merged with owned balances
 
 proc mergePopularWithOwned*(popular: seq[PopularGroup],
-    owned: seq[TokenSelectorItem], showCommunityAssets: bool): seq[TokenSelectorItem] =
+    owned: seq[TokenSelectorItem], showCommunityAssets: bool,
+    widenTokenRefsFromOwned = true): seq[TokenSelectorItem] =
   ## The all-tokens / search path (showAllTokens): the row set follows the
   ## popular list (all-tokens page or backend search result); a popular token the
   ## user owns is enriched with its owned balance data (chips / currentBalance /
@@ -132,12 +133,22 @@ proc mergePopularWithOwned*(popular: seq[PopularGroup],
       item.decimals = o.decimals
       item.marketPrice = o.marketPrice
       # The "All" filter splits a multi-chain holding into one row per chain, so we need to merge the owned refs in
-      # so every per-chain row can resolve its contract address.
-      var chains = item.tokens.mapIt(it.chainId).toHashSet
-      for t in o.tokens:
-        if t.chainId notin chains:
-          item.tokens.add(TokenSelectorTokenRef(key: t.key, chainId: t.chainId))
-          chains.incl(t.chainId)
+      if widenTokenRefsFromOwned:
+        var chains = item.tokens.mapIt(it.chainId).toHashSet
+        for t in o.tokens:
+          if t.chainId notin chains:
+            item.tokens.add(TokenSelectorTokenRef(key: t.key, chainId: t.chainId))
+            chains.incl(t.chainId)
+      elif item.tokens.len > 0:
+        let refChains = item.tokens.mapIt(it.chainId).toHashSet
+        if item.chips.anyIt(it.chainId notin refChains):
+          item.chips = item.chips.filterIt(it.chainId in refChains)
+          var total = 0.0
+          for chip in item.chips:
+            total += chip.balance
+          item.currentBalance = total
+          item.currencyBalance = total * item.marketPrice
+          item.hasBalance = total != 0.0
     result.add(item)
 
 proc filterToEnabledChains(items: seq[TokenSelectorItem],
@@ -167,11 +178,12 @@ proc buildDisplayItems*(
   let owned = buildTokenSelectorItems(ownedGroups, networks, params)
   if searchActive:
     let merged = filterToEnabledChains(
-      mergePopularWithOwned(searchGroups, owned, params.showCommunityAssets),
-      params.enabledChainIds)
+      mergePopularWithOwned(searchGroups, owned, params.showCommunityAssets, widenTokenRefsFromOwned = false),
+      params.enabledChainIds
+    )
     if mode == TokenSelectorMode.Owned:
       let ownedKeys = owned.mapIt(it.key).toHashSet
-      return merged.filterIt(it.key in ownedKeys)
+      return merged.filterIt(it.key in ownedKeys and it.chips.len > 0)
     return merged
   if mode == TokenSelectorMode.AllTokens:
     return filterToEnabledChains(

--- a/storybook/qmlTests/tests/tst_AssetSelector.qml
+++ b/storybook/qmlTests/tests/tst_AssetSelector.qml
@@ -199,6 +199,110 @@ Item {
             compare(button.icon, Constants.tokenIcon("DAI"))
         }
 
+        // Clicking the other panel's token from an unscoped list must resolve
+        // to another of its chains — never the blocked chain-address pair.
+        function test_selectionSkipsTheNonInteractiveChain() {
+            // fresh model: the fixture's has no `tokens` role, and a ListModel's
+            // role set is frozen by its first append
+            const data = createTemporaryQmlObject("import QtQml.Models; ListModel {}", root)
+            data.append({
+                key: "usdc_key", communityId: "", name: "USD Coin",
+                currencyBalance: 0, symbol: "USDC",
+                logoUri: Constants.tokenIcon("USDC"),
+                balances: [],
+                tokens: [ { chainId: 1, key: "1-0xaaa" }, { chainId: 10, key: "10-0xbbb" } ],
+                sectionName: "Popular assets"
+            })
+
+            const selector = createTemporaryObject(selectorCmp, root)
+            selector.model = data
+            selector.nonInteractiveKey = "usdc_key"
+            selector.nonInteractiveChainId = 1
+            waitForRendering(selector)
+
+            mouseClick(selector)
+            const listView = findChild(selector.Overlay.overlay, "assetsListView")
+            verify(listView)
+            waitForRendering(listView)
+
+            const usdc = listView.itemAtIndex(0)
+            verify(usdc)
+            verify(usdc.rowAt(0).enabled)
+
+            usdc.selectFirst()
+            compare(selector.selectedSpy.count, 1)
+            compare(selector.selectedSpy.signalArguments[0][0], "usdc_key")
+            compare(selector.selectedSpy.signalArguments[0][1], 10)
+        }
+
+        // Even if a selection slips past the row's disabled state (keyboard
+        // paths, stale model), the selector must not commit the blocked pair —
+        // nor an unresolved chain that a later adoption could land on it.
+        function test_finalGuardBlocksTheNonInteractivePair() {
+            const data = createTemporaryQmlObject("import QtQml.Models; ListModel {}", root)
+            data.append({
+                key: "only1_key", communityId: "", name: "OnlyOne",
+                currencyBalance: 0, symbol: "ONE", logoUri: "",
+                balances: [],
+                tokens: [ { chainId: 1, key: "1-0xccc" } ],
+                sectionName: "Popular assets"
+            })
+
+            const selector = createTemporaryObject(selectorCmp, root)
+            selector.model = data
+            selector.nonInteractiveKey = "only1_key"
+            selector.nonInteractiveChainId = 1
+            waitForRendering(selector)
+
+            mouseClick(selector) // open the dropdown
+            const panel = findChild(selector.Overlay.overlay, "searchableAssetsPanel")
+            verify(panel)
+
+            // bypass the delegate and emit straight from the panel: the only
+            // deployment is the blocked chain, so nothing may be committed
+            panel.selected("only1_key", -1)
+            compare(selector.selectedSpy.count, 0)
+            compare(selector.isSelected, false)
+            verify(!!findChild(selector.Overlay.overlay, "searchableAssetsPanel"),
+                   "the dropdown stays open instead of closing on a refused pick")
+
+            panel.selected("only1_key", 1) // the blocked pair, explicitly
+            compare(selector.selectedSpy.count, 0)
+            compare(selector.isSelected, false)
+        }
+
+        // With the -1 wildcard the token is excluded on every chain: even a
+        // selection arriving with a CONCRETE chain must be refused.
+        function test_finalGuardBlocksWildcardExclusionOnAnyChain() {
+            const data = createTemporaryQmlObject("import QtQml.Models; ListModel {}", root)
+            data.append({
+                key: "usdc_key", communityId: "", name: "USD Coin",
+                currencyBalance: 0, symbol: "USDC",
+                logoUri: Constants.tokenIcon("USDC"),
+                balances: [],
+                tokens: [ { chainId: 1, key: "1-0xaaa" }, { chainId: 10, key: "10-0xbbb" } ],
+                sectionName: "Popular assets"
+            })
+
+            const selector = createTemporaryObject(selectorCmp, root)
+            selector.model = data
+            selector.nonInteractiveKey = "usdc_key"
+            selector.nonInteractiveChainId = -1
+            waitForRendering(selector)
+
+            mouseClick(selector) // open the dropdown
+            const panel = findChild(selector.Overlay.overlay, "searchableAssetsPanel")
+            verify(panel)
+
+            panel.selected("usdc_key", 1)  // concrete chain under the wildcard
+            compare(selector.selectedSpy.count, 0)
+            compare(selector.isSelected, false)
+
+            panel.selected("usdc_key", -1) // unresolved chain
+            compare(selector.selectedSpy.count, 0)
+            compare(selector.isSelected, false)
+        }
+
         function test_searchNotPersistent() {
             const selector = createTemporaryObject(selectorCmp, root)
             const button = selector.contentItem

--- a/storybook/qmlTests/tests/tst_SearchableAssetsPanel.qml
+++ b/storybook/qmlTests/tests/tst_SearchableAssetsPanel.qml
@@ -405,6 +405,120 @@ Item {
             compare(sttBridge.rowAt(0).enabled, true)
         }
 
+        // On "All" (no chain filter) the other side's token collapses into one
+        // aggregate row; it must stay selectable when the token also lives on
+        // other chains — only a token locked to the excluded chain (or excluded
+        // everywhere via -1) is blocked.
+        function test_nonInteractiveAggregateRowSelectableOnAnotherChain() {
+            const networks = createTemporaryQmlObject("import QtQml.Models; ListModel {}", root)
+            networks.append(networksData)
+
+            // fresh source: the fixture's model has no `tokens` role, and a
+            // ListModel's role set is frozen by its first append
+            const data = createTemporaryQmlObject("import QtQml.Models; ListModel {}", root)
+            data.append({
+                key: "usdc_key", communityId: "", name: "USD Coin",
+                currencyBalance: 0, symbol: "USDC", logoUri: Constants.tokenIcon("USDC"),
+                balances: [],
+                tokens: [ { chainId: 1, key: "1-0xaaa" }, { chainId: 10, key: "10-0xbbb" } ],
+                sectionName: "Popular assets"
+            })
+            data.append({
+                key: "only1_key", communityId: "", name: "OnlyOne",
+                currencyBalance: 0, symbol: "ONE", logoUri: "",
+                balances: [],
+                tokens: [ { chainId: 1, key: "1-0xccc" } ],
+                sectionName: "Popular assets"
+            })
+
+            const control = createTemporaryObject(panelCmp, root, { networksModel: networks })
+            control.sourceModel = data
+            control.panel.nonInteractiveKey = "usdc_key"
+            control.panel.nonInteractiveChainId = 1
+
+            const listView = findChild(control, "assetsListView")
+            waitForRendering(listView)
+            compare(listView.count, 2)
+
+            const usdc = listView.itemAtIndex(0)
+            verify(usdc)
+            compare(usdc.rowCount, 1)          // no balances -> one aggregate row
+            compare(usdc.rowAt(0).enabled, true)   // chain 10 is a legal pick
+
+            control.panel.nonInteractiveKey = "only1_key"
+            const only1 = listView.itemAtIndex(1)
+            verify(only1)
+            compare(only1.rowAt(0).enabled, false) // no other chain to pick
+            compare(usdc.rowAt(0).enabled, true)   // no longer the excluded key
+
+            // -1 still excludes the holding on every chain
+            control.panel.nonInteractiveKey = "usdc_key"
+            control.panel.nonInteractiveChainId = -1
+            compare(usdc.rowAt(0).enabled, false)
+        }
+
+        // nonInteractiveChainId === -1 excludes the holding on EVERY chain —
+        // the per-chain split rows of a multi-chain holding included.
+        function test_wildcardExclusionDisablesEveryPerChainRow() {
+            const networks = createTemporaryQmlObject("import QtQml.Models; ListModel {}", root)
+            networks.append(networksData)
+
+            const control = createTemporaryObject(panelCmp, root, { networksModel: networks })
+            control.panel.nonInteractiveKey = "stt_key"
+            control.panel.nonInteractiveChainId = -1
+
+            const listView = findChild(control, "assetsListView")
+            waitForRendering(listView)
+
+            // STT sits on 3 chains -> 3 concrete rows, all of them blocked
+            const stt = listView.itemAtIndex(0)
+            verify(stt)
+            compare(stt.rowCount, 3)
+            for (let i = 0; i < stt.rowCount; i++)
+                compare(stt.rowAt(i).enabled, false)
+
+            mouseClick(stt.rowAt(1))
+            compare(control.panel.selectedSpy.count, 0)
+
+            // other holdings stay unaffected
+            compare(listView.itemAtIndex(1).rowAt(0).enabled, true)
+        }
+
+        // Enter must be as strict as the mouse: a result available only on the
+        // excluded chain is not selectable by keyboard either.
+        function test_keyboardSelectionRespectsDisabledRows() {
+            const data = createTemporaryQmlObject("import QtQml.Models; ListModel {}", root)
+            data.append({
+                key: "only1_key", communityId: "", name: "OnlyOne",
+                currencyBalance: 0, symbol: "ONE", logoUri: "",
+                balances: [],
+                tokens: [ { chainId: 1, key: "1-0xccc" } ],
+                sectionName: "Popular assets"
+            })
+
+            const control = createTemporaryObject(panelCmp, root)
+            control.sourceModel = data
+            control.panel.nonInteractiveKey = "only1_key"
+            control.panel.nonInteractiveChainId = 1
+
+            const listView = findChild(control, "assetsListView")
+            const searchBox = findChild(control, "searchBox")
+            control.searchKeyword = "one"
+            searchBox.text = "one"
+            waitForRendering(listView)
+            compare(listView.count, 1)
+            verify(!listView.itemAtIndex(0).rowAt(0).enabled)
+
+            // the Enter/Return handlers funnel through selectFirst()
+            listView.itemAtIndex(0).selectFirst()
+            compare(control.panel.selectedSpy.count, 0)
+
+            // once unblocked, the same path selects it
+            control.panel.nonInteractiveKey = ""
+            listView.itemAtIndex(0).selectFirst()
+            compare(control.panel.selectedSpy.count, 1)
+        }
+
         function test_singleRowWhenChainFilterSet() {
             const networks = createTemporaryQmlObject("import QtQml.Models; ListModel {}", root)
             networks.append(networksData)

--- a/test/nim/token_groups_model_test.nim
+++ b/test/nim/token_groups_model_test.nim
@@ -5,7 +5,7 @@
 ## insert+remove+reorder; reorder read-back (remove+insert, no moves) + no reset;
 ## stable-set refresh emits no reset / no move / no spurious churn.
 
-import unittest, tables, sequtils
+import unittest, tables, sequtils, strutils
 import nimqml
 
 import app/modules/main/wallet_section/all_tokens/token_groups_model
@@ -370,3 +370,97 @@ suite "token_groups_model - lazy pagination with pinned rows":
     check not m.hasMoreItemsForSource()        # everything is loaded already
     m.fetchMore()                              # must be a clean no-op
     check m.getLoadedGroups().len == 11
+
+suite "token_groups_model - search by contract address":
+
+  # Cross-chain group: the group key ("usd-coin") does NOT embed the contract
+  # address, so these only pass when the search matches the per-token
+  # address fields, not just key/name/symbol.
+  const usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" # mixed case on purpose
+  # the group's chain-10 deployment: a DIFFERENT contract under the same group
+  const usdcOptimismAddress = "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+
+  proc mkGroupAt(key, address, name, symbol: string): TokenGroupItem =
+    let tok = createTokenItem(TokenDto(
+      chainId: 1, address: address, crossChainId: key,
+      name: name, symbol: symbol, decimals: 18))
+    TokenGroupItem(key: key, name: name, symbol: symbol,
+      decimals: 18, logoUri: "", tokens: @[tok])
+
+  proc withDeployment(group: TokenGroupItem, chainId: int,
+      address: string): TokenGroupItem =
+    group.tokens.add(createTokenItem(TokenDto(
+      chainId: chainId, address: address, crossChainId: group.key,
+      name: group.name, symbol: group.symbol, decimals: 18)))
+    group
+
+  proc newSearchModel(): TokenGroupsModel =
+    gGroups = @[
+      mkGroupAt("usd-coin", usdcAddress, "USD Coin", "USDC")
+        .withDeployment(10, usdcOptimismAddress),
+      mkGroupAt("dai", "0x6B175474E89094C44Da98b954EedeAC495271d0F", "Dai", "DAI"),
+    ]
+    newTokenGroupsModel(groupsDataSource(), marketValuesDataSource(),
+      modelModes = @[ModelMode.NoMarketDetails, ModelMode.UseLazyLoading, ModelMode.IsSearchResult],
+      lazyLoadingBatchSize = 10, lazyLoadingInitialCount = 10)
+
+  proc resultKeys(m: TokenGroupsModel): seq[string] =
+    m.getLoadedGroups().mapIt(it.key)
+
+  test "a full address matches regardless of case and 0x prefix":
+    let m = newSearchModel()
+    m.search(usdcAddress)                          # as pasted (mixed case)
+    check m.resultKeys() == @["usd-coin"]
+    m.search(usdcAddress.toUpperAscii())           # 0X + uppercase
+    check m.resultKeys() == @["usd-coin"]
+    m.search(usdcAddress[2 .. ^1].toLowerAscii())  # no prefix, lowercase
+    check m.resultKeys() == @["usd-coin"]
+
+  test "a partial address matches, prefixed or bare":
+    let m = newSearchModel()
+    m.search("0xa0b86991")     # address prefix, 0x kept
+    check m.resultKeys() == @["usd-coin"]
+    m.search("eb0ce36")        # a slice from the middle, no 0x
+    check m.resultKeys() == @["usd-coin"]
+    m.search("0xa0b")          # explicit 0x allows even a short needle
+    check m.resultKeys() == @["usd-coin"]
+
+  test "short or non-hex keywords never match through the address":
+    let m = newSearchModel()
+    m.search("a0b")            # 3 bare hex digits: too ambiguous
+    check m.resultKeys().len == 0
+    m.search("0xnothex")
+    check m.resultKeys().len == 0
+
+  test "an address hit doesn't shadow ordinary text matches":
+    let m = newSearchModel()
+    m.search("dai")            # plain symbol/name search still works
+    check m.resultKeys() == @["dai"]
+
+  test "an address match narrows the result to the matched deployment":
+    # the usd-coin group holds DIFFERENT contracts on chain 1 and chain 10 —
+    # a searched address identifies one deployment, not the whole group,
+    # so a chain-scoped consumer can never resolve it to the other contract
+    let m = newSearchModel()
+    m.search(usdcAddress)
+    check m.resultKeys() == @["usd-coin"]
+    var tokens = m.getLoadedGroups()[0].tokens
+    check tokens.len == 1
+    check tokens[0].chainId == 1
+    check tokens[0].address == usdcAddress
+
+    m.search(usdcOptimismAddress)
+    check m.resultKeys() == @["usd-coin"]
+    tokens = m.getLoadedGroups()[0].tokens
+    check tokens.len == 1
+    check tokens[0].chainId == 10
+    check tokens[0].address == usdcOptimismAddress
+
+    # and the narrowing never touches the catalog's own group
+    check gGroups[0].tokens.len == 2
+
+  test "a text match keeps every deployment of the group":
+    let m = newSearchModel()
+    m.search("usd coin")
+    check m.resultKeys() == @["usd-coin"]
+    check m.getLoadedGroups()[0].tokens.len == 2

--- a/test/nim/token_selector_builder_test.nim
+++ b/test/nim/token_selector_builder_test.nim
@@ -292,6 +292,28 @@ suite "buildDisplayItems — path selection":
       searchGroups = @[popular("SNT"), popular("DAI")])
     check searched.mapIt(it.key) == @["SNT"]        # still visible; DAI unowned -> dropped
 
+  test "Owned mode + address-narrowed search requires deployment-level ownership":
+    # The account owns the group ONLY on chain 10; the searched contract
+    # address matched the chain-1 deployment (the search narrowed the row's
+    # refs to it). Group-level ownership must not resurrect the row — send
+    # would offer a deployment the account doesn't own.
+    let ownedOn10 = @[group("USDC", price = 1.0,
+      balances = @[bal("0xA", 10, "1000000000000000000")])]
+    var narrowed = popular("USDC")
+    narrowed.tokens = @[(key: "1-0xaaa", chainId: 1)]
+    let items = buildDisplayItems(ownedOn10, networks, noFilterParams(),
+      TokenSelectorMode.Owned, searchActive = true, popularGroups = @[],
+      searchGroups = @[narrowed])
+    check items.len == 0
+
+    # the un-narrowed row (full refs incl. chain 10) is owned there -> kept
+    var full = popular("USDC")
+    full.tokens = @[(key: "1-0xaaa", chainId: 1), (key: "10-0xbbb", chainId: 10)]
+    let items2 = buildDisplayItems(ownedOn10, networks, noFilterParams(),
+      TokenSelectorMode.Owned, searchActive = true, popularGroups = @[],
+      searchGroups = @[full])
+    check items2.mapIt(it.key) == @["USDC"]
+
   test "AllTokens mode + search: results shown even when not owned":
     let items = buildDisplayItems(ownedGroups, networks, noFilterParams(),
       TokenSelectorMode.AllTokens, searchActive = true, popularGroups = @[],

--- a/test/nim/token_selector_model_test.nim
+++ b/test/nim/token_selector_model_test.nim
@@ -343,6 +343,38 @@ suite "TokenSelectorModel - producer-driven recompute":
     m.setEnabledChainId(-1)
     check m.keysInOrder() == @["1-0xaehron", "bsc-native"]
 
+  test "an address-narrowed search row stays scoped to the matched chain":
+    # The backend search narrowed the group to the chain-1 deployment the
+    # searched contract address matched. The user also owns the group on
+    # chain 10 (a DIFFERENT contract) — that must not re-widen the row: under
+    # a chain-10 filter the row is hidden, never resolved to the other
+    # contract.
+    let m = newTokenSelectorModel(TokenSelectorMode.AllTokens)
+    var source: TokenSelectorSource
+    source.getSearch = proc(): seq[PopularGroup] =
+      @[PopularGroup(key: "usd-coin", name: "USD Coin", symbol: "USDC",
+                     tokens: @[(key: "1-0xa0b8", chainId: 1)])]
+    m.setSource(source)
+    m.setOwnedSource(@[
+      AggTokenGroup(key: "usd-coin", name: "USD Coin", symbol: "USDC",
+        decimals: 18,
+        balances: @[AggBalance(account: "0xA", chainId: 1,
+                               balance: parse("1000000000000000000", UInt256)),
+                    AggBalance(account: "0xA", chainId: 10,
+                               balance: parse("2000000000000000000", UInt256))],
+        tokens: @[(key: "1-0xa0b8", chainId: 1), (key: "10-0x0b2c", chainId: 10)])
+    ], networks)
+    m.search("0xa0b8")
+    # "All" (no filter): the row lists ONLY the matched deployment — the owned
+    # balance on the other chain must not expand it back onto chain 10
+    check m.keysInOrder() == @["usd-coin"]
+    check m.balancesModelForKey("usd-coin").chainIdsInOrder() == @[1]
+    check m.tokensModelForKey("usd-coin").rowCount(nil) == 1
+    m.setEnabledChainId(1)   # the matched deployment's chain: shown
+    check m.keysInOrder() == @["usd-coin"]
+    m.setEnabledChainId(10)  # merely owned there: hidden
+    check m.keysInOrder().len == 0
+
   test "an active chain filter scopes the popular catalog to tokens on that chain":
     let m = newTokenSelectorModel(TokenSelectorMode.AllTokens)
     var source: TokenSelectorSource

--- a/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
@@ -134,21 +134,38 @@ Control {
                     return
                 }
 
+                const excludedChainId = entry.key === root.nonInteractiveKey
+                                      ? root.nonInteractiveChainId : -1
+
                 let resolvedChainId = chainId
                 if (resolvedChainId === -1) {
                     const refs = entry.tokens ?? entry.balances
-                    if (!!refs && refs.ModelCount.count > 0) {
-                        if (root.selectedChainId !== -1 && ModelUtils.contains(refs, "chainId", root.selectedChainId))
+                    const refsCount = !!refs ? refs.ModelCount.count : 0
+                    if (refsCount > 0) {
+                        if (root.selectedChainId !== -1
+                                && root.selectedChainId !== excludedChainId
+                                && ModelUtils.contains(refs, "chainId", root.selectedChainId)) {
                             resolvedChainId = root.selectedChainId
-                        else {
-                            const firstChain = ModelUtils.get(refs, 0, "chainId")
-                            if (firstChain !== undefined)
-                                resolvedChainId = firstChain
+                        } else {
+                            for (let i = 0; i < refsCount; i++) {
+                                const refChain = ModelUtils.get(refs, i, "chainId")
+                                if (refChain !== undefined && refChain !== excludedChainId) {
+                                    resolvedChainId = refChain
+                                    break
+                                }
+                            }
                         }
-                    } else if (root.selectedChainId !== -1) {
+                    } else if (root.selectedChainId !== -1
+                               && root.selectedChainId !== excludedChainId) {
                         resolvedChainId = root.selectedChainId
                     }
                 }
+
+                if (entry.key === root.nonInteractiveKey
+                        && (root.nonInteractiveChainId === -1
+                            || resolvedChainId === -1
+                            || resolvedChainId === root.nonInteractiveChainId))
+                    return
 
                 setCurrentAndClose(entry.symbol, entry.logoUri || Constants.tokenIcon(entry.symbol), entry.key)
                 root.selected(entry.key, resolvedChainId)

--- a/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
@@ -245,7 +245,13 @@ Control {
                 }
 
                 function selectFirst() {
-                    rowsRepeater.itemAt(0).clicked()
+                    for (let i = 0; i < rowsRepeater.count; i++) {
+                        const row = rowsRepeater.itemAt(i)
+                        if (!!row && row.enabled) {
+                            row.clicked()
+                            return
+                        }
+                    }
                 }
 
                 Repeater {
@@ -254,6 +260,8 @@ Control {
                     model: holdingRows.chainRows
 
                     delegate: TokenSelectorAssetDelegate {
+                        id: assetDelegate
+
                         required property var modelData
                         required property int index
 
@@ -267,9 +275,24 @@ Control {
                                      && (rowChainId === -1 || rowChainId === root.highlightedChainId)
                         readonly property int effectiveChainId: rowChainId !== -1 ? rowChainId
                                                                                   : root.selectedChainId
+                        readonly property bool selectableOnAnotherChain: {
+                            assetDelegate.tokensTracker.revision
+                            assetDelegate.balancesTracker.revision
+                            const refs = holding.tokens ?? holding.balances
+                            if (!refs)
+                                return false
+                            const refsCount = refs.ModelCount.count
+                            for (let i = 0; i < refsCount; i++)
+                                if (ModelUtils.get(refs, i, "chainId") !== root.nonInteractiveChainId)
+                                    return true
+                            return false
+                        }
                         enabled: holding.key !== root.nonInteractiveKey
-                                 || (effectiveChainId !== -1
-                                     && effectiveChainId !== root.nonInteractiveChainId)
+                                 || (root.nonInteractiveChainId !== -1
+                                     && ((effectiveChainId !== -1
+                                          && effectiveChainId !== root.nonInteractiveChainId)
+                                         || (effectiveChainId === -1
+                                             && selectableOnAnotherChain)))
                         isAutoHovered: d.validSearchResultExists && holdingRows.index === 0
                                        && index === 0 && !listViewHoverHandler.hovered
 


### PR DESCRIPTION
The search now scans all tokens per chain for token address (including full or partial, case-insensitive, "0x" optional) match.

Closes #22372 

https://github.com/user-attachments/assets/8b6145d3-336b-463d-beae-4606015270d8

