### PR TITLE
fix(chat): keep the bridge author's name and avatar on contact updates

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -2,7 +2,7 @@ import nimqml, chronicles, sequtils, uuids, sets, times, tables, system
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller
-import ../../../../shared_models/[message_model, message_item, contacts_utils]
+import ../../../../shared_models/[message_model, message_item]
 import ../../../../shared_models/link_preview_model
 import ../../../../../global/global_singleton
 import ../../../../../core/eventemitter
@@ -435,13 +435,7 @@ method updateContactDetails*(self: Module, contactId: string) =
 
   for item in self.view.model().modelContactUpdateIterator(contactId):
     if item.senderId == contactId:
-      item.senderDisplayName = updatedContact.defaultDisplayName
-      item.senderUsesDefaultName = resolveUsesDefaultName(updatedContact.dto.localNickname, updatedContact.dto.name, updatedContact.dto.displayName)
-      item.senderOptionalName = updatedContact.optionalName
-      item.senderIcon = updatedContact.icon
-      item.senderIsAdded = updatedContact.dto.added
-      item.senderTrustStatus = updatedContact.dto.trustStatus
-      item.senderEnsVerified = updatedContact.dto.ensVerified
+      item.updateSenderDetails(updatedContact)
 
     if item.quotedMessageAuthorDetails.dto.id == contactId:
       item.quotedMessageAuthorDetails = updatedContact

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -322,11 +322,7 @@ method onContactDetailsUpdated*(self: Module, contactId: string) =
   let updatedContact = self.controller.getContactDetails(contactId)
   for item in self.view.pinnedModel().modelContactUpdateIterator(contactId):
     if item.senderId == contactId:
-      item.senderDisplayName = updatedContact.defaultDisplayName
-      item.senderOptionalName = updatedContact.optionalName
-      item.senderEnsVerified = updatedContact.dto.ensVerified
-      item.senderIcon = updatedContact.icon
-      item.senderTrustStatus = updatedContact.dto.trustStatus
+      item.updateSenderDetails(updatedContact)
 
     if item.quotedMessageAuthorDetails.dto.id == contactId:
       item.quotedMessageAuthorDetails = updatedContact

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -10,7 +10,7 @@ import ./link_preview_model as link_preview_model
 import ./payment_request_model as payment_request_model
 
 export types.ContentType
-import message_reaction_model, message_transaction_parameters_item
+import message_reaction_model, message_transaction_parameters_item, contacts_utils
 
 type
   Item* = ref object
@@ -217,6 +217,8 @@ proc initMessageItem*(
     result.senderId = discordMessage.author.id
     result.senderDisplayName = discordMessage.author.name
     result.senderIcon = discordMessage.author.localUrl
+    result.senderOptionalName = ""
+    result.senderUsesDefaultName = false
     result.timestamp = parseInt(discordMessage.timestamp)*1000
 
     if result.senderIcon == "":
@@ -234,6 +236,8 @@ proc initMessageItem*(
     result.unparsedText = bridgeMessage.content
     result.senderDisplayName = bridgeMessage.userName
     result.senderIcon = bridgeMessage.userAvatar
+    result.senderOptionalName = ""
+    result.senderUsesDefaultName = false
     result.bridgeName = bridgeMessage.bridgeName
 
   if senderId == "":
@@ -401,6 +405,24 @@ proc senderEnsVerified*(self: Item): bool {.inline.} =
 
 proc `senderEnsVerified=`*(self: Item, value: bool) {.inline.} =
   self.senderEnsVerified = value
+
+proc isBridged*(self: Item): bool {.inline.} =
+  self.contentType == ContentType.BridgeMessage or self.contentType == ContentType.DiscordMessage
+
+# Applies a contact update to the message sender. A bridged message was authored
+# outside Status, so the identity its header renders -- display name, secondary
+# name and avatar -- is the external author's and survives the update. The
+# remaining fields describe the Status account that relayed the message and are
+# kept in sync.
+proc updateSenderDetails*(self: Item, contact: ContactDetails) =
+  if not self.isBridged:
+    self.senderDisplayName = contact.defaultDisplayName
+    self.senderOptionalName = contact.optionalName
+    self.senderUsesDefaultName = resolveUsesDefaultName(contact.dto.localNickname, contact.dto.name, contact.dto.displayName)
+    self.senderIcon = contact.icon
+  self.senderIsAdded = contact.dto.added
+  self.senderTrustStatus = contact.dto.trustStatus
+  self.senderEnsVerified = contact.dto.ensVerified
 
 proc outgoingStatus*(self: Item): string {.inline.} =
   self.outgoingStatus

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -452,3 +452,124 @@ suite "media server port refresh":
     model.updateMediaServerPort(40000)
 
     check(model.items[0].messageImage == newBase & "/messages/images?messageId=0x1")
+
+# A bridged message (contentType 18) is authored outside Status: the name and
+# the avatar on it belong to the external author, not to the Status account
+# that relayed it. A contact update for that account refreshes the account's
+# own attributes but must leave the presented identity alone, otherwise every
+# bridged message in the chat is renamed to the relaying account (#22355).
+suite "contact updates on bridged messages":
+  const bridgeAuthorName = "thedatabro"
+  const bridgeAuthorAvatar = "https://cdn.example.com/thedatabro.png"
+
+  let relayingAccount = ContactDetails(
+    defaultDisplayName: "Sam Hyde",
+    optionalName: "samhyde.eth",
+    icon: "https://localhost:34567/contactImages?publicKey=0xsender",
+    dto: ContactsDto(
+      id: "0xsender",
+      displayName: "Sam Hyde",
+      localNickname: "Sam",
+      added: true,
+      trustStatus: TrustStatus.Trusted,
+      ensVerified: true,
+    ),
+  )
+
+  proc createItem(contentType: ContentType, sender: ContactDetails): Item =
+    return message_model.createMessageItemFromDtos(
+      message = MessageDto(
+        id: "0x1",
+        clock: 1,
+        contentType: contentType,
+        bridgeMessage: BridgeMessage(
+          bridgeName: "discord",
+          userName: bridgeAuthorName,
+          userAvatar: bridgeAuthorAvatar,
+          content: "gm",
+        ),
+        discordMessage: DiscordMessage(
+          timestamp: "1700000000",
+          content: "gm",
+          author: DiscordMessageAuthor(
+            id: "42",
+            name: bridgeAuthorName,
+            avatarUrl: bridgeAuthorAvatar,
+          ),
+        ),
+      ),
+      communityId = "",
+      sender = sender,
+      isCurrentUser = false,
+      renderedMessageText = "",
+      clearText = "",
+    )
+
+  test "a bridge message keeps the bridge author's name and avatar":
+    let item = createItem(ContentType.BridgeMessage, ContactDetails())
+    require(item.senderDisplayName == bridgeAuthorName)
+
+    item.updateSenderDetails(relayingAccount)
+
+    check(item.senderDisplayName == bridgeAuthorName)
+    check(item.senderIcon == bridgeAuthorAvatar)
+
+  test "a discord message keeps the discord author's name and avatar":
+    let item = createItem(ContentType.DiscordMessage, ContactDetails())
+    require(item.senderDisplayName == bridgeAuthorName)
+
+    item.updateSenderDetails(relayingAccount)
+
+    check(item.senderDisplayName == bridgeAuthorName)
+    check(item.senderIcon == bridgeAuthorAvatar)
+
+  test "a bridge message keeps the bridge author's secondary name":
+    # senderOptionalName renders in parentheses right next to the display name,
+    # so the relaying account's nickname would read as the bridge author's.
+    # usesDefaultName picks the generic contact glyph over initials, and a
+    # bridge author always has a real name, so it stays false.
+    let item = createItem(ContentType.BridgeMessage, ContactDetails())
+
+    item.updateSenderDetails(relayingAccount)
+
+    check(item.senderOptionalName == "")
+    check(item.senderUsesDefaultName == false)
+
+  test "a bridged message is built without the relaying account's secondary name":
+    # The relaying account is already known when the item is built, so its
+    # nickname has to be kept out at construction too, not only on updates.
+    for contentType in [ContentType.BridgeMessage, ContentType.DiscordMessage]:
+      let item = createItem(contentType, relayingAccount)
+
+      check(item.senderDisplayName == bridgeAuthorName)
+      check(item.senderIcon == bridgeAuthorAvatar)
+      check(item.senderOptionalName == "")
+      check(item.senderUsesDefaultName == false)
+
+  test "an ordinary message is built with the contact's secondary name":
+    let item = createItem(ContentType.Message, relayingAccount)
+
+    check(item.senderOptionalName == relayingAccount.optionalName)
+
+  test "a bridge message still tracks the relaying account's attributes":
+    let item = createItem(ContentType.BridgeMessage, ContactDetails())
+
+    item.updateSenderDetails(relayingAccount)
+
+    check(item.senderIsAdded)
+    check(item.senderTrustStatus == TrustStatus.Trusted)
+    check(item.senderEnsVerified)
+
+  test "an ordinary message takes the contact's name and avatar":
+    let item = createItem(ContentType.Message, ContactDetails())
+    require(item.senderDisplayName == "")
+
+    item.updateSenderDetails(relayingAccount)
+
+    check(item.senderDisplayName == relayingAccount.defaultDisplayName)
+    check(item.senderIcon == relayingAccount.icon)
+    check(item.senderOptionalName == relayingAccount.optionalName)
+    check(item.senderUsesDefaultName == false)
+    check(item.senderIsAdded)
+    check(item.senderTrustStatus == TrustStatus.Trusted)
+    check(item.senderEnsVerified)

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -251,6 +251,7 @@ Control {
                     imageWidth: root.messageDetails.sender.profileImage.assetSettings.width
                     imageHeight: root.messageDetails.sender.profileImage.assetSettings.height
                     isBridgedAccount: root.messageDetails.contentType === StatusMessage.ContentType.BridgeMessage
+                    bridgeBadgeImage: root.messageDetails.sender.badgeImage || Assets.svg("bridge")
                     onClicked: (mouse) => root.profilePictureClicked(this, mouse)
 
                     LoadingSkeletonTile {

--- a/ui/StatusQ/src/StatusQ/Components/StatusUserImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusUserImage.qml
@@ -68,6 +68,9 @@ Loader {
 
         bridgeBadge.visible: root.isBridgedAccount
         bridgeBadge.image.source: root.bridgeBadgeImage
+        // bridge.svg is a transparent landscape glyph; without a fill the
+        // avatar shows through and the icon reads as a stray mark.
+        bridgeBadge.color: Theme.palette.indirectColor1
 
         Loader {
             anchors.fill: parent

--- a/ui/StatusQ/src/StatusQ/Components/StatusUserImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusUserImage.qml
@@ -17,6 +17,9 @@ Loader {
     property bool disabled: false
     property bool loading: false
     property bool isBridgedAccount: false
+    // Badge shown when isBridgedAccount. Defaults to a bridge-agnostic glyph:
+    // the message may come from any bridge, not only Discord.
+    property url bridgeBadgeImage: Assets.svg("bridge")
     // TODO replace this with booleans since we do not have access to Constants
     property int onlineStatus: -1
 
@@ -64,7 +67,7 @@ Loader {
         }
 
         bridgeBadge.visible: root.isBridgedAccount
-        bridgeBadge.image.source: Assets.svg("discord-bridge")
+        bridgeBadge.image.source: root.bridgeBadgeImage
 
         Loader {
             anchors.fill: parent

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -13664,7 +13664,11 @@ to load</source>
 <context>
     <name>ProfileHeader</name>
     <message>
-        <source>Bridged from Discord</source>
+        <source>Bridged account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bridged from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -13746,8 +13746,12 @@ selhalo</translation>
 <context>
     <name>ProfileHeader</name>
     <message>
-        <source>Bridged from Discord</source>
-        <translation>Propojeno z Discordu</translation>
+        <source>Bridged account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bridged from %1</source>
+        <translation type="unfinished">Přemostěno z %1</translation>
     </message>
     <message>
         <source>Select different image</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -13679,8 +13679,12 @@ al cargar</translation>
 <context>
     <name>ProfileHeader</name>
     <message>
-        <source>Bridged from Discord</source>
-        <translation>Conectado desde Discord</translation>
+        <source>Bridged account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bridged from %1</source>
+        <translation type="unfinished">Conectado desde %1</translation>
     </message>
     <message>
         <source>Select different image</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -13678,8 +13678,12 @@ Seul le détenteur du jeton Owner peut distribuer des jetons TokenMaster. Ces je
 <context>
     <name>ProfileHeader</name>
     <message>
-        <source>Bridged from Discord</source>
-        <translation>Importé depuis Discord</translation>
+        <source>Bridged account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bridged from %1</source>
+        <translation type="unfinished">Transmis depuis %1</translation>
     </message>
     <message>
         <source>Select different image</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -13613,8 +13613,12 @@ to load</source>
 <context>
     <name>ProfileHeader</name>
     <message>
-        <source>Bridged from Discord</source>
-        <translation>Discord에서 브리지됨</translation>
+        <source>Bridged account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bridged from %1</source>
+        <translation type="unfinished">%1에서 브리지됨</translation>
     </message>
     <message>
         <source>Select different image</source>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -13749,8 +13749,12 @@ to load</source>
 <context>
     <name>ProfileHeader</name>
     <message>
-        <source>Bridged from Discord</source>
-        <translation>Перенесено з Discord</translation>
+        <source>Bridged account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bridged from %1</source>
+        <translation type="unfinished">Перенесено з %1</translation>
     </message>
     <message>
         <source>Select different image</source>

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -45,6 +45,7 @@ Item {
     property bool loading: false
     readonly property bool compact: root.imageSize === ProfileHeader.ImageSize.Compact
     property bool isBridgedAccount: false
+    property string bridgeName: ""
 
     signal clicked()
     signal editClicked()
@@ -127,6 +128,7 @@ Item {
                 loading: root.loading
                 onlineStatus: root.onlineStatus
                 isBridgedAccount: root.isBridgedAccount
+                bridgeBadgeImage: Assets.svg(Utils.bridgeBadgeAsset(root.bridgeName))
             }
 
             StatusRoundButton {
@@ -246,7 +248,13 @@ Item {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
             visible: root.pubkeyVisible
-            text: root.isBridgedAccount ? qsTr("Bridged from Discord") : Utils.getElidedPk(compressedPubKey)
+            text: {
+                if (!root.isBridgedAccount)
+                    return Utils.getElidedPk(compressedPubKey)
+                if (!root.bridgeName)
+                    return qsTr("Bridged account")
+                return qsTr("Bridged from %1").arg(Utils.bridgeDisplayName(root.bridgeName))
+            }
             horizontalAlignment: Text.AlignHCenter
             font.pixelSize: Theme.additionalTextSize
             color: Theme.palette.secondaryText

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -251,7 +251,10 @@ Loader {
             trustStatus: contactDetails.trustStatus,
             onlineStatus: contactDetails.onlineStatus,
             usesDefaultName: contactDetails.usesDefaultName,
-            hasLocalNickname: !!contactDetails.localNickname
+            hasLocalNickname: !!contactDetails.localNickname,
+            // A quoted message carries no bridge name, so the popup falls back
+            // to a bridge-agnostic label there.
+            bridgeName: isReply ? "" : root.bridgeName
         }
 
         d.preventVirtualKeyboardOpening()
@@ -578,9 +581,6 @@ Loader {
             }
         }
 
-        function correctBridgeNameCapitalization(bridgeName) {
-            return (bridgeName === "discord") ? "Discord" : bridgeName
-        }
 
         // Qt's Popup/Menu stashes the activeFocusItem on open and restores it on close via
         // an internal forceActiveFocus call. It causes that text edit gains focus and opens
@@ -1041,7 +1041,7 @@ Loader {
                         if (isDiscordMessage)  {
                             return qsTr("Imported from discord")
                         } else if (isBridgeMessage) {
-                            return qsTr("Bridged from %1").arg(d.correctBridgeNameCapitalization(root.bridgeName))
+                            return qsTr("Bridged from %1").arg(Utils.bridgeDisplayName(root.bridgeName))
                         }
                         return ""
                     }
@@ -1079,7 +1079,7 @@ Loader {
                         pubkey: root.senderId
                         color: root.Theme.palette.userCustomizationColors[Utils.colorIdForPubkey(root.senderId)]
                     }
-                    sender.badgeImage: Assets.svg("discord-bridge")
+                    sender.badgeImage: Assets.svg(Utils.bridgeBadgeAsset(root.bridgeName))
                 }
 
                 replyDetails: StatusMessageDetails {

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -20,6 +20,7 @@ StatusMenu {
     property int contactType: Constants.contactType.nonContact
     property int onlineStatus: Constants.onlineStatus.unknown
     property int profileType: Constants.profileType.regular
+    property string bridgeName: ""
     property bool hasLocalNickname: false
     property bool usesDefaultName: false
     property int chatType: Constants.chatType.unknown
@@ -57,6 +58,7 @@ StatusMenu {
         isBlocked: root.profileType === Constants.profileType.blocked
         isCurrentUser: root.profileType === Constants.profileType.self
         isBridgedAccount: root.profileType === Constants.profileType.bridged
+        bridgeName: root.bridgeName
         Binding on onlineStatus {
             value: root.onlineStatus
             when: root.profileType !== Constants.profileType.bridged

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -1208,6 +1208,16 @@ QtObject {
         xhr.send();
     }
 
+    // Only Discord has a dedicated glyph; every other bridge gets the generic
+    // one rather than being mislabelled as Discord.
+    function bridgeBadgeAsset(bridgeName) {
+        return bridgeName === "discord" ? "discord-bridge" : "bridge"
+    }
+
+    function bridgeDisplayName(bridgeName) {
+        return bridgeName === "discord" ? "Discord" : bridgeName
+    }
+
     function getProfileType(isMe, isBridgedAccount, isBlocked) {
         if (isMe)
             return Constants.profileType.self


### PR DESCRIPTION
A bridged message is created with the external author's name and avatar, but any contact update for the relaying account overwrote them. A message posted as `thedatabro` flipped to the bot account's own display name and picture

* both contact-update loops go through a new `Item.updateSenderDetails`, which skips the four fields that compose the rendered author identity for bridge and discord messages
*  `initMessageItem` clears `senderOptionalName` and `senderUsesDefaultName` for bridged messages, so a nicknamed relaying account no longer shows up in parentheses
* `usesDefaultName` stays `false`: a bridge author always has a real name, so the avatar must render initials 

status-go https://github.com/status-im/status-go/pull/7805 



https://github.com/user-attachments/assets/211ba289-0669-4eda-b58f-1c52dc770649



