### PR TITLE
Chat parser: proper Unicode grapheme segmentation using QTextBoundaryFinder

### DIFF
--- a/ui/StatusQ/include/StatusQ/markdownast.h
+++ b/ui/StatusQ/include/StatusQ/markdownast.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QString>
+#include <QStringView>
+#include <QTextBoundaryFinder>
 #include <QVector>
 
 // A small, GUI-free AST for the simplified, line-oriented markdown dialect used
@@ -72,9 +74,35 @@ QString dump(const Node& node, bool withRanges = true);
 // sequence is treated as one unit. Shared by the live highlighter and the static renderer.
 bool isEmojiCodePoint(char32_t cp);
 
+// True when `text` contains at least one emoji code point (isEmojiCodePoint).
+bool clusterHasEmoji(QStringView text);
+
 // True when `text` consists solely of emoji code points and whitespace (spaces, tabs and line
 // breaks are allowed between/around the emojis), with at least one emoji present. Used by the
 // static renderer to enlarge emoji-only messages. Empty or whitespace-only text returns false.
 bool isOnlyEmoji(const QString& text);
+
+// Walks `text` grapheme cluster by grapheme cluster (the correct Unicode segmentation), invoking
+// `fn(cluster, start, end)` for each — `start`/`end` being indices into `text`. `fn` returns bool:
+// false stops the walk early, true continues. The cluster is a QStringView into `text` (no per-cluster
+// allocation); it is valid only for the duration of the call, so a callback that keeps it beyond that
+// (stores it, hands it to insertText, …) must `.toString()` a copy.
+template<typename Fn>
+void forEachGraphemeCluster(const QString& text, Fn&& fn)
+{
+    QTextBoundaryFinder bf(QTextBoundaryFinder::Grapheme, text);
+    const QStringView view(text);
+    int cs = 0;
+    for (int ce = bf.toNextBoundary(); ce >= 0; ce = bf.toNextBoundary()) {
+        if (ce > cs && !fn(view.mid(cs, ce - cs), cs, ce))
+            return;
+        cs = ce;
+    }
+}
+
+// Maps one emoji grapheme cluster to the bundled Twemoji svg url under `base` (a directory url ending
+// in '/', file:// or qrc:), following twemoji.js' rule. The set of available svg basenames under a
+// base is listed once and cached, and is the source of truth for what renders as an image.
+QString twemojiSvgUrl(const QString& base, QStringView cluster);
 
 } // namespace Markdown

--- a/ui/StatusQ/src/chatinputhighlighter.cpp
+++ b/ui/StatusQ/src/chatinputhighlighter.cpp
@@ -7,18 +7,15 @@
 #include <QClipboard>
 #include <QColor>
 #include <QDataStream>
-#include <QFile>
 #include <QFontDatabase>
 #include <QFontMetricsF>
 #include <QGuiApplication>
 #include <QMimeData>
 #include <QTextBlock>
 #include <QTextBlockFormat>
-#include <QTextBoundaryFinder>
 #include <QTextCharFormat>
 #include <QTextCursor>
 #include <QTextImageFormat>
-#include <QUrl>
 #include <QVariantMap>
 #include <QVector>
 
@@ -82,46 +79,8 @@ char32_t codePointAt(const QString& s, qsizetype i, qsizetype& units)
     return c.unicode();
 }
 
-// Local path a url resolves to for an existence check, covering the two StatusQ deployments:
-// filesystem (file://) and bundled resources (qrc:/).
-QString localPathForUrl(const QString& url)
-{
-    const QUrl u(url);
-    if (u.scheme() == QLatin1String("qrc"))
-        return QLatin1Char(':') + u.path();
-    if (u.isLocalFile())
-        return u.toLocalFile();
-    return url;
-}
-
-// Maps a single emoji (one grapheme cluster) to its bundled Twemoji SVG url under `base`, following
-// twemoji.js' grabTheRightIcon/toCodePoint rule: keep all code points if the run contains U+200D
-// (ZWJ), otherwise strip U+FE0F; join code points as lowercase hex with '-'. Returns "" when no
-// svg exists for it (graceful fallback: the emoji stays as text / font rendering).
-QString twemojiSvgUrl(const QString& base, const QString& emoji)
-{
-    if (base.isEmpty())
-        return {};
-
-    const bool hasZwj = emoji.contains(QChar(0x200D));
-    QString name;
-    for (qsizetype i = 0; i < emoji.size();) {
-        qsizetype units = 1;
-        const char32_t cp = codePointAt(emoji, i, units);
-        i += units;
-        if (!hasZwj && cp == 0xFE0F)
-            continue;
-        if (!name.isEmpty())
-            name += QLatin1Char('-');
-        name += QString::number(cp, 16);
-    }
-    if (name.isEmpty())
-        return {};
-    const QString url = base + name + QStringLiteral(".svg");
-    if (!QFile::exists(localPathForUrl(url)))
-        return {};
-    return url;
-}
+// Cluster → svg url resolution (asset set + presentation guard) lives in Markdown::twemojiSvgUrl,
+// shared with the static renderer.
 
 // True if the block text at [i, ...) starts an emoji code point (never matches the U+FFFC of an
 // existing image/mention object, so conversion is idempotent).
@@ -1174,44 +1133,18 @@ void ChatInputHighlighter::convertEmojisToImages(bool joinUndo)
 
     const int lineHeight = qMax(1, qRound(QFontMetricsF(doc->defaultFont()).height()));
 
-    // Collect every emoji (grapheme cluster) as a document range with its Twemoji url. Emoji runs
-    // are segmented per-cluster so ZWJ sequences map to their combined svg and adjacent distinct
-    // emoji each get their own image. U+FFFC of existing objects never matches (isEmojiCodePoint),
-    // so this is idempotent.
+    // Collect every emoji (grapheme cluster) the app ships an svg for as a document
+    // range with its Twemoji url.
     struct Run { int start; int end; QString text; QString url; };
     QVector<Run> runs;
     for (QTextBlock b = doc->begin(); b != doc->end(); b = b.next()) {
-        const QString t = b.text();
         const int base = b.position();
-        qsizetype i = 0;
-        while (i < t.size()) {
-            qsizetype units = 1;
-            if (!startsEmoji(t, i, units)) {
-                i += units;
-                continue;
-            }
-            const qsizetype runStart = i;
-            i += units;
-            while (i < t.size()) {
-                qsizetype u2 = 1;
-                if (!startsEmoji(t, i, u2))
-                    break;
-                i += u2;
-            }
-            const QString run = t.mid(runStart, i - runStart);
-            QTextBoundaryFinder bf(QTextBoundaryFinder::Grapheme, run);
-            int cs = 0;
-            for (int ce = bf.toNextBoundary(); ce >= 0; ce = bf.toNextBoundary()) {
-                if (ce > cs) {
-                    const QString cluster = run.mid(cs, ce - cs);
-                    const QString url = twemojiSvgUrl(m_twemojiBaseUrl, cluster);
-                    if (!url.isEmpty())
-                        runs.append({ int(base + runStart + cs), int(base + runStart + ce),
-                                      cluster, url });
-                }
-                cs = ce;
-            }
-        }
+        Markdown::forEachGraphemeCluster(b.text(), [&](QStringView cluster, int cs, int ce) {
+            const QString url = Markdown::twemojiSvgUrl(m_twemojiBaseUrl, cluster);
+            if (!url.isEmpty()) // retained past the callback ⇒ materialise an owning copy
+                runs.append({ base + cs, base + ce, cluster.toString(), url });
+            return true;
+        });
     }
     if (runs.isEmpty())
         return;
@@ -1238,7 +1171,7 @@ bool ChatInputHighlighter::insertEmojiObject(QTextCursor& cursor, const QString&
 {
     if (!m_imageEmojis || !document())
         return false;
-    const QString url = twemojiSvgUrl(m_twemojiBaseUrl, emoji);
+    const QString url = Markdown::twemojiSvgUrl(m_twemojiBaseUrl, emoji);
     if (url.isEmpty())
         return false;
     const int lineHeight = qMax(1, qRound(QFontMetricsF(document()->defaultFont()).height()));
@@ -1259,43 +1192,29 @@ void ChatInputHighlighter::insertEmojiAwareText(QTextCursor& cursor, const QStri
     if (cursor.hasSelection())
         cursor.removeSelectedText();
 
-    qsizetype i = 0;
-    while (i < text.size()) {
-        qsizetype units = 1;
-        if (!startsEmoji(text, i, units)) {
-            // Run of non-emoji text — inserted verbatim (preserving any '\n' handling).
-            const qsizetype s = i;
-            i += units;
-            while (i < text.size()) {
-                qsizetype u2 = 1;
-                if (startsEmoji(text, i, u2))
-                    break;
-                i += u2;
-            }
-            cursor.insertText(text.mid(s, i - s));
-            continue;
+    // Segment into grapheme clusters; each cluster the app ships an svg for becomes an inline image,
+    // everything else is buffered and inserted verbatim (one insertText per text span preserves '\n'
+    // handling). Asset existence — not a code-point range — decides what is an emoji, so whole
+    // sequences (subdivision flags, keycaps, ZWJ) resolve to their combined svg.
+    QString pending;
+    const auto flushPending = [&] {
+        if (!pending.isEmpty()) {
+            cursor.insertText(pending);
+            pending.clear();
         }
-        // Run of emoji code points — segment per grapheme cluster; image each (text fallback).
-        const qsizetype runStart = i;
-        i += units;
-        while (i < text.size()) {
-            qsizetype u2 = 1;
-            if (!startsEmoji(text, i, u2))
-                break;
-            i += u2;
+    };
+    Markdown::forEachGraphemeCluster(text, [&](QStringView cluster, int, int) {
+        if (Markdown::twemojiSvgUrl(m_twemojiBaseUrl, cluster).isEmpty()) {
+            pending.append(cluster);
+        } else {
+            flushPending();
+            const QString emoji = cluster.toString(); // needed by insertImage / insertText (own QString)
+            if (!insertEmojiObject(cursor, emoji)) // asset present ⇒ succeeds; defensive fallback
+                cursor.insertText(emoji);
         }
-        const QString run = text.mid(runStart, i - runStart);
-        QTextBoundaryFinder bf(QTextBoundaryFinder::Grapheme, run);
-        int cs = 0;
-        for (int ce = bf.toNextBoundary(); ce >= 0; ce = bf.toNextBoundary()) {
-            if (ce > cs) {
-                const QString cluster = run.mid(cs, ce - cs);
-                if (!insertEmojiObject(cursor, cluster))
-                    cursor.insertText(cluster);
-            }
-            cs = ce;
-        }
-    }
+        return true;
+    });
+    flushPending();
 }
 
 void ChatInputHighlighter::insertTextWithEmojis(int position, const QString& text)
@@ -1682,29 +1601,21 @@ void ChatInputHighlighter::highlightBlock(const QString& text)
         else
             emojiFormat.setProperty(QTextFormat::FontPointSize, base.pointSizeF() * 1.2);
 
-        auto codePointAt = [&](qsizetype k, qsizetype& units) -> char32_t {
-            const QChar c = text[k];
-            if (c.isHighSurrogate() && k + 1 < blockLen && text[k + 1].isLowSurrogate()) {
-                units = 2;
-                return QChar::surrogateToUcs4(c, text[k + 1]);
+        // Enlarge whole grapheme clusters: a cluster is emoji when it holds any emoji code point,
+        // so keycaps (base 0-9 # *) and subdivision flags are sized as one unit rather than split.
+        int runStart = -1; // start of the current run of consecutive emoji clusters, or -1
+        Markdown::forEachGraphemeCluster(text, [&](QStringView cluster, int start, int) {
+            if (Markdown::clusterHasEmoji(cluster)) {
+                if (runStart < 0)
+                    runStart = start;
+            } else if (runStart >= 0) {
+                setFormat(runStart, start - runStart, emojiFormat);
+                runStart = -1;
             }
-            units = 1;
-            return c.unicode();
-        };
-
-        qsizetype k = 0;
-        while (k < blockLen) {
-            qsizetype units = 1;
-            if (Markdown::isEmojiCodePoint(codePointAt(k, units))) {
-                const qsizetype start = k;
-                k += units;
-                while (k < blockLen && Markdown::isEmojiCodePoint(codePointAt(k, units)))
-                    k += units;
-                setFormat(static_cast<int>(start), static_cast<int>(k - start), emojiFormat);
-            } else {
-                k += units;
-            }
-        }
+            return true;
+        });
+        if (runStart >= 0)
+            setFormat(runStart, text.size() - runStart, emojiFormat);
     }
 }
 

--- a/ui/StatusQ/src/markdownast.cpp
+++ b/ui/StatusQ/src/markdownast.cpp
@@ -1,5 +1,10 @@
 #include "StatusQ/markdownast.h"
 
+#include <QDir>
+#include <QHash>
+#include <QSet>
+#include <QUrl>
+
 namespace {
 
 QString kindName(Markdown::NodeKind kind)
@@ -63,6 +68,49 @@ void dumpNode(const Markdown::Node& node, int depth, bool withRanges, QString& o
         dumpNode(child, depth + 1, withRanges, out);
 }
 
+// Reads the code point at `i`, advancing `units` over a surrogate pair.
+char32_t codePointAt(QStringView s, int i, int& units)
+{
+    const QChar c = s[i];
+    if (c.isHighSurrogate() && i + 1 < s.size() && s[i + 1].isLowSurrogate()) {
+        units = 2;
+        return QChar::surrogateToUcs4(c, s[i + 1]);
+    }
+    units = 1;
+    return c.unicode();
+}
+
+// Local path the base url (a directory ending in '/') resolves to, covering the two StatusQ
+// deployments: filesystem (file://) and bundled resources (qrc:/).
+QString localDirForUrl(const QString& url)
+{
+    const QUrl u(url);
+    if (u.scheme() == QLatin1String("qrc"))
+        return QLatin1Char(':') + u.path();
+    if (u.isLocalFile())
+        return u.toLocalFile();
+    return url;
+}
+
+// Basenames (without ".svg") of the Twemoji assets bundled under `base`, listed once per base and
+// cached. This asset set is the source of truth for which grapheme clusters render as an emoji
+// image.
+const QSet<QString>& twemojiAssetNames(const QString& base)
+{
+    static QHash<QString, QSet<QString>> cache;
+    const auto it = cache.constFind(base);
+    if (it != cache.constEnd())
+        return it.value();
+
+    QSet<QString> names;
+    const QDir dir(localDirForUrl(base));
+    const auto entries = dir.entryList(QStringList{QStringLiteral("*.svg")}, QDir::Files);
+    names.reserve(entries.size());
+    for (const QString& e : entries)
+        names.insert(e.left(e.size() - 4)); // strip ".svg"
+    return *cache.insert(base, std::move(names));
+}
+
 } // namespace
 
 namespace Markdown {
@@ -91,29 +139,59 @@ bool isEmojiCodePoint(char32_t cp)
         || (cp == 0x200D);                    // zero-width joiner
 }
 
+bool clusterHasEmoji(QStringView text)
+{
+    for (int i = 0; i < text.size();) {
+        int units = 1;
+        if (isEmojiCodePoint(codePointAt(text, i, units)))
+            return true;
+        i += units;
+    }
+    return false;
+}
+
 bool isOnlyEmoji(const QString& text)
 {
+    // Classify per grapheme cluster (not per code point): a keycap (0-9 # *) or subdivision flag
+    // has non-emoji code points inside an otherwise-emoji cluster, so a per-code-point test would
+    // wrongly reject them. Whitespace between/around emojis is allowed.
     bool hasEmoji = false;
-    int i = 0;
-    while (i < text.size()) {
-        const QChar c = text[i];
-        if (c.isSpace()) {
-            ++i;
-            continue;
+    bool onlyEmoji = true;
+    forEachGraphemeCluster(text, [&](QStringView cluster, int, int) {
+        if (cluster.trimmed().isEmpty())
+            return true; // whitespace between/around emojis is allowed
+        if (!clusterHasEmoji(cluster)) {
+            onlyEmoji = false;
+            return false; // a non-emoji cluster settles it — stop early
         }
-        char32_t cp;
-        if (c.isHighSurrogate() && i + 1 < text.size() && text[i + 1].isLowSurrogate()) {
-            cp = QChar::surrogateToUcs4(c, text[i + 1]);
-            i += 2;
-        } else {
-            cp = c.unicode();
-            ++i;
-        }
-        if (!isEmojiCodePoint(cp))
-            return false;
         hasEmoji = true;
+        return true;
+    });
+    return onlyEmoji && hasEmoji;
+}
+
+QString twemojiSvgUrl(const QString& base, QStringView cluster)
+{
+    // Presentation guard: image only clusters carrying an emoji code point, so default-text symbols
+    // that happen to ship an svg (© U+00A9, ® U+00AE, ™ U+2122) stay text unless written with VS16.
+    if (base.isEmpty() || !clusterHasEmoji(cluster))
+        return {};
+
+    const bool hasZwj = cluster.contains(QChar(0x200D));
+    QString name;
+    for (int i = 0; i < cluster.size();) {
+        int units = 1;
+        const char32_t cp = codePointAt(cluster, i, units);
+        i += units;
+        if (!hasZwj && cp == 0xFE0F) // twemoji.js toCodePoint: drop VS16 unless the cluster is a ZWJ seq
+            continue;
+        if (!name.isEmpty())
+            name += QLatin1Char('-');
+        name += QString::number(cp, 16);
     }
-    return hasEmoji;
+    if (name.isEmpty() || !twemojiAssetNames(base).contains(name))
+        return {};
+    return base + name + QStringLiteral(".svg");
 }
 
 } // namespace Markdown

--- a/ui/StatusQ/src/markdownhtml.cpp
+++ b/ui/StatusQ/src/markdownhtml.cpp
@@ -1,8 +1,6 @@
 #include "StatusQ/markdownhtml.h"
 
-#include <QFile>
-#include <QTextBoundaryFinder>
-#include <QUrl>
+#include <QHash>
 #include <QVariantMap>
 
 namespace {
@@ -37,56 +35,14 @@ QString escapeInline(const QString& s)
 }
 
 // A font-size span for one emoji run (font-based rendering).
-QString emojiFontSpan(const QString& emoji, int emojiPx)
+QString emojiFontSpan(QStringView emoji, int emojiPx)
 {
     return QStringLiteral("<span style=\"font-size:%1px\">%2</span>").arg(emojiPx).arg(emoji);
 }
 
 // ── image-based emoji (Twemoji) — used when an emoji base url is supplied ────────
-
-// Local path a url resolves to for an existence check (filesystem or bundled qrc:).
-QString localPathForUrl(const QString& url)
-{
-    const QUrl u(url);
-    if (u.scheme() == QLatin1String("qrc"))
-        return QLatin1Char(':') + u.path();
-    if (u.isLocalFile())
-        return u.toLocalFile();
-    return url;
-}
-
-// Maps a single emoji (one grapheme cluster) to its Twemoji svg url under `base`, following
-// twemoji.js' rule (drop U+FE0F unless the cluster has a ZWJ; join code points as lowercase hex
-// with '-'). "" when no svg exists. Mirrors chatinputhighlighter.cpp's twemojiSvgUrl.
-QString twemojiSvgUrl(const QString& base, const QString& emoji)
-{
-    if (base.isEmpty())
-        return {};
-    const bool hasZwj = emoji.contains(QChar(0x200D));
-    QString name;
-    for (qsizetype i = 0; i < emoji.size();) {
-        const QChar c = emoji[i];
-        char32_t cp;
-        if (c.isHighSurrogate() && i + 1 < emoji.size() && emoji[i + 1].isLowSurrogate()) {
-            cp = QChar::surrogateToUcs4(c, emoji[i + 1]);
-            i += 2;
-        } else {
-            cp = c.unicode();
-            i += 1;
-        }
-        if (!hasZwj && cp == 0xFE0F)
-            continue;
-        if (!name.isEmpty())
-            name += QLatin1Char('-');
-        name += QString::number(cp, 16);
-    }
-    if (name.isEmpty())
-        return {};
-    const QString url = base + name + QStringLiteral(".svg");
-    if (!QFile::exists(localPathForUrl(url)))
-        return {};
-    return url;
-}
+// Cluster → svg url resolution (asset set + presentation guard) lives in Markdown::twemojiSvgUrl,
+// shared with the live highlighter.
 
 // Renders an emoji run as Twemoji <img> tags: segmented per grapheme cluster so ZWJ sequences map
 // to their combined svg and adjacent emoji each get their own image. Clusters without a Twemoji svg
@@ -94,58 +50,49 @@ QString twemojiSvgUrl(const QString& base, const QString& emoji)
 QString emojiImagesHtml(const QString& run, int emojiPx, const QString& emojiBaseUrl)
 {
     QString out;
-    QTextBoundaryFinder bf(QTextBoundaryFinder::Grapheme, run);
-    int cs = 0;
-    for (int ce = bf.toNextBoundary(); ce >= 0; ce = bf.toNextBoundary()) {
-        if (ce > cs) {
-            const QString cluster = run.mid(cs, ce - cs);
-            const QString url = twemojiSvgUrl(emojiBaseUrl, cluster);
-            if (!url.isEmpty())
-                out += QStringLiteral("<img src=\"%1\" width=\"%2\" height=\"%2\""
-                                      " style=\"vertical-align:bottom\">").arg(url).arg(emojiPx);
-            else
-                out += emojiFontSpan(cluster, emojiPx);
-        }
-        cs = ce;
-    }
+    Markdown::forEachGraphemeCluster(run, [&](QStringView cluster, int, int) {
+        const QString url = Markdown::twemojiSvgUrl(emojiBaseUrl, cluster);
+        if (!url.isEmpty())
+            out += QStringLiteral("<img src=\"%1\" width=\"%2\" height=\"%2\""
+                                  " style=\"vertical-align:bottom\">").arg(url).arg(emojiPx);
+        else
+            out += emojiFontSpan(cluster, emojiPx);
+        return true;
+    });
     return out;
 }
 
-// Renders each run of emoji code points in `s` (already HTML-escaped). `emojiPx <= 0` leaves the
-// string unchanged. When `emojiBaseUrl` is empty, each run is wrapped in a font-size span so the
-// rich-text view enlarges them ~to the line height (font-based). When set, each emoji is emitted as
-// a Twemoji <img>. Safe on escaped text: entities and <br/> are ASCII, never in the emoji ranges.
+// Renders each run of emoji in `s` (already HTML-escaped). `emojiPx <= 0` leaves the string
+// unchanged. When `emojiBaseUrl` is empty, each run is wrapped in a font-size span so the rich-text
+// view enlarges them ~to the line height (font-based). When set, each emoji is emitted as a Twemoji
+// <img>. Safe on escaped text: entities and <br/> are ASCII, never in the emoji ranges.
 QString emojiWrap(const QString& s, int emojiPx, const QString& emojiBaseUrl)
 {
     if (emojiPx <= 0)
         return s;
 
-    const auto codePointAt = [&](int i, int& units) -> char32_t {
-        if (s[i].isHighSurrogate() && i + 1 < s.size() && s[i + 1].isLowSurrogate()) {
-            units = 2;
-            return QChar::surrogateToUcs4(s[i], s[i + 1]);
-        }
-        units = 1;
-        return s[i].unicode();
-    };
-
     QString out;
     out.reserve(s.size());
-    int i = 0;
-    while (i < s.size()) {
-        int units = 1;
-        if (Markdown::isEmojiCodePoint(codePointAt(i, units))) {
-            const int start = i;
-            do { i += units; }
-            while (i < s.size() && Markdown::isEmojiCodePoint(codePointAt(i, units)));
-            const QString run = s.mid(start, i - start);
-            out += emojiBaseUrl.isEmpty() ? emojiFontSpan(run, emojiPx)
-                                          : emojiImagesHtml(run, emojiPx, emojiBaseUrl);
+    int runStart = -1; // start of the current maximal run of consecutive emoji clusters, or -1
+    const auto flushRun = [&](int end) {
+        const QString run = s.mid(runStart, end - runStart);
+        out += emojiBaseUrl.isEmpty() ? emojiFontSpan(run, emojiPx)
+                                      : emojiImagesHtml(run, emojiPx, emojiBaseUrl);
+        runStart = -1;
+    };
+    Markdown::forEachGraphemeCluster(s, [&](QStringView cluster, int start, int /*end*/) {
+        if (Markdown::clusterHasEmoji(cluster)) {
+            if (runStart < 0)
+                runStart = start;
         } else {
-            out += s.mid(i, units);
-            i += units;
+            if (runStart >= 0)
+                flushRun(start);
+            out.append(cluster);
         }
-    }
+        return true;
+    });
+    if (runStart >= 0)
+        flushRun(s.size());
     return out;
 }
 
@@ -157,24 +104,6 @@ QString wrapCodeEmojis(const QString& escaped, int emojiPx, const QString& emoji
     if (emojiBaseUrl.isEmpty() || emojiPx <= 0)
         return escaped;
     return emojiWrap(escaped, emojiPx, emojiBaseUrl); // image mode ⇒ <img> per run, no font-size span
-}
-
-// Whether `s` contains at least one emoji code point.
-bool containsEmoji(const QString& s)
-{
-    for (int i = 0; i < s.size();) {
-        char32_t cp;
-        if (s[i].isHighSurrogate() && i + 1 < s.size() && s[i + 1].isLowSurrogate()) {
-            cp = QChar::surrogateToUcs4(s[i], s[i + 1]);
-            i += 2;
-        } else {
-            cp = s[i].unicode();
-            i += 1;
-        }
-        if (Markdown::isEmojiCodePoint(cp))
-            return true;
-    }
-    return false;
 }
 
 // Concatenates the raw (escaped, newlines preserved) text of every Text descendant,
@@ -522,7 +451,7 @@ void walk(const QVector<Node>& nodes, unsigned emph, BlockAcc& a,
             // In image-emoji mode, a block that actually contains an emoji also carries an HTML
             // variant (Twemoji <img> in a <pre> that keeps the monospace + whitespace) so the view
             // can render it as rich text. Plain code blocks omit it and stay PlainText, unchanged.
-            if (!emojiBaseUrl.isEmpty() && containsEmoji(code)) {
+            if (!emojiBaseUrl.isEmpty() && Markdown::clusterHasEmoji(code)) {
                 codeBlock[QStringLiteral("codeHtml")] =
                     QStringLiteral("<pre>%1</pre>").arg(wrapCodeEmojis(escape(code), emojiPx, emojiBaseUrl));
             }

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -50,6 +50,9 @@ add_test(NAME MarkdownParserTest COMMAND MarkdownParserTest)
 
 add_executable(MarkdownHtmlTest src/tst_markdownhtml.cpp)
 target_link_libraries(MarkdownHtmlTest PRIVATE Qt::Test StatusQ)
+# Real Twemoji svg assets, so image-mode emoji tests can exercise the actual asset set.
+target_compile_definitions(MarkdownHtmlTest PRIVATE
+    TWEMOJI_SVG_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../src/assets/twemoji/svg/")
 add_test(NAME MarkdownHtmlTest COMMAND MarkdownHtmlTest)
 
 # MarkdownUtils pulls in QFont (QtGui) via its header, so this test also needs Qt::Gui.

--- a/ui/StatusQ/tests/src/tst_markdownhtml.cpp
+++ b/ui/StatusQ/tests/src/tst_markdownhtml.cpp
@@ -1,4 +1,5 @@
 #include <QTest>
+#include <QUrl>
 
 #include <StatusQ/markdownhtml.h>
 #include <StatusQ/markdownparser.h>
@@ -534,6 +535,16 @@ private slots:
         return b[i].toMap()["html"].toString();
     }
 
+    // file:// base url for the real Twemoji svg dir (see TWEMOJI_SVG_DIR compile definition), so
+    // image-mode tests exercise the actual bundled asset set.
+    static QString twemojiBase()
+    {
+        QString base = QUrl::fromLocalFile(QStringLiteral(TWEMOJI_SVG_DIR)).toString();
+        if (!base.endsWith(QLatin1Char('/')))
+            base += QLatin1Char('/');
+        return base;
+    }
+
     // With a positive emojiPx an emoji run in text is wrapped in a font-size span.
     void blocks_emojiWrappedWhenSized()
     {
@@ -549,6 +560,67 @@ private slots:
         const QString two = QString::fromUcs4(U"\U0001F600\U0001F601");
         const QVariantList b = toBlocks(parse(two), {}, 18);
         QCOMPARE(blockHtml(b), "<span style=\"font-size:18px\">" + two + "</span>");
+    }
+
+    // Subdivision flags (England/Scotland/Wales) are a base black flag U+1F3F4 followed by
+    // Unicode tag characters (U+E0020..U+E007F). The whole tag sequence must stay in one emoji
+    // run / one span — otherwise the run stops at the base flag and renders as a black flag.
+    void blocks_emojiFlagTagSequenceGroupedInOneSpan()
+    {
+        const QString england = QString::fromUcs4(
+            U"\U0001F3F4\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067\U000E007F");
+        const QVariantList b = toBlocks(parse(england), {}, 18);
+        QCOMPARE(blockHtml(b), "<span style=\"font-size:18px\">" + england + "</span>");
+    }
+
+    // Keycap emoji (0-9 # *) are base ASCII + U+FE0F + U+20E3; the ASCII base is not an emoji code
+    // point, so a per-code-point scan would split it off. The whole cluster must stay one run.
+    void blocks_emojiKeycapGroupedInOneSpan()
+    {
+        const QString one = QString::fromUcs4(U"\U00000031\U0000FE0F\U000020E3"); // 1️⃣
+        const QVariantList b = toBlocks(parse(one), {}, 18);
+        QCOMPARE(blockHtml(b), "<span style=\"font-size:18px\">" + one + "</span>");
+    }
+
+    // The base url + asset set drives image mode: a real Twemoji svg dir is provided, so the flag
+    // resolves to its combined subdivision-flag svg — never the bare U+1F3F4 black-flag svg.
+    void blocks_emojiFlagImageUsesCombinedAsset()
+    {
+        const QString base = twemojiBase();
+        const QString england = QString::fromUcs4(
+            U"\U0001F3F4\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067\U000E007F");
+        const QString html = blockHtml(toBlocks(parse(england), {}, 18, base));
+        QVERIFY2(html.contains("1f3f4-e0067-e0062-e0065-e006e-e0067-e007f.svg"), qPrintable(html));
+        QVERIFY2(!html.contains("/1f3f4.svg"), qPrintable(html)); // not the bare black flag
+    }
+
+    // Keycap in image mode resolves to its combined "31-20e3" svg, not a chopped base digit.
+    void blocks_emojiKeycapImageUsesCombinedAsset()
+    {
+        const QString base = twemojiBase();
+        const QString one = QString::fromUcs4(U"\U00000031\U0000FE0F\U000020E3"); // 1️⃣
+        const QString html = blockHtml(toBlocks(parse(one), {}, 18, base));
+        QVERIFY2(html.contains("31-20e3.svg"), qPrintable(html));
+    }
+
+    // Presentation guard: © (U+00A9) ships an svg (a9.svg) but defaults to *text* presentation, so a
+    // bare © must stay literal text — not become a colour emoji image — even in image mode.
+    void blocks_emojiBareTextSymbolNotImaged()
+    {
+        const QString base = twemojiBase();
+        const QString copyright = QString::fromUcs4(U"\U000000A9"); // © without VS16
+        const QString html = blockHtml(toBlocks(parse("(c) " + copyright), {}, 18, base));
+        QVERIFY2(!html.contains("a9.svg"), qPrintable(html));
+        QVERIFY2(html.contains(copyright), qPrintable(html)); // preserved as text
+    }
+
+    // ...but the explicit emoji-presentation form ©️ (© + VS16 U+FE0F) does image to a9.svg.
+    void blocks_emojiTextSymbolWithVs16Imaged()
+    {
+        const QString base = twemojiBase();
+        const QString copyrightEmoji = QString::fromUcs4(U"\U000000A9\U0000FE0F"); // ©️
+        const QString html = blockHtml(toBlocks(parse(copyrightEmoji), {}, 18, base));
+        QVERIFY2(html.contains("a9.svg"), qPrintable(html));
     }
 
     // emojiPx == 0 (default) leaves the text untouched.


### PR DESCRIPTION
### What does the PR do

This PR fixes the architecture defect: `isEmojiCodePoint` was used to detect emoji boundaries. It was approximation, not correct Unicode-compliant boundary detector. The old approach is now replaced by proper Unicode grapheme segmentation  via `QTextBoundaryFinder`. Morever now Twemoji asset set is the literal source of truth for what the app can display.

Closes: #22270


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Markdown parser and syntax highlighter.

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality


<img width="542" height="587" alt="image" src="https://github.com/user-attachments/assets/1c32dea4-c766-4f6d-ad55-58071ffcf65b" />


### Impact on end user

All emojis displayed correctly.

### How to test

Insert emojis lie :england: or :four: which were not rendered correctly before.

### Risk 

Low
