### PR TITLE
fix(wallet): dedupe per-chain balance chips in the swap

### DIFF
--- a/src/app/modules/shared_models/token_selector_builder.nim
+++ b/src/app/modules/shared_models/token_selector_builder.nim
@@ -60,7 +60,11 @@ proc buildTokenSelectorItems*(groups: seq[AggTokenGroup],
     if g.communityId.len > 0 and not params.showCommunityAssets:
       continue
 
-    var chips: seq[TokenSelectorChip] = @[]
+    # Balances are per (account, chain); chips are keyed per chain in the
+    # balances submodel. With no account filter a chain held by several
+    # accounts yields several rows for the same chain, so sum per chain first
+    # or the submodel sync trips on the duplicate key.
+    var perChain = initOrderedTable[int, UInt256]()
     var total = 0.u256
     for b in g.balances:
       if accountLower.len > 0 and b.account.toLowerAscii != accountLower:
@@ -70,10 +74,14 @@ proc buildTokenSelectorItems*(groups: seq[AggTokenGroup],
       if b.balance.isZero and not params.showZeroBalanceForDefaultTokens:
         continue
       total = total + b.balance
-      let net = netByChain.getOrDefault(b.chainId)
-      chips.add(TokenSelectorChip(chainId: b.chainId, iconUrl: net.iconUrl,
-        chainName: net.chainName, balance: toFloatUnits(b.balance, g.decimals),
-        rawBalance: $b.balance))
+      perChain[b.chainId] = perChain.getOrDefault(b.chainId, 0.u256) + b.balance
+
+    var chips: seq[TokenSelectorChip] = @[]
+    for chainId, balance in perChain:
+      let net = netByChain.getOrDefault(chainId)
+      chips.add(TokenSelectorChip(chainId: chainId, iconUrl: net.iconUrl,
+        chainName: net.chainName, balance: toFloatUnits(balance, g.decimals),
+        rawBalance: $balance))
 
     # Drop groups with no surviving balance (QML `balancesModelCount != 0`).
     if chips.len == 0:

--- a/test/nim/token_selector_builder_test.nim
+++ b/test/nim/token_selector_builder_test.nim
@@ -98,6 +98,26 @@ suite "buildTokenSelectorItems — aggregation":
     check it.currentBalance == 0.0
     check not it.hasBalance                # currentBalance 0 -> popular section
 
+  test "same-chain balances from several accounts merge into one chip":
+    # Regression: with no account filter (e.g. the form reset clearing
+    # accountAddress), two accounts holding the token on the same chain used to
+    # produce two chips with the same chainId, tripping the balances submodel's
+    # duplicate-key assert - surfacing as a SIGSEGV through the seaqt exception
+    # boundary when opening/closing the swap modal.
+    let g = group("ETH", balances = @[
+      bal("0xA", 1, "1000000000000000000"),   # 1.0 mainnet
+      bal("0xB", 1, "2000000000000000000"),   # 2.0 mainnet, second account
+      bal("0xA", 10, "500000000000000000"),   # 0.5 optimism
+    ])
+    let it = buildTokenSelectorItems(@[g], networks, noFilterParams()).findItem("ETH")
+    check it.chips.len == 2
+    # sorted by balance descending, so the merged mainnet chip comes first
+    check it.chips[0].chainId == 1
+    check it.chips[0].balance == 3.0
+    check it.chips[0].rawBalance == "3000000000000000000"
+    check it.chips[1].chainId == 10
+    check it.currentBalance == 3.5
+
   test "group with no surviving balances is dropped":
     let g = group("ZERO", balances = @[bal("0xA", 1, "0")])
     let items = buildTokenSelectorItems(@[g], networks, noFilterParams())


### PR DESCRIPTION
Corresponding `nimqml-seaqt` PR:
- https://github.com/seaqt/nimqml-seaqt/pull/16

buildTokenSelectorItems has one balance chip per AggBalance row, and those rows are per (account, chain). With no account filter (exactly the state during the swap form reset and initial picker setup) a token held on the same chain by two or more accounts produced duplicate chips for that chainId, conflicting with the balances submodel's duplicate-key assert in model_sync.setItemsWithSync which is recompute on every picker (setAccountAddress, search, setEnabledChainId, refreshModels).

Before the nimqml-seaqt boundary hardening, that Defect escaped the Qt callback into C++, where a goto-exceptions raise degrades into a nil return plus a leaked error flag — surfacing as a random SIGSEGV in VirtualQAbstractListModel::index (this == nullptr) under QQuickPopup::closed() when opening/closing the swap modal, far from the actual raise site.

Sum balances per chain before emitting chips, so each chain yields one chip carrying the aggregated logical balance and raw wei total - also the correct display when no account filter is active.

Potentially fixes https://github.com/status-im/status-app/issues/22315, but mainly was to fix a crash that was happening when running/closing Swap popup if the Wallet has 2+ accounts and each has the same tokens on the same chains.  