### PR TITLE
chore: disable autofocus to enter password input field if biometrics is used for signing

### DIFF
--- a/storybook/qmlTests/tests/tst_AuthSignPopupBase.qml
+++ b/storybook/qmlTests/tests/tst_AuthSignPopupBase.qml
@@ -6,7 +6,6 @@ import QtTest
 import StatusQ
 
 import shared.popups.auth_sign_base 1.0
-
 import utils
 
 Item {
@@ -55,6 +54,76 @@ Item {
                 requestCount++
                 return Keychain.StatusSuccess
             }
+        }
+    }
+
+    TestCase {
+        name: "AuthSignPopupBase_passwordFocus"
+        when: windowShown
+
+        property var popup: null
+        property var mockKeychain: null
+
+        function init() {
+            mockKeychain = createTemporaryObject(mockedKeychainComponent, root)
+            verify(!!mockKeychain)
+        }
+
+        function cleanup() {
+            if (popup) {
+                popup.destroy()
+                popup = null
+            }
+        }
+
+        function createSoftwareWalletPopup(keyUid, performPasswordAction) {
+            popup = createTemporaryObject(componentUnderTest, root, {
+                                              keychain: mockKeychain,
+                                              keyUid: keyUid,
+                                              userProfileKeyUid: keyUid,
+                                              userProfileMigratedToColdWallet: false,
+                                              isKeycardKeyPair: false,
+                                              performPasswordAction: performPasswordAction
+            })
+            verify(!!popup)
+            popup.open()
+            tryCompare(popup, "opened", true)
+        }
+
+        function test_passwordOnlyFocusesInput() {
+            createSoftwareWalletPopup("key-without-biometrics", password => true)
+
+            tryVerify(() => !!findChild(popup, "authenticationPasswordInput"))
+            const passwordInput = findChild(popup, "authenticationPasswordInput")
+            tryCompare(passwordInput, "activeFocus", true)
+        }
+
+        function test_biometricSuccessDoesNotFocusInput() {
+            let providedPassword = ""
+            createSoftwareWalletPopup("key-uid-1", password => {
+                                          providedPassword = password
+                                          return true
+                                      })
+
+            tryCompare(mockKeychain, "requestCount", 1)
+            mockKeychain.getCredentialRequestCompleted(Keychain.StatusSuccess, "secret")
+
+            compare(providedPassword, "secret")
+            tryVerify(() => !!findChild(popup, "authenticationPasswordInput"))
+            const passwordInput = findChild(popup, "authenticationPasswordInput")
+            verify(!!passwordInput)
+            compare(passwordInput.activeFocus, false)
+        }
+
+        function test_biometricCredentialMismatchFocusesInput() {
+            createSoftwareWalletPopup("key-uid-1", password => false)
+
+            tryCompare(mockKeychain, "requestCount", 1)
+            mockKeychain.getCredentialRequestCompleted(Keychain.StatusSuccess, "stale-secret")
+
+            tryVerify(() => !!findChild(popup, "authenticationPasswordInput"))
+            const passwordInput = findChild(popup, "authenticationPasswordInput")
+            tryCompare(passwordInput, "activeFocus", true)
         }
     }
 

--- a/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
+++ b/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
@@ -192,6 +192,7 @@ StatusDialog {
                 return
             }
             if (status !== Keychain.StatusSuccess || secret.length === 0) {
+                d.autoFocusPasswordInput = true
                 d.biometricsInProgress = false
                 d.showToast(status)
                 return
@@ -219,6 +220,7 @@ StatusDialog {
                                                 && !root.externalAuthorization // the authentication popup runs its own biometrics
                                                 && (!root.isKeycardKeyPair || root.keyUid === root.userProfileKeyUid)
                                                 && keychain.hasCredential(root.useKeyUid) === Keychain.StatusSuccess
+        property bool autoFocusPasswordInput: !d.usingBiometrics
 
         onUsingBiometricsChanged: d.tryAutoStartBiometrics()
 
@@ -278,6 +280,7 @@ StatusDialog {
         ////////////////////////////////////////////////////////////////////////////////
 
         function startBiometrics() {
+            d.autoFocusPasswordInput = false
             d.biometricsInProgress = true
             d.error = ""
             d.credentialCameFromBiometrics = false
@@ -302,6 +305,7 @@ StatusDialog {
                 }
                 if (d.usingBiometrics && d.credentialCameFromBiometrics) {
                     d.credentialMismatchAfterBiometrics = true
+                    d.autoFocusPasswordInput = true
                 }
                 return
             }
@@ -437,6 +441,7 @@ StatusDialog {
     Component {
         id: enterPasswordComponent
         EnterPassword {
+            autoFocusInput: d.autoFocusPasswordInput
             onAccepted: d.performPasswordActionInternal()
         }
     }

--- a/ui/imports/shared/popups/auth_sign_base/states/EnterPassword.qml
+++ b/ui/imports/shared/popups/auth_sign_base/states/EnterPassword.qml
@@ -4,7 +4,6 @@ import QtQuick.Controls
 
 import StatusQ.Core
 import StatusQ.Core.Theme
-import StatusQ.Core.Utils as SQUtils
 import StatusQ.Controls
 
 import utils
@@ -13,11 +12,19 @@ Control {
     id: root
 
     property bool wrongPassword: false
+    property bool autoFocusInput: true
 
     property alias password: passwordInput.text
     readonly property bool passwordValid: passwordInput.text !== "" && !root.wrongPassword
 
     signal accepted()
+
+    function focusInputIfRequested() {
+        if (root.autoFocusInput)
+            passwordInput.forceActiveFocus(Qt.MouseFocusReason)
+    }
+
+    onAutoFocusInputChanged: root.focusInputIfRequested()
 
     topPadding: Theme.halfPadding
     bottomPadding: Theme.halfPadding
@@ -54,7 +61,7 @@ Control {
             Layout.maximumWidth: parent.width
             placeholderText: qsTr("Password")
             selectByMouse: true
-            focus: !SQUtils.Utils.isMobile
+            focus: root.autoFocusInput
 
             onTextChanged: root.wrongPassword = false
 
@@ -79,7 +86,5 @@ Control {
         }
     }
 
-    Component.onCompleted: {
-        passwordInput.forceActiveFocus(Qt.MouseFocusReason)
-    }
+    Component.onCompleted: root.focusInputIfRequested()
 }


### PR DESCRIPTION
Created for @sunleos to test the keyboard, since only he can reproduce it.

Another try/approach, since the first one here https://github.com/status-im/status-app/pull/22396 didn't fix the issue.

Fixes https://github.com/status-im/status-app/issues/22383