### PR TITLE
fix(MessageView): allow closing the emoji popup 

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -80,6 +80,10 @@ QC.Popup {
     */
     property bool fillHeightOnBottomSheet: false
 
+    closePolicy: root.bottomSheet ? QC.Popup.CloseOnEscape | QC.Popup.CloseOnPressOutside
+                                  : QC.Popup.CloseOnEscape | QC.Popup.CloseOnPressOutsideParent
+
+
     QtObject {
        id: d
        readonly property var window: root.contentItem.Window.window
@@ -108,7 +112,6 @@ QC.Popup {
             parent: root.directParent
             modal: false
             dim: false
-            closePolicy: QC.Popup.CloseOnEscape | QC.Popup.CloseOnPressOutsideParent
 
             x: root.relativeX
             y: root.relativeY
@@ -124,7 +127,6 @@ QC.Popup {
             parent: root.QC.Overlay.overlay || parent
             modal: true
             dim: true
-            closePolicy: QC.Popup.CloseOnEscape | QC.Popup.CloseOnPressOutside
 
             x: 0
             y: d.windowHeight - height

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1752,7 +1752,7 @@ Item {
                 active: d.doShowMessagingBanner && d.canShowMessagingBanner
                 delay: false
                 type: ModuleWarning.Warning
-                text: qsTr("Not Connected to Logos network")
+                text: qsTr("Not Connected to P2P network")
                 buttonText: qsTr("How to fix")
                 closeBtnVisible: false
                 Layout.fillWidth: true

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1811,6 +1811,10 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Not Connected to P2P network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>CoinGecko connection successful</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1943,10 +1947,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     </message>
     <message>
         <source>POKT &amp; Infura down for %1. %1 token balances cannot be retrieved.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not Connected to Logos network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1823,6 +1823,10 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
         <translation>Import komunity &apos;%1&apos; byl zrušen</translation>
     </message>
     <message>
+        <source>Not Connected to P2P network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>CoinGecko connection successful</source>
         <translation>Připojení ke službě CoinGecko proběhlo úspěšně</translation>
     </message>
@@ -1957,10 +1961,6 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
     <message>
         <source>POKT &amp; Infura down for %1. %1 token balances cannot be retrieved.</source>
         <translation>POKT &amp; Infura mimo provoz pro %1. Zůstatky tokenů %1 nelze načíst.</translation>
-    </message>
-    <message>
-        <source>Not Connected to Logos network</source>
-        <translation>Není připojeno k síti Logos</translation>
     </message>
     <message>
         <source>How to fix</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1812,6 +1812,10 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
         <translation>Importación de la comunidad &apos;%1&apos; cancelada</translation>
     </message>
     <message>
+        <source>Not Connected to P2P network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>CoinGecko connection successful</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1945,10 +1949,6 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
     <message>
         <source>POKT &amp; Infura down for %1. %1 token balances cannot be retrieved.</source>
         <translation>POKT e Infura caídos para %1. No se pueden obtener los balances de tokens de %1.</translation>
-    </message>
-    <message>
-        <source>Not Connected to Logos network</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>How to fix</source>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -1812,6 +1812,10 @@ de &quot;%1&quot; à &quot;%2&quot;</translation>
         <translation>L’importation de la communauté «&#xa0;%1&#xa0;» a été annulée</translation>
     </message>
     <message>
+        <source>Not Connected to P2P network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>CoinGecko connection successful</source>
         <translation>Connexion à CoinGecko établie</translation>
     </message>
@@ -1945,10 +1949,6 @@ de &quot;%1&quot; à &quot;%2&quot;</translation>
     <message>
         <source>POKT &amp; Infura down for %1. %1 token balances cannot be retrieved.</source>
         <translation>POKT et Infura sont hors service pour %1. Impossible de récupérer les soldes des jetons %1.</translation>
-    </message>
-    <message>
-        <source>Not Connected to Logos network</source>
-        <translation>Non connecté au réseau Logos</translation>
     </message>
     <message>
         <source>How to fix</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1796,6 +1796,10 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>커뮤니티 &apos;%1&apos; 가져오기가 취소되었습니다</translation>
     </message>
     <message>
+        <source>Not Connected to P2P network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>CoinGecko connection successful</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1928,10 +1932,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     <message>
         <source>POKT &amp; Infura down for %1. %1 token balances cannot be retrieved.</source>
         <translation>%1에 대해 POKT 및 Infura가 중단됨. %1 토큰 잔액을 가져올 수 없습니다.</translation>
-    </message>
-    <message>
-        <source>Not Connected to Logos network</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>How to fix</source>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -1823,6 +1823,10 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>Імпорт спільноти «%1» скасовано</translation>
     </message>
     <message>
+        <source>Not Connected to P2P network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>CoinGecko connection successful</source>
         <translation>Підключення до CoinGecko успішне</translation>
     </message>
@@ -1957,10 +1961,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     <message>
         <source>POKT &amp; Infura down for %1. %1 token balances cannot be retrieved.</source>
         <translation>POKT та Infura недоступні для %1. Не вдалося отримати баланси токенів %1.</translation>
-    </message>
-    <message>
-        <source>Not Connected to Logos network</source>
-        <translation>Немає підключення до мережі Logos</translation>
     </message>
     <message>
         <source>How to fix</source>

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -642,6 +642,13 @@ Loader {
         on_ChatLogViewAncestorXTraceChanged: contextMenu?.close() // will run destruction/cleanup
     }
 
+    Binding {
+        target: root?.emojiPopup ?? null
+        property: "closePolicy"
+        value: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        when: d.emojiPopupOpened
+    }
+
     Timer {
         id: hoverMessageContextMenuCloseTimer
         // Keep the hover menu alive while the pointer moves from the message to the popup.


### PR DESCRIPTION
### What does the PR do

- by clicking anywhere outside the popup, not just outside of this message
- adjust the StatusDropdown to be able to override the `closePolicy` externally in a regular manner; forcing it thru internal `Binding`s prevents this; preserves the previous behavior

Fixes https://github.com/status-im/status-app/issues/21316

Separate fix to drop one more "Logos" occurrence

### Affected areas

MessageView, StatusDropdown

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality


https://github.com/user-attachments/assets/5cbc5b41-c371-4408-9725-6aa2b62f36e7



### Impact on end user

UX

### How to test

- click the "Add reaction" button to open the Emoji popup
- click outside the popup on the same or different messages, should close

### Risk 

low
