### PR TITLE
perf(chat): low-end message view lag fixes

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -4,6 +4,7 @@ import ../../app_service/common/utils as common_utils
 import ./html_utils
 import stew/byteutils
 import ./utils/qrcodegen
+import ./utils/pubkey_memo
 import std/json
 import chronicles
 
@@ -23,6 +24,8 @@ logScope:
 
 QtObject:
   type Utils* = ref object of QObject
+    colorIdCache: PubkeyMemo[int]
+    emojiHashCache: PubkeyMemo[string]
 
   proc isCompressedPubKey*(self: Utils, publicKey: string): bool
   proc getDecompressedPk*(self: Utils, compressedKey: string): string
@@ -36,6 +39,8 @@ QtObject:
 
   proc setup(self: Utils) =
     self.QObject.setup
+    self.colorIdCache = newPubkeyMemo[int]()
+    self.emojiHashCache = newPubkeyMemo[string]()
 
   proc delete*(self: Utils) =
     self.QObject.delete
@@ -163,17 +168,18 @@ QtObject:
   proc escapeHtml*(self: Utils, text: string): string {.slot.} =
     result = common_utils.escape_html(text)
 
-  proc getEmojiHashAsJson*(self: Utils, publicKey: string): string {.slot.} =
-    var pk = publicKey
+  proc decompressedPk(self: Utils, publicKey: string): string =
     if self.isCompressedPubKey(publicKey):
-      pk = self.getDecompressedPk(publicKey)
-    procs_from_visual_identity_service.getEmojiHashAsJson(pk)
+      return self.getDecompressedPk(publicKey)
+    publicKey
+
+  proc getEmojiHashAsJson*(self: Utils, publicKey: string): string {.slot.} =
+    self.emojiHashCache.get(publicKey, proc(key: string): string =
+      procs_from_visual_identity_service.getEmojiHashAsJson(self.decompressedPk(key)))
 
   proc getColorId*(self: Utils, publicKey: string): int {.slot.} =
-    var pk = publicKey
-    if self.isCompressedPubKey(publicKey):
-      pk = self.getDecompressedPk(publicKey)
-    int(procs_from_visual_identity_service.colorIdOf(pk))
+    self.colorIdCache.get(publicKey, proc(key: string): int =
+      int(procs_from_visual_identity_service.colorIdOf(self.decompressedPk(key))))
 
   proc getCompressedPk*(self: Utils, publicKey: string): string {.slot.} =
     compressPk(publicKey)

--- a/src/app/global/utils/pubkey_memo.nim
+++ b/src/app/global/utils/pubkey_memo.nim
@@ -1,0 +1,31 @@
+## Memoization for the pure per-public-key derivations exposed by `Utils`
+## (color id, emoji hash). A miss costs up to three status-go FFI round-trips
+## while the result never changes for a given key, and the UI asks for them
+## once per message row it dresses.
+
+import std/[options, tables]
+
+type PubkeyMemo*[T] = ref object
+  entries: Table[string, T]
+
+proc newPubkeyMemo*[T](): PubkeyMemo[T] =
+  PubkeyMemo[T](entries: initTable[string, T]())
+
+## Returns the memoized value for `publicKey`, calling `compute` only on a miss.
+proc get*[T](self: PubkeyMemo[T], publicKey: string,
+             compute: proc(publicKey: string): T): T =
+  self.entries.withValue(publicKey, hit):
+    return hit[]
+  result = compute(publicKey)
+  self.entries[publicKey] = result
+
+proc peek*[T](self: PubkeyMemo[T], publicKey: string): Option[T] =
+  self.entries.withValue(publicKey, hit):
+    return some(hit[])
+  return none(T)
+
+proc len*[T](self: PubkeyMemo[T]): int =
+  self.entries.len
+
+proc clear*[T](self: PubkeyMemo[T]) =
+  self.entries.clear()

--- a/storybook/pages/MessageRowsSkeletonPage.qml
+++ b/storybook/pages/MessageRowsSkeletonPage.qml
@@ -11,25 +11,31 @@ import Storybook
 SplitView {
     id: root
 
-    SplitView {
-        orientation: Qt.Vertical
+    Item {
         SplitView.fillWidth: true
+        SplitView.fillHeight: true
 
-        Item {
-            SplitView.fillWidth: true
-            SplitView.fillHeight: true
+        Theme.style: darkThemeSwitch.checked ? Theme.Style.Dark : Theme.Style.Light
 
-            Rectangle {
-                anchors.centerIn: parent
-                width: widthSlider.value
-                height: parent.height - 40
-                color: Theme.palette.baseColor4
-                border.color: Theme.palette.baseColor2
+        Rectangle {
+            anchors.centerIn: parent
+            width: widthSlider.value
+            height: parent.height - 40
+            color: Theme.palette.baseColor4
+            border.color: Theme.palette.baseColor2
+            clip: true
 
-                MessageRowsSkeleton {
-                    anchors.fill: parent
-                    anchors.margins: Theme.padding
+            // Bottom-anchored like the paging placeholder: shrinking the
+            // height via the slider must keep the pattern at the bottom
+            // seam pinned while the top edge moves.
+            MessageRowsSkeleton {
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    bottom: parent.bottom
+                    margins: Theme.padding
                 }
+                height: heightSlider.value
             }
         }
     }
@@ -49,6 +55,19 @@ SplitView {
                 to: 1000
                 value: 700
                 stepSize: 1
+            }
+            Label { text: "Skeleton height: %1".arg(heightSlider.value) }
+            Slider {
+                id: heightSlider
+                Layout.fillWidth: true
+                from: 200
+                to: 100000
+                value: 12000
+                stepSize: 50
+            }
+            Switch {
+                id: darkThemeSwitch
+                text: "Dark theme"
             }
             Item { Layout.fillHeight: true }
         }

--- a/storybook/qmlTests/tests/tst_ChatLoaderSection.qml
+++ b/storybook/qmlTests/tests/tst_ChatLoaderSection.qml
@@ -526,6 +526,37 @@ Item {
 
 
 
+        // The chrome's panel-switch state must reach the shared messages
+        // view as its dress hold: held while a switch runs,
+        // released when it ends.
+        function test_panelSwitchStateReachesDressHold() {
+            harness.active = true
+            const loader = harness.item
+            verify(!!loader)
+            tryVerify(() => loader.status === Loader.Ready, 60000)
+            tryVerify(() => !!activeReadyLogView(loader), 120000)
+
+            const lv = findChild(loader, "chatLogView")
+            verify(!!lv)
+            let messagesView = lv
+            while (messagesView
+                   && typeof messagesView.dressHold === "undefined") {
+                messagesView = messagesView.parent
+            }
+            verify(!!messagesView,
+                   "the messages view must be an ancestor of the log view")
+
+            const chrome = findChild(loader, "sectionChrome")
+            verify(!!chrome)
+
+            compare(messagesView.dressHold, false,
+                    "no switch running: the hold must be down")
+            chrome.panelSwitchStarted()
+            tryCompare(messagesView, "dressHold", true)
+            chrome.panelSwitchEnded()
+            tryCompare(messagesView, "dressHold", false)
+        }
+
         // The message context menu opens for a rendered message (the input
         // simulation variants live in tst_MessageLongTapMenu, where the
         // fixture geometry is faithful)

--- a/storybook/qmlTests/tests/tst_ChatTextViewRecycling.qml
+++ b/storybook/qmlTests/tests/tst_ChatTextViewRecycling.qml
@@ -1,0 +1,285 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Components
+
+Item {
+    id: root
+    width: 600
+    height: 400
+
+    Component {
+        id: componentUnderTest
+
+        ChatTextView {
+            width: 400
+            font.pixelSize: 15
+        }
+    }
+
+    TestCase {
+        id: testCase
+        name: "ChatTextViewRecycling"
+        when: windowShown
+
+        property ChatTextView control: null
+
+        function init() {
+            control = createTemporaryObject(componentUnderTest, root)
+            verify(control)
+        }
+
+        // Recursively collects the leaf text renderers (Text/TextEdit/Label) under `item`,
+        // in document order — the items whose identity block recycling must preserve.
+        function collectTextItems(item) {
+            const out = []
+            const walk = (it) => {
+                if (typeof it.text === "string")
+                    out.push(it)
+                const kids = it.children
+                for (let i = 0; i < kids.length; ++i)
+                    walk(kids[i])
+            }
+            walk(item)
+            return out
+        }
+
+        // True when some rendered text item under `item` contains `substr`.
+        function renders(item, substr) {
+            const items = collectTextItems(item)
+            for (let i = 0; i < items.length; ++i)
+                if (items[i].text.indexOf(substr) >= 0)
+                    return true
+            return false
+        }
+
+        // ── identity preservation (the fast path) ────────────────────────────────
+
+        // Rebinding paragraph→paragraph (different text) keeps the same rendered item
+        // instance and shows the new text.
+        function test_paragraphRebindKeepsInstance() {
+            control.blocks = [{ type: "text", html: "hello" }]
+            tryVerify(() => control.implicitHeight > 0)
+
+            const before = collectTextItems(control)
+            compare(before.length, 1)
+            verify(renders(control, "hello"))
+
+            control.blocks = [{ type: "text", html: "world" }]
+
+            const after = collectTextItems(control)
+            compare(after.length, 1)
+            verify(after[0] === before[0], "paragraph item was recreated instead of recycled")
+            verify(renders(control, "world"), "new text not shown")
+            verify(!renders(control, "hello"), "old text still shown")
+        }
+
+        // Same fast path in selectable mode (TextEdit renderers).
+        function test_paragraphRebindKeepsInstance_selectable() {
+            control.selectable = true
+            control.blocks = [{ type: "text", html: "hello" }]
+            tryVerify(() => control.implicitHeight > 0)
+
+            const before = collectTextItems(control)
+            compare(before.length, 1)
+
+            control.blocks = [{ type: "text", html: "world" }]
+
+            const after = collectTextItems(control)
+            compare(after.length, 1)
+            verify(after[0] === before[0], "selectable paragraph item was recreated")
+            verify(renders(control, "world"))
+            verify(!renders(control, "hello"))
+        }
+
+        // A multi-block rebind with an unchanged type sequence recycles every item.
+        function test_sameShapeMultiBlockKeepsAllInstances() {
+            control.blocks = [
+                { type: "text", html: "para one" },
+                { type: "code", code: "a = 1" }
+            ]
+            tryVerify(() => control.implicitHeight > 0)
+
+            const before = collectTextItems(control)
+            compare(before.length, 2)
+
+            control.blocks = [
+                { type: "text", html: "para two" },
+                { type: "code", code: "b = 2" }
+            ]
+
+            const after = collectTextItems(control)
+            compare(after.length, 2)
+            for (let i = 0; i < before.length; ++i)
+                verify(after[i] === before[i], "block " + i + " was recreated")
+            verify(renders(control, "para two"))
+            verify(renders(control, "b = 2"))
+            verify(!renders(control, "para one"))
+            verify(!renders(control, "a = 1"))
+        }
+
+        // Quote sub-blocks (replies render through this path) are recycled too.
+        function test_quoteNestedRebindKeepsInstance() {
+            control.blocks = [{ type: "quote", blocks: [{ type: "text", html: "inner one" }] }]
+            tryVerify(() => control.implicitHeight > 0)
+
+            const before = collectTextItems(control)
+            compare(before.length, 1)
+
+            control.blocks = [{ type: "quote", blocks: [{ type: "text", html: "inner two" }] }]
+
+            const after = collectTextItems(control)
+            compare(after.length, 1)
+            verify(after[0] === before[0], "nested quote item was recreated")
+            verify(renders(control, "inner two"))
+            verify(!renders(control, "inner one"))
+        }
+
+        // ── shape change (the recreate fallback) ─────────────────────────────────
+
+        // Renders `blocks` in a fresh view and compares its pixels against `ctrl` — the
+        // recycled/rebuilt view must be indistinguishable from a fresh build.
+        function verifyMatchesFreshBuild(ctrl, blocks) {
+            const fresh = createTemporaryObject(componentUnderTest, root,
+                                                { blocks: blocks, y: 200 })
+            verify(fresh)
+            // Both views relayout asynchronously — wait until their heights settle and agree.
+            tryVerify(() => fresh.implicitHeight > 0 && ctrl.implicitHeight === fresh.implicitHeight,
+                      5000, "rebound view height differs from a fresh build")
+            verify(grabImage(ctrl).equals(grabImage(fresh)),
+                   "rebound view renders differently from a fresh build")
+        }
+
+        // Count change (paragraph → paragraph+code) falls back to recreation and matches
+        // a fresh build.
+        function test_countChangeRecreatesAndMatchesFreshBuild() {
+            control.blocks = [{ type: "text", html: "hello" }]
+            tryVerify(() => control.implicitHeight > 0)
+            compare(collectTextItems(control).length, 1)
+
+            const blocks = [
+                { type: "text", html: "hello" },
+                { type: "code", code: "x = 1" }
+            ]
+            control.blocks = blocks
+            tryVerify(() => collectTextItems(control).length === 2)
+            verify(renders(control, "hello"))
+            verify(renders(control, "x = 1"))
+
+            verifyMatchesFreshBuild(control, blocks)
+        }
+
+        // Type change with an unchanged count (paragraph → code) rebuilds that block's
+        // renderer and matches a fresh build.
+        function test_typeChangeRecreatesRendererAndMatchesFreshBuild() {
+            control.blocks = [{ type: "text", html: "hello" }]
+            tryVerify(() => control.implicitHeight > 0)
+
+            const blocks = [{ type: "code", code: "y = 2" }]
+            control.blocks = blocks
+            tryVerify(() => renders(control, "y = 2"))
+            verify(!renders(control, "hello"), "old paragraph text still shown")
+
+            verifyMatchesFreshBuild(control, blocks)
+        }
+
+        // Shrinking the count drops the extra items and matches a fresh build.
+        function test_countShrinkMatchesFreshBuild() {
+            control.blocks = [
+                { type: "text", html: "hello" },
+                { type: "code", code: "x = 1" },
+                { type: "quote", blocks: [{ type: "text", html: "quoted" }] }
+            ]
+            tryVerify(() => control.implicitHeight > 0)
+
+            const blocks = [{ type: "text", html: "bye" }]
+            control.blocks = blocks
+            tryVerify(() => collectTextItems(control).length === 1)
+            verify(renders(control, "bye"))
+            verify(!renders(control, "x = 1"))
+            verify(!renders(control, "quoted"))
+
+            verifyMatchesFreshBuild(control, blocks)
+        }
+
+        // ── no stale state across recycled rebinds ───────────────────────────────
+
+        // Rebinding a mention/link/code-rich message to plain text (same shape → recycled
+        // item) leaves no remnants of the old content.
+        function test_noStaleRichContentAfterRecycledRebind() {
+            control.blocks = [{
+                type: "text",
+                html: '<a href="0xabc" class="mention">@alice</a> see '
+                      + '<a href="https://stale.example">https://stale.example</a> and <code>fooCode</code>'
+            }]
+            tryVerify(() => control.implicitHeight > 0)
+            verify(renders(control, "@alice"))
+            verify(renders(control, "stale.example"))
+            verify(renders(control, "fooCode"))
+
+            const before = collectTextItems(control)
+            compare(before.length, 1)
+
+            control.blocks = [{ type: "text", html: "plain text" }]
+
+            const after = collectTextItems(control)
+            compare(after.length, 1)
+            verify(after[0] === before[0], "item was recreated instead of recycled")
+            verify(renders(control, "plain text"))
+            verify(!renders(control, "@alice"), "stale mention remnant")
+            verify(!renders(control, "0xabc"), "stale mention href remnant")
+            verify(!renders(control, "stale.example"), "stale link remnant")
+            verify(!renders(control, "fooCode"), "stale code-span remnant")
+
+            verifyMatchesFreshBuild(control, [{ type: "text", html: "plain text" }])
+        }
+
+        // ── edited marker across recycled rebinds ────────────────────────────────
+
+        // Toggling `edited` recycles the text-last block (same shape) and the marker
+        // appears/disappears correctly on the same item instance.
+        function test_editedToggleOnRecycledTextBlock() {
+            control.blocks = [{ type: "text", html: "hello" }]
+            tryVerify(() => control.implicitHeight > 0)
+
+            const before = collectTextItems(control)
+            compare(before.length, 1)
+            verify(!renders(control, "(edited)"))
+
+            control.edited = true
+            let after = collectTextItems(control)
+            compare(after.length, 1)
+            verify(after[0] === before[0], "edited:true recreated the text item")
+            tryVerify(() => renders(control, "(edited)"), 1000, "marker not shown")
+            verify(renders(control, "hello"))
+
+            control.edited = false
+            after = collectTextItems(control)
+            compare(after.length, 1)
+            verify(after[0] === before[0], "edited:false recreated the text item")
+            tryVerify(() => !renders(control, "(edited)"), 1000, "marker not removed")
+            verify(renders(control, "hello"))
+        }
+
+        // With a non-text last block the marker is its own trailing block: toggling `edited`
+        // changes the count (recreate path) and the marker still comes and goes correctly.
+        function test_editedToggleWithTrailingCodeBlock() {
+            control.blocks = [
+                { type: "text", html: "hello" },
+                { type: "code", code: "x = 1" }
+            ]
+            tryVerify(() => control.implicitHeight > 0)
+            compare(collectTextItems(control).length, 2)
+
+            control.edited = true
+            tryVerify(() => renders(control, "(edited)"), 1000, "marker not shown after code block")
+            compare(collectTextItems(control).length, 3)
+
+            control.edited = false
+            tryVerify(() => !renders(control, "(edited)"), 1000, "marker not removed")
+            compare(collectTextItems(control).length, 2)
+            verify(renders(control, "hello"))
+            verify(renders(control, "x = 1"))
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_FlingContinuity.qml
+++ b/storybook/qmlTests/tests/tst_FlingContinuity.qml
@@ -1,0 +1,659 @@
+import QtQuick
+import QtTest
+
+import StatusQ 0.1
+import utils
+
+import shared.views.chat
+
+import AppLayouts.Chat.views
+import AppLayouts.Chat.stores as ChatStores
+
+/*
+ Scroll freeze: content geometry never mutates while the
+ message view is in motion — window slides, atomic reveals and placeholder
+ resizes all wait for rest, so nothing cancels an active flick or jumps the
+ scrollbar. Fetches stay free (eager prefetch), and a settle that
+ out-scrolled the window teleports through the window-record restore path.
+*/
+Item {
+    id: root
+
+    width: 800
+    height: 600
+
+    ChatStores.RootStore { id: rootStoreMock }
+
+    ListModel { id: messagesModel }
+    ListModel { id: messagesModelB }
+
+    component ContentModuleMock: QtObject {
+        id: moduleMock
+
+        property string mockChatId: "chat-1"
+        property var mockModel
+
+        function markAllMessagesRead() {}
+
+        readonly property var chatDetails: QtObject {
+            readonly property string id: moduleMock.mockChatId
+            readonly property int type: Constants.chatType.oneToOne
+            readonly property bool active: true
+            readonly property bool highlight: false
+            property bool hasUnreadMessages: false
+            readonly property bool canPost: true
+            readonly property bool canView: true
+            readonly property bool canPostReactions: true
+            readonly property string emoji: ""
+        }
+
+        readonly property var messagesModule: QtObject {
+            readonly property var model: moduleMock.mockModel
+            property bool loading: false
+            property bool keepUnread: false
+
+            property int loadMoreCalls: 0
+
+            signal messageSuccessfullySent()
+            signal sendingMessageFailed(string error)
+            signal reactionActionFailed()
+            signal scrollToMessage(int messageIndex)
+
+            function getChatId() { return moduleMock.mockChatId }
+            function loadMoreMessages() { loadMoreCalls++ }
+            function updateKeepUnread(flag) {}
+        }
+
+        function getMyChatId() { return moduleMock.mockChatId }
+        function amIChatAdmin() { return false }
+    }
+
+    ContentModuleMock {
+        id: contentModuleMock
+
+        mockChatId: "chat-1"
+        mockModel: messagesModel
+    }
+
+    ContentModuleMock {
+        id: contentModuleMockB
+
+        mockChatId: "chat-2"
+        mockModel: messagesModelB
+    }
+
+    Component {
+        id: poolComp
+
+        DelegatePool {
+            DelegatePoolKind {
+                objectName: "messageKind"
+                kind: "message"
+                target: 0
+
+                delegate: Component {
+                    MessageView {}
+                }
+            }
+        }
+    }
+
+    Component {
+        id: sectionComp
+
+        Item {
+            id: harness
+
+            width: 800
+            height: 600
+
+            property DelegatePool rowPool: null
+            property bool dressHold: false
+            property int activeIndex: 0
+
+            readonly property Item activeShell: {
+                if (activeIndex === 0)
+                    return shellA
+                if (activeIndex === 1)
+                    return shellB
+                return null
+            }
+
+            readonly property ChatStores.MessageStore fallbackMessageStore: ChatStores.MessageStore {
+                messageModule: null
+            }
+
+            ChatContentView {
+                id: shellA
+                anchors.fill: parent
+                visible: harness.activeIndex === 0
+                rootStore: rootStoreMock
+                chatContentModule: contentModuleMock
+                chatId: "chat-1"
+                chatType: Constants.chatType.oneToOne
+            }
+
+            ChatContentView {
+                id: shellB
+                anchors.fill: parent
+                visible: harness.activeIndex === 1
+                rootStore: rootStoreMock
+                chatContentModule: contentModuleMockB
+                chatId: "chat-2"
+                chatType: Constants.chatType.oneToOne
+            }
+
+            Item {
+                id: parkingHolder
+                anchors.fill: parent
+                visible: false
+            }
+
+            ChatMessagesView {
+                parent: harness.activeShell ? harness.activeShell.messagesSlot
+                                            : parkingHolder
+                anchors.fill: parent
+
+                rowPool: harness.rowPool
+                dressHold: harness.dressHold
+                rootStore: rootStoreMock
+                messageStore: harness.activeShell ? harness.activeShell.messageStore
+                                                  : harness.fallbackMessageStore
+                chatContentModule: harness.activeShell ? harness.activeShell.chatContentModule
+                                                       : null
+                chatId: harness.activeShell ? harness.activeShell.chatId : ""
+                isOneToOne: true
+                usersModel: ListModel {}
+                joined: true
+            }
+        }
+    }
+
+    TestCase {
+        name: "FlingContinuity"
+        when: windowShown
+
+        function cleanup() {
+            contentModuleMock.messagesModule.loading = false
+            contentModuleMockB.messagesModule.loading = false
+            contentModuleMock.messagesModule.loadMoreCalls = 0
+            contentModuleMockB.messagesModule.loadMoreCalls = 0
+            messagesModel.clear()
+            messagesModelB.clear()
+        }
+
+        function appendMessage(i, contentType) {
+            messagesModel.append(messageRoles("msg-" + i, i, Date.now() - i * 60000, contentType))
+        }
+
+        function messageRoles(id, i, ts, contentType) {
+            return {
+                id: id,
+                communityId: "",
+                compressedKey: "zQ3peer",
+                prevMsgIndex: i + 1,
+                nextMsgIndex: i - 1,
+                prevMsgTimestamp: ts - 60000,
+                nextMsgTimestamp: ts + 60000,
+                prevMsgSenderId: "",
+                prevMsgContentType: 1,
+                prevMsgDeleted: false,
+                timestamp: ts,
+                responseToMessageWithId: "",
+                senderId: "0xpeer",
+                senderDisplayName: "Peer",
+                senderOptionalName: "",
+                senderIcon: "",
+                senderIsAdded: true,
+                senderEnsVerified: false,
+                senderTrustStatus: 0,
+                amISender: false,
+                usesDefaultName: true,
+                messageText: "Message " + i + " — the quick brown fox jumps over the lazy dog.",
+                unparsedText: "Message " + i,
+                messageImage: "",
+                messageAttachments: "",
+                albumImagesCount: 0,
+                albumMessageImages: "",
+                contentType: contentType === undefined ? 1 : contentType,
+                sticker: "",
+                stickerPack: -1,
+                editMode: false,
+                isEdited: false,
+                outgoingStatus: "",
+                resendError: "",
+                mentioned: false,
+                gapFrom: 0,
+                gapTo: 0,
+                quotedMessageText: "",
+                quotedMessageParsedText: "",
+                quotedMessageFrom: "",
+                quotedMessageContentType: 1,
+                quotedMessageDeleted: false,
+                quotedMessageAuthorName: "",
+                quotedMessageAuthorDisplayName: "",
+                quotedMessageAuthorThumbnailImage: "",
+                quotedMessageAuthorEnsVerified: false,
+                quotedMessageAuthorIsContact: false,
+                quotedMessageAlbumImagesCount: 0,
+                quotedMessageAlbumMessageImages: "",
+                reactions: "",
+                pinned: false,
+                pinnedBy: "",
+                deleted: false,
+                deletedBy: "",
+                deletedByContactDisplayName: "",
+                deletedByContactIcon: "",
+                bridgeName: "",
+                links: "",
+                transactionParameters: ""
+            }
+        }
+
+        function openPooledChat(messageCount, poolIntervalMs) {
+            for (let i = 0; i < messageCount; ++i)
+                appendMessage(i)
+
+            const pool = createTemporaryObject(poolComp, root,
+                                               { backgroundIntervalMs: poolIntervalMs })
+            verify(!!pool)
+            const view = createTemporaryObject(sectionComp, root, { rowPool: pool })
+            verify(!!view)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            const kind = findChild(pool, "messageKind")
+            verify(!!kind)
+
+            tryVerify(() => listView.count > 0, 20000)
+            tryVerify(() => !internal.initialFillActive, 20000,
+                      "the initial batch must reveal")
+
+            return { pool: pool, kind: kind, view: view,
+                     listView: listView, internal: internal }
+        }
+
+        function builtCount(chat) {
+            return chat.internal.acquiredCount + chat.kind.readyCount
+        }
+
+        function waitForFullPool(chat) {
+            tryVerify(() => builtCount(chat) >= chat.kind.target, 60000,
+                      "the pool must reach its target, built "
+                      + builtCount(chat) + " of " + chat.kind.target)
+        }
+
+        function waitForQuietWindow(chat) {
+            const internal = chat.internal
+            tryVerify(() => internal.stagedCount === 0, 30000,
+                      "staged rows must all reveal")
+            let last = ""
+            let stable = 0
+            for (let i = 0; i < 400 && stable < 8; ++i) {
+                wait(25)
+                const now = internal.windowStart + ".." + internal.windowEnd
+                stable = (now === last) ? stable + 1 : 0
+                last = now
+            }
+            verify(stable >= 8, "the window must stop moving, at " + last)
+            waitForRendering(chat.listView)
+        }
+
+        // The row whose top currently sits at (or just below) the viewport
+        // top: the smallest non-negative viewport offset.
+        function rowIndexAtViewportTop(listView) {
+            let best = -1
+            let bestOffset = Number.MAX_VALUE
+            for (let i = 0; i < listView.count; ++i) {
+                const off = listView.viewportOffsetToRow(i)
+                if (isNaN(off) || off < -2)
+                    continue
+                if (off < bestOffset) {
+                    bestOffset = off
+                    best = i
+                }
+            }
+            return best
+        }
+
+        function sourceIndexOfRow(listView, internal, i) {
+            return internal.windowStart + i
+        }
+
+        // ---- Regression gate: repeated flings up through history ----
+        // The freeze invariant, observed from the physics side: across six
+        // full flings no flick is cancelled, contentY never touches the top
+        // clamp, content geometry (height, row positions) never changes
+        // mid-motion — and the window still advances, so the freeze does not
+        // starve paging.
+        function test_flingContinuityAcrossRepeatedFlings() {
+            const chat = openPooledChat(800, 0)
+            const listView = chat.listView
+            const internal = chat.internal
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+
+            listView.maximumFlickVelocity = 4000
+            listView.flickDeceleration = 1500
+
+            listView.contentY = listView.contentHeight - listView.height
+            waitForRendering(listView)
+
+            const startWindowEnd = internal.windowEnd
+
+            let flickCancels = 0
+            let topTouches = 0
+            let contentHeightChanges = 0
+            let downwardJumps = 0
+            let maxTrackedContentShift = 0
+            let maxTrackedScreenJump = 0
+
+            for (let round = 0; round < 6; ++round) {
+                let tracked = null
+                for (let i = 0; i < listView.count; ++i) {
+                    const it = listView.itemAtRow(i)
+                    if (it && it.visible && it.height > 0) {
+                        tracked = it
+                        break
+                    }
+                }
+                verify(!!tracked, "round " + round + " needs a visible row to track")
+                let lastContentPos = tracked.y
+                let lastScreenY = tracked.y - listView.contentY
+
+                const startCy = listView.contentY
+                let travel = 0
+                listView.flick(0, 3000)
+                // a real fast fling raises the velocity dress gate; offscreen
+                // flick() never updates verticalVelocity, so drive it directly
+                internal.updateScrollGate(listView.height * 2)
+                tryVerify(() => listView.flickingVertically, 1000,
+                          "round " + round + " flick must start")
+
+                let lastCy = listView.contentY
+                let lastCh = listView.contentHeight
+                let lastTickMs = Date.now()
+                for (let t = 0; t < 400; ++t) {
+                    wait(16)
+                    if (!listView.flickingVertically)
+                        break
+                    const nowMs = Date.now()
+                    const cy = listView.contentY
+                    const ch = listView.contentHeight
+                    if (Math.abs(ch - lastCh) > 0.5)
+                        contentHeightChanges++
+                    if (cy - lastCy > 0.5)
+                        downwardJumps++
+                    if (cy <= 1)
+                        topTouches++
+                    if (!tracked.retired) {
+                        const shift = Math.abs(tracked.y - lastContentPos)
+                        if (shift > maxTrackedContentShift)
+                            maxTrackedContentShift = shift
+                        lastContentPos = tracked.y
+                        const sy = tracked.y - cy
+                        // one frame of fling motion, at the measured tick
+                        // length (offscreen ticks jitter well past 16ms)
+                        const naturalMotion = 3000 * (nowMs - lastTickMs) / 1000
+                        const excess = Math.abs(sy - lastScreenY) - naturalMotion
+                        if (excess > maxTrackedScreenJump)
+                            maxTrackedScreenJump = excess
+                        lastScreenY = sy
+                    }
+                    travel = startCy - cy
+                    lastCy = cy
+                    lastCh = ch
+                    lastTickMs = nowMs
+                }
+                if (travel < 1500 && listView.contentY > 1)
+                    flickCancels++
+
+                internal.updateScrollGate(0)
+                tryVerify(() => !listView.moving, 5000)
+                // mid-history the paging timer keeps nibbling at the window
+                // (the pool caps it below viewport + both prefetch margins),
+                // so wait for the staged reveal, not for total quiet — the
+                // freeze gates every mutation during the next fling anyway
+                tryVerify(() => internal.stagedCount === 0, 30000,
+                          "round " + round + " settle batch must reveal")
+                waitForRendering(listView)
+            }
+
+            console.info("[FLING] flickCancels=" + flickCancels
+                         + " topTouches=" + topTouches
+                         + " contentHeightChanges=" + contentHeightChanges
+                         + " downwardJumps=" + downwardJumps
+                         + " maxTrackedContentShift=" + maxTrackedContentShift.toFixed(0)
+                         + " maxTrackedScreenJumpExcess=" + maxTrackedScreenJump.toFixed(0)
+                         + " window " + startWindowEnd + " -> " + internal.windowEnd)
+
+            compare(flickCancels, 0)
+            compare(topTouches, 0)
+            compare(contentHeightChanges, 0)
+            compare(downwardJumps, 0)
+            verify(maxTrackedContentShift <= 2,
+                   "rows must hold their content position mid-motion, shifted "
+                   + maxTrackedContentShift)
+            // content shift 0 already proves rows only move with the scroll;
+            // the excess over the fling's own per-tick motion is sampling
+            // jitter, bounded loosely (baseline reveals jumped rows by
+            // hundreds to thousands of px)
+            verify(maxTrackedScreenJump <= 150,
+                   "a row's screen move per tick must stay within a frame of "
+                   + "fling motion, excess " + maxTrackedScreenJump)
+            verify(internal.windowEnd > startWindowEnd + 30,
+                   "the window must advance across the fling sequence, still at "
+                   + internal.windowEnd)
+        }
+
+        // ---- Teleport slide: settle at the placeholder's far edge ----
+        // A deep-scroll to the very top of the placeholder settles with the
+        // window at the oldest loaded row — row-exact at the edge — and the
+        // viewport pinned there through the atomic reveal.
+        function test_teleportLandsAtOldestLoadedRowAtFarEdge() {
+            const chat = openPooledChat(400, 0)
+            const listView = chat.listView
+            const internal = chat.internal
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+
+            // park deep inside the placeholder, then let the fling run out
+            // against the top clamp: the motion-end settle happens exactly at
+            // the placeholder's far edge
+            listView.maximumFlickVelocity = 4000
+            listView.flickDeceleration = 1500
+            listView.contentY = 150
+            listView.flick(0, 2000)
+            tryVerify(() => listView.moving, 1000)
+            tryVerify(() => !listView.moving, 10000)
+            verify(listView.contentY <= 1, "the fling must run out at the top clamp")
+
+            tryVerify(() => internal.windowEnd === 399, 5000,
+                      "the teleport must land at the oldest loaded row, at "
+                      + internal.windowEnd)
+            tryVerify(() => internal.stagedCount === 0, 30000,
+                      "the teleport batch must reveal")
+            // let the at-rest paging tail run its no-op fetch and drop the
+            // exhausted top placeholder; the pin must survive that collapse
+            wait(600)
+            compare(internal.windowEnd, 399)
+
+            const idx = listView.count - 1
+            const item = listView.itemAtRow(idx)
+            verify(!!item && item.visible, "the oldest loaded row must be shown")
+            compare(String(item.messageId), "msg-399")
+            const offset = listView.viewportOffsetToRow(idx)
+            verify(!isNaN(offset))
+            verify(Math.abs(offset) <= 5,
+                   "the viewport must stay pinned to the teleport target, offset "
+                   + offset)
+        }
+
+        // ---- Teleport slide: mid-placeholder settle ----
+        // A settle deep inside the placeholder (but short of its far edge)
+        // lands within estimate error of depth ÷ avgRowHeight, and the
+        // reveal pins the viewport so it does not visibly jump.
+        function test_teleportMidPlaceholderLandsWithinEstimate() {
+            const chat = openPooledChat(800, 0)
+            const listView = chat.listView
+            const internal = chat.internal
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+
+            const avg = internal.avgRowHeight > 0 ? internal.avgRowHeight : 48
+            const depthTarget = 90 * avg
+            verify(internal.topPlaceholderHeight > depthTarget,
+                   "the placeholder must be deeper than the target depth")
+            listView.contentY = internal.topPlaceholderHeight - depthTarget
+            listView.flick(0, 300)
+            tryVerify(() => listView.moving, 1000)
+
+            const windowEndBefore = internal.windowEnd
+            const depth = listView.viewportDepthIntoTopPlaceholder()
+            verify(depth > 0, "the viewport must sit inside the placeholder")
+            const expected = windowEndBefore + Math.round(depth / avg)
+            verify(expected < 799 - 30, "the target must stay short of the far edge")
+            listView.cancelFlick()
+            tryVerify(() => !listView.moving, 5000)
+
+            tryVerify(() => internal.stagedCount === 0, 30000,
+                      "the teleport batch must reveal")
+            waitForRendering(listView)
+
+            const topIdx = rowIndexAtViewportTop(listView)
+            verify(topIdx >= 0, "a row must sit at the viewport top after reveal")
+            const landedTop = sourceIndexOfRow(listView, internal, topIdx)
+            verify(Math.abs(landedTop - expected) <= 3,
+                   "the viewport must be pinned at the estimated row: expected "
+                   + expected + ", showing " + landedTop)
+        }
+
+        // ---- Assimilation stays free, geometry stays frozen ----
+        // History rows arriving mid-motion must not move contentHeight or
+        // contentY; the placeholder absorbs them at rest.
+        function test_assimilationFrozenWhileMoving() {
+            const chat = openPooledChat(300, 0)
+            const listView = chat.listView
+            const internal = chat.internal
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+
+            listView.contentY = listView.contentHeight - listView.height
+            waitForRendering(listView)
+
+            listView.flick(0, 1200)
+            tryVerify(() => listView.moving, 1000)
+
+            const chBefore = listView.contentHeight
+            const topBefore = internal.topPlaceholderHeight
+            for (let i = 300; i < 360; ++i)
+                appendMessage(i)
+
+            let contentHeightChanges = 0
+            let downwardJumps = 0
+            let lastCy = listView.contentY
+            for (let t = 0; t < 400; ++t) {
+                wait(16)
+                if (!listView.moving)
+                    break
+                if (Math.abs(listView.contentHeight - chBefore) > 0.5)
+                    contentHeightChanges++
+                if (listView.contentY - lastCy > 0.5)
+                    downwardJumps++
+                lastCy = listView.contentY
+                compare(internal.topPlaceholderHeight, topBefore)
+            }
+            compare(contentHeightChanges, 0)
+            compare(downwardJumps, 0)
+
+            tryVerify(() => !listView.moving, 10000)
+            tryVerify(() => internal.topPlaceholderHeight > topBefore, 5000,
+                      "the placeholder must absorb the new history at rest")
+        }
+
+        // ---- Eager history prefetch ----
+        // Scrolling deep into the placeholder fires loadMoreMessages before
+        // the settle, and the in-flight guard blocks repeats until the fetch
+        // actually grows the history.
+        function test_prefetchFiresDuringPlaceholderScroll() {
+            const chat = openPooledChat(60, 0)
+            const listView = chat.listView
+            const internal = chat.internal
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            contentModuleMock.messagesModule.loadMoreCalls = 0
+
+            listView.maximumFlickVelocity = 4000
+            listView.flickDeceleration = 1500
+            listView.contentY = listView.contentHeight - listView.height
+            waitForRendering(listView)
+
+            listView.flick(0, 3000)
+            tryVerify(() => listView.moving, 1000)
+
+            let firedWhileMoving = false
+            for (let t = 0; t < 400; ++t) {
+                wait(16)
+                if (contentModuleMock.messagesModule.loadMoreCalls > 0) {
+                    firedWhileMoving = listView.moving
+                    break
+                }
+                if (!listView.moving)
+                    break
+            }
+            verify(firedWhileMoving,
+                   "the fetch must fire while still scrolling, before the settle")
+            compare(contentModuleMock.messagesModule.loadMoreCalls, 1)
+
+            // the mock fetch brings nothing: with the history count unchanged
+            // no further request may fire — not during the rest of the
+            // motion, not at settle, not from the at-rest paging tail
+            tryVerify(() => !listView.moving, 10000)
+            tryVerify(() => internal.stagedCount === 0, 30000)
+            wait(600)
+            compare(contentModuleMock.messagesModule.loadMoreCalls, 1)
+        }
+
+        // ---- Per-side placeholder heights ----
+        // After up-slides the bottom placeholder reflects windowStart — the
+        // rows actually below the window — never the top's remaining
+        // estimate (the coupled height that caused the slide ping-pong).
+        function test_perSidePlaceholderHeights() {
+            const chat = openPooledChat(800, 0)
+            const listView = chat.listView
+            const internal = chat.internal
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+
+            // park the viewport in the upper half of the window rows, then
+            // drive up-slides directly until one trades the recent end
+            listView.contentY = internal.topPlaceholderHeight + 100
+            waitForRendering(listView)
+            for (let i = 0; i < 10 && internal.windowStart === 0; ++i) {
+                internal.slideWindowToHistory()
+                tryVerify(() => internal.stagedCount === 0, 20000,
+                          "slide " + i + " must reveal")
+            }
+            verify(internal.windowStart > 0,
+                   "up-slides must start trading the recent end")
+
+            // sampled in one turn: window bounds and the latched heights are
+            // kept consistent within an event dispatch
+            const windowStart = internal.windowStart
+            const windowEnd = internal.windowEnd
+            const bottomHeight = internal.bottomPlaceholderHeight
+            const topHeight = internal.topPlaceholderHeight
+            const avg = internal.avgRowHeight > 0 ? internal.avgRowHeight : 48
+            const expectedBottom = Math.max(listView.height,
+                                            Math.min(windowStart, 300) * avg)
+            fuzzyCompare(bottomHeight, expectedBottom, 1)
+            const expectedTop = Math.max(listView.height,
+                                         Math.min(800 - 1 - windowEnd, 300) * avg)
+            fuzzyCompare(topHeight, expectedTop, 1)
+            verify(bottomHeight < topHeight,
+                   "the bottom placeholder must not inherit the top's estimate")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_MessageRowsSkeletonTiling.qml
+++ b/storybook/qmlTests/tests/tst_MessageRowsSkeletonTiling.qml
@@ -1,0 +1,208 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Core.Theme
+
+import AppLayouts.Chat.panels
+
+/*
+ The message-rows skeleton doubles as the paging placeholder, which on a
+ low-end device can be ~180k px tall. Item cost must be O(1) in height:
+ exactly one pattern block of real tiles, rendered into one texture, tiled
+ with single-node quads. Height changes must never rebuild the block, and
+ the tiling is anchored to the bottom edge so the pattern at the seam with
+ real rows stays pinned when a reveal shrinks the placeholder.
+
+ Offscreen note: no pixel/grab assertions here — only instance counts,
+ positions and live-texture wiring.
+*/
+Item {
+    id: root
+
+    width: 800
+    height: 600
+
+    Component {
+        id: skeletonComp
+
+        MessageRowsSkeleton {
+            width: 800
+        }
+    }
+
+    TestCase {
+        name: "MessageRowsSkeletonTiling"
+        when: windowShown
+
+        function findAllByObjectName(item, name) {
+            const found = []
+            function walk(obj) {
+                for (let i = 0; i < obj.children.length; ++i) {
+                    const child = obj.children[i]
+                    if (child.objectName === name)
+                        found.push(child)
+                    walk(child)
+                }
+            }
+            walk(item)
+            return found
+        }
+
+        // leaf items with a color — the LoadingSkeletonTile rectangles
+        function findTiles(item) {
+            const found = []
+            function walk(obj) {
+                for (let i = 0; i < obj.children.length; ++i) {
+                    const child = obj.children[i]
+                    if (!child.children.length && child.color !== undefined)
+                        found.push(child)
+                    walk(child)
+                }
+            }
+            walk(item)
+            return found
+        }
+
+        function bottomQuad(skeleton) {
+            const quads = findAllByObjectName(skeleton, "patternQuad")
+            verify(quads.length > 0)
+            let best = quads[0]
+            for (let i = 1; i < quads.length; ++i) {
+                if (quads[i].y > best.y)
+                    best = quads[i]
+            }
+            return best
+        }
+
+        function test_tallSkeletonIsOneBlockPlusQuads() {
+            const height = 100000
+            const skeleton = createTemporaryObject(skeletonComp, root,
+                                                   { height })
+            verify(!!skeleton)
+            waitForRendering(skeleton) // lets the block's positioners settle
+
+            const blocks = findAllByObjectName(skeleton, "patternBlock")
+            compare(blocks.length, 1)
+
+            const block = blocks[0]
+            verify(block.height > 0)
+
+            // the rest of the height is quads, one per block-sized step
+            const step = block.height + Theme.padding
+            const quads = findAllByObjectName(skeleton, "patternQuad")
+            compare(quads.length, Math.ceil((height - block.height) / step))
+
+            // O(height/500) — a couple hundred, not the ~8,500 items of the
+            // per-height Repeater this replaces
+            verify(quads.length <= height / 500 + 1)
+
+            // quads are single nodes: no children of their own
+            for (let i = 0; i < quads.length; ++i)
+                compare(quads[i].children.length, 0)
+
+            // together the block and quads leave no blank screenful
+            let covered = block.height
+            for (let i = 0; i < quads.length; ++i)
+                covered += quads[i].height
+            verify(covered + (quads.length + 1) * Theme.padding >= height)
+        }
+
+        function test_seamStaysPinnedToBottomOnShrink() {
+            const skeleton = createTemporaryObject(skeletonComp, root,
+                                                   { height: 5000 })
+            verify(!!skeleton)
+            waitForRendering(skeleton) // lets the block's positioners settle
+
+            const block = findAllByObjectName(skeleton, "patternBlock")[0]
+            verify(!!block)
+
+            const quad = bottomQuad(skeleton)
+            const quadBottomOffset = skeleton.height - (quad.y + quad.height)
+            compare(block.y + block.height, skeleton.height)
+
+            // a reveal shrinks the placeholder from the top
+            skeleton.height = 3200
+
+            const quadAfter = bottomQuad(skeleton)
+            compare(skeleton.height - (quadAfter.y + quadAfter.height),
+                    quadBottomOffset)
+            compare(block.y + block.height, skeleton.height)
+        }
+
+        function test_heightChangesDoNotRebuildBlock() {
+            const skeleton = createTemporaryObject(skeletonComp, root,
+                                                   { height: 2000 })
+            verify(!!skeleton)
+            waitForRendering(skeleton) // lets the block's positioners settle
+
+            const block = findAllByObjectName(skeleton, "patternBlock")[0]
+            verify(!!block)
+            const tileCount = findTiles(block).length
+            verify(tileCount > 0)
+
+            const heights = [40000, 300, 100000, 1234]
+            for (let i = 0; i < heights.length; ++i) {
+                skeleton.height = heights[i]
+
+                const blocks = findAllByObjectName(skeleton, "patternBlock")
+                compare(blocks.length, 1)
+                verify(blocks[0] === block) // same instance, never recreated
+                compare(findTiles(block).length, tileCount)
+            }
+        }
+
+        function test_quadsSampleOneLiveBlockTexture() {
+            const skeleton = createTemporaryObject(skeletonComp, root,
+                                                   { height: 5000 })
+            verify(!!skeleton)
+            waitForRendering(skeleton) // lets the block's positioners settle
+
+            const block = findAllByObjectName(skeleton, "patternBlock")[0]
+            const sources = findAllByObjectName(skeleton, "patternBlockSource")
+            compare(sources.length, 1)
+
+            const source = sources[0]
+            verify(source.live) // texture follows block changes (width, theme)
+            verify(source.sourceItem === block)
+
+            const quads = findAllByObjectName(skeleton, "patternQuad")
+            verify(quads.length > 0)
+            for (let i = 0; i < quads.length; ++i)
+                verify(quads[i].source === source)
+        }
+
+        function test_widthChangeReshapesBlockWithoutRebuild() {
+            const skeleton = createTemporaryObject(skeletonComp, root,
+                                                   { height: 5000 })
+            verify(!!skeleton)
+            waitForRendering(skeleton) // lets the block's positioners settle
+
+            const block = findAllByObjectName(skeleton, "patternBlock")[0]
+            compare(block.width, 800)
+
+            skeleton.width = 500
+
+            compare(block.width, 500) // the live texture samples the new shape
+            verify(findAllByObjectName(skeleton, "patternBlock")[0] === block)
+        }
+
+        function test_themeChangeRestylesBlockWithoutRebuild() {
+            const skeleton = createTemporaryObject(skeletonComp, root,
+                                                   { height: 5000 })
+            verify(!!skeleton)
+            waitForRendering(skeleton) // lets the block's positioners settle
+
+            const block = findAllByObjectName(skeleton, "patternBlock")[0]
+            const tile = findTiles(block)[0]
+            verify(!!tile)
+            const colorBefore = String(tile.color)
+
+            skeleton.Theme.style = skeleton.Theme.style === Theme.Style.Dark
+                                   ? Theme.Style.Light
+                                   : Theme.Style.Dark
+
+            verify(String(tile.color) !== colorBefore)
+            verify(findAllByObjectName(skeleton, "patternBlock")[0] === block)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_PacedDrainOrder.qml
+++ b/storybook/qmlTests/tests/tst_PacedDrainOrder.qml
@@ -1,0 +1,550 @@
+import QtQuick
+import QtTest
+
+import StatusQ 0.1
+import utils
+
+import shared.views.chat
+
+import AppLayouts.Chat.views
+import AppLayouts.Chat.stores as ChatStores
+
+/*
+ Queue-only dressing: the paced drain is the ONLY caller of
+ doAcquire — no dress trigger (availability signal, reveal, slide, restore,
+ live insert) dresses synchronously inside a signal handler — and the drain
+ dresses at most one row per slice, viewport-nearest-first, so the skeleton
+ clears where the user is looking.
+*/
+Item {
+    id: root
+
+    width: 800
+    height: 600
+
+    ChatStores.RootStore { id: rootStoreMock }
+
+    ListModel { id: messagesModel }
+    ListModel { id: messagesModelB }
+
+    component ContentModuleMock: QtObject {
+        id: moduleMock
+
+        property string mockChatId: "chat-1"
+        property var mockModel
+
+        function markAllMessagesRead() {}
+
+        readonly property var chatDetails: QtObject {
+            readonly property string id: moduleMock.mockChatId
+            readonly property int type: Constants.chatType.oneToOne
+            readonly property bool active: true
+            readonly property bool highlight: false
+            property bool hasUnreadMessages: false
+            readonly property bool canPost: true
+            readonly property bool canView: true
+            readonly property bool canPostReactions: true
+            readonly property string emoji: ""
+        }
+
+        readonly property var messagesModule: QtObject {
+            readonly property var model: moduleMock.mockModel
+            property bool loading: false
+            property bool keepUnread: false
+
+            signal messageSuccessfullySent()
+            signal sendingMessageFailed(string error)
+            signal reactionActionFailed()
+            signal scrollToMessage(int messageIndex)
+
+            function getChatId() { return moduleMock.mockChatId }
+            function loadMoreMessages() {}
+            function updateKeepUnread(flag) {}
+        }
+
+        function getMyChatId() { return moduleMock.mockChatId }
+        function amIChatAdmin() { return false }
+    }
+
+    ContentModuleMock {
+        id: contentModuleMock
+
+        mockChatId: "chat-1"
+        mockModel: messagesModel
+    }
+
+    ContentModuleMock {
+        id: contentModuleMockB
+
+        mockChatId: "chat-2"
+        mockModel: messagesModelB
+    }
+
+    Component {
+        id: poolComp
+
+        DelegatePool {
+            DelegatePoolKind {
+                objectName: "messageKind"
+                kind: "message"
+                target: 0
+
+                delegate: Component {
+                    MessageView {}
+                }
+            }
+        }
+    }
+
+    Component {
+        id: sectionComp
+
+        Item {
+            id: harness
+
+            width: 800
+            height: 600
+
+            property DelegatePool rowPool: null
+            property int activeIndex: 0
+
+            readonly property Item activeShell: {
+                if (activeIndex === 0)
+                    return shellA
+                if (activeIndex === 1)
+                    return shellB
+                return null
+            }
+
+            readonly property ChatStores.MessageStore fallbackMessageStore: ChatStores.MessageStore {
+                messageModule: null
+            }
+
+            ChatContentView {
+                id: shellA
+                anchors.fill: parent
+                visible: harness.activeIndex === 0
+                rootStore: rootStoreMock
+                chatContentModule: contentModuleMock
+                chatId: "chat-1"
+                chatType: Constants.chatType.oneToOne
+            }
+
+            ChatContentView {
+                id: shellB
+                anchors.fill: parent
+                visible: harness.activeIndex === 1
+                rootStore: rootStoreMock
+                chatContentModule: contentModuleMockB
+                chatId: "chat-2"
+                chatType: Constants.chatType.oneToOne
+            }
+
+            Item {
+                id: parkingHolder
+                anchors.fill: parent
+                visible: false
+            }
+
+            ChatMessagesView {
+                parent: harness.activeShell ? harness.activeShell.messagesSlot
+                                            : parkingHolder
+                anchors.fill: parent
+
+                rowPool: harness.rowPool
+                rootStore: rootStoreMock
+                messageStore: harness.activeShell ? harness.activeShell.messageStore
+                                                  : harness.fallbackMessageStore
+                chatContentModule: harness.activeShell ? harness.activeShell.chatContentModule
+                                                       : null
+                chatId: harness.activeShell ? harness.activeShell.chatId : ""
+                isOneToOne: true
+                usersModel: ListModel {}
+                joined: true
+            }
+        }
+    }
+
+    Component {
+        id: signalSpyComp
+
+        SignalSpy {}
+    }
+
+    // Records the row index of every shell the moment it gets dressed:
+    // acquiredCount increments once per doAcquire, after pooledItem is set.
+    Component {
+        id: dressOrderProbeComp
+
+        Connections {
+            id: probe
+
+            property var listView
+            property var dressed: ({})
+            property var order: []
+
+            // marks currently dressed rows without recording them
+            function prime() {
+                for (let k = 0; k < probe.listView.count; ++k) {
+                    const item = probe.listView.itemAtRow(k)
+                    if (item && item.pooledItem)
+                        probe.dressed[String(item.messageId)] = true
+                }
+            }
+
+            function onAcquiredCountChanged() {
+                for (let k = 0; k < probe.listView.count; ++k) {
+                    const item = probe.listView.itemAtRow(k)
+                    if (!item)
+                        continue
+                    const id = String(item.messageId)
+                    if (!item.pooledItem) {
+                        // a release fires the same signal: unmark, so the
+                        // row's re-dress is recorded
+                        delete probe.dressed[id]
+                    } else if (!probe.dressed[id]) {
+                        probe.dressed[id] = true
+                        probe.order.push(k)
+                    }
+                }
+            }
+        }
+    }
+
+    TestCase {
+        name: "PacedDrainOrder"
+        when: windowShown
+
+        function cleanup() {
+            contentModuleMock.messagesModule.loading = false
+            contentModuleMockB.messagesModule.loading = false
+            messagesModel.clear()
+            messagesModelB.clear()
+        }
+
+        function appendMessage(i, contentType) {
+            messagesModel.append(messageRoles("msg-" + i, i, Date.now() - i * 60000, contentType))
+        }
+
+        function appendMessageB(i, contentType) {
+            messagesModelB.append(messageRoles("b-" + i, i, Date.now() - i * 60000, contentType))
+        }
+
+        function insertNewest(i) {
+            messagesModel.insert(0, messageRoles("msg-new-" + i, -1 - i,
+                                                 Date.now() + (i + 1) * 60000))
+        }
+
+        function messageRoles(id, i, ts, contentType) {
+            return {
+                id: id,
+                communityId: "",
+                compressedKey: "zQ3peer",
+                prevMsgIndex: i + 1,
+                nextMsgIndex: i - 1,
+                prevMsgTimestamp: ts - 60000,
+                nextMsgTimestamp: ts + 60000,
+                prevMsgSenderId: "",
+                prevMsgContentType: 1,
+                prevMsgDeleted: false,
+                timestamp: ts,
+                responseToMessageWithId: "",
+                senderId: "0xpeer",
+                senderDisplayName: "Peer",
+                senderOptionalName: "",
+                senderIcon: "",
+                senderIsAdded: true,
+                senderEnsVerified: false,
+                senderTrustStatus: 0,
+                amISender: false,
+                usesDefaultName: true,
+                messageText: "Message " + i + " — the quick brown fox jumps over the lazy dog.",
+                unparsedText: "Message " + i,
+                messageImage: "",
+                messageAttachments: "",
+                albumImagesCount: 0,
+                albumMessageImages: "",
+                contentType: contentType === undefined ? 1 : contentType,
+                sticker: "",
+                stickerPack: -1,
+                editMode: false,
+                isEdited: false,
+                outgoingStatus: "",
+                resendError: "",
+                mentioned: false,
+                gapFrom: 0,
+                gapTo: 0,
+                quotedMessageText: "",
+                quotedMessageParsedText: "",
+                quotedMessageFrom: "",
+                quotedMessageContentType: 1,
+                quotedMessageDeleted: false,
+                quotedMessageAuthorName: "",
+                quotedMessageAuthorDisplayName: "",
+                quotedMessageAuthorThumbnailImage: "",
+                quotedMessageAuthorEnsVerified: false,
+                quotedMessageAuthorIsContact: false,
+                quotedMessageAlbumImagesCount: 0,
+                quotedMessageAlbumMessageImages: "",
+                reactions: "",
+                pinned: false,
+                pinnedBy: "",
+                deleted: false,
+                deletedBy: "",
+                deletedByContactDisplayName: "",
+                deletedByContactIcon: "",
+                bridgeName: "",
+                links: "",
+                transactionParameters: ""
+            }
+        }
+
+        function openPooledChat(messageCount, poolIntervalMs) {
+            for (let i = 0; i < messageCount; ++i)
+                appendMessage(i)
+
+            const pool = createTemporaryObject(poolComp, root,
+                                               { backgroundIntervalMs: poolIntervalMs })
+            verify(!!pool)
+            const view = createTemporaryObject(sectionComp, root, { rowPool: pool })
+            verify(!!view)
+
+            const listView = findChild(view, "chatLogView")
+            verify(!!listView)
+            const internal = findChild(view, "chatMessagesViewInternal")
+            verify(!!internal)
+            const kind = findChild(pool, "messageKind")
+            verify(!!kind)
+
+            tryVerify(() => listView.count > 0, 20000)
+            tryVerify(() => !internal.initialFillActive, 20000,
+                      "the initial batch must reveal")
+
+            return { pool: pool, kind: kind, view: view,
+                     listView: listView, internal: internal }
+        }
+
+        function builtCount(chat) {
+            return chat.internal.acquiredCount + chat.kind.readyCount
+        }
+
+        function waitForFullPool(chat) {
+            tryVerify(() => builtCount(chat) >= chat.kind.target, 60000,
+                      "the pool must reach its target, built "
+                      + builtCount(chat) + " of " + chat.kind.target)
+        }
+
+        function waitForQuietWindow(chat) {
+            const internal = chat.internal
+            tryVerify(() => internal.stagedCount === 0, 30000,
+                      "staged rows must all reveal")
+            let last = ""
+            let stable = 0
+            for (let i = 0; i < 400 && stable < 8; ++i) {
+                wait(25)
+                const now = internal.windowStart + ".." + internal.windowEnd
+                stable = (now === last) ? stable + 1 : 0
+                last = now
+            }
+            verify(stable >= 8, "the window must stop moving, at " + last)
+            waitForRendering(chat.listView)
+        }
+
+        // Severs the paging timer so manual window moves and released rows
+        // stay where the test put them.
+        function severPaging(chat) {
+            chat.listView.moreUpAvailable = false
+            chat.listView.moreDownAvailable = false
+        }
+
+        function topmostVisibleRow(listView) {
+            let best = null
+            let bestY = Number.MAX_VALUE
+            for (let k = 0; k < listView.count; ++k) {
+                const item = listView.itemAtRow(k)
+                if (!item || !item.visible || item.height <= 0)
+                    continue
+                const y = item.mapToItem(listView, 0, 0).y
+                if (y + item.height <= 0 || y >= listView.height)
+                    continue
+                if (y < bestY) {
+                    bestY = y
+                    best = item
+                }
+            }
+            return best ? ({ id: String(best.messageId), y: bestY }) : null
+        }
+
+        function scrollMidHistory(chat) {
+            severPaging(chat)
+            for (let i = 0; i < 20 && chat.internal.windowStart === 0; ++i) {
+                chat.internal.slideWindowToHistory()
+                waitForQuietWindow(chat)
+            }
+            verify(chat.internal.windowStart > 0,
+                   "the window must slide into history, at "
+                   + chat.internal.windowStart + ".." + chat.internal.windowEnd)
+            const mid = Math.floor(chat.listView.count / 2)
+            const item = chat.listView.itemAtRow(mid)
+            verify(!!item)
+            chat.listView.contentY += item.mapToItem(chat.listView, 0, 0).y - 10
+            waitForQuietWindow(chat)
+            verify(!chat.listView.stickingToNewest)
+        }
+
+        // A live insert — the one path that used to dress synchronously in
+        // the shell's Component.onCompleted — only enqueues: no dress runs in
+        // the insert's own event-loop turn, the drain dresses it later.
+        function test_liveInsertNeverDressesSynchronously() {
+            // short chat over a fast pool: plenty of ready items, so the old
+            // synchronous path WOULD have dressed on the spot
+            const chat = openPooledChat(10, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            severPaging(chat)
+            verify(chat.kind.readyCount > 0,
+                   "precondition: the pool must have ready items")
+
+            const spy = createTemporaryObject(signalSpyComp, root,
+                                              { target: chat.internal,
+                                                signalName: "acquiredCountChanged" })
+            verify(spy.valid)
+
+            insertNewest(1)
+
+            const shell = chat.listView.itemAtRow(0)
+            verify(!!shell, "the live shell must exist in the insert's turn")
+            compare(String(shell.messageId), "msg-new-1")
+            compare(spy.count, 0,
+                    "no dress may run in the same turn as the insert")
+            verify(!shell.pooledItem,
+                   "the live shell must not be dressed synchronously")
+
+            tryVerify(() => !!shell.pooledItem, 5000,
+                      "the drain must dress the live shell in a later turn")
+        }
+
+        // A burst of availability events piles enqueues up, never dresses:
+        // each drain slice dresses exactly one row.
+        function test_availabilityBurstDressesOnePerSlice() {
+            const chat = openPooledChat(30, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            severPaging(chat)
+
+            // three waiting shells and three availability events at once
+            const shells = [0, 1, 2].map(k => chat.listView.itemAtRow(k))
+            for (let i = 0; i < shells.length; ++i) {
+                verify(!!shells[i].pooledItem)
+                shells[i].releasePooled()
+            }
+
+            const spy = createTemporaryObject(signalSpyComp, root,
+                                              { target: chat.internal,
+                                                signalName: "acquiredCountChanged" })
+            verify(spy.valid)
+
+            for (let i = 0; i < shells.length; ++i)
+                chat.internal.enqueueDress(shells[i])
+            compare(spy.count, 0,
+                    "enqueueing must never dress in the same turn")
+            compare(chat.internal.dressQueue.length, 3)
+
+            chat.internal.drainDressQueue()
+            compare(spy.count, 1, "one drain slice dresses exactly one row")
+            compare(chat.internal.dressQueue.length, 2)
+
+            chat.internal.drainDressQueue()
+            compare(spy.count, 2, "one drain slice dresses exactly one row")
+            compare(chat.internal.dressQueue.length, 1)
+
+            tryVerify(() => shells.every(s => !!s.pooledItem), 5000,
+                      "the scheduled drain must finish the queue")
+        }
+
+        // Viewport at the bottom: rows near the bottom (row 0) dress before
+        // rows near the top, whatever order they were released or enqueued.
+        function test_bottomViewportDressesBottomFirst() {
+            const chat = openPooledChat(30, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            severPaging(chat)
+            verify(chat.listView.stickingToNewest,
+                   "precondition: the view sticks to the newest message")
+
+            const top = chat.listView.count - 1
+            verify(top >= 3, "the window must span enough rows")
+
+            const probe = createTemporaryObject(dressOrderProbeComp, root,
+                                                { target: chat.internal,
+                                                  listView: chat.listView })
+            verify(!!probe)
+            probe.prime()
+
+            // scrambled release order: two bottom rows, two top rows — the
+            // availability cascade re-enqueues them, the drain must sort
+            const released = [top - 1, 0, top, 1]
+            for (let i = 0; i < released.length; ++i) {
+                const shell = chat.listView.itemAtRow(released[i])
+                verify(!!shell.pooledItem)
+                shell.releasePooled()
+            }
+
+            tryVerify(() => probe.order.length === released.length, 10000,
+                      "all released rows must re-dress, got "
+                      + JSON.stringify(probe.order))
+            compare(JSON.stringify(probe.order),
+                    JSON.stringify([0, 1, top - 1, top]),
+                    "bottom rows must dress before top rows")
+        }
+
+        // A restored mid-history window dresses the rows nearest the restored
+        // viewport position first, spreading outward.
+        function test_restoreDressesNearestRestoredPositionFirst() {
+            const chat = openPooledChat(300, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+
+            scrollMidHistory(chat)
+            const expected = topmostVisibleRow(chat.listView)
+            verify(!!expected, "a viewport row must exist to record")
+
+            // section flip away: the record is captured, every item released
+            chat.view.visible = false
+            tryCompare(chat.internal, "acquiredCount", 0)
+
+            const probe = createTemporaryObject(dressOrderProbeComp, root,
+                                                { target: chat.internal,
+                                                  listView: chat.listView })
+            verify(!!probe)
+
+            chat.view.visible = true
+            tryVerify(() => probe.order.length > 0
+                            && probe.order.length === chat.listView.count, 20000,
+                      "the restored window must dress completely, got "
+                      + probe.order.length + " of " + chat.listView.count)
+            waitForQuietWindow(chat)
+
+            // the restore must still land where the record says
+            const actual = topmostVisibleRow(chat.listView)
+            verify(!!actual, "the restored view must show rows")
+            compare(actual.id, expected.id,
+                    "the top-most visible row must be restored")
+
+            // nearest-first: the dress order walks outward from the first
+            // dressed row — distances never decrease along the order
+            const order = probe.order
+            verify(order.length >= 3)
+            const ref = order[0]
+            for (let i = 1; i < order.length; ++i) {
+                verify(Math.abs(order[i] - ref) >= Math.abs(order[i - 1] - ref),
+                       "dress order must spread outward from the restored "
+                       + "position, got " + JSON.stringify(order))
+            }
+            // and the reference is the restored viewport, not a window edge
+            verify(ref > 0 && ref < chat.listView.count - 1,
+                   "the first dressed row must sit inside the window, got "
+                   + ref + " of 0.." + (chat.listView.count - 1))
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_PacedDrainOrder.qml
+++ b/storybook/qmlTests/tests/tst_PacedDrainOrder.qml
@@ -106,6 +106,7 @@ Item {
             height: 600
 
             property DelegatePool rowPool: null
+            property bool dressHold: false
             property int activeIndex: 0
 
             readonly property Item activeShell: {
@@ -152,6 +153,7 @@ Item {
                 anchors.fill: parent
 
                 rowPool: harness.rowPool
+                dressHold: harness.dressHold
                 rootStore: rootStoreMock
                 messageStore: harness.activeShell ? harness.activeShell.messageStore
                                                   : harness.fallbackMessageStore
@@ -496,6 +498,254 @@ Item {
             compare(JSON.stringify(probe.order),
                     JSON.stringify([0, 1, top - 1, top]),
                     "bottom rows must dress before top rows")
+        }
+
+        // lets scheduled drain slices and availability cascades run; used
+        // for negative assertions (nothing may dress while held)
+        function settle() {
+            for (let i = 0; i < 10; ++i)
+                wait(20)
+        }
+
+        // Dress hold: with the hold up, every trigger enqueues
+        // but nothing dresses; release drains paced, viewport-nearest-first.
+        function test_holdEnqueuesAndReleaseDrainsNearestFirst() {
+            const chat = openPooledChat(30, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            severPaging(chat)
+            verify(chat.listView.stickingToNewest,
+                   "precondition: the view sticks to the newest message")
+
+            const top = chat.listView.count - 1
+            verify(top >= 3, "the window must span enough rows")
+
+            const probe = createTemporaryObject(dressOrderProbeComp, root,
+                                                { target: chat.internal,
+                                                  listView: chat.listView })
+            verify(!!probe)
+            probe.prime()
+
+            chat.view.dressHold = true
+
+            const released = [top - 1, 0, top, 1]
+            for (let i = 0; i < released.length; ++i) {
+                const shell = chat.listView.itemAtRow(released[i])
+                verify(!!shell.pooledItem)
+                shell.releasePooled()
+            }
+
+            settle()
+            compare(probe.order.length, 0, "held: nothing may dress")
+            compare(chat.internal.dressQueue.length, released.length,
+                    "held: every trigger must enqueue, once each")
+
+            chat.view.dressHold = false
+            tryVerify(() => probe.order.length === released.length, 10000,
+                      "release must drain the queue, got "
+                      + JSON.stringify(probe.order))
+            compare(JSON.stringify(probe.order),
+                    JSON.stringify([0, 1, top - 1, top]),
+                    "the released drain must dress viewport-nearest-first")
+            compare(chat.internal.dressQueue.length, 0)
+        }
+
+        // Rapid on-off toggles (interrupted animations) must lose or
+        // duplicate nothing and must always end fully drained.
+        function test_rapidToggleEndsFullyDrained() {
+            const chat = openPooledChat(30, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            severPaging(chat)
+
+            const dressedBefore = chat.internal.acquiredCount
+            const probe = createTemporaryObject(dressOrderProbeComp, root,
+                                                { target: chat.internal,
+                                                  listView: chat.listView })
+            verify(!!probe)
+            probe.prime()
+
+            chat.view.dressHold = true
+            const released = [0, 1, 2, 3]
+            for (let i = 0; i < released.length; ++i) {
+                const shell = chat.listView.itemAtRow(released[i])
+                verify(!!shell.pooledItem)
+                shell.releasePooled()
+            }
+
+            chat.view.dressHold = false
+            chat.view.dressHold = true
+            chat.view.dressHold = false
+            chat.view.dressHold = true
+            compare(chat.internal.dressQueue.length, released.length,
+                    "toggling must neither lose nor duplicate queue entries")
+
+            settle()
+            compare(probe.order.length, 0, "held: nothing may dress")
+            compare(chat.internal.dressQueue.length, released.length)
+
+            chat.view.dressHold = false
+            tryVerify(() => probe.order.length === released.length, 10000,
+                      "release must drain the queue, got "
+                      + JSON.stringify(probe.order))
+            tryCompare(chat.internal, "acquiredCount", dressedBefore)
+            compare(chat.internal.dressQueue.length, 0)
+            for (let k = 0; k < released.length; ++k) {
+                verify(!!chat.listView.itemAtRow(released[k]).pooledItem,
+                       "row " + released[k] + " must end dressed")
+            }
+        }
+
+        // A hold raised mid-drain stops the drain after the current slice;
+        // release resumes it to completion.
+        function test_holdMidDrainStopsAfterCurrentSlice() {
+            const chat = openPooledChat(30, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            severPaging(chat)
+
+            const shells = [0, 1, 2].map(k => chat.listView.itemAtRow(k))
+            for (let i = 0; i < shells.length; ++i) {
+                verify(!!shells[i].pooledItem)
+                shells[i].releasePooled()
+            }
+
+            const spy = createTemporaryObject(signalSpyComp, root,
+                                              { target: chat.internal,
+                                                signalName: "acquiredCountChanged" })
+            verify(spy.valid)
+            compare(chat.internal.dressQueue.length, shells.length)
+
+            chat.internal.drainDressQueue()
+            compare(spy.count, 1, "one drain slice dresses exactly one row")
+            compare(chat.internal.dressQueue.length, shells.length - 1)
+
+            chat.view.dressHold = true
+            settle()
+            compare(spy.count, 1,
+                    "held mid-drain: no further slice may dress")
+            compare(chat.internal.dressQueue.length, shells.length - 1)
+
+            chat.view.dressHold = false
+            tryVerify(() => shells.every(s => !!s.pooledItem), 5000,
+                      "release must resume the drain to completion")
+            compare(chat.internal.dressQueue.length, 0)
+        }
+
+        // Scroll gate: fast-fling velocity holds dressing
+        // like a panel switch; the queue grows, and the drain resumes by
+        // itself once the velocity decays below the exit threshold.
+        function test_fastScrollHoldsDressingUntilVelocityDecays() {
+            const chat = openPooledChat(30, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            severPaging(chat)
+
+            const probe = createTemporaryObject(dressOrderProbeComp, root,
+                                                { target: chat.internal,
+                                                  listView: chat.listView })
+            verify(!!probe)
+            probe.prime()
+
+            const enter = chat.internal.fastScrollEnterVelocity
+            const exit = chat.internal.fastScrollExitVelocity
+            chat.internal.updateScrollGate(enter * 1.5)
+            verify(chat.internal.fastScroll,
+                   "fast velocity must raise the gate")
+
+            const released = [0, 1, 2, 3]
+            for (let i = 0; i < released.length; ++i) {
+                const shell = chat.listView.itemAtRow(released[i])
+                verify(!!shell.pooledItem)
+                shell.releasePooled()
+            }
+
+            settle()
+            compare(probe.order.length, 0,
+                    "held by velocity: nothing may dress")
+            compare(chat.internal.dressQueue.length, released.length)
+
+            // a decaying fling still above the exit threshold keeps holding
+            chat.internal.updateScrollGate(exit * 1.2)
+            verify(chat.internal.fastScroll)
+            // dropping below exit resumes the drain, no explicit release
+            chat.internal.updateScrollGate(exit * 0.5)
+            verify(!chat.internal.fastScroll)
+            tryVerify(() => probe.order.length === released.length, 10000,
+                      "the drain must resume on its own, got "
+                      + JSON.stringify(probe.order))
+            compare(chat.internal.dressQueue.length, 0)
+        }
+
+        // Oscillation between the enter and exit thresholds must not thrash
+        // the gate: enter only above the high mark, exit only below the low.
+        function test_scrollGateHysteresis() {
+            const chat = openPooledChat(10, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+
+            const enter = chat.internal.fastScrollEnterVelocity
+            const exit = chat.internal.fastScrollExitVelocity
+            verify(exit < enter, "exit threshold must sit below enter")
+            const between = (enter + exit) / 2
+
+            verify(!chat.internal.fastScroll)
+            chat.internal.updateScrollGate(between)
+            verify(!chat.internal.fastScroll,
+                   "between thresholds: the gate must stay down")
+            chat.internal.updateScrollGate(enter * 1.1)
+            verify(chat.internal.fastScroll)
+            chat.internal.updateScrollGate(between)
+            verify(chat.internal.fastScroll,
+                   "between thresholds: the gate must stay up")
+            chat.internal.updateScrollGate(between)
+            verify(chat.internal.fastScroll)
+            chat.internal.updateScrollGate(exit * 0.5)
+            verify(!chat.internal.fastScroll)
+            chat.internal.updateScrollGate(between)
+            verify(!chat.internal.fastScroll,
+                   "between thresholds: the gate must stay down")
+        }
+
+        // The two hold inputs compose: either alone holds the drain, and
+        // dressing resumes only when both have cleared.
+        function test_holdInputsCompose() {
+            const chat = openPooledChat(30, 0)
+            waitForFullPool(chat)
+            waitForQuietWindow(chat)
+            severPaging(chat)
+
+            const probe = createTemporaryObject(dressOrderProbeComp, root,
+                                                { target: chat.internal,
+                                                  listView: chat.listView })
+            verify(!!probe)
+            probe.prime()
+
+            chat.view.dressHold = true
+            chat.internal.updateScrollGate(
+                chat.internal.fastScrollEnterVelocity * 2)
+
+            const released = [0, 1, 2]
+            for (let i = 0; i < released.length; ++i) {
+                const shell = chat.listView.itemAtRow(released[i])
+                verify(!!shell.pooledItem)
+                shell.releasePooled()
+            }
+
+            settle()
+            compare(probe.order.length, 0, "both up: nothing may dress")
+
+            chat.view.dressHold = false
+            settle()
+            compare(probe.order.length, 0,
+                    "velocity alone must keep holding")
+            compare(chat.internal.dressQueue.length, released.length)
+
+            chat.internal.updateScrollGate(0)
+            tryVerify(() => probe.order.length === released.length, 10000,
+                      "both cleared: the drain must run, got "
+                      + JSON.stringify(probe.order))
+            compare(chat.internal.dressQueue.length, 0)
         }
 
         // A restored mid-history window dresses the rows nearest the restored

--- a/storybook/qmlTests/tests/tst_StatusTimeStampLabel.qml
+++ b/storybook/qmlTests/tests/tst_StatusTimeStampLabel.qml
@@ -12,6 +12,7 @@ import StatusQ.Core
    previous-year buckets                    → test_relativeBuckets
  - full mode (showFullTimestamp)            → test_fullTimestampMode
  - hover → tooltip with the full date-time  → test_hoverTooltip
+ - relative label vs the shared clock tick  → test_relativeLabelIgnoresSecondsTicks
 */
 Item {
     id: root
@@ -22,6 +23,11 @@ Item {
     Component {
         id: labelComp
         StatusTimeStampLabel {}
+    }
+
+    Component {
+        id: spyComp
+        SignalSpy {}
     }
 
     TestCase {
@@ -67,6 +73,62 @@ Item {
                 showFullTimestamp: true
             })
             compare(label.text, LocaleUtils.formatDateTime(ts))
+        }
+
+        // INTENT (perf): formatRelativeTimestamp is day-granular ("Today 14:23"),
+        // so the label must follow the shared timer's DAY counter, not its
+        // per-second one. Bound to seconds it re-formats every visible row once
+        // a second forever — pure GUI-thread churn for a value that cannot move.
+        // The timer does not run offscreen, so the ticks are driven directly
+        // through the singleton's own timer object instead of waiting on wall time.
+        function test_relativeLabelIgnoresSecondsTicks() {
+            const label = createTemporaryObject(labelComp, root,
+                                                { timestamp: Date.now() - 60 * 1000 })
+            verify(!!label)
+            waitForRendering(label)
+
+            const initialText = label.text
+            const initialDays = StatusSharedUpdateTimer.daysActive
+            const initialSeconds = StatusSharedUpdateTimer.secondsActive
+            const textSpy = createTemporaryObject(spyComp, root, {
+                target: label, signalName: "textChanged" })
+
+            for (let i = 0; i < 5; ++i)
+                StatusSharedUpdateTimer.d.tick()
+
+            compare(StatusSharedUpdateTimer.secondsActive, initialSeconds + 5,
+                    "the ticks must have actually advanced the per-second counter")
+            compare(StatusSharedUpdateTimer.daysActive, initialDays,
+                    "seconds ticks within the same day must not advance the day counter")
+            compare(label.clockTick, initialDays,
+                    "the label's clock dependency must not move on seconds ticks")
+            compare(textSpy.count, 0,
+                    "the relative label must not re-format on seconds ticks")
+            compare(label.text, initialText)
+        }
+
+        // The day counter is what the label DOES depend on: crossing local
+        // midnight has to advance it, or "Today 23:59" would never become
+        // "Yesterday 23:59" for a chat left open overnight.
+        function test_dayBoundaryAdvancesTheDayCounter() {
+            const timer = StatusSharedUpdateTimer.d
+            const before = StatusSharedUpdateTimer.daysActive
+
+            // pretend the last tick landed on yesterday's midnight
+            timer.dayStart = timer.dayStart - dayMs
+            timer.tick()
+
+            compare(StatusSharedUpdateTimer.daysActive, before + 1,
+                    "crossing a day boundary must advance the day counter")
+            const label = createTemporaryObject(labelComp, root,
+                                                { timestamp: Date.now() - dayMs })
+            verify(!!label)
+            compare(label.clockTick, StatusSharedUpdateTimer.daysActive,
+                    "the label must follow the day counter")
+            // and it settles back onto the real day, so one boundary counts once
+            timer.tick()
+            compare(StatusSharedUpdateTimer.daysActive, before + 1,
+                    "a further tick on the same day must not advance it again")
         }
 
         function test_hoverTooltip() {

--- a/test/nim/pubkey_memo_test.nim
+++ b/test/nim/pubkey_memo_test.nim
@@ -1,0 +1,89 @@
+## Unit tests for the per-public-key memo backing `Utils.getColorId` /
+## `Utils.getEmojiHashAsJson`. Pure Nim — no Qt, no status-go: the memo is the
+## seam, and a counting `compute` closure stands in for the FFI round-trips.
+
+import std/[options, strutils]
+import unittest
+
+import app/global/utils/pubkey_memo
+
+suite "PubkeyMemo":
+
+  test "repeated lookups of the same key compute once":
+    let memo = newPubkeyMemo[int]()
+    var calls = 0
+    let compute = proc(pk: string): int =
+      calls.inc
+      pk.len
+
+    check memo.get("0x04aa", compute) == 6
+    check calls == 1
+    for _ in 0 ..< 20:
+      check memo.get("0x04aa", compute) == 6
+    check calls == 1
+
+  test "distinct keys miss and are kept side by side":
+    let memo = newPubkeyMemo[int]()
+    var calls = 0
+    let compute = proc(pk: string): int =
+      calls.inc
+      pk.len
+
+    check memo.get("zQ3sh", compute) == 5
+    check memo.get("0x04aa", compute) == 6
+    check calls == 2
+    check memo.len == 2
+    # both still served from the cache, and not swapped
+    check memo.get("zQ3sh", compute) == 5
+    check memo.get("0x04aa", compute) == 6
+    check calls == 2
+
+  test "memoized results are identical to the uncached ones":
+    let memo = newPubkeyMemo[string]()
+    let derive = proc(pk: string): string = pk.toUpperAscii & ":" & $pk.len
+    let compute = proc(pk: string): string = derive(pk)
+
+    for key in ["", "0x04aa", "zQ3shWQXBHRFmpTvUnKPUZ", "0X04AA"]:
+      check memo.get(key, compute) == derive(key)
+      check memo.get(key, compute) == derive(key)
+
+  test "the empty key is a normal cache entry, not a miss every time":
+    let memo = newPubkeyMemo[int]()
+    var calls = 0
+    let compute = proc(pk: string): int =
+      calls.inc
+      -1
+
+    check memo.get("", compute) == -1
+    check memo.get("", compute) == -1
+    check calls == 1
+
+  test "a falsy computed value is still cached":
+    let memo = newPubkeyMemo[int]()
+    var calls = 0
+    let compute = proc(pk: string): int =
+      calls.inc
+      0
+
+    check memo.get("0x04aa", compute) == 0
+    check memo.get("0x04aa", compute) == 0
+    check calls == 1
+
+  test "peek reports hits without computing, clear empties the memo":
+    let memo = newPubkeyMemo[int]()
+    var calls = 0
+    let compute = proc(pk: string): int =
+      calls.inc
+      7
+
+    check memo.peek("0x04aa").isNone
+    check calls == 0
+    discard memo.get("0x04aa", compute)
+    check memo.peek("0x04aa") == some(7)
+    check calls == 1
+
+    memo.clear()
+    check memo.len == 0
+    check memo.peek("0x04aa").isNone
+    discard memo.get("0x04aa", compute)
+    check calls == 2

--- a/ui/StatusQ/include/StatusQ/markdownutils.h
+++ b/ui/StatusQ/include/StatusQ/markdownutils.h
@@ -56,4 +56,16 @@ public:
     // (e.g. "0x04ab…", "0x00001"). Parsed via the Markdown AST, so "@0x…" tokens inside
     // code spans/blocks are excluded. Empty when there are none.
     Q_INVOKABLE QStringList mentions(const QString& text) const;
+
+    // Test seam for the toBlocks memo (not exposed to QML): cumulative hit/miss counters
+    // plus the cache's current entry count and capacity.
+    struct CacheStats
+    {
+        int hits = 0;
+        int misses = 0;
+        int size = 0;
+        int capacity = 0;
+    };
+    static CacheStats toBlocksCacheStats();
+    static void clearToBlocksCache();
 };

--- a/ui/StatusQ/src/StatusQ/Components/ChatSingleLineTextView.qml
+++ b/ui/StatusQ/src/StatusQ/Components/ChatSingleLineTextView.qml
@@ -35,6 +35,28 @@ Control {
     font.family: Fonts.baseFont.family
     font.pixelSize: Theme.primaryTextFontSize
 
+    QtObject {
+        id: d
+
+        // CSS (mirrors ChatTextView.richTextFor) plus a quote color rule. Kept out of
+        // the text binding: the body changes on every dress, these colors almost never do.
+        readonly property string styleSheet:
+            "<style>code { background-color: " + root.codeBackgroundColor
+            + "; font-family: '" + Fonts.codeFont.family + "' }"
+            + " a { color: " + root.linkColor + " }"
+            + " a.mention { color: " + root.mentionTextColor
+            + "; background-color: " + root.mentionBackgroundColor
+            + "; text-decoration: none }"
+            + " span.quote { color: " + root.quoteTextColor + " }"
+            + "</style>"
+
+        readonly property string editedMarker: {
+            if (!root.edited)
+                return ""
+            return StringUtils.editedMarker(Theme.palette.baseColor1, root.editedMarkerFontSize)
+        }
+    }
+
     contentItem: Text {
         id: label
 
@@ -46,21 +68,7 @@ Control {
         font.pixelSize: root.font.pixelSize
         clip: true
 
-        // CSS (mirrors ChatTextView.richTextFor) plus a quote color rule, prepended to the body.
-        text: {
-            const style = "<style>code { background-color: " + root.codeBackgroundColor
-                        + "; font-family: '" + Fonts.codeFont.family + "' }"
-                        + " a { color: " + root.linkColor + " }"
-                        + " a.mention { color: " + root.mentionTextColor
-                        + "; background-color: " + root.mentionBackgroundColor
-                        + "; text-decoration: none }"
-                        + " span.quote { color: " + root.quoteTextColor + " }"
-                        + "</style>"
-            const marker = root.edited
-                ? StringUtils.editedMarker(Theme.palette.baseColor1, root.editedMarkerFontSize)
-                : ""
-            return style + root.html + marker
-        }
+        text: d.styleSheet + root.html + d.editedMarker
 
         // Right-edge fade ("dimming") when the single line overflows. Painted as a gradient that
         // blends into `fadeColor` on top of the glyphs — rather than masking the text through an

--- a/ui/StatusQ/src/StatusQ/Components/ChatTextView.qml
+++ b/ui/StatusQ/src/StatusQ/Components/ChatTextView.qml
@@ -500,17 +500,22 @@ Control {
         spacing: d.padding
 
         Repeater {
-            model: d.renderBlocks
+            // Integer model so a rebind with an unchanged block count keeps the instantiated
+            // delegates alive and only re-evaluates their `block` bindings (recycling); a type
+            // change swaps just that delegate's Loader content, a count change regenerates all.
+            model: d.renderBlocks.length
 
             // One Loader per block builds only the matching renderer (text/code or quote).
             delegate: Loader {
                 id: blk
 
-                required property var modelData
-                readonly property var block: modelData
+                required property int index
+                // Null-safe: on a count change the Repeater may tear this delegate down after
+                // `renderBlocks` already shrank.
+                readonly property var block: d.renderBlocks[index] ?? null
 
                 Layout.fillWidth: true
-                sourceComponent: blk.block.type === "quote" ? quoteComp : textComp
+                sourceComponent: blk.block?.type === "quote" ? quoteComp : textComp
 
                 Component {
                     id: textComp
@@ -518,13 +523,17 @@ Control {
                     BlockText {
                         width: blk.width
                         selectable: root.selectable
-                        isCode: blk.block.type === "code"
-                        content: blk.block.type === "code" ? (blk.block.code || "")
-                                                           : (blk.block.html || "")
-                        codeHtml: blk.block.type === "code" ? (blk.block.codeHtml || "") : ""
-                        bold: !!blk.block.bold
-                        italic: !!blk.block.italic
-                        strikethrough: !!blk.block.strikethrough
+                        isCode: blk.block?.type === "code"
+                        content: {
+                            const b = blk.block
+                            if (!b)
+                                return ""
+                            return b.type === "code" ? (b.code || "") : (b.html || "")
+                        }
+                        codeHtml: blk.block?.type === "code" ? (blk.block.codeHtml || "") : ""
+                        bold: !!(blk.block?.bold)
+                        italic: !!(blk.block?.italic)
+                        strikethrough: !!(blk.block?.strikethrough)
                     }
                 }
 
@@ -532,6 +541,10 @@ Control {
                     id: quoteComp
 
                     RowLayout {
+                        id: quoteRow
+
+                        readonly property var quoteBlocks: blk.block?.blocks ?? []
+
                         spacing: d.padding
 
                         Rectangle {
@@ -548,21 +561,26 @@ Control {
                             spacing: d.padding
 
                             Repeater {
-                                model: blk.block.blocks
+                                model: quoteRow.quoteBlocks.length
 
                                 delegate: BlockText {
-                                    required property var modelData
+                                    required property int index
+                                    readonly property var subBlock: quoteRow.quoteBlocks[index] ?? null
 
                                     Layout.fillWidth: true
 
                                     selectable: root.selectable
-                                    isCode: modelData.type === "code"
-                                    content: modelData.type === "code" ? (modelData.code || "")
-                                                                       : (modelData.html || "")
-                                    codeHtml: modelData.type === "code" ? (modelData.codeHtml || "") : ""
-                                    bold: !!modelData.bold
-                                    italic: !!modelData.italic
-                                    strikethrough: !!modelData.strikethrough
+                                    isCode: subBlock?.type === "code"
+                                    content: {
+                                        const b = subBlock
+                                        if (!b)
+                                            return ""
+                                        return b.type === "code" ? (b.code || "") : (b.html || "")
+                                    }
+                                    codeHtml: subBlock?.type === "code" ? (subBlock.codeHtml || "") : ""
+                                    bold: !!(subBlock?.bold)
+                                    italic: !!(subBlock?.italic)
+                                    strikethrough: !!(subBlock?.strikethrough)
                                     textColor: root.quoteTextColor // dim quoted text
                                 }
                             }

--- a/ui/StatusQ/src/StatusQ/Components/StatusTimeStampLabel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusTimeStampLabel.qml
@@ -11,6 +11,14 @@ StatusBaseText {
     property double timestamp: 0
     property bool showFullTimestamp
 
+    // The clock dependency of the relative label, named so it can be asserted on:
+    // formatRelativeTimestamp is day-granular ("Today 14:23"), so it may only be
+    // re-evaluated when the local day changes. Bound to the shared timer's
+    // per-second counter instead, it re-formats every visible row once a second
+    // forever, for a value that cannot move. Binding re-evaluation is invisible
+    // from QML, so this property is what a test can hold on to.
+    readonly property int clockTick: StatusSharedUpdateTimer.daysActive
+
     color: Theme.palette.baseColor1
     font.pixelSize: Theme.tertiaryTextFontSize
     visible: !!text
@@ -27,7 +35,7 @@ StatusBaseText {
         Binding on formattedLabel {
             when: !root.showFullTimestamp && root.timestamp && root.visible
             value: {
-                StatusSharedUpdateTimer.secondsActive
+                root.clockTick
                 return LocaleUtils.formatRelativeTimestamp(root.timestamp)
             }
             restoreMode: Binding.RestoreBinding

--- a/ui/StatusQ/src/StatusQ/Core/StatusSharedUpdateTimer.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusSharedUpdateTimer.qml
@@ -7,23 +7,45 @@ QtObject {
 
     readonly property alias secondsActive: d.secondsActive
 
+    // Advances once per local calendar-day boundary, derived from the same 1s tick.
+    // Bind to this instead of `secondsActive` for day-granular values (relative
+    // timestamps): they can only change at midnight, so a per-second dependency
+    // re-evaluates them ~86400x more often than the value can actually move.
+    readonly property alias daysActive: d.daysActive
+
     signal triggered()
 
     readonly property Timer d: Timer {
         id: d
         property int secondsActive: 0
+        property int daysActive: 0
+        // Midnight of the day the last tick landed on, in local time (the same
+        // day boundary LocaleUtils.daysTo() uses).
+        property double dayStart: d.localDayStart()
+
+        function localDayStart() {
+            const now = new Date()
+            now.setHours(0, 0, 0, 0)
+            return now.getTime()
+        }
+
+        function tick() {
+            d.secondsActive++
+            const today = d.localDayStart()
+            if (today !== d.dayStart) {
+                d.dayStart = today
+                d.daysActive++
+            }
+            root.triggered()
+        }
+
         interval: 1000
         running: Qt.application.state === Qt.ApplicationActive
         repeat: true
-        onTriggered: {
-            d.secondsActive++
-            root.triggered()
-        }
+        onTriggered: d.tick()
         onRunningChanged: {
-            if (running) {
-                d.secondsActive++
-                root.triggered()
-            }
+            if (running)
+                d.tick()
         }
     }
 }

--- a/ui/StatusQ/src/markdownutils.cpp
+++ b/ui/StatusQ/src/markdownutils.cpp
@@ -4,6 +4,7 @@
 #include "StatusQ/markdownhtml.h"
 #include "StatusQ/markdownparser.h"
 
+#include <QCache>
 #include <QFontMetricsF>
 
 namespace {
@@ -36,6 +37,52 @@ void collectMentionKeys(const Markdown::Node& node, QStringList& out)
         collectMentionKeys(c, out);
 }
 
+// toBlocks is a pure function of its inputs and the pooled message rows re-dress the same
+// content repeatedly, so results are memoized. The cached QVariantList is returned by
+// (implicitly shared) value and consumers must treat it as immutable. GUI-thread only:
+// the QML singleton lives on the engine's (main) thread, so no locking.
+constexpr int kToBlocksCacheCapacity = 500;
+
+struct ToBlocksCache
+{
+    QCache<QString, QVariantList> entries{kToBlocksCacheCapacity};
+    int hits = 0;
+    int misses = 0;
+};
+
+ToBlocksCache& toBlocksCache()
+{
+    static ToBlocksCache cache;
+    return cache;
+}
+
+// Collision-free composite key over the full input tuple: variable-length fields are
+// length-prefixed (self-delimiting), numeric fields are ';'-terminated.
+QString toBlocksCacheKey(const QString& text, const QVariantMap& mentions, const QFont& font,
+                         bool formatUnclosedCodeFence, bool fullLineHeightEmojis,
+                         int emojiSizeOffset, const QString& emojiBaseUrl)
+{
+    QString key;
+    key.reserve(text.size() + 64);
+    const auto add = [&key](const QString& part) {
+        key += QString::number(part.size());
+        key += QLatin1Char(':');
+        key += part;
+    };
+    add(text);
+    add(font.key()); // QFontMetricsF(font).height() feeds the emoji pixel size
+    add(emojiBaseUrl);
+    key += QLatin1Char(formatUnclosedCodeFence ? '1' : '0');
+    key += QLatin1Char(fullLineHeightEmojis ? '1' : '0');
+    key += QString::number(emojiSizeOffset);
+    key += QLatin1Char(';');
+    for (auto it = mentions.cbegin(); it != mentions.cend(); ++it) {
+        add(it.key());
+        add(it.value().toString()); // only the string form is read (collectTextMentions)
+    }
+    return key;
+}
+
 } // namespace
 
 MarkdownUtils::MarkdownUtils(QObject* parent)
@@ -56,6 +103,15 @@ QVariantList MarkdownUtils::toBlocks(const QString& text, const QVariantMap& men
                                      bool fullLineHeightEmojis, int emojiSizeOffset,
                                      const QString& emojiBaseUrl) const
 {
+    auto& cache = toBlocksCache();
+    const QString key = toBlocksCacheKey(text, mentions, font, formatUnclosedCodeFence,
+                                         fullLineHeightEmojis, emojiSizeOffset, emojiBaseUrl);
+    if (const QVariantList* cached = cache.entries.object(key)) {
+        ++cache.hits;
+        return *cached;
+    }
+    ++cache.misses;
+
     Markdown::Options opts;
     opts.formatUnclosedCodeFence = formatUnclosedCodeFence;
     const Markdown::Node root = Markdown::parse(text, opts);
@@ -69,7 +125,25 @@ QVariantList MarkdownUtils::toBlocks(const QString& text, const QVariantMap& men
     // height (only the emoji runs, so blank lines keep their normal height).
     if (emojiSizeOffset > 0 && Markdown::isOnlyEmoji(text))
         emojiPx = qRound(lineHeight) + emojiSizeOffset;
-    return Markdown::toBlocks(root, mentionMap, emojiPx, emojiBaseUrl);
+
+    const QVariantList blocks = Markdown::toBlocks(root, mentionMap, emojiPx, emojiBaseUrl);
+    cache.entries.insert(key, new QVariantList(blocks));
+    return blocks;
+}
+
+MarkdownUtils::CacheStats MarkdownUtils::toBlocksCacheStats()
+{
+    const auto& cache = toBlocksCache();
+    return {cache.hits, cache.misses, static_cast<int>(cache.entries.size()),
+            static_cast<int>(cache.entries.maxCost())};
+}
+
+void MarkdownUtils::clearToBlocksCache()
+{
+    auto& cache = toBlocksCache();
+    cache.entries.clear();
+    cache.hits = 0;
+    cache.misses = 0;
 }
 
 QString MarkdownUtils::singleLineHtml(const QString& text, const QVariantMap& mentions,

--- a/ui/StatusQ/tests/src/tst_markdownutils.cpp
+++ b/ui/StatusQ/tests/src/tst_markdownutils.cpp
@@ -67,6 +67,100 @@ private slots:
                 + kKeyA + QStringLiteral(" counts");
         QCOMPARE(utils.mentions(text), QStringList{kKeyA});
     }
+
+    // ── toBlocks memo ──
+
+    void toBlocksIdenticalInputsParseOnce()
+    {
+        MarkdownUtils::clearToBlocksCache();
+
+        const QString text = QStringLiteral("hey @") + kKeyA
+                + QStringLiteral(" look at `code` and **bold** 😀");
+        const QVariantMap mentions{{kKeyA, QStringLiteral("Alice")}};
+
+        const QVariantList first = utils.toBlocks(text, mentions, QFont(), false, true, 4,
+                                                  QStringLiteral("qrc:/emoji/"));
+        const QVariantList second = utils.toBlocks(text, mentions, QFont(), false, true, 4,
+                                                   QStringLiteral("qrc:/emoji/"));
+
+        QCOMPARE(second, first);
+        const auto stats = MarkdownUtils::toBlocksCacheStats();
+        QCOMPARE(stats.misses, 1);
+        QCOMPARE(stats.hits, 1);
+    }
+
+    void toBlocksDifferingInputsMissCache()
+    {
+        MarkdownUtils::clearToBlocksCache();
+
+        const QString text = QStringLiteral("same text @") + kKeyA + QStringLiteral(" 😀");
+        QFont bigFont;
+        bigFont.setPixelSize(30);
+
+        // Baseline, then vary exactly one input per call — every call must be a miss.
+        utils.toBlocks(text);
+        utils.toBlocks(text, {{kKeyA, QStringLiteral("Alice")}});
+        utils.toBlocks(text, {{kKeyA, QStringLiteral("Bob")}});
+        utils.toBlocks(text, {}, bigFont);
+        utils.toBlocks(text, {}, QFont(), true /*formatUnclosedCodeFence*/);
+        utils.toBlocks(text, {}, QFont(), false, true /*fullLineHeightEmojis*/);
+        utils.toBlocks(text, {}, QFont(), false, false, 7 /*emojiSizeOffset*/);
+        utils.toBlocks(text, {}, QFont(), false, false, 0, QStringLiteral("qrc:/emoji/"));
+
+        const auto stats = MarkdownUtils::toBlocksCacheStats();
+        QCOMPARE(stats.hits, 0);
+        QCOMPARE(stats.misses, 8);
+        QCOMPARE(stats.size, 8);
+    }
+
+    void toBlocksEvictionRespectsCap()
+    {
+        MarkdownUtils::clearToBlocksCache();
+
+        const int cap = MarkdownUtils::toBlocksCacheStats().capacity;
+        QVERIFY(cap > 0);
+        for (int i = 0; i < cap + 50; ++i) {
+            utils.toBlocks(QStringLiteral("message %1").arg(i));
+            QVERIFY(MarkdownUtils::toBlocksCacheStats().size <= cap);
+        }
+        QCOMPARE(MarkdownUtils::toBlocksCacheStats().size, cap);
+    }
+
+    void toBlocksCachedHitEqualsFreshParse_data()
+    {
+        QTest::addColumn<QString>("text");
+        QTest::addColumn<QVariantMap>("mentions");
+
+        QTest::newRow("plain") << QStringLiteral("just some plain text") << QVariantMap{};
+        QTest::newRow("mentions")
+                << QStringLiteral("hi @") + kKeyA + QStringLiteral(" and @0x00001!")
+                << QVariantMap{{kKeyA, QStringLiteral("Alice")}};
+        QTest::newRow("code") << QStringLiteral("before\n```\nlet x = 1\n```\nafter")
+                              << QVariantMap{};
+        QTest::newRow("emoji-only") << QStringLiteral("😀😀") << QVariantMap{};
+        QTest::newRow("links") << QStringLiteral("see https://status.app and **bold**")
+                               << QVariantMap{};
+        QTest::newRow("edited-style")
+                << QStringLiteral("> quoted\n\nreply with `code` and _italic_")
+                << QVariantMap{};
+    }
+
+    void toBlocksCachedHitEqualsFreshParse()
+    {
+        QFETCH(QString, text);
+        QFETCH(QVariantMap, mentions);
+
+        MarkdownUtils::clearToBlocksCache();
+        const QVariantList fresh = utils.toBlocks(text, mentions, QFont(), false, true, 4,
+                                                  QStringLiteral("qrc:/emoji/"));
+        const QVariantList cached = utils.toBlocks(text, mentions, QFont(), false, true, 4,
+                                                   QStringLiteral("qrc:/emoji/"));
+
+        const auto stats = MarkdownUtils::toBlocksCacheStats();
+        QCOMPARE(stats.misses, 1);
+        QCOMPARE(stats.hits, 1);
+        QCOMPARE(cached, fresh);
+    }
 };
 
 QTEST_MAIN(TestMarkdownUtils)

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -114,6 +114,7 @@ StackLayout {
     property var emojiPopup
     property var stickersPopup
     property DelegatePool rowPool: null
+    property bool dressHold: false
 
     // Unfurling related data:
     property bool gifUnfurlingEnabled
@@ -316,6 +317,7 @@ StackLayout {
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
             rowPool: root.rowPool
+            dressHold: root.dressHold
             sectionItemModel: root.sectionItemModel
             joinedMembersCount: root.sectionItemModel?.joinedMembersCount ?? 0
             areTestNetworksEnabled: root.networksStore.areTestNetworksEnabled

--- a/ui/app/AppLayouts/Chat/panels/MessageRowsSkeleton.qml
+++ b/ui/app/AppLayouts/Chat/panels/MessageRowsSkeleton.qml
@@ -9,6 +9,13 @@ import StatusQ.Core.Theme
 // ChatInputSkeleton when the real input is not on screen. Plain positioners
 // on purpose — skeletons must stay near-free, QtQuick.Layouts polish is too
 // expensive here.
+//
+// As a paging placeholder this can be given hundreds of screens of height, so
+// the item cost must stay O(1) in height: exactly one pattern block of real
+// tiles is instantiated, rendered once into a texture, and the height above
+// it is filled with plain single-node quads sampling that texture. Height
+// changes only add/remove/reposition quads; the texture re-renders only when
+// the block itself changes (panel width, theme).
 LoadingSkeletonGroup {
     id: root
 
@@ -16,7 +23,28 @@ LoadingSkeletonGroup {
     // that don't fit are clipped at the top instead of bleeding below
     clip: true
 
+    QtObject {
+        id: d
+
+        // vertical rhythm of the tiling: one block plus the same gap the
+        // bottom-anchored Column used to leave between repeated blocks
+        readonly property real step: block.height + Theme.padding
+
+        // the count divisor is floored at a safe underestimate of the block
+        // height: the block reports partial heights while its nested
+        // positioners settle, and reacting to those would churn thousands of
+        // transient quads on a very tall placeholder
+        readonly property int quadCount: block.height > 0
+                                         ? Math.max(0, Math.ceil((root.height - block.height)
+                                                                 / Math.max(d.step, 400)))
+                                         : 0
+    }
+
     Column {
+        id: block
+
+        objectName: "patternBlock"
+
         anchors {
             left: parent.left
             right: parent.right
@@ -24,92 +52,110 @@ LoadingSkeletonGroup {
         }
         spacing: Theme.padding
 
-        // The pattern block is repeated to fill whatever height the skeleton
-        // is given — as a paging placeholder it can stand in for many screens
-        // of messages, and a fast fling must never reach blank space. The
-        // divisor is a safe underestimate of the block height; the surplus
-        // block is clipped at the top.
+        // name/line widths are fractions of the available text width
+        // so the shape survives narrow and wide panels alike
         Repeater {
-            model: Math.max(1, Math.ceil(root.height / 500))
+            model: [
+                { name: 0.22, lines: [0.95, 0.9, 0.86, 0.5] },
+                { separator: true },
+                { name: 0.18, lines: [0.6], card: true },
+                { name: 0.26, lines: [0.92, 0.35] },
+                { separator: true },
+                { name: 0.2, lines: [0.88, 0.44] },
+            ]
 
-            delegate: Column {
-                width: parent ? parent.width : 0
-                spacing: Theme.padding
+            delegate: DelegateChooser {
+                role: "separator"
 
-                // name/line widths are fractions of the available text width
-                // so the shape survives narrow and wide panels alike
-                Repeater {
-                    model: [
-                        { name: 0.22, lines: [0.95, 0.9, 0.86, 0.5] },
-                        { separator: true },
-                        { name: 0.18, lines: [0.6], card: true },
-                        { name: 0.26, lines: [0.92, 0.35] },
-                        { separator: true },
-                        { name: 0.2, lines: [0.88, 0.44] },
-                    ]
+                DelegateChoice {
+                    roleValue: true
 
-                    delegate: DelegateChooser {
-                        role: "separator"
+                    LoadingSkeletonTile {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        implicitWidth: 96
+                        implicitHeight: 12
+                    }
+                }
+                DelegateChoice {
+                    Row {
+                        id: entry
 
-                        DelegateChoice {
-                            roleValue: true
+                        required property var modelData
+
+                        // available width for the text bars; derived
+                        // from the stable root width, not the row
+                        // itself, to avoid a sizing cycle
+                        readonly property real textWidth:
+                            Math.max(0, root.width - 40 - Theme.halfPadding)
+
+                        width: parent.width
+                        spacing: Theme.halfPadding
+
+                        LoadingSkeletonTile {
+                            implicitWidth: 40
+                            implicitHeight: 40
+                            radius: width / 2
+                        }
+                        Column {
+                            spacing: 6
 
                             LoadingSkeletonTile {
-                                anchors.horizontalCenter: parent.horizontalCenter
-                                implicitWidth: 96
+                                implicitWidth: entry.textWidth * (entry.modelData.name ?? 0.2)
                                 implicitHeight: 12
                             }
-                        }
-                        DelegateChoice {
-                            Row {
-                                id: entry
-
-                                required property var modelData
-
-                                // available width for the text bars; derived
-                                // from the stable root width, not the row
-                                // itself, to avoid a sizing cycle
-                                readonly property real textWidth:
-                                    Math.max(0, root.width - 40 - Theme.halfPadding)
-
-                                width: parent.width
-                                spacing: Theme.halfPadding
+                            Repeater {
+                                model: entry.modelData.lines ?? []
 
                                 LoadingSkeletonTile {
-                                    implicitWidth: 40
-                                    implicitHeight: 40
-                                    radius: width / 2
+                                    required property real modelData
+
+                                    implicitWidth: entry.textWidth * modelData
+                                    implicitHeight: 14
                                 }
-                                Column {
-                                    spacing: 6
-
-                                    LoadingSkeletonTile {
-                                        implicitWidth: entry.textWidth * (entry.modelData.name ?? 0.2)
-                                        implicitHeight: 12
-                                    }
-                                    Repeater {
-                                        model: entry.modelData.lines ?? []
-
-                                        LoadingSkeletonTile {
-                                            required property real modelData
-
-                                            implicitWidth: entry.textWidth * modelData
-                                            implicitHeight: 14
-                                        }
-                                    }
-                                    // attachment / link-preview card
-                                    LoadingSkeletonTile {
-                                        visible: !!entry.modelData.card
-                                        implicitWidth: Math.min(320, entry.textWidth * 0.6)
-                                        implicitHeight: 150
-                                        radius: Theme.radius
-                                    }
-                                }
+                            }
+                            // attachment / link-preview card
+                            LoadingSkeletonTile {
+                                visible: !!entry.modelData.card
+                                implicitWidth: Math.min(320, entry.textWidth * 0.6)
+                                implicitHeight: 150
+                                radius: Theme.radius
                             }
                         }
                     }
                 }
             }
+        }
+    }
+
+    // The one live texture every tiled quad samples; follows the block, so
+    // it re-renders on panel-width and theme changes and nothing else
+    ShaderEffectSource {
+        id: blockTexture
+
+        objectName: "patternBlockSource"
+
+        visible: false
+        sourceItem: block
+        live: true
+    }
+
+    // Textured quads (default shaders — no custom shader) filling the height
+    // above the block, positioned relative to the bottom edge so the pattern
+    // at the seam with real rows stays pinned when a reveal shrinks the
+    // placeholder; the topmost quad is clipped at the top
+    Repeater {
+        model: d.quadCount
+
+        ShaderEffect {
+            objectName: "patternQuad"
+
+            required property int index
+
+            property var source: blockTexture
+
+            width: root.width
+            height: block.height
+            y: root.height - block.height - (index + 1) * d.step
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -47,6 +47,7 @@ Item {
     property var emojiPopup
     property var stickersPopup
     property DelegatePool rowPool: null
+    property bool dressHold: false
     property bool areTestNetworksEnabled
 
     /*
@@ -542,6 +543,7 @@ Item {
 
                 rootStore: root.rootStore
                 rowPool: root.rowPool
+                dressHold: root.dressHold
                 formatBalance: d.formatBalance
                 emojiPopup: root.emojiPopup
                 stickersPopup: root.stickersPopup

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -52,6 +52,7 @@ Item {
     property bool dressHold: false
     Component.onCompleted: {
         d.applyPoolTarget()
+        d.updatePlaceholderHeights()
         d.viewCompleted = true
     }
 
@@ -439,6 +440,160 @@ Item {
                 d.scheduleDrain()
         }
 
+        // ---- Scroll freeze: content geometry never mutates
+        // while the view is in motion — drag, fling and the whole
+        // deceleration tail. Slides, reveals and placeholder resizes wait
+        // for rest; fetches, model assimilation and dress-queueing stay
+        // free. Deliberately broader than the velocity gate above: any
+        // programmatic contentY correction cancels an active flick, so the
+        // geometry underneath the physics must simply not change.
+        readonly property bool viewMoving: chatLogView.moving
+
+        onViewMovingChanged: {
+            if (!d.viewMoving)
+                d.settleAfterMotion()
+        }
+
+        // A staged batch that completed mid-motion; revealed at settle.
+        property bool revealOnRest: false
+
+        // Per-side placeholder estimates: top covers the history above the
+        // window, bottom the recent rows below it — never each other, so a
+        // slide resizes only the end it moved (the coupled max() height is
+        // what made the bottom placeholder pop into the viewport mid-fling
+        // and ping-pong the window). Floored at a viewport only while that
+        // side pages, because the height doubles as the paging trigger depth.
+        readonly property real liveTopPlaceholderHeight: {
+            const remaining = Math.max(0, d.historyCount - 1 - d.windowEnd)
+            const estimate = Math.min(remaining, 300) * d.rowHeightOr48()
+            const active = d.olderMessagesAvailable || d.stagedCount > 0
+            return Math.max(active ? chatLogView.height : 0, estimate)
+        }
+        readonly property real liveBottomPlaceholderHeight: {
+            const estimate = Math.min(Math.max(0, d.windowStart), 300)
+                             * d.rowHeightOr48()
+            return Math.max(d.windowStart > 0 ? chatLogView.height : 0,
+                            estimate)
+        }
+
+        // What the view actually gets: latched while in motion, following
+        // the live estimates at rest.
+        property real topPlaceholderHeight: 0
+        property real bottomPlaceholderHeight: 0
+
+        onLiveTopPlaceholderHeightChanged: d.updatePlaceholderHeights()
+        onLiveBottomPlaceholderHeightChanged: d.updatePlaceholderHeights()
+
+        function updatePlaceholderHeights() {
+            if (d.viewMoving)
+                return
+            d.topPlaceholderHeight = d.liveTopPlaceholderHeight
+            d.bottomPlaceholderHeight = d.liveBottomPlaceholderHeight
+        }
+
+        // The viewport top's estimated history row while it sits inside the
+        // top placeholder: pixel depth ÷ avgRowHeight past the window's
+        // history end — the same estimate the scrollbar renders, so the
+        // landing is self-consistent — exactly the oldest loaded row at the
+        // placeholder's far edge. -1 outside the placeholder.
+        function scrollTargetRow() {
+            const depth = chatLogView.viewportDepthIntoTopPlaceholder()
+            if (depth <= 0 || d.historyCount === 0)
+                return -1
+            if (depth >= d.topPlaceholderHeight - 1)
+                return d.historyCount - 1
+            const rowHeight = d.avgRowHeight > 0 ? d.avgRowHeight : 48
+            return Math.min(d.historyCount - 1,
+                            d.windowEnd + Math.round(depth / rowHeight))
+        }
+
+        // Settle: everything motion deferred happens here. Capture first,
+        // then mutate — the teleport target must be read from the frozen
+        // geometry before the placeholder heights unlatch.
+        function settleAfterMotion() {
+            const target = d.scrollTargetRow()
+            d.updatePlaceholderHeights()
+            if (target > d.windowEnd + d.windowChunkSize
+                    && d.dressActive && !d.initialFillActive
+                    && !d.pendingRestore && d.teleportToRow(target)) {
+                d.revealOnRest = false
+                return
+            }
+            if (d.revealOnRest) {
+                d.revealOnRest = false
+                d.checkStagedReady()
+            }
+        }
+
+        // Teleport slide: the viewport out-scrolled the window by more than
+        // a chunk, so instead of unrolling every chunk in between the whole
+        // window releases and re-admits at the target through the window
+        // record restore path, which pins the viewport to the target row at
+        // the atomic reveal — never a raw contentY write.
+        function teleportToRow(targetIndex) {
+            const id = SQUtils.ModelUtils.get(root.messageStore.messagesModel,
+                                              targetIndex, "id")
+            if (id === undefined || id === null)
+                return false
+            const span = Math.max(1, d.windowEnd - d.windowStart + 1)
+            d.windowAtInitial = false
+            // same chat, same session: the restore's fetch-guard reset does
+            // not apply — a fetch already fired for this history count must
+            // not repeat until it actually grows the history
+            const lastFetch = d.lastFetchHistoryCount
+            d.restoreWindow(targetIndex,
+                            { oldestRowId: String(id), span: span, offset: 0 })
+            d.lastFetchHistoryCount = lastFetch
+            return true
+        }
+
+        // Rows a trade may evict: rows fully outside the viewport on the
+        // evicted side. The "a viewport's worth survives" size cap assumes
+        // the viewport rides the slide's leading edge; after a teleport it
+        // sits at the window's history end, where an unguarded recent-trade
+        // evicts the very rows being read and the window walks away from
+        // the viewport. A viewport anchored to the newest message is not
+        // free-floating — the anchor re-pins it, so nothing needs guarding.
+        function tradableRows(fromRecentEnd) {
+            if (chatLogView.stickingToNewest)
+                return d.maxWindowSize
+            let rows = 0
+            for (let i = 0; i < chatLogView.count; ++i) {
+                const item = chatLogView.itemAtRow(i)
+                if (!item || !item.visible || item.height <= 0)
+                    continue
+                const y = item.mapToItem(chatLogView.contentItem, 0, 0).y
+                if (fromRecentEnd) {
+                    if (y >= chatLogView.contentY + chatLogView.height)
+                        ++rows
+                } else if (y + item.height <= chatLogView.contentY) {
+                    ++rows
+                }
+            }
+            return rows
+        }
+
+        // Eager history prefetch: fetching is pure I/O and stays free during
+        // motion. While the viewport scrolls through the placeholder toward
+        // the loaded-history end, fire the fetch early so the settle usually
+        // finds its rows already loaded. The lastFetchHistoryCount guard
+        // blocks repeats until the fetch actually grows the history.
+        function prefetchHistoryAhead() {
+            if (!d.viewMoving)
+                return
+            if (root.rootStore.loadingHistoryMessagesInProgress
+                    || d.historyExhausted || !d.mayFetchMoreHistory)
+                return
+            const depth = chatLogView.viewportDepthIntoTopPlaceholder()
+            if (depth <= 0)
+                return
+            const rowHeight = d.avgRowHeight > 0 ? d.avgRowHeight : 48
+            if (d.windowEnd + depth / rowHeight
+                    < d.historyCount - 1 - d.windowChunkSize)
+                return
+            d.lastFetchHistoryCount = d.historyCount
+            messageStore.loadMoreMessages()
+        }
 
         function enqueueDress(shell) {
             if (d.dressQueue.indexOf(shell) === -1)
@@ -812,6 +967,7 @@ Item {
             d.stagedShells = []
             d.stagedIds.clear()
             d.syncStagedCount()
+            d.revealOnRest = false
             revealTimeout.stop()
         }
 
@@ -819,6 +975,12 @@ Item {
         // a partial one (better than wedging paging on a pathological row).
         function revealStaged() {
             revealTimeout.stop()
+            // scroll freeze: a batch completing mid-motion holds its atomic
+            // reveal until rest — the skeleton keeps covering it
+            if (d.viewMoving) {
+                d.revealOnRest = true
+                return
+            }
             if (d.initialFillActive) {
                 d.initialFillActive = false
                 if (root.rowPool)
@@ -925,8 +1087,10 @@ Item {
 
         function slideWindowToHistory(allowTrade = true) {
             // one batch at a time: the paging timer keeps asking while the
-            // placeholder shows, and the next chunk must wait for this one
-            if (d.stagedCount > 0 || d.initialFillActive || !d.dressActive)
+            // placeholder shows, and the next chunk must wait for this one.
+            // Frozen in motion: no slide may start until the view rests.
+            if (d.stagedCount > 0 || d.initialFillActive || !d.dressActive
+                    || d.viewMoving)
                 return
 
             if (d.windowEnd < d.historyCount - 1) {
@@ -947,7 +1111,8 @@ Item {
                     const size = d.windowEnd - d.windowStart + 1
                     const slide = allowTrade
                                 ? Math.min(wanted - grow,
-                                           Math.max(0, size - d.initialRevealTarget))
+                                           Math.max(0, size - d.initialRevealTarget),
+                                           d.tradableRows(true))
                                 : 0
                     if (grow + slide === 0) {
                         // dry and nothing to trade: grow the pool instead of
@@ -981,7 +1146,7 @@ Item {
 
         function slideWindowToRecent() {
             if (d.stagedCount > 0 || d.windowStart <= 0
-                    || d.initialFillActive || !d.dressActive)
+                    || d.initialFillActive || !d.dressActive || d.viewMoving)
                 return
 
             if (d.usePool) {
@@ -990,7 +1155,8 @@ Item {
                 const grow = Math.min(wanted, headroom)
                 const size = d.windowEnd - d.windowStart + 1
                 const slide = Math.min(wanted - grow,
-                                       Math.max(0, size - d.initialRevealTarget))
+                                       Math.max(0, size - d.initialRevealTarget),
+                                       d.tradableRows(false))
                 if (grow + slide === 0) {
                     root.rowPool.boost(d.rowPoolKind, 1)
                     return
@@ -1273,15 +1439,10 @@ Item {
         // roughly proportional across reveals: the rows a reveal adds are
         // taken out of the placeholder, keeping the content height steady.
         // One per side, each standing for its own span, so a slide resizes
-        // only the end it moved — a shared height popped the opposite
-        // placeholder into the viewport and ping-ponged the slide direction.
-        topPlaceholderHeight: {
-            const remaining = Math.max(0, d.historyCount - 1 - d.windowEnd)
-            return Math.max(chatLogView.height,
-                            Math.min(remaining, 300) * d.rowHeightOr48())
-        }
-        bottomPlaceholderHeight: Math.max(chatLogView.height,
-                                          Math.min(d.windowStart, 300) * d.rowHeightOr48())
+        // only the end it moved. Latched while the view is in motion
+        // (scroll freeze).
+        topPlaceholderHeight: d.topPlaceholderHeight
+        bottomPlaceholderHeight: d.bottomPlaceholderHeight
 
         // Page one viewport ahead of the scroll so a batch is usually
         // revealed before its placeholder is ever seen.
@@ -1291,6 +1452,7 @@ Item {
         onMoreDownRequested: d.slideWindowToRecent()
 
         onVerticalVelocityChanged: d.updateScrollGate(Math.abs(verticalVelocity))
+        onContentYChanged: d.prefetchHistoryAhead()
 
         onRowPositioned: row => {
             const item = chatLogView.itemAtRow(row)

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -253,9 +253,8 @@ Item {
 
         function applyPendingRestore() {
             const restore = d.pendingRestore
-            // cleared a turn later, not here: the pooled rebind makes the
-            // whole restore synchronous, and the marker scroll it must win
-            // over can arrive in the same turn, right after the reveal
+            // cleared a turn later, not here: the marker scroll this restore
+            // must win over can arrive in the same turn as the reveal
             Qt.callLater(function() {
                 if (d.pendingRestore === restore)
                     d.pendingRestore = null
@@ -432,6 +431,53 @@ Item {
                 d.dressQueue.splice(i, 1)
         }
 
+        // Drain order: viewport-nearest-first, so the skeleton clears where
+        // the user is looking. Undressed shells hold no geometry (invisible,
+        // zero height), so distance is counted in rows from a reference row
+        // resolved fresh at every slice — never from insertion order.
+        function dressReferenceRow() {
+            if (d.pendingRestore) {
+                // restoring mid-history: the record's offset is the viewport
+                // top's distance below the window's top row (the highest
+                // proxy row); estimate the rows above the viewport center at
+                // the running average height
+                const rowHeight = d.avgRowHeight > 0 ? d.avgRowHeight : 48
+                const rowsAbove = (d.pendingRestore.offset
+                                   + chatLogView.height / 2) / rowHeight
+                return Math.max(0, Math.round(
+                                    d.windowEnd - d.windowStart - rowsAbove))
+            }
+            // fresh open and every bottom-pinned view: row 0 is the bottom
+            if (chatLogView.stickingToNewest)
+                return 0
+            // mid-history without a restore in flight: the dressed rows
+            // still on screen locate the viewport
+            const center = chatLogView.contentY + chatLogView.height / 2
+            let best = 0
+            let bestDistance = Number.MAX_VALUE
+            for (let i = 0; i < chatLogView.count; ++i) {
+                const item = chatLogView.itemAtRow(i)
+                if (!item || !item.visible || item.height <= 0)
+                    continue
+                const distance = Math.abs(center - item.mapToItem(
+                                     chatLogView.contentItem,
+                                     0, item.height / 2).y)
+                if (distance < bestDistance) {
+                    bestDistance = distance
+                    best = i
+                }
+            }
+            return best
+        }
+
+        function sortDressQueue() {
+            if (d.dressQueue.length < 2)
+                return
+            const ref = d.dressReferenceRow()
+            d.dressQueue.sort((a, b) => Math.abs(a.index - ref)
+                                        - Math.abs(b.index - ref))
+        }
+
         function drainDressQueue() {
             d.drainScheduled = false
             // an un-dressed view must never take items — whatever is queued
@@ -440,13 +486,17 @@ Item {
                 d.dressQueue = []
                 return
             }
-            const deadline = Date.now() + 8
+            // at most one dress per slice: a single dress already fills a
+            // frame on the devices this paces for, and the callLater chain
+            // yields to rendering between slices
+            d.sortDressQueue()
             while (d.dressQueue.length) {
                 const shell = d.dressQueue.shift()
-                if (shell && !shell.retired)
-                    shell.doAcquire()
-                if (Date.now() >= deadline)
-                    break
+                if (!shell || shell.retired || !shell.pooled
+                        || shell.pooledItem)
+                    continue
+                shell.doAcquire()
+                break
             }
             if (d.dressQueue.length)
                 d.scheduleDrain()
@@ -1416,18 +1466,16 @@ Item {
                 releasePooled()
             }
 
-            // Staged rows dress through the paced queue: a rebind rebuilds the
-            // message's inner content (text blocks, previews), and a whole
-            // window of them in one turn is a seconds-long freeze. Only a live
-            // row — already revealed, the user is looking at its spot — binds
-            // on the spot.
+            // Every dress goes through the paced queue: a rebind rebuilds the
+            // message's inner content (text blocks, previews), one costs a
+            // whole frame on a low-end device, and any trigger (availability,
+            // reveal, slide, restore, live insert) can fire for a window's
+            // worth of shells in one turn. The drain is doAcquire's only
+            // caller — nothing dresses inside a signal handler.
             function tryAcquire() {
                 if (!pooled || pooledItem || retired || !root.rowPool)
                     return
-                if (revealed)
-                    doAcquire()
-                else
-                    d.enqueueDress(shell)
+                d.enqueueDress(shell)
             }
 
             // Guards the pool's availability cascade re-entering THIS shell

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -46,6 +46,10 @@ Item {
     // (popups, storybook pages) build rows inline as before.
     property DelegatePool rowPool: null
     onRowPoolChanged: d.applyPoolTarget()
+
+    // Dress hold (ADR 0007): raised while a view transition runs. Dress
+    // triggers keep enqueuing; the drain waits and restarts on release.
+    property bool dressHold: false
     Component.onCompleted: {
         d.applyPoolTarget()
         d.viewCompleted = true
@@ -411,6 +415,30 @@ Item {
         property var dressQueue: []
         property bool drainScheduled: false
 
+        // ---- Scroll gate: a fast fling holds
+        // dressing exactly like a panel switch — a dress blows the frame
+        // when motion makes dropped frames most visible. Velocity-only:
+        // `moving` stays true through the whole deceleration tail and a
+        // resting finger mid-drag must dress. Hysteresis (enter high, exit
+        // low) keeps the gate from flapping around one threshold.
+        readonly property real fastScrollEnterVelocity: chatLogView.height
+        readonly property real fastScrollExitVelocity: chatLogView.height * 0.4
+        property bool fastScroll: false
+
+        function updateScrollGate(speed) {
+            if (!d.fastScroll && speed > d.fastScrollEnterVelocity)
+                d.fastScroll = true
+            else if (d.fastScroll && speed < d.fastScrollExitVelocity)
+                d.fastScroll = false
+        }
+
+        // Either hold input gates the drain; both must clear to dress.
+        readonly property bool dressHeld: root.dressHold || d.fastScroll
+        onDressHeldChanged: {
+            if (!d.dressHeld && d.dressQueue.length)
+                d.scheduleDrain()
+        }
+
 
         function enqueueDress(shell) {
             if (d.dressQueue.indexOf(shell) === -1)
@@ -486,6 +514,9 @@ Item {
                 d.dressQueue = []
                 return
             }
+            // held: the queue keeps accumulating, release restarts the drain
+            if (d.dressHeld)
+                return
             // at most one dress per slice: a single dress already fills a
             // frame on the devices this paces for, and the callLater chain
             // yields to rendering between slices
@@ -1258,6 +1289,8 @@ Item {
 
         onMoreUpRequested: d.slideWindowToHistory(!chatLogView.stickingToNewest)
         onMoreDownRequested: d.slideWindowToRecent()
+
+        onVerticalVelocityChanged: d.updateScrollGate(Math.abs(verticalVelocity))
 
         onRowPositioned: row => {
             const item = chatLogView.itemAtRow(row)

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -83,6 +83,7 @@ Item {
     property var emojiPopup
     property var stickersPopup
     property DelegatePool rowPool: null
+    property bool dressHold: false
     property bool stickersLoaded: false
 
     readonly property var chatContentModule: rootStore.currentChatContentModule() || null
@@ -504,6 +505,7 @@ Item {
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
             rowPool: root.rowPool
+            dressHold: root.dressHold
             viewAndPostHoldingsModel: root.viewAndPostPermissionsModel
             canPost: !root.rootStore.chatCommunitySectionModule.isCommunity() || root.canPost
             amISectionAdmin: root.amISectionAdmin

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -273,6 +273,7 @@ Loader {
             navToMsgList:                   Qt.binding(() => root.rootStore.navToMsgList),
             leftPanelWidthOverride:         Qt.binding(() => root.leftPanelWidthOverride),
             rowPool:                        Qt.binding(() => root.rowPool),
+            dressHold:                      Qt.binding(() => d.panelSwitchOngoing),
         })
     }
 

--- a/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
@@ -341,6 +341,7 @@ Loader {
             navToMsgDetails:                Qt.binding(() => root.rootStore.navToMsgDetails),
             leftPanelWidthOverride:         Qt.binding(() => root.leftPanelWidthOverride),
             rowPool:                        Qt.binding(() => root.rowPool),
+            dressHold:                      Qt.binding(() => d.panelSwitchOngoing),
         })
     }
 

--- a/ui/imports/shared/views/chat/ChatMessagesFlickable.qml
+++ b/ui/imports/shared/views/chat/ChatMessagesFlickable.qml
@@ -167,6 +167,21 @@ Flickable {
         return repeater.itemAt(row)
     }
 
+    /*!
+       How deep the viewport top sits inside the top placeholder, in px from
+       the placeholder's bottom edge, clamped to [0, placeholder height]: 0
+       when the viewport is below the placeholder, the full height at its far
+       edge (the oldest loaded row). The owner maps this depth to an estimated
+       history row for the teleport slide and the eager history prefetch.
+    */
+    function viewportDepthIntoTopPlaceholder() {
+        if (!topPlaceholder.visible || topPlaceholder.height <= 0)
+            return 0
+        const bottomEdge = content.y + topPlaceholder.y + topPlaceholder.height
+        return Math.max(0, Math.min(topPlaceholder.height,
+                                    bottomEdge - root.contentY))
+    }
+
     QtObject {
         id: d
 


### PR DESCRIPTION
> **Stack 3/3** — message view performance
> 1. #21970 model window + staged reveal
> 2. #22409 pooled, rebindable message rows
> 3. **low-end device lag fixes** ← _this PR_ (base: `perf/message-row-pool`)
>
> Message-history virtualization (dense model over new status-go window/rank APIs) follows later, separately.

### What does the PR do

Profiling the pooled message view on a low-end Android device showed the GUI thread nearly pegged during chat switches and scrolling. Each commit here attacks one measured cost:

| Commit | Device finding | Fix |
|---|---|---|
| Skeleton tiling | The paging placeholder (up to ~180k px on a phone) was filled with ~8,500 skeleton items, 0.9–1.9 s per switch. | One pattern block rendered once into a texture and tiled with plain quads. Item cost no longer depends on placeholder height. |
| Paced drain | A pooled dress costs ~90 ms; availability dressed synchronously, 17 back-to-back = a 1.5 s freeze. | Every dress goes through one queue, at most one row per event-loop turn, nearest the viewport first. |
| Dress holds | Dresses dropped frames during swipe transitions and fast flings. | Dressing pauses during panel transitions and above ~1 viewport/s of scroll velocity (with hysteresis), then resumes where the view lands. |
| toBlocks memo | Markdown parsing ~15 ms per message, repeated on every re-dress. | A 500-entry LRU keyed on the full input tuple. |
| Block recycling | ChatTextView recreated all its block items on every rebind (~35 ms of the 90 ms). | Same-shape rebinds keep the block delegates and only re-evaluate bindings. |
| Scroll freeze | Mid-fling slides/reveals changed geometry under the physics and cancelled flicks. | Content geometry is frozen while moving; at rest a deep overshoot teleports the window through the window-record path. Fetching stays free. |
| Per-row costs | FFI round-trips per sender (151 in 21 s), per-second timestamp re-formatting (1,290 in 21 s), stylesheet rebuilds per reply. | Pubkey memo (Nim), day-granular timestamp tick, hoisted stylesheet. |

### Affected areas

Chat message list (scrolling, chat switching, mobile panel swipes); StatusQ `ChatTextView`, `MarkdownUtils`, `StatusTimeStampLabel`, `StatusSharedUpdateTimer`; Nim `Utils.getColorId` / `getEmojiHashAsJson`.

### Quality checklist

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

_To follow with a device build of the full stack._

### Impact on end user

On low-end devices: responsive chat switches (a brief skeleton instead of a frozen UI), smooth flings through long histories, and less idle CPU while a chat is open.

### How to test

- Low-end Android is the target:
  - switch between busy community channels;
  - fling hard through a long history and back;
  - swipe between panels in portrait;
  - leave a chat open for a minute, since idle CPU should be low.
- Storybook: **MessageRowsSkeleton** page (tiling at large heights).
- Tests: `tst_MessageRowsSkeletonTiling`, `tst_PacedDrainOrder`, `tst_FlingContinuity`, `tst_ChatTextViewRecycling`, `tst_StatusTimeStampLabel`, StatusQ `tst_markdownutils`, Nim `pubkey_memo_test`.

### Risk

- Skeleton tiling uses `ShaderEffectSource` with default shaders; no custom `.qsb`.
- The scroll freeze changes when geometry updates. Worst case is a deferred reveal showing skeleton slightly longer after a fling.
- The toBlocks cache shares immutable block lists by value; consumers must not mutate them (ChatTextView copies before appending its edited marker).
