### PR TITLE
ci: keep less artifacts for PR builds, 1 per PR

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -53,9 +53,10 @@ pipeline {
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
-      artifactDaysToKeepStr: '30'
+      daysToKeepStr: isPRBuild ? '14' : '30',
+      artifactNumToKeepStr: isPRBuild ? '1' : '10',
+      artifactDaysToKeepStr: isPRBuild ? '7' : '30',
+      removeLastBuild: isPRBuild,
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -75,9 +75,10 @@ pipeline {
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '10',
-      artifactDaysToKeepStr: '30'
+      daysToKeepStr: isPRBuild ? '14' : '30',
+      artifactNumToKeepStr: isPRBuild ? '1' : '10',
+      artifactDaysToKeepStr: isPRBuild ? '7' : '30',
+      removeLastBuild: isPRBuild,
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -81,9 +81,10 @@ pipeline {
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
-      artifactDaysToKeepStr: '30'
+      daysToKeepStr: isPRBuild ? '14' : '30',
+      artifactNumToKeepStr: isPRBuild ? '1' : '10',
+      artifactDaysToKeepStr: isPRBuild ? '7' : '30',
+      removeLastBuild: isPRBuild,
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -60,9 +60,10 @@ pipeline {
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '10',
-      artifactDaysToKeepStr: '30'
+      daysToKeepStr: isPRBuild ? '14' : '30',
+      artifactNumToKeepStr: isPRBuild ? '1' : '10',
+      artifactDaysToKeepStr: isPRBuild ? '7' : '30',
+      removeLastBuild: isPRBuild,
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')


### PR DESCRIPTION
`master-01.he-eu-hel1.ci.devel`

```
❯ sudo du -sh /docker/jenkins/data/jobs/status-app/jobs/prs/jobs/*/jobs/*/jobs/* | sort -h | tail -5
11G	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/linux/jobs/x86_64/jobs/package-flatpak
18G	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/android/jobs/arm64/jobs/package
28G	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/linux/jobs/x86_64/jobs/package
35G	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/windows/jobs/x86_64/jobs/package
57G	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/macos/jobs/aarch64/jobs/package
```

Currently some PRs have 2+ builds, which is not needed. We need only the latest.

For example:
```
❯ du -sh /docker/jenkins/data/jobs/status-app/jobs/prs/jobs/windows/jobs/x86_64/jobs/package/branches/PR-22050/builds/*
1.1M	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/windows/jobs/x86_64/jobs/package/branches/PR-22050/builds/1
410M	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/windows/jobs/x86_64/jobs/package/branches/PR-22050/builds/2
410M	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/windows/jobs/x86_64/jobs/package/branches/PR-22050/builds/3
410M	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/windows/jobs/x86_64/jobs/package/branches/PR-22050/builds/4
410M	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/windows/jobs/x86_64/jobs/package/branches/PR-22050/builds/5
4.0K	/docker/jenkins/data/jobs/status-app/jobs/prs/jobs/windows/jobs/x86_64/jobs/package/branches/PR-22050/builds/permalinks
```

Also remove stale PR builds (older than 7 days).