### PR TITLE
fix: close popup on tap outside the popup

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
@@ -99,7 +99,6 @@ Control {
         height: Math.min(implicitHeight, d.windowHeight - button.mapToItem(null, 0, button.height).y - d.bottomPadding)
         fillHeightOnBottomSheet: true
 
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
         padding: 0
 
         contentItem: SearchableAssetsPanel {

--- a/ui/imports/shared/controls/ProfileButton.qml
+++ b/ui/imports/shared/controls/ProfileButton.qml
@@ -84,8 +84,6 @@ StatusIconTabButton {
 
         directParent: root
 
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
-
         relativeY: root.y - userStatusContextMenu.height + root.height
         relativeX: root.x + root.width + 8
 


### PR DESCRIPTION
The issues happened cause recently closePolicy was update in StatusDropdown which is the parent component of those popups and they inherited policy and they are:
- Mobile bottom sheet: CloseOnEscape | CloseOnPressOutside
- Desktop dropdown: CloseOnEscape | CloseOnPressOutsideParent

Closing policy removed from the following component since it is inherited:
- UserStatusContextMenu popup
- SearchableAssetsPanel popup

Fixes #22400