### PR TITLE
fix(AppMain): unbreak opening sidebar in narrow/portrait view

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -341,7 +341,7 @@ QtObject {
                 if (!item)
                     return false
                 const str = item.toString()
-                return str.includes("QQuickPopupItem") && !str.includes("StatusToolTip")
+                return str.includes("QQuickPopupItem") && !str.includes("StatusToolTip") && !str.includes("MessageContextMenuView")
             }).length > 0
     }
 }


### PR DESCRIPTION
### What does the PR do

- with a mouse attached; the `MessageContextMenuView` was considered as a plain popup, thus blocking the Sidebar rainbow handle from appearing

Fixes #22391

### Affected areas

Sidebar/Utils

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="862" height="2142" alt="image" src="https://github.com/user-attachments/assets/8b152f80-d2b5-48a6-ab01-748774669d9b" />

### Impact on end user

UX

### How to test

- get to the narrow/portrait mode on desktop, sidebar hidden
- hover over a message item

### Risk 

low
