### PR TITLE
cherry-pick: market, wallet, dapps, browser fixes from 2.39

### DIFF
--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -39,6 +39,7 @@ NIM_TESTS_MODEL_SPY := \
 	assets_adaptor_model_test \
 	collectibles_selector_model_test \
 	grouped_account_assets_model_test \
+	market_leaderboard_model_test \
 	member_model_test \
 	model_sync_move_test \
 	model_sync_unified_test \

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -1,5 +1,6 @@
 import app/modules/shared_models/model_utils
-import nimqml, tables, options
+import app/modules/shared/model_sync
+import nimqml, tables
 
 import app_service/service/market/service as market_service
 
@@ -17,8 +18,9 @@ type
     PriceChangePercentage24h
 
 type
-  # Items are refs the service mutates in place, so values are copied, not items
-  SnapshotRow = object
+  # The service mutates its MarketItem refs in place, so the model keeps its own
+  # value copies: that is what a diff against the previous state runs on.
+  LeaderboardRow = object
     key: string
     name: string
     symbol: string
@@ -28,10 +30,10 @@ type
     totalVolume: float64
     priceChangePercentage24h: float64
 
-proc toSnapshot(items: seq[MarketItem]): seq[SnapshotRow] =
-  result = newSeqOfCap[SnapshotRow](items.len)
+proc toRows(items: seq[MarketItem]): seq[LeaderboardRow] =
+  result = newSeqOfCap[LeaderboardRow](items.len)
   for item in items:
-    result.add(SnapshotRow(
+    result.add(LeaderboardRow(
       key: item.key,
       name: item.name,
       symbol: item.symbol,
@@ -42,20 +44,22 @@ proc toSnapshot(items: seq[MarketItem]): seq[SnapshotRow] =
       priceChangePercentage24h: item.priceChangePercentage24h,
     ))
 
-proc changedRolesFor(item: MarketItem, prev: SnapshotRow): seq[int] =
-  if item.name != prev.name: result.add(ModelRole.Name.int)
-  if item.symbol != prev.symbol: result.add(ModelRole.Symbol.int)
-  if item.image != prev.image: result.add(ModelRole.Image.int)
-  if item.currentPrice != prev.currentPrice: result.add(ModelRole.CurrentPrice.int)
-  if item.marketCap != prev.marketCap: result.add(ModelRole.MarketCap.int)
-  if item.totalVolume != prev.totalVolume: result.add(ModelRole.TotalVolume.int)
-  if item.priceChangePercentage24h != prev.priceChangePercentage24h:
+proc syncKey(it: LeaderboardRow): string = it.key
+proc syncRoles(o, n: LeaderboardRow): seq[int] =
+  result = @[]
+  if o.name != n.name: result.add(ModelRole.Name.int)
+  if o.symbol != n.symbol: result.add(ModelRole.Symbol.int)
+  if o.image != n.image: result.add(ModelRole.Image.int)
+  if o.currentPrice != n.currentPrice: result.add(ModelRole.CurrentPrice.int)
+  if o.marketCap != n.marketCap: result.add(ModelRole.MarketCap.int)
+  if o.totalVolume != n.totalVolume: result.add(ModelRole.TotalVolume.int)
+  if o.priceChangePercentage24h != n.priceChangePercentage24h:
     result.add(ModelRole.PriceChangePercentage24h.int)
 
 QtObject:
   type MarketLeaderboardModel* = ref object of QAbstractListModel
     delegate: io_interface.MarketLeaderboardDataSource
-    snapshot: seq[SnapshotRow]
+    items: seq[LeaderboardRow]
 
   proc setup(self: MarketLeaderboardModel)
   proc delete(self: MarketLeaderboardModel)
@@ -67,7 +71,7 @@ QtObject:
     result.delegate = delegate
 
   method rowCount(self: MarketLeaderboardModel, index: QModelIndex = nil): int =
-    return self.delegate.getMarketLeaderboardList().len
+    return self.items.len
 
   method roleNames(self: MarketLeaderboardModel): Table[int, string] =
     {
@@ -81,18 +85,10 @@ QtObject:
       ModelRole.PriceChangePercentage24h.int:"priceChangePercentage24h",
     }.toTable
 
-  proc getRoleFromName(self: MarketLeaderboardModel, roleName: string): Option[int] =
-    for roleInt, name in self.roleNames():
-      if name == roleName:
-        return some(roleInt)
-    return none(int)
-
   method data(self: MarketLeaderboardModel, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.rowCount(), role, ModelRole)
 
-    # the only way to read items from service is by this single method getMarketLeaderboardList
-
-    let item = self.delegate.getMarketLeaderboardList()[index.row]
+    let item = self.items[index.row]
 
     let enumRole = role.ModelRole
     case enumRole:
@@ -113,47 +109,18 @@ QtObject:
       of ModelRole.PriceChangePercentage24h:
         result = newQVariant(item.priceChangePercentage24h)
 
-  proc sameRowsAsSnapshot(self: MarketLeaderboardModel, items: seq[MarketItem]): bool =
-    if items.len != self.snapshot.len:
-      return false
-    for i in 0 ..< items.len:
-      if items[i].key != self.snapshot[i].key:
-        return false
-    return true
-
+  # Both entry points read the service's current page and diff it against the
+  # rows on display: granular insert/remove for a page change, dataChanged with
+  # the touched roles for a price tick, nothing for an unchanged page.
   proc modelsUpdated*(self: MarketLeaderboardModel) =
-    let items = self.delegate.getMarketLeaderboardList()
-
-    # A reset drops every delegate in the views, so report roles where possible
-    if not self.sameRowsAsSnapshot(items):
-      self.beginResetModel()
-      self.snapshot = toSnapshot(items)
-      self.endResetModel()
-      return
-
-    for i in 0 ..< items.len:
-      let changedRoles = changedRolesFor(items[i], self.snapshot[i])
-      if changedRoles.len > 0:
-        notifyRangeRolesChanged(i, i, changedRoles)
-
-    self.snapshot = toSnapshot(items)
+    self.modelSync(self.items, toRows(self.delegate.getMarketLeaderboardList()))
 
   proc pageUpdated*(self: MarketLeaderboardModel, updates: seq[LeaderboardTokenUpdated]) =
-    for update in updates:
-      var changedRoles: seq[int] = @[]
-      for field in update.changedFields:
-        let roleOpt = self.getRoleFromName(field)
-        if roleOpt.isSome:
-          changedRoles.add(roleOpt.get())
-
-      if changedRoles.len > 0:
-        notifyRangeRolesChanged(update.index, update.index, changedRoles)
-
-    self.snapshot = toSnapshot(self.delegate.getMarketLeaderboardList())
+    self.modelsUpdated()
 
   when defined(testing) or defined(QT_MODEL_SPY):
     proc keysInOrder*(self: MarketLeaderboardModel): seq[string] =
-      for it in self.delegate.getMarketLeaderboardList(): result.add(it.key)
+      for it in self.items: result.add(it.key)
 
   proc setup(self: MarketLeaderboardModel) =
     self.QAbstractListModel.setup

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -151,6 +151,10 @@ QtObject:
 
     self.snapshot = toSnapshot(self.delegate.getMarketLeaderboardList())
 
+  when defined(testing) or defined(QT_MODEL_SPY):
+    proc keysInOrder*(self: MarketLeaderboardModel): seq[string] =
+      for it in self.delegate.getMarketLeaderboardList(): result.add(it.key)
+
   proc setup(self: MarketLeaderboardModel) =
     self.QAbstractListModel.setup
 

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -16,9 +16,46 @@ type
     TotalVolume
     PriceChangePercentage24h
 
+type
+  # Items are refs the service mutates in place, so values are copied, not items
+  SnapshotRow = object
+    key: string
+    name: string
+    symbol: string
+    image: string
+    currentPrice: float64
+    marketCap: float64
+    totalVolume: float64
+    priceChangePercentage24h: float64
+
+proc toSnapshot(items: seq[MarketItem]): seq[SnapshotRow] =
+  result = newSeqOfCap[SnapshotRow](items.len)
+  for item in items:
+    result.add(SnapshotRow(
+      key: item.key,
+      name: item.name,
+      symbol: item.symbol,
+      image: item.image,
+      currentPrice: item.currentPrice,
+      marketCap: item.marketCap,
+      totalVolume: item.totalVolume,
+      priceChangePercentage24h: item.priceChangePercentage24h,
+    ))
+
+proc changedRolesFor(item: MarketItem, prev: SnapshotRow): seq[int] =
+  if item.name != prev.name: result.add(ModelRole.Name.int)
+  if item.symbol != prev.symbol: result.add(ModelRole.Symbol.int)
+  if item.image != prev.image: result.add(ModelRole.Image.int)
+  if item.currentPrice != prev.currentPrice: result.add(ModelRole.CurrentPrice.int)
+  if item.marketCap != prev.marketCap: result.add(ModelRole.MarketCap.int)
+  if item.totalVolume != prev.totalVolume: result.add(ModelRole.TotalVolume.int)
+  if item.priceChangePercentage24h != prev.priceChangePercentage24h:
+    result.add(ModelRole.PriceChangePercentage24h.int)
+
 QtObject:
   type MarketLeaderboardModel* = ref object of QAbstractListModel
     delegate: io_interface.MarketLeaderboardDataSource
+    snapshot: seq[SnapshotRow]
 
   proc setup(self: MarketLeaderboardModel)
   proc delete(self: MarketLeaderboardModel)
@@ -76,9 +113,30 @@ QtObject:
       of ModelRole.PriceChangePercentage24h:
         result = newQVariant(item.priceChangePercentage24h)
 
+  proc sameRowsAsSnapshot(self: MarketLeaderboardModel, items: seq[MarketItem]): bool =
+    if items.len != self.snapshot.len:
+      return false
+    for i in 0 ..< items.len:
+      if items[i].key != self.snapshot[i].key:
+        return false
+    return true
+
   proc modelsUpdated*(self: MarketLeaderboardModel) =
-    self.beginResetModel()
-    self.endResetModel()
+    let items = self.delegate.getMarketLeaderboardList()
+
+    # A reset drops every delegate in the views, so report roles where possible
+    if not self.sameRowsAsSnapshot(items):
+      self.beginResetModel()
+      self.snapshot = toSnapshot(items)
+      self.endResetModel()
+      return
+
+    for i in 0 ..< items.len:
+      let changedRoles = changedRolesFor(items[i], self.snapshot[i])
+      if changedRoles.len > 0:
+        notifyRangeRolesChanged(i, i, changedRoles)
+
+    self.snapshot = toSnapshot(items)
 
   proc pageUpdated*(self: MarketLeaderboardModel, updates: seq[LeaderboardTokenUpdated]) =
     for update in updates:
@@ -90,6 +148,8 @@ QtObject:
 
       if changedRoles.len > 0:
         notifyRangeRolesChanged(update.index, update.index, changedRoles)
+
+    self.snapshot = toSnapshot(self.delegate.getMarketLeaderboardList())
 
   proc setup(self: MarketLeaderboardModel) =
     self.QAbstractListModel.setup

--- a/src/app_service/service/accounts/dto/create_account_request.nim
+++ b/src/app_service/service/accounts/dto/create_account_request.nim
@@ -29,6 +29,7 @@ type
 
     logLevel*: Option[string]
     logFilePath*: string
+    walletConnectProjectID*: string
     logEnabled*: bool
 
     previewPrivacy*: bool
@@ -68,6 +69,7 @@ proc toJson*(self: CreateAccountRequest): JsonNode =
     "wakuV2Fleet": self.wakuV2Fleet,
     "wakuV2LightClient": self.wakuV2LightClient,
     "logFilePath": self.logFilePath,
+    "walletConnectProjectID": self.walletConnectProjectID,
     "logEnabled": self.logEnabled,
     "previewPrivacy": self.previewPrivacy,
     "autoRefreshTokensEnabled": self.autoRefreshTokensEnabled,

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -212,6 +212,7 @@ QtObject:
         walletSecretsConfig: buildWalletSecrets(),
         walletConfig: buildWalletConfig(),
         apiConfig: defaultApiConfig(),
+        walletConnectProjectID: main_constants.WALLET_CONNECT_PROJECT_ID,
       )
 
   proc buildCreateAccountRequest(password: string, displayName: string, imagePath: string,

--- a/storybook/pages/MarketLayoutPage.qml
+++ b/storybook/pages/MarketLayoutPage.qml
@@ -48,6 +48,8 @@ SplitView {
                 return LocaleUtils.currencyAmountToLocaleString(abc, options)
             }
             currentPage: -1
+            // the section loader does this in the app
+            Component.onCompleted: fetchMarketTokens(1, pageSize)
             onRequestLaunchSwap: console.warn("Request Launch Swap")
             onFetchMarketTokens: (pageNumber, pageSize) => {
                 console.warn("Fetch Market Tokens with PageSize: %1 and PageNumber:%2".arg(pageSize).arg(pageNumber))

--- a/storybook/qmlTests/tests/tst_LazyTabStack.qml
+++ b/storybook/qmlTests/tests/tst_LazyTabStack.qml
@@ -46,6 +46,19 @@ Item {
         }
     }
 
+    // the stack itself created asynchronously, as inside the wallet section
+    Component {
+        id: nestedAsyncComponentUnderTest
+        Loader {
+            anchors.fill: parent
+            asynchronous: true
+            sourceComponent: LazyTabStack {
+                asynchronous: true
+                tabComponents: [tabA, tabB, tabC]
+            }
+        }
+    }
+
     TestCase {
         name: "LazyTabStack"
         when: windowShown
@@ -95,6 +108,17 @@ Item {
             controlUnderTest.currentIndex = 0
             verify(controlUnderTest.itemAt(0).parent.visible)
             verify(!controlUnderTest.itemAt(2).parent.visible)
+        }
+
+        function test_becomesReadyWhenCreatedAsynchronouslyItself() {
+            d.createdA = 0
+            const outer = createTemporaryObject(nestedAsyncComponentUnderTest, root)
+            verify(!!outer)
+            tryCompare(outer, "status", Loader.Ready)
+            const control = outer.item
+            verify(!!control)
+            tryVerify(() => control.currentReady)
+            compare(d.createdA, 1)
         }
 
         function test_reportsReadinessWhileLoadingAsynchronously() {

--- a/storybook/qmlTests/tests/tst_LazyTabStack.qml
+++ b/storybook/qmlTests/tests/tst_LazyTabStack.qml
@@ -1,0 +1,118 @@
+import QtQuick
+import QtTest
+
+import shared.controls
+
+Item {
+    id: root
+    width: 400
+    height: 300
+
+    QtObject {
+        id: d
+        property int createdA: 0
+        property int createdB: 0
+        property int createdC: 0
+    }
+
+    Component {
+        id: tabA
+        Item { Component.onCompleted: d.createdA++ }
+    }
+    Component {
+        id: tabB
+        Item { Component.onCompleted: d.createdB++ }
+    }
+    Component {
+        id: tabC
+        Item { Component.onCompleted: d.createdC++ }
+    }
+
+    Component {
+        id: componentUnderTest
+        LazyTabStack {
+            anchors.fill: parent
+            asynchronous: false
+            tabComponents: [tabA, tabB, tabC]
+        }
+    }
+
+    Component {
+        id: asyncComponentUnderTest
+        LazyTabStack {
+            anchors.fill: parent
+            asynchronous: true
+            tabComponents: [tabA, tabB, tabC]
+        }
+    }
+
+    TestCase {
+        name: "LazyTabStack"
+        when: windowShown
+
+        property LazyTabStack controlUnderTest: null
+
+        function init() {
+            d.createdA = 0
+            d.createdB = 0
+            d.createdC = 0
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+        }
+
+        function test_createsOnlyTheCurrentTab() {
+            verify(!!controlUnderTest)
+            compare(controlUnderTest.currentIndex, 0)
+            compare(d.createdA, 1)
+            compare(d.createdB, 0)
+            compare(d.createdC, 0)
+            verify(controlUnderTest.currentReady)
+            verify(!!controlUnderTest.itemAt(0))
+            compare(controlUnderTest.itemAt(1), null)
+        }
+
+        function test_keepsAViewAliveAcrossSwitches() {
+            controlUnderTest.currentIndex = 1
+            compare(d.createdB, 1)
+            const tabBItem = controlUnderTest.itemAt(1)
+            verify(!!tabBItem)
+
+            controlUnderTest.currentIndex = 0
+            controlUnderTest.currentIndex = 1
+
+            compare(d.createdA, 1)
+            compare(d.createdB, 1)
+            compare(d.createdC, 0)
+            compare(controlUnderTest.itemAt(1), tabBItem)
+            verify(!!controlUnderTest.itemAt(0))
+        }
+
+        function test_showsOnlyTheCurrentTab() {
+            controlUnderTest.currentIndex = 2
+            verify(controlUnderTest.currentReady)
+            verify(!controlUnderTest.itemAt(0).parent.visible)
+            verify(controlUnderTest.itemAt(2).parent.visible)
+
+            controlUnderTest.currentIndex = 0
+            verify(controlUnderTest.itemAt(0).parent.visible)
+            verify(!controlUnderTest.itemAt(2).parent.visible)
+        }
+
+        function test_reportsReadinessWhileLoadingAsynchronously() {
+            d.createdA = 0
+            d.createdB = 0
+            const control = createTemporaryObject(asyncComponentUnderTest, root)
+            verify(!!control)
+            verify(!control.currentReady)
+            tryVerify(() => control.currentReady)
+            compare(d.createdA, 1)
+
+            control.currentIndex = 1
+            verify(!control.currentReady)
+            tryVerify(() => control.currentReady)
+            compare(d.createdB, 1)
+
+            control.currentIndex = 0
+            verify(control.currentReady)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_MarketLayout.qml
+++ b/storybook/qmlTests/tests/tst_MarketLayout.qml
@@ -45,6 +45,7 @@ Item {
             }
             currentPage: -1
             onFetchMarketTokens: {
+                d.fetchCount++
                 d.startIndex = ((pageNumber - 1) * pageSize) + 1
                 d.endIndex = Math.min(pageNumber * pageSize, totalTokensCount)
                 currentPage = pageNumber
@@ -56,6 +57,7 @@ Item {
         id: d
         property int startIndex: 0
         property int endIndex: 0
+        property int fetchCount: 0
     }
 
     SignalSpy {
@@ -71,7 +73,10 @@ Item {
         when: windowShown
 
         function init() {
+            d.fetchCount = 0
             controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            // The section loader owns fetching, so the test harness plays that part
+            controlUnderTest.fetchMarketTokens(1, controlUnderTest.pageSize)
             signalSpyLaunchSwap.clear()
         }
 
@@ -199,27 +204,59 @@ Item {
             }
         }
 
-        function test_loadingState() {
-            verify(!!controlUnderTest)
+        function test_doesNotFetchOnItsOwn() {
+            d.fetchCount = 0
+            const control = createTemporaryObject(componentUnderTest, root)
+            verify(!!control)
+            compare(d.fetchCount, 0)
+        }
 
-            verify(!controlUnderTest.loading)
-
-            const regularModel = findChild(controlUnderTest, "regularModel")
-            verify(!!regularModel)
+        function test_showsSkeletonsWhenThereIsNothingToShow() {
             const loadingModel = findChild(controlUnderTest, "loadingModel")
             verify(!!loadingModel)
             const tokensList = findChild(controlUnderTest.centerPanel, "tokensList")
             verify(!!tokensList)
 
-            // Loading true
+            // an out of range page leaves the view without any row to show
+            controlUnderTest.fetchMarketTokens(999, controlUnderTest.pageSize)
+            compare(controlUnderTest.tokensModel.count, 0)
+
             controlUnderTest.loading = true
             compare(tokensList.model, loadingModel)
             compare(tokensList.count, 100)
+        }
 
-            // Loading false
+        function test_keepsRowsWhileRefreshing() {
+            const regularModel = findChild(controlUnderTest, "regularModel")
+            verify(!!regularModel)
+            const tokensList = findChild(controlUnderTest.centerPanel, "tokensList")
+            verify(!!tokensList)
+            verify(tokensList.count > 0)
+
+            controlUnderTest.loading = true
+            compare(tokensList.model, regularModel)
+            compare(tokensList.count, controlUnderTest.tokensModel.count)
+
             controlUnderTest.loading = false
             compare(tokensList.model, regularModel)
             compare(tokensList.count, controlUnderTest.tokensModel.count)
+        }
+
+        function test_showsSkeletonsWhenSwitchingPage() {
+            const loadingModel = findChild(controlUnderTest, "loadingModel")
+            verify(!!loadingModel)
+            const tokensList = findChild(controlUnderTest.centerPanel, "tokensList")
+            verify(!!tokensList)
+            const footer = findChild(tokensList, "marketFooter")
+            verify(!!footer)
+
+            footer.switchPage(2)
+            controlUnderTest.loading = true
+            compare(tokensList.model, loadingModel)
+
+            controlUnderTest.loading = false
+            const regularModel = findChild(controlUnderTest, "regularModel")
+            compare(tokensList.model, regularModel)
         }
     }
 }

--- a/test/nim/market_leaderboard_model_test.nim
+++ b/test/nim/market_leaderboard_model_test.nim
@@ -1,0 +1,90 @@
+## Signal-level tests for MarketLeaderboardModel. Compile -d:QT_MODEL_SPY.
+##
+## Acceptance gate: a price tick on a page emits one dataChanged carrying only
+## the changed roles; switching to a page with other tokens emits granular
+## insert/remove and NO reset; a token that only moves keeps its row alive.
+## Only the first load (empty -> N) is allowed to reset.
+
+import unittest, tables
+import nimqml
+
+import app/modules/main/market_section/market_leaderboard_model
+import app/modules/main/market_section/io_interface
+import app_service/service/market/service_items
+import app/modules/shared/qt_model_spy
+
+proc token(key: string, price: float64 = 1.0): MarketItem =
+  MarketItem(key: key, name: key & " coin", symbol: key, image: key & ".png",
+             currentPrice: price, marketCap: 10.0, totalVolume: 5.0,
+             priceChangePercentage24h: 0.5)
+
+suite "MarketLeaderboardModel":
+  var page: seq[MarketItem]
+  let source: MarketLeaderboardDataSource = (
+    getMarketLeaderboardList: proc(): var seq[MarketItem] = page
+  )
+
+  setup:
+    page = @[token("btc", 100.0), token("eth", 10.0), token("sol", 1.0)]
+
+  test "first load resets once and exposes the page":
+    let model = newMarketLeaderboardModel(source)
+    let spy = newQtModelSpy()
+    spy.enable()
+    model.modelsUpdated()
+    spy.disable()
+
+    check spy.countResets() == 1
+    check model.keysInOrder() == @["btc", "eth", "sol"]
+
+  test "a price tick emits one dataChanged with only the changed roles":
+    let model = newMarketLeaderboardModel(source)
+    model.modelsUpdated()
+    var priceRole = -1
+    for role, name in model.roleNames():
+      if name == "currentPrice": priceRole = role
+
+    # the service mutates the same item in place before notifying
+    page[1].currentPrice = 11.0
+    let spy = newQtModelSpy()
+    spy.enable()
+    model.pageUpdated(@[])
+    spy.disable()
+
+    check spy.countResets() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    require spy.countDataChanged() == 1
+    let change = spy.getDataChanged()[0]
+    check change.topLeft == 1
+    check change.bottomRight == 1
+    check change.roles == @[priceRole]
+
+  test "switching page does not reset the model":
+    let model = newMarketLeaderboardModel(source)
+    model.modelsUpdated()
+
+    page = @[token("sol", 1.0), token("ada"), token("dot")]
+    let spy = newQtModelSpy()
+    spy.enable()
+    model.modelsUpdated()
+    spy.disable()
+
+    check spy.countResets() == 0
+    check spy.countInserts() > 0
+    check spy.countRemoves() > 0
+    check model.keysInOrder() == @["sol", "ada", "dot"]
+
+  test "an unchanged page is silent":
+    let model = newMarketLeaderboardModel(source)
+    model.modelsUpdated()
+
+    let spy = newQtModelSpy()
+    spy.enable()
+    model.modelsUpdated()
+    spy.disable()
+
+    check spy.countResets() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    check spy.countDataChanged() == 0

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -357,7 +357,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG c61e5d45fca60babca12e8ba0610bca0817d9af9
+      GIT_TAG 10429c13aa3e2f7e877e953a6699ba1705226fef
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/app/AppLayouts/Market/MarketLayout.qml
+++ b/ui/app/AppLayouts/Market/MarketLayout.qml
@@ -49,10 +49,13 @@ StatusSectionLayout {
 
         // Read-only flag that turns true when the component enters a “compact” layout automatically on resize.
         readonly property bool compactMode: root.width < 600
+
+        // set while the page being loaded is not the one currently on screen
+        property bool pageSwitching: false
     }
 
     onCurrentPageChanged: listView.positionViewAtBeginning()
-    Component.onCompleted: root.fetchMarketTokens(1, root.pageSize)
+    onLoadingChanged: if (!root.loading) d.pageSwitching = false
 
     centerPanel: ColumnLayout {
         anchors.fill: parent
@@ -104,13 +107,16 @@ StatusSectionLayout {
                 pageSize: root.pageSize
                 totalCount: root.totalTokensCount
                 currentPage: root.currentPage
-                onSwitchPage: root.fetchMarketTokens(pageNumber, root.pageSize)
+                onSwitchPage: {
+                    d.pageSwitching = true
+                    root.fetchMarketTokens(pageNumber, root.pageSize)
+                }
                 visible: listView.count > 0 && !root.loading
                 height: visible ? implicitHeight : 0
                 compactMode: d.compactMode
             }
 
-            model: root.loading ? loadingModel: regularModel
+            model: root.loading && (regularModel.count === 0 || d.pageSwitching) ? loadingModel : regularModel
         }
 
         // loading items model

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -61,8 +61,11 @@ QtObject {
         4. "description" to "communityDescription"
         in communitiesModule.model so that it can be easily
         joined with the Collectibles model */
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _communitiesModel: !!communitiesModule ? communitiesModule.model : null
+
     readonly property var _renamedCommunitiesModel: RolesRenamingModel {
-        sourceModel: communitiesModule.model
+        sourceModel: root._communitiesModel
         mapping: [
             RoleRename {
                 from: "id"

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
@@ -271,11 +271,13 @@ SQUtils.QObject {
         }
     }
 
-    // Timeout for the corner case where the URL was already dismissed and the SDK doesn't respond with an error nor advances with the proposal
+    // Timeout for the corner case where the URL was already dismissed and the SDK doesn't respond with an error nor advances with the proposal.
+    // Covers both the pair RPC and the wait for the dApp's session proposal to
+    // travel through the relay, so it has to tolerate a slow network.
     Timer {
         id: timeoutTimer
 
-        interval: 10000 // (10 seconds)
+        interval: 30000 // (30 seconds)
         running: false
         repeat: false
 

--- a/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -84,8 +84,11 @@ QtObject {
         4. "description" to "communityDescription"
         in communitiesModule.model so that it can be easily
         joined with the Collectibles model */
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _communitiesModel: !!communitiesModule ? communitiesModule.model : null
+
     readonly property var _renamedCommunitiesModel: RolesRenamingModel {
-        sourceModel: communitiesModule.model
+        sourceModel: root._communitiesModel
         mapping: [
             RoleRename {
                 from: "id"

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -56,8 +56,11 @@ QtObject {
 
     readonly property bool areTestNetworksEnabled: networksModule.areTestNetworksEnabled
 
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _savedAddressesModel: !!walletSectionSavedAddresses ? walletSectionSavedAddresses.model : null
+
     property var savedAddresses: SortFilterProxyModel {
-        sourceModel: walletSectionSavedAddresses.model
+        sourceModel: root._savedAddressesModel
         filters: [
             ValueFilter {
                 roleName: "isTest"

--- a/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
@@ -75,8 +75,11 @@ QtObject {
         4. "description" to "communityDescription"
     in communitiesModule.model so that it can be easily
     joined with the Account Assets model */
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _communitiesModel: !!communitiesModule ? communitiesModule.model : null
+
     readonly property var _renamedCommunitiesModel: RolesRenamingModel {
-        sourceModel: communitiesModule.model
+        sourceModel: root._communitiesModel
         mapping: [
             RoleRename {
                 from: "id"

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -327,7 +327,7 @@ RightTabBaseView {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 Layout.topMargin: Theme.padding
-                active: mainViewLoader.status !== Loader.Ready
+                active: !mainViews.currentReady
                 visible: active
                 sourceComponent: {
                     switch (walletTabBar.currentIndex) {
@@ -438,14 +438,15 @@ RightTabBaseView {
                 }
             }
 
-            Loader {
-                id: mainViewLoader
+            LazyTabStack {
+                id: mainViews
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 Layout.topMargin: Theme.padding
                 asynchronous: true
-                visible: status === Loader.Ready
-                sourceComponent: d.walletViewsMap[walletTabBar.currentIndex]
+                visible: currentReady
+                tabComponents: d.walletViewsMap
+                currentIndex: walletTabBar.currentIndex
 
                 Component {
                     id: assetsView

--- a/ui/imports/shared/controls/LazyTabStack.qml
+++ b/ui/imports/shared/controls/LazyTabStack.qml
@@ -1,0 +1,50 @@
+import QtQuick
+
+/// One loader per tab: a view is created when its tab is first selected and
+/// kept alive, so switching back to it only toggles visibility.
+Item {
+    id: root
+
+    required property var tabComponents
+    property int currentIndex: 0
+    property bool asynchronous: true
+
+    readonly property bool currentReady: d.currentLoader?.status === Loader.Ready
+
+    function itemAt(index) {
+        const loader = repeater.itemAt(index) as Loader
+        return loader ? loader.item : null
+    }
+
+    QtObject {
+        id: d
+
+        readonly property Loader currentLoader: {
+            repeater.count
+            return repeater.itemAt(root.currentIndex) as Loader
+        }
+    }
+
+    Repeater {
+        id: repeater
+
+        model: root.tabComponents.length
+
+        delegate: Loader {
+            id: loader
+
+            required property int index
+            readonly property bool current: root.currentIndex === loader.index
+            property bool activated: false
+
+            anchors.fill: parent
+            asynchronous: root.asynchronous
+            active: loader.activated
+            visible: loader.current && loader.status === Loader.Ready
+            sourceComponent: root.tabComponents[loader.index]
+
+            onCurrentChanged: if (loader.current) loader.activated = true
+            Component.onCompleted: if (loader.current) loader.activated = true
+        }
+    }
+}

--- a/ui/imports/shared/controls/LazyTabStack.qml
+++ b/ui/imports/shared/controls/LazyTabStack.qml
@@ -19,10 +19,7 @@ Item {
     QtObject {
         id: d
 
-        readonly property Loader currentLoader: {
-            repeater.count
-            return repeater.itemAt(root.currentIndex) as Loader
-        }
+        property Loader currentLoader: null
     }
 
     Repeater {
@@ -43,8 +40,15 @@ Item {
             visible: loader.current && loader.status === Loader.Ready
             sourceComponent: root.tabComponents[loader.index]
 
-            onCurrentChanged: if (loader.current) loader.activated = true
-            Component.onCompleted: if (loader.current) loader.activated = true
+            function takeOver() {
+                if (!loader.current)
+                    return
+                loader.activated = true
+                d.currentLoader = loader
+            }
+
+            onCurrentChanged: takeOver()
+            Component.onCompleted: takeOver()
         }
     }
 }

--- a/ui/imports/shared/controls/qmldir
+++ b/ui/imports/shared/controls/qmldir
@@ -25,6 +25,7 @@ ImportKeypairInfo 1.0 ImportKeypairInfo.qml
 InformationTag 1.0 InformationTag.qml
 InformationTile 1.0 InformationTile.qml
 Input 1.0 Input.qml
+LazyTabStack 1.0 LazyTabStack.qml
 LinkPreviewDebugView 1.0 LinkPreviewDebugView.qml
 LoadingTokenDelegate 1.0 LoadingTokenDelegate.qml
 Padding 1.0 Padding.qml

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -32,8 +32,11 @@ QtObject {
     property var tmpActivityController0: walletSection.tmpActivityController0
     readonly property var _tmpActivityController1: walletSection.tmpActivityController1
     readonly property var tempActivityController1Model: _tmpActivityController1.model
+    // proxies must not bind to context properties directly: registered late, they never re-evaluate
+    readonly property var _savedAddressesModel: !!walletSectionSavedAddresses ? walletSectionSavedAddresses.model : null
+
     property var savedAddressesModel: SortFilterProxyModel {
-        sourceModel: walletSectionSavedAddresses.model
+        sourceModel: root._savedAddressesModel
         filters: [
             ValueFilter {
                 roleName: "isTest"


### PR DESCRIPTION
Cherry-pick from `release/2.39.x`:

- https://github.com/status-im/status-app/pull/22316
- https://github.com/status-im/status-app/pull/22338
- https://github.com/status-im/status-app/pull/22345
- https://github.com/status-im/status-app/pull/22367

Needs https://github.com/status-im/status-go/pull/7814 for the WalletConnect create-account project ID. Vendor bump after that lands.