### PR TITLE
fix(e2e_appium): schedule the longest test modules first

### DIFF
--- a/test/e2e_appium/conftest.py
+++ b/test/e2e_appium/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from .config import get_config, setup_logging, log_test_start, log_test_end
 from .config.logging_config import get_logger, LoggingConfig
 from .support.screenshot import save_screenshot, save_page_source
-from core import peer_containers
+from core import collection_order, peer_containers
 from core.stash_keys import MULTI_DEVICE_MANAGERS_KEY, PEER_REFUSED_KEY
 from core.capacity_reserver import set_shared_pending_counter
 from core.shared_counter import FileBasedCounter, create_shared_counter
@@ -298,6 +298,11 @@ def pytest_runtest_setup(item):
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):
     """Automatically add single_device marker to tests with device_count(1)."""
+    # Before anything else: loadscope hands modules out in collection order, so
+    # the longest must be first or a worker starts it once the others are idle.
+    # Deselection below only removes items, which keeps this order intact.
+    items[:] = collection_order.heaviest_first(items)
+
     for item in items:
         device_count_marker = item.get_closest_marker("device_count")
         if device_count_marker:

--- a/test/e2e_appium/core/collection_order.py
+++ b/test/e2e_appium/core/collection_order.py
@@ -1,0 +1,48 @@
+"""Hand the longest test modules to xdist first.
+
+The loadscope scheduler pops work units from the front of the collection order
+(``workqueue.popitem(last=False)``) and gives a worker the next module whenever
+it goes free. A long module collected last is therefore started alone, after
+every other worker has run dry, and the whole run waits for it. Longest-first
+puts the short modules in that tail instead.
+"""
+
+# Seconds per module, from a green five-worker run. Only used for ordering, so
+# drift costs a little balance, never correctness.
+MODULE_SECONDS = {
+    "tests/messaging/test_z_chat_management_backend.py": 769,
+    "tests/messaging/test_message_actions_backend.py": 743,
+    "tests/test_onboarding_import_seed.py": 516,
+    "tests/messaging/test_message_received_backend.py": 372,
+    "tests/test_navigation_drawer.py": 367,
+    "tests/test_wallet_accounts_basic.py": 338,
+    "tests/test_settings_password_change_password.py": 286,
+}
+
+# An unlisted module is assumed heavy so a newly added one is scheduled early
+# rather than becoming the tail. Guessing high costs nothing: a module that
+# turns out to be quick just frees its worker sooner.
+UNKNOWN_MODULE_SECONDS = 300
+
+
+def module_of(nodeid: str) -> str:
+    return nodeid.split("::", 1)[0]
+
+
+def module_cost(nodeid: str) -> int:
+    return MODULE_SECONDS.get(module_of(nodeid), UNKNOWN_MODULE_SECONDS)
+
+
+def heaviest_first(items: list) -> list:
+    """``items`` reordered so whole modules run longest-first.
+
+    Order inside a module is left alone: some classes carry state from one test
+    to the next.
+    """
+    first_seen: dict[str, int] = {}
+    for index, item in enumerate(items):
+        first_seen.setdefault(module_of(item.nodeid), index)
+    return sorted(
+        items,
+        key=lambda item: (-module_cost(item.nodeid), first_seen[module_of(item.nodeid)]),
+    )

--- a/test/e2e_appium/tests/test_collection_order.py
+++ b/test/e2e_appium/tests/test_collection_order.py
@@ -1,0 +1,64 @@
+"""Guards for longest-first module scheduling. No device, no network."""
+
+from pathlib import Path
+
+import pytest
+
+from core.collection_order import (
+    MODULE_SECONDS,
+    UNKNOWN_MODULE_SECONDS,
+    heaviest_first,
+    module_cost,
+)
+
+pytestmark = pytest.mark.gate
+
+E2E_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Item:
+    def __init__(self, nodeid):
+        self.nodeid = nodeid
+
+    def __repr__(self):
+        return self.nodeid
+
+
+def _order(items):
+    return [i.nodeid for i in heaviest_first(items)]
+
+
+def test_the_longest_module_is_handed_out_first():
+    light = "tests/test_settings_password_change_password.py"
+    heavy = "tests/messaging/test_z_chat_management_backend.py"
+    items = [_Item(f"{light}::a"), _Item(f"{heavy}::b")]
+    assert _order(items)[0].startswith(heavy)
+
+
+def test_order_inside_a_module_is_left_alone():
+    m = "tests/messaging/test_group_chat.py"
+    items = [_Item(f"{m}::test_0{n}") for n in range(1, 5)]
+    assert _order(items) == [i.nodeid for i in items]
+
+
+def test_an_unlisted_module_is_assumed_heavy():
+    # A new module must not silently become the tail.
+    known_light = min(MODULE_SECONDS.values())
+    assert UNKNOWN_MODULE_SECONDS > known_light
+    items = [
+        _Item("tests/test_settings_password_change_password.py::a"),
+        _Item("tests/test_brand_new_module.py::b"),
+    ]
+    assert _order(items)[0].startswith("tests/test_brand_new_module.py")
+
+
+def test_every_costed_module_still_exists():
+    # A renamed file leaves a dead entry, and the module silently falls back to
+    # the default. Nothing else would notice.
+    missing = [m for m in MODULE_SECONDS if not (E2E_ROOT / m).is_file()]
+    assert not missing, f"cost table names modules that no longer exist: {missing}"
+
+
+def test_cost_is_read_from_the_module_not_the_test():
+    m = "tests/messaging/test_z_chat_management_backend.py"
+    assert module_cost(f"{m}::TestX::test_y") == MODULE_SECONDS[m]


### PR DESCRIPTION
Reordering mobile e2e tests to improve timing